### PR TITLE
CLOUDP-112126: logs keyProvider list command

### DIFF
--- a/internal/cli/opsmanager/logs/list_key_provider.go
+++ b/internal/cli/opsmanager/logs/list_key_provider.go
@@ -30,7 +30,7 @@ type KeyProviderListOpts struct {
 	fs   afero.Fs
 }
 
-var listTmpl = `{{ range . }}{{ .Provider }}:{{if .Filename}} Filename = {{ .Filename }}{{end}}{{if .UniqueKeyID}} Unique Key ID = "{{ .UniqueKeyID }}"{{end}}{{if .KmipServerName}} Kmip Server Name = "{{ .KmipServerName }}"{{end}}{{if .KmipPort}} Kmip Port = "{{ .KmipPort }}"{{end}}{{if .KeyWrapMethod}} Key Wrap Method = "{{ .KeyWrapMethod }}"{{end}}
+var listTmpl = `{{ range . }}{{ .Provider }}:{{if .Filename}} Filename = {{ .Filename }}{{end}}{{if .UniqueKeyID}} Unique Key ID = "{{ .UniqueKeyID }}"{{end}}{{if .KMIPServerName}} KMIP Server Name = "{{ .KMIPServerName }}"{{end}}{{if .KMIPPort}} KMIP Port = "{{ .KMIPPort }}"{{end}}{{if .KeyWrapMethod}} Key Wrap Method = "{{ .KeyWrapMethod }}"{{end}}
 {{ end }}`
 
 func (opts *KeyProviderListOpts) initStore() func() error {

--- a/internal/cli/opsmanager/logs/list_key_provider_test.go
+++ b/internal/cli/opsmanager/logs/list_key_provider_test.go
@@ -18,15 +18,34 @@
 package logs
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/spf13/afero"
 )
 
 func TestKeyProviderListOpts_Run(t *testing.T) {
+	fileJSON := []byte(`{"ts":{"$date":{"$numberLong":"1644232049921"}},"version":"0.0","compressionMode":"zstd","keyStoreIdentifier":{"provider":"local","filename":"localKey"},"encryptedKey":{"$binary":{"base64":"+yjPCaKKE1M8fZmPGzGHkyfHYxaw34okpavsHzpd8iPVx2+JjOhXwXw5E2FdI5Rcb5JgmcPUFRPISh/7Si1R/g==","subType":"0"}},"MAC":"qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA","auditRecordType":"header"}
+{"ts":{"$date":{"$numberLong":"1644232049922"}},"log":"1Lu4o8XVMM/Rg7GKAQAAAAEAAAAAAAAA/8tXQ36mEd90OaAOzCOSti7N5a2jr0B9ek48/uvyteG/zUJHyM16Hs3wMEhDqTQGBwGhWSHEqXh0/5Jbz6tXsYHhDTMr1BOsn1zaavZScx/CkO5+Hd8Vx+zeFPREtQTe1y+JngXSIroezeyV0/zF4YC4vpug+OZtrEQLNEgwT2bjaqUyaKDbmzCNetd2Ff/eFfMFzinbzKVgXAC7T4YmDuowqXommEXLIBiYh2u4VagwJKZRw5OGZjnvqwyVpSPgGqLxGKUoFigh3NgC6EuGi17VIs5BLRZOIw7+OfbPgQQiKzjCxCk="}
+{"ts":{"$date":{"$numberLong":"1644232049921"}},"version":"0.0","compressionMode":"zstd","keyStoreIdentifier":{"provider":"kmip","uniqueKeyID":"uniqueKeyID","kmipServerName":"kmipServerName","kmipPort":"kmipPort","keyWrapMethod":"get"},"encryptedKey":{"$binary":{"base64":"+yjPCaKKE1M8fZmPGzGHkyfHYxaw34okpavsHzpd8iPVx2+JjOhXwXw5E2FdI5Rcb5JgmcPUFRPISh/7Si1R/g==","subType":"0"}},"MAC":"qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA","auditRecordType":"header"}
+{"ts":{"$date":{"$numberLong":"1644232049922"}},"log":"1Lu4o8XVMM/Rg7GKAQAAAAEAAAAAAAAA/8tXQ36mEd90OaAOzCOSti7N5a2jr0B9ek48/uvyteG/zUJHyM16Hs3wMEhDqTQGBwGhWSHEqXh0/5Jbz6tXsYHhDTMr1BOsn1zaavZScx/CkO5+Hd8Vx+zeFPREtQTe1y+JngXSIroezeyV0/zF4YC4vpug+OZtrEQLNEgwT2bjaqUyaKDbmzCNetd2Ff/eFfMFzinbzKVgXAC7T4YmDuowqXommEXLIBiYh2u4VagwJKZRw5OGZjnvqwyVpSPgGqLxGKUoFigh3NgC6EuGi17VIs5BLRZOIw7+OfbPgQQiKzjCxCk="}`)
+
 	listOpts := &KeyProviderListOpts{
 		file: "test",
+		fs:   afero.NewMemMapFs(),
 	}
+	bufOut := new(bytes.Buffer)
+	_ = listOpts.InitOutput(bufOut, listTmpl)()
+	_ = afero.WriteFile(listOpts.fs, "test", fileJSON, 0600)
 
 	if err := listOpts.Run(); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	expected := `local: Filename = localKey
+kmip: Unique Key ID = "uniqueKeyID" Kmip Server Name = "kmipServerName" Kmip Port = "kmipPort" Key Wrap Method = "get"
+`
+	if bufOut.String() != expected {
+		t.Fatalf("Run() expected: %s got: %v", expected, bufOut.String())
 	}
 }

--- a/internal/cli/opsmanager/logs/list_key_provider_test.go
+++ b/internal/cli/opsmanager/logs/list_key_provider_test.go
@@ -43,7 +43,7 @@ func TestKeyProviderListOpts_Run(t *testing.T) {
 	}
 
 	expected := `local: Filename = localKey
-kmip: Unique Key ID = "uniqueKeyID" Kmip Server Name = "kmipServerName" Kmip Port = "kmipPort" Key Wrap Method = "get"
+kmip: Unique Key ID = "uniqueKeyID" KMIP Server Name = "kmipServerName" KMIP Port = "kmipPort" Key Wrap Method = "get"
 `
 	if bufOut.String() != expected {
 		t.Fatalf("Run() expected: %s got: %v", expected, bufOut.String())

--- a/internal/decryption/encrypted_audit_log.go
+++ b/internal/decryption/encrypted_audit_log.go
@@ -30,8 +30,8 @@ type AuditLogLineKeyStoreIdentifier struct {
 	Filename *string
 	// kmip
 	UniqueKeyID    *string
-	KmipServerName *string
-	KmipPort       *string
+	KMIPServerName *string
+	KMIPPort       *string
 	KeyWrapMethod  *keyproviders.KMIPKeyWrapMethod
 	// aws
 	Key      *string
@@ -77,8 +77,8 @@ func (logLine *AuditLogLine) KeyProvider(opts KeyProviderOpts) (keyproviders.Key
 	case keyproviders.KMIP:
 		return &keyproviders.KMIPKeyIdentifier{
 			UniqueKeyID:               *logLine.KeyStoreIdentifier.UniqueKeyID,
-			ServerName:                *logLine.KeyStoreIdentifier.KmipServerName,
-			ServerPort:                *logLine.KeyStoreIdentifier.KmipPort,
+			ServerName:                *logLine.KeyStoreIdentifier.KMIPServerName,
+			ServerPort:                *logLine.KeyStoreIdentifier.KMIPPort,
 			KeyWrapMethod:             *logLine.KeyStoreIdentifier.KeyWrapMethod,
 			ServerCAFileName:          opts.KMIPServerCAFileName,
 			ClientCertificateFileName: opts.KMIPClientCertificateFileName,


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Implement `mongocli om logs keyProvider list` command
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-112126

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

Run `mongocli om logs keyProvider list --file test.json`

Result:
```
local: Filename = localKey
kmip: Unique Key ID = "uniqueKeyID" Kmip Server Name = "kmipServerName" Kmip Port = "kmipPort" Key Wrap Method = "get"
```

`test.json`
```json
{"ts":{"$date":{"$numberLong":"1644232049921"}},"version":"0.0","compressionMode":"zstd","keyStoreIdentifier":{"provider":"local","filename":"localKey"},"encryptedKey":{"$binary":{"base64":"+yjPCaKKE1M8fZmPGzGHkyfHYxaw34okpavsHzpd8iPVx2+JjOhXwXw5E2FdI5Rcb5JgmcPUFRPISh/7Si1R/g==","subType":"0"}},"MAC":"qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA","auditRecordType":"header"}
{"ts":{"$date":{"$numberLong":"1644232049922"}},"log":"1Lu4o8XVMM/Rg7GKAQAAAAEAAAAAAAAA/8tXQ36mEd90OaAOzCOSti7N5a2jr0B9ek48/uvyteG/zUJHyM16Hs3wMEhDqTQGBwGhWSHEqXh0/5Jbz6tXsYHhDTMr1BOsn1zaavZScx/CkO5+Hd8Vx+zeFPREtQTe1y+JngXSIroezeyV0/zF4YC4vpug+OZtrEQLNEgwT2bjaqUyaKDbmzCNetd2Ff/eFfMFzinbzKVgXAC7T4YmDuowqXommEXLIBiYh2u4VagwJKZRw5OGZjnvqwyVpSPgGqLxGKUoFigh3NgC6EuGi17VIs5BLRZOIw7+OfbPgQQiKzjCxCk="}
{"ts":{"$date":{"$numberLong":"1644232049921"}},"version":"0.0","compressionMode":"zstd","keyStoreIdentifier":{"provider":"kmip","uniqueKeyID":"uniqueKeyID","kmipServerName":"kmipServerName","kmipPort":"kmipPort","keyWrapMethod":"get"},"encryptedKey":{"$binary":{"base64":"+yjPCaKKE1M8fZmPGzGHkyfHYxaw34okpavsHzpd8iPVx2+JjOhXwXw5E2FdI5Rcb5JgmcPUFRPISh/7Si1R/g==","subType":"0"}},"MAC":"qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA","auditRecordType":"header"}
{"ts":{"$date":{"$numberLong":"1644232049922"}},"log":"1Lu4o8XVMM/Rg7GKAQAAAAEAAAAAAAAA/8tXQ36mEd90OaAOzCOSti7N5a2jr0B9ek48/uvyteG/zUJHyM16Hs3wMEhDqTQGBwGhWSHEqXh0/5Jbz6tXsYHhDTMr1BOsn1zaavZScx/CkO5+Hd8Vx+zeFPREtQTe1y+JngXSIroezeyV0/zF4YC4vpug+OZtrEQLNEgwT2bjaqUyaKDbmzCNetd2Ff/eFfMFzinbzKVgXAC7T4YmDuowqXommEXLIBiYh2u4VagwJKZRw5OGZjnvqwyVpSPgGqLxGKUoFigh3NgC6EuGi17VIs5BLRZOIw7+OfbPgQQiKzjCxCk="}
```