### PR TITLE
CLOUDP-114754: Investigate how we will set the Segment API-key on the  CLI clients

### DIFF
--- a/.atlascli.goreleaser.yml
+++ b/.atlascli.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
       binary: bin/atlas
       main: ./cmd/atlas/atlas.go
       ldflags:
-        - -s -w -X github.com/mongodb/mongocli/internal/version.Version={{.Version}} -X github.com/mongodb/mongocli/internal/version.GitCommit={{.FullCommit}}
+        - -s -w -X github.com/mongodb/mongocli/internal/version.Version={{.Version}} -X github.com/mongodb/mongocli/internal/version.GitCommit={{.FullCommit}} -X github.com/mongodb/mongocli/internal/version.SegmentKey=${.Env.SEGMENT_KEY}
     id: macos
     goos: [darwin]
     goarch: [amd64,arm64]

--- a/.mongocli.goreleaser.yml
+++ b/.mongocli.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
       binary: bin/mongocli
       main: ./cmd/mongocli/mongocli.go
       ldflags:
-        - -s -w -X github.com/mongodb/mongocli/internal/version.Version={{.Version}} -X github.com/mongodb/mongocli/internal/version.GitCommit={{.FullCommit}}
+        - -s -w -X github.com/mongodb/mongocli/internal/version.Version={{.Version}} -X github.com/mongodb/mongocli/internal/version.GitCommit={{.FullCommit}} -X github.com/mongodb/mongocli/internal/version.SegmentKey=${.Env.SEGMENT_KEY}
     id: macos
     goos: [darwin]
     goarch: [amd64,arm64]

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ifeq ($(ATLAS_VERSION),) # use git describe if we don't have an atlascli tag
 endif
 
 
-LINKER_FLAGS=-s -w -X github.com/mongodb/mongocli/internal/version.GitCommit=${MCLI_GIT_SHA}
+LINKER_FLAGS=-s -w -X github.com/mongodb/mongocli/internal/version.GitCommit=${MCLI_GIT_SHA} -X github.com/mongodb/mongocli/internal/version.SegmentKey=${SEGMENT_KEY}
 MCLI_LINKER_FLAGS=${LINKER_FLAGS} -X github.com/mongodb/mongocli/internal/config.ToolName=$(MCLI_BINARY_NAME) -X github.com/mongodb/mongocli/internal/version.Version=${MCLI_VERSION}
 ATLAS_LINKER_FLAGS=${LINKER_FLAGS} -X github.com/mongodb/mongocli/internal/config.ToolName=atlascli -X github.com/mongodb/mongocli/internal/version.Version=${ATLAS_VERSION}
 ATLAS_E2E_BINARY?=../../bin/${ATLAS_BINARY_NAME}

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -74,6 +74,7 @@ functions:
           - goreleaser_config
           - github_token
           - unstable
+          - segment_key
         env:
           <<: *go_options
         binary: build/package/package.sh

--- a/build/package/package.sh
+++ b/build/package/package.sh
@@ -22,6 +22,7 @@ export NOTARY_SERVICE_URL=${notary_service_url:?}
 export MACOS_NOTARY_KEY=${notary_service_key_id:?}
 export MACOS_NOTARY_SECRET=${notary_service_secret:?}
 export GORELEASER_KEY=${goreleaser_key:?}
+export SEGMENT_KEY=${segment_key:?}
 export VERSION_GIT
 
 VERSION_GIT="$(git tag --list "${tool_name:?}/v*" --sort=committerdate | tail -1 | cut -d "v" -f 2)"

--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -168,6 +168,7 @@ func Builder(profile *string) *cobra.Command {
 
 	rootCmd.PersistentFlags().StringVarP(profile, flag.Profile, flag.ProfileShort, "", usage.Profile)
 
+	fmt.Printf("This is the Segment API key: %s\n", version.SegmentKey)
 	return rootCmd
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -19,3 +19,6 @@ var Version string
 
 // GitCommit git sha of the build.
 var GitCommit string
+
+// SegmentKey key used to communicate with segment.
+var SegmentKey string


### PR DESCRIPTION
Ticket: CLOUDP-114754
<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
**DO NOT MERGE THIS PR.**

This is a POC of how we could include the segment key into the clis at build time.

**Goal**: We want to use the SEGMENT API KEY without leaking it.
**Solution**: Adding the segment key at build time in the makefile (used for testing) and in the release process when generating new binaries.