### PR TITLE
CLOUDP-115605: [MongoCLI] Improve config command to accept opsmanager

### DIFF
--- a/docs/mongocli/command/mongocli-config.txt
+++ b/docs/mongocli/command/mongocli-config.txt
@@ -75,12 +75,17 @@ Examples
 
    To configure the tool to work with Atlas for Government
    $ mongocli config --service cloudgov
+   $ mongocli config --service gov
    
    To configure the tool to work with Cloud Manager
    $ mongocli config --service cloud-manager
+   $ mongocli config --service cloudmanager
+   $ mongocli config --service cm
 
    To configure the tool to work with Ops Manager
    $ mongocli config --service ops-manager
+   $ mongocli config --service opsmanager
+   $ mongocli config --service om
 
 
 Related Commands

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -102,6 +102,7 @@ func (opts *opts) validateService() error {
 
 	if opts.Service == "opsmanager" || opts.Service == "om" {
 		opts.Service = config.OpsManagerService
+		return nil
 	}
 
 	if opts.Service != config.OpsManagerService && opts.Service != config.CloudManagerService && opts.Service != config.CloudGovService {

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -106,7 +106,7 @@ func (opts *opts) validateService() error {
 	}
 
 	if opts.Service != config.OpsManagerService && opts.Service != config.CloudManagerService && opts.Service != config.CloudGovService {
-		return fmt.Errorf("the service '%s' is not supported. Please run 'mongocli config --help' to see the list of available services", opts.Service)
+		return fmt.Errorf("the '%s' service is not supported. Please run 'mongocli config --help' to see the list of available services", opts.Service)
 	}
 
 	return nil

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -104,7 +104,7 @@ func (opts *opts) validateService() error {
 		opts.Service = config.OpsManagerService
 	}
 
-	if opts.Service != config.OpsManagerURL() && opts.Service != config.CloudManagerService && opts.Service != config.CloudGovService {
+	if opts.Service != config.OpsManagerService && opts.Service != config.CloudManagerService && opts.Service != config.CloudGovService {
 		return fmt.Errorf("the service '%s' is not supported. Please run 'mongocli config --help' to see the list of available services", opts.Service)
 	}
 

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -132,10 +132,12 @@ To find out more, see the documentation: https://docs.mongodb.com/mongocli/stabl
   
   To configure the tool to work with Cloud Manager
   $ mongocli config --service cloud-manager
+  $ mongocli config --service cloudmanager
   $ mongocli config --service cm
 
   To configure the tool to work with Ops Manager
   $ mongocli config --service ops-manager
+  $ mongocli config --service opsmanager
   $ mongocli config --service om
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -106,7 +106,7 @@ func Credentials() error {
 
 	configCMD := "config"
 	if config.BinName() == "atlas" {
-		configCMD += "init"
+		configCMD += " init"
 	}
 	return fmt.Errorf(
 		"%w\n\nTo set credentials, run: %s %s",


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-115605

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->


**Issue**: users can only run the config command with `--service ops-manager` or `--service cloud-manager`. If they try to run `config --service opsmanager` they are not able to config mongocli with ops manager


**The goal of this PR is to allow users to use `opsmanager`, `om`, `cloudmanager`, and `cm` with the `mongocli config` command.**


```
./bin/mongocli config --help
Configure settings in a user profile.
All settings are optional. You can specify settings individually by running:
$ mongocli config set --help

You can also use environment variables (MCLI_*) when running the tool.
To find out more, see the documentation: https://docs.mongodb.com/mongocli/stable/configure/environment-variables/.

Usage:
  mongocli config [flags]
  mongocli config [command]

Examples:

  To configure the tool to work with Atlas
  $ mongocli config

  To configure the tool to work with Atlas for Government
  $ mongocli config --service cloudgov
  $ mongocli config --service gov

  To configure the tool to work with Cloud Manager
  $ mongocli config --service cloud-manager
  $ mongocli config --service cloudmanager
  $ mongocli config --service cm

  To configure the tool to work with Ops Manager
  $ mongocli config --service ops-manager
  $ mongocli config --service opsmanager
  $ mongocli config --service om


Available Commands:
  set         Configure specific properties of a profile.
  list        List available profiles.
  describe    Return a specific profile.
  rename      Rename a profile.
  delete      Delete a profile.

Flags:
  -h, --help             help for config
      --service string   Type of MongoDB service. Valid values are cloud, cloudgov, cloud-manager, or ops-manager. (default "cloud")

Global Flags:
  -P, --profile string   Profile to use from your configuration file.

Use "mongocli config [command] --help" for more information about a command.
```


```
./bin/mongocli config --service om
You are configuring a profile for mongocli.

All values are optional and you can use environment variables (MCLI_*) instead.

Enter [?] on any option to get help.

? URL to Access Ops Manager: [? for help]
```

```
./bin/mongocli config --service opsmanager
You are configuring a profile for mongocli.

All values are optional and you can use environment variables (MCLI_*) instead.

Enter [?] on any option to get help.

? URL to Access Ops Manager: [? for help]
```

