### PR TITLE
fix: fix copy for the login command

### DIFF
--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -142,7 +142,7 @@ func (opts *loginOpts) oauthFlow(ctx context.Context) error {
 	_, _ = fmt.Fprintf(opts.OutWriter, `
 First, copy your one-time code: %s-%s
 
-Next, sign with your browser and enter the code.
+Next, sign in with your browser and enter the code.
 
 Or go to %s
 

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -107,7 +107,7 @@ func Test_loginOpts_Run(t *testing.T) {
 	assert.Equal(t, `
 First, copy your one-time code: 1234-5678
 
-Next, sign with your browser and enter the code.
+Next, sign in with your browser and enter the code.
 
 Or go to http://localhost
 


### PR DESCRIPTION
## Proposed changes

Small copy fix

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments
