### PR TITLE
CLOUDP-114869: Add atlascli commands

### DIFF
--- a/docs/atlascli/command/atlas-logs-decrypt.txt
+++ b/docs/atlascli/command/atlas-logs-decrypt.txt
@@ -99,5 +99,5 @@ Examples
 .. code-block::
 
 
-   $ atlascli decrypt --file logPath --out resultPath --awsAccessKey accessKey --awsSecretKey secretKey --awsSessionToken sessionToken
+   $ atlas decrypt --file logPath --out resultPath --awsAccessKey accessKey --awsSecretKey secretKey --awsSessionToken sessionToken
 

--- a/docs/atlascli/command/atlas-logs-decrypt.txt
+++ b/docs/atlascli/command/atlas-logs-decrypt.txt
@@ -1,0 +1,103 @@
+.. _atlas-logs-decrypt:
+
+==================
+atlas logs decrypt
+==================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Decrypts a log file with the provided local key file or KMIP files.
+
+Syntax
+------
+
+.. code-block::
+
+   atlas logs decrypt [options]
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - --awsAccessKey
+     - string
+     - false
+     - AWS Access Key ID that is part of long-term credentials.
+   * - --awsSecretKey
+     - string
+     - false
+     - AWS Secret Access Key  that is part of long-term credentials.
+   * - --awsSessionToken
+     - string
+     - false
+     - AWS session token used with temporary security credentials.
+   * - --azureClientId
+     - string
+     - false
+     - Application (client) ID assigned by Azure portal - App registrations experience.
+   * - --azureSecret
+     - string
+     - false
+     - Application secret created in the Azure app registration portal.
+   * - --azureTenantId
+     - string
+     - false
+     - Tenant value in the path of the request can be used to control who can sign into the application.
+   * - -f, --file
+     - string
+     - true
+     - Path to the file that contains encrypted audit logs.
+   * - --gcpServiceAccountKey
+     - string
+     - false
+     - GCP service account key file.
+   * - -h, --help
+     - 
+     - false
+     - help for decrypt
+   * - --out
+     - string
+     - false
+     - Path to the file where the decrypted audit log will be written. If not specified the default would be to write to stdout.
+   * - -o, --output
+     - string
+     - false
+     - Output format. Valid values are json, json-path, go-template, or go-template-file.
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+
+   $ atlascli decrypt --file logPath --out resultPath --awsAccessKey accessKey --awsSecretKey secretKey --awsSessionToken sessionToken
+

--- a/docs/atlascli/command/atlas-logs-keyProviders-list.txt
+++ b/docs/atlascli/command/atlas-logs-keyProviders-list.txt
@@ -1,0 +1,71 @@
+.. _atlas-logs-keyProviders-list:
+
+============================
+atlas logs keyProviders list
+============================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Lists all key provider configurations found in the encrypted log file.
+
+Syntax
+------
+
+.. code-block::
+
+   atlas logs keyProviders list [options]
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -f, --file
+     - string
+     - true
+     - Path to the file that contains encrypted audit logs.
+   * - -h, --help
+     - 
+     - false
+     - help for list
+   * - -o, --output
+     - string
+     - false
+     - Output format. Valid values are json, json-path, go-template, or go-template-file.
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+
+   $ mongocli ops-manager listKeyProvider --file log.gz
+

--- a/docs/atlascli/command/atlas-logs-keyProviders-list.txt
+++ b/docs/atlascli/command/atlas-logs-keyProviders-list.txt
@@ -67,5 +67,5 @@ Examples
 .. code-block::
 
 
-   $ mongocli ops-manager listKeyProvider --file log.gz
+   $ atlas listKeyProvider --file log.gz
 

--- a/docs/atlascli/command/atlas-logs-keyProviders.txt
+++ b/docs/atlascli/command/atlas-logs-keyProviders.txt
@@ -1,8 +1,8 @@
-.. _atlas-logs:
+.. _atlas-logs-keyProviders:
 
-==========
-atlas logs
-==========
+=======================
+atlas logs keyProviders
+=======================
 
 .. default-domain:: mongodb
 
@@ -12,7 +12,7 @@ atlas logs
    :depth: 1
    :class: singlecol
 
-Download host logs for your project.
+Manage your key collections.
 
 Options
 -------
@@ -28,7 +28,7 @@ Options
    * - -h, --help
      - 
      - false
-     - help for logs
+     - help for keyProviders
 
 Inherited Options
 -----------------
@@ -49,15 +49,11 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`atlas-logs-decrypt` - Decrypts a log file with the provided local key file or KMIP files.
-* :ref:`atlas-logs-download` - Download a host mongodb logs.
-* :ref:`atlas-logs-keyProviders` - Manage your key collections.
+* :ref:`atlas-logs-keyProviders-list` - Lists all key provider configurations found in the encrypted log file.
 
 
 .. toctree::
    :titlesonly:
 
-   decrypt </command/atlas-logs-decrypt>
-   download </command/atlas-logs-download>
-   keyProviders </command/atlas-logs-keyProviders>
+   list </command/atlas-logs-keyProviders-list>
 

--- a/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
@@ -40,14 +40,14 @@ Options
      - 
      - false
      - help for decrypt
-   * - --kimipServerCAFile
-     - string
-     - false
-     - Path to the CA file used to connect to the KMIP speaking server.
    * - --kmipClientCertificateFile
      - string
      - false
      - Path to the Client Cert file used to connect to the KMIP speaking server.
+   * - --kmipServerCAFile
+     - string
+     - false
+     - Path to the CA file used to connect to the KMIP speaking server.
    * - --localKeyFile
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
@@ -40,14 +40,14 @@ Options
      - 
      - false
      - help for decrypt
-   * - --kimipServerCAFile
-     - string
-     - false
-     - Path to the CA file used to connect to the KMIP speaking server.
    * - --kmipClientCertificateFile
      - string
      - false
      - Path to the Client Cert file used to connect to the KMIP speaking server.
+   * - --kmipServerCAFile
+     - string
+     - false
+     - Path to the CA file used to connect to the KMIP speaking server.
    * - --localKeyFile
      - string
      - false

--- a/internal/cli/atlas/atlas.go
+++ b/internal/cli/atlas/atlas.go
@@ -86,7 +86,7 @@ func Builder() *cobra.Command {
 		events.Builder(),
 		metrics.Builder(),
 		performanceadvisor.Builder(),
-		logs.Builder(),
+		logs.MongoCLIBuilder(),
 		processes.Builder(),
 		privateendpoints.Builder(),
 		networking.Builder(),

--- a/internal/cli/atlas/logs/decrypt.go
+++ b/internal/cli/atlas/logs/decrypt.go
@@ -47,13 +47,6 @@ type DecryptAzureOpts struct {
 	azureSecret   string
 }
 
-func (opts *DecryptOpts) initStore() func() error {
-	// Keeping for now, not sure if needed
-	return func() error {
-		return nil
-	}
-}
-
 func (opts *DecryptOpts) initFiles() func() error {
 	// Validate the provided files can be open
 	return func() error {
@@ -73,7 +66,7 @@ func (opts *DecryptOpts) Run() error {
 	return opts.Print(opts.inFileName)
 }
 
-// mongocli om logs decrypt --file <encryptedLogFile> --out <outputLogFile>.
+// atlas logs decrypt --file <encryptedLogFile> --out <outputLogFile>.
 func DecryptBuilder() *cobra.Command {
 	opts := &DecryptOpts{}
 	cmd := &cobra.Command{
@@ -82,7 +75,7 @@ func DecryptBuilder() *cobra.Command {
 		Example: `
   $ atlascli decrypt --file logPath --out resultPath --awsAccessKey accessKey --awsSecretKey secretKey --awsSessionToken sessionToken`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.PreRunE(opts.initFiles(), opts.initStore(), opts.initFlags())
+			return opts.PreRunE(opts.initFiles(), opts.initFlags())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()

--- a/internal/cli/atlas/logs/decrypt.go
+++ b/internal/cli/atlas/logs/decrypt.go
@@ -1,0 +1,113 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"github.com/mongodb/mongocli/internal/cli"
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/usage"
+	"github.com/spf13/cobra"
+)
+
+type DecryptOpts struct {
+	cli.GlobalOpts
+	cli.OutputOpts
+	inFileName  string
+	outFileName string
+	awsOpts     DecryptAWSOpts
+	gcpOpts     DecryptGCPOpts
+	azureOpts   DecryptAzureOpts
+}
+
+type DecryptAWSOpts struct {
+	awsAccessKey       string
+	awsSecretAccessKey string
+	awsSessionToken    string
+}
+
+type DecryptGCPOpts struct {
+	gcpServiceAccountKey string
+}
+
+type DecryptAzureOpts struct {
+	azureClientID string
+	azureTenantID string
+	azureSecret   string
+}
+
+func (opts *DecryptOpts) initStore() func() error {
+	// Keeping for now, not sure if needed
+	return func() error {
+		return nil
+	}
+}
+
+func (opts *DecryptOpts) initFiles() func() error {
+	// Validate the provided files can be open
+	return func() error {
+		return nil
+	}
+}
+
+func (opts *DecryptOpts) initFlags() func() error {
+	// Validate all needed flags are set or try to retrieve right credentials.
+	return func() error {
+		return nil
+	}
+}
+
+func (opts *DecryptOpts) Run() error {
+	// Run the command. For now printing the file path.
+	return opts.Print(opts.inFileName)
+}
+
+// mongocli om logs decrypt --file <encryptedLogFile> --out <outputLogFile>.
+func DecryptBuilder() *cobra.Command {
+	opts := &DecryptOpts{}
+	cmd := &cobra.Command{
+		Use:   "decrypt",
+		Short: "Decrypts a log file with the provided local key file or KMIP files.",
+		Example: `
+  $ atlascli decrypt --file logPath --out resultPath --awsAccessKey accessKey --awsSecretKey secretKey --awsSessionToken sessionToken`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.PreRunE(opts.initFiles(), opts.initStore(), opts.initFlags())
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.inFileName, flag.File, flag.FileShort, "", usage.EncryptedLogFile)
+	cmd.Flags().StringVarP(&opts.outFileName, flag.Out, "", "", usage.OutputLogFile)
+
+	cmd.Flags().StringVarP(&opts.awsOpts.awsAccessKey, flag.AWSAccessKey, "", "", usage.DecryptAWSAccessKey)
+	cmd.Flags().StringVarP(&opts.awsOpts.awsSecretAccessKey, flag.AWSSecretKey, "", "", usage.DecryptAWSSecretKey)
+	cmd.Flags().StringVarP(&opts.awsOpts.awsSessionToken, flag.AWSSessionToken, "", "", usage.AWSSessionToken)
+
+	cmd.Flags().StringVarP(&opts.azureOpts.azureClientID, flag.AzureClientID, "", "", usage.AzureClientID)
+	cmd.Flags().StringVarP(&opts.azureOpts.azureTenantID, flag.AzureTenantID, "", "", usage.AzureTenantID)
+	cmd.Flags().StringVarP(&opts.azureOpts.azureSecret, flag.AzureSecret, "", "", usage.AzureSecret)
+
+	cmd.Flags().StringVarP(&opts.gcpOpts.gcpServiceAccountKey, flag.GCPServiceAccountKey, "", "", usage.GCPServiceAccountKey)
+
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+
+	_ = cmd.MarkFlagRequired(flag.File)
+
+	_ = cmd.MarkFlagFilename(flag.File)
+	_ = cmd.MarkFlagFilename(flag.Out)
+
+	return cmd
+}

--- a/internal/cli/atlas/logs/decrypt.go
+++ b/internal/cli/atlas/logs/decrypt.go
@@ -73,7 +73,7 @@ func DecryptBuilder() *cobra.Command {
 		Use:   "decrypt",
 		Short: "Decrypts a log file with the provided local key file or KMIP files.",
 		Example: `
-  $ atlascli decrypt --file logPath --out resultPath --awsAccessKey accessKey --awsSecretKey secretKey --awsSessionToken sessionToken`,
+  $ atlas decrypt --file logPath --out resultPath --awsAccessKey accessKey --awsSecretKey secretKey --awsSessionToken sessionToken`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.initFiles(), opts.initFlags())
 		},

--- a/internal/cli/atlas/logs/decrypt_test.go
+++ b/internal/cli/atlas/logs/decrypt_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+// +build unit
+
+package logs
+
+import (
+	"testing"
+)
+
+func TestDecrypt_Run(t *testing.T) {
+	listOpts := &DecryptOpts{
+		inFileName: "test",
+	}
+
+	if err := listOpts.Run(); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}

--- a/internal/cli/atlas/logs/decrypt_test.go
+++ b/internal/cli/atlas/logs/decrypt_test.go
@@ -19,8 +19,30 @@ package logs
 
 import (
 	"testing"
+
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/test"
 )
 
+func TestDecryptBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		DecryptBuilder(),
+		0,
+		[]string{
+			flag.File,
+			flag.Out,
+			flag.AzureSecret,
+			flag.AzureClientID,
+			flag.AzureTenantID,
+			flag.AzureClientID,
+			flag.AWSSecretKey,
+			flag.AWSSecretKey,
+			flag.AWSSessionToken,
+			flag.GCPServiceAccountKey,
+		},
+	)
+}
 func TestDecrypt_Run(t *testing.T) {
 	listOpts := &DecryptOpts{
 		inFileName: "test",

--- a/internal/cli/atlas/logs/key_providers.go
+++ b/internal/cli/atlas/logs/key_providers.go
@@ -1,0 +1,31 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func KeyProvidersBuilder() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "keyProviders",
+		Aliases: []string{"keys"},
+		Short:   "Manage your key collections.",
+	}
+
+	cmd.AddCommand(KeyProvidersListBuilder())
+
+	return cmd
+}

--- a/internal/cli/atlas/logs/key_providers_test.go
+++ b/internal/cli/atlas/logs/key_providers_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+// +build unit
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongocli/internal/test"
+)
+
+func TestKeyProvidersBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		KeyProvidersBuilder(),
+		1,
+		[]string{},
+	)
+}

--- a/internal/cli/atlas/logs/list_key_provider.go
+++ b/internal/cli/atlas/logs/list_key_provider.go
@@ -39,7 +39,7 @@ func (opts *KeyProviderListOpts) Run() error {
 	return opts.Print(opts.file)
 }
 
-// mongocli om logs listKeyProvider --file <encryptedLogFile>.
+// atlas logs listKeyProvider --file <encryptedLogFile>.
 func KeyProvidersListBuilder() *cobra.Command {
 	opts := &KeyProviderListOpts{}
 	cmd := &cobra.Command{

--- a/internal/cli/atlas/logs/list_key_provider.go
+++ b/internal/cli/atlas/logs/list_key_provider.go
@@ -1,0 +1,68 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"github.com/mongodb/mongocli/internal/cli"
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/usage"
+	"github.com/spf13/cobra"
+)
+
+type KeyProviderListOpts struct {
+	cli.GlobalOpts
+	cli.OutputOpts
+	file string
+}
+
+func (opts *KeyProviderListOpts) initStore() func() error {
+	// Keeping for now, not sure if needed
+	return func() error {
+		return nil
+	}
+}
+
+func (opts *KeyProviderListOpts) Run() error {
+	// Run the command. For now printing the file path.
+	return opts.Print(opts.file)
+}
+
+// mongocli om logs listKeyProvider --file <encryptedLogFile>.
+func KeyProvidersListBuilder() *cobra.Command {
+	opts := &KeyProviderListOpts{}
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "Lists all key provider configurations found in the encrypted log file.",
+		Example: `
+  $ mongocli ops-manager listKeyProvider --file log.gz`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.PreRunE(
+				opts.initStore(),
+				opts.InitOutput(cmd.OutOrStdout(), ""),
+			)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.file, flag.File, flag.FileShort, "", usage.EncryptedLogFile)
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+
+	_ = cmd.MarkFlagRequired(flag.File)
+	_ = cmd.MarkFlagFilename(flag.File)
+	return cmd
+}

--- a/internal/cli/atlas/logs/list_key_provider.go
+++ b/internal/cli/atlas/logs/list_key_provider.go
@@ -47,7 +47,7 @@ func KeyProvidersListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "Lists all key provider configurations found in the encrypted log file.",
 		Example: `
-  $ mongocli ops-manager listKeyProvider --file log.gz`,
+  $ atlas listKeyProvider --file log.gz`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.initStore(),

--- a/internal/cli/atlas/logs/list_key_provider_test.go
+++ b/internal/cli/atlas/logs/list_key_provider_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+// +build unit
+
+package logs
+
+import (
+	"testing"
+)
+
+func TestKeyProviderListOpts_Run(t *testing.T) {
+	listOpts := &KeyProviderListOpts{
+		file: "test",
+	}
+
+	if err := listOpts.Run(); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}

--- a/internal/cli/atlas/logs/logs.go
+++ b/internal/cli/atlas/logs/logs.go
@@ -19,7 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Builder() *cobra.Command {
+// MongoCLIBuilder is used in mongocli until atlascli is released.
+func MongoCLIBuilder() *cobra.Command {
 	const use = "logs"
 	cmd := &cobra.Command{
 		Use:     use,
@@ -27,6 +28,23 @@ func Builder() *cobra.Command {
 		Short:   "Download host logs for your project.",
 	}
 	cmd.AddCommand(DownloadBuilder())
+
+	return cmd
+}
+
+// Builder is the up-to-date builder used by atlascli.
+func Builder() *cobra.Command {
+	const use = "logs"
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: cli.GenerateAliases(use),
+		Short:   "Download host logs for your project.",
+	}
+	cmd.AddCommand(
+		DownloadBuilder(),
+		KeyProvidersBuilder(),
+		DecryptBuilder(),
+	)
 
 	return cmd
 }

--- a/internal/cli/atlas/logs/logs_test.go
+++ b/internal/cli/atlas/logs/logs_test.go
@@ -1,0 +1,42 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+// +build unit
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongocli/internal/test"
+)
+
+func TestBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		Builder(),
+		3,
+		[]string{},
+	)
+}
+
+func TestMongoCLIBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		MongoCLIBuilder(),
+		1,
+		[]string{},
+	)
+}

--- a/internal/cli/opsmanager/logs/decrypt.go
+++ b/internal/cli/opsmanager/logs/decrypt.go
@@ -31,13 +31,6 @@ type DecryptOpts struct {
 	localKeyFileName              string
 }
 
-func (opts *DecryptOpts) initStore() func() error {
-	// Keeping for now, not sure if needed
-	return func() error {
-		return nil
-	}
-}
-
 func (opts *DecryptOpts) initFiles() func() error {
 	// Validate the provided files can be open
 	return func() error {
@@ -59,7 +52,7 @@ func DecryptBuilder() *cobra.Command {
 		Example: `
   $ mongocli ops-manager decrypt --localKey filePath --file logPath --out resultPath`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return opts.PreRunE(opts.initFiles(), opts.initStore())
+			return opts.PreRunE(opts.initFiles())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()

--- a/internal/cli/opsmanager/logs/decrypt_test.go
+++ b/internal/cli/opsmanager/logs/decrypt_test.go
@@ -19,7 +19,25 @@ package logs
 
 import (
 	"testing"
+
+	"github.com/mongodb/mongocli/internal/flag"
+	"github.com/mongodb/mongocli/internal/test"
 )
+
+func TestDecryptBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		DecryptBuilder(),
+		0,
+		[]string{
+			flag.File,
+			flag.Out,
+			flag.LocalKeyFile,
+			flag.KMIPClientCertificateFile,
+			flag.KMIPServerCAFile,
+		},
+	)
+}
 
 func TestDecrypt_Run(t *testing.T) {
 	listOpts := &DecryptOpts{

--- a/internal/cli/opsmanager/logs/logs_test.go
+++ b/internal/cli/opsmanager/logs/logs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc
+// Copyright 2022 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -272,6 +272,11 @@ const (
 	Gov                                      = "gov"                             // Gov flag
 	Version                                  = "version"                         // Version flag
 	LocalKeyFile                             = "localKeyFile"                    // LocalKeyFile flag
-	KMIPServerCAFile                         = "kimipServerCAFile"               // KMIPServerCAFile flag
+	KMIPServerCAFile                         = "kmipServerCAFile"                // KMIPServerCAFile flag
 	KMIPClientCertificateFile                = "kmipClientCertificateFile"       // KMIPClientCertificateFile flag
+	GCPServiceAccountKey                     = "gcpServiceAccountKey"            // GCPServiceAccountKey flag
+	AzureClientID                            = "azureClientId"                   // AzureClientID flag
+	AzureTenantID                            = "azureTenantId"                   // AzureTenantID flag
+	AzureSecret                              = "azureSecret"                     // AzureSecret flag
+	AWSSessionToken                          = "awsSessionToken"                 // AWSSessionToken flag
 )

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -313,4 +313,11 @@ const (
 	LocalKeyFile                             = "Path to the file that contains the Key Encryption Key (used to encrypt the Log Encryption Key)."
 	KMIPServerCAFile                         = "Path to the CA file used to connect to the KMIP speaking server."
 	KMIPClientCertificateFile                = "Path to the Client Cert file used to connect to the KMIP speaking server."
+	GCPServiceAccountKey                     = "GCP service account key file."
+	AzureClientID                            = "Application (client) ID assigned by Azure portal - App registrations experience."
+	AzureTenantID                            = "Tenant value in the path of the request can be used to control who can sign into the application."
+	AzureSecret                              = "Application secret created in the Azure app registration portal."
+	DecryptAWSAccessKey                      = "AWS Access Key ID that is part of long-term credentials."
+	DecryptAWSSecretKey                      = "AWS Secret Access Key  that is part of long-term credentials." //nolint:gosec // This is just a message not a credential
+	AWSSessionToken                          = "AWS session token used with temporary security credentials."   //nolint:gosec // This is just a message not a credential
 )


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-114869](https://jira.mongodb.org/browse/CLOUDP-114869)

Commands:
`atlas logs keyProviders list --file test`
`atlas logs decrypt --file test`

* Note: adding commands only to atlascli
* Note: code for keyProviders list the same as ops-manager/cloud-manager

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

```
➜  mongocli git:(CLOUDP-114869) ./bin/atlas logs decrypt --file tst
tst
  mongocli git:(CLOUDP-114869) ./bin/atlas logs decrypt --help
Decrypts a log file with the provided local key file or KMIP files.

Usage:
  atlas logs decrypt [flags]

Examples:

  $ atlas decrypt --file logPath --out resultPath --awsAccessKey accessKey --awsSecretKey secretKey --awsSessionToken sessionToken

Flags:
      --awsAccessKey string           AWS Access Key ID that is part of long-term credentials.
      --awsSecretKey string           AWS Secret Access Key  that is part of long-term credentials.
      --awsSessionToken string        AWS session token used with temporary security credentials.
      --azureClientId string          Application (client) ID assigned by Azure portal - App registrations experience.
      --azureSecret string            Application secret created in the Azure app registration portal.
      --azureTenantId string          Tenant value in the path of the request can be used to control who can sign into the application.
  -f, --file string                   Path to the file that contains encrypted audit logs.
      --gcpServiceAccountKey string   GCP service account key file.
  -h, --help                          help for decrypt
      --out string                    Path to the file where the decrypted audit log will be written. If not specified the default would be to write to stdout.
  -o, --output string                 Output format. Valid values are json, json-path, go-template, or go-template-file.

Global Flags:
  -P, --profile string   Profile to use from your configuration file.
```

```
➜  mongocli git:(CLOUDP-114869) ./bin/atlas logs keyProviders list --file tst
tst

➜  mongocli git:(CLOUDP-114869)  ./bin/atlas logs keyProviders list --help
Lists all key provider configurations found in the encrypted log file.

Usage:
  atlas logs keyProviders list [flags]

Aliases:
  list, ls

Examples:

  $ atlas listKeyProvider --file log.gz

Flags:
  -f, --file string     Path to the file that contains encrypted audit logs.
  -h, --help            help for list
  -o, --output string   Output format. Valid values are json, json-path, go-template, or go-template-file.

Global Flags:
  -P, --profile string   Profile to use from your configuration file.
```