### PR TITLE
CLOUDP-112093: Validate encrypted audit log records

### DIFF
--- a/internal/decryption/header.go
+++ b/internal/decryption/header.go
@@ -121,9 +121,9 @@ func processHeader(logLine *AuditLogLine, opts KeyProviderOpts) (*DecryptSection
 	}
 
 	return &DecryptSection{
-		lek:               lek,
-		compressionMode:   header.CompressionMode,
-		processedLogLines: 0,
+		lek:                    lek,
+		compressionMode:        header.CompressionMode,
+		lastKeyInvocationCount: 0,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Validate encrypted audit log records
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-112093

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

Error results will be unformatted example:
```json
{"uuid":{"$binary":{"base64":"+mOPbB12RDGgTsXXjR8R/A==","subType":"04"}},"local":{"isSystemUser":true},"roles":[],"result":0,"ts":{"$date":"2022-02-07T11:07:29.922Z"},"atype":"startup","remote":{"isSystemUser":true},"users":[],"param":{"options":{"auditLog":{"path":"auditLog.json","compressionMode":"zstd","destination":"file","format":"JSON","localAuditKeyFile":"localKey"}}}}
logRecordIdx missmatch, expected: 2, actual: 3
{"atype":"createCollection","users":[],"param":{"ns":"admin.system.version"},"result":0,"ts":{"$date":"2022-02-07T11:07:30.645Z"},"uuid":{"$binary":{"base64":"+mOPbB12RDGgTsXXjR8R/A==","subType":"04"}},"local":{"isSystemUser":true},"remote":{"isSystemUser":true},"roles":[]}
{"roles":[],"atype":"createIndex","uuid":{"$binary":{"base64":"+mOPbB12RDGgTsXXjR8R/A==","subType":"04"}},"users":[],"param":{"indexSpec":{"v":2,"key":{"_id":1},"name":"_id_"},"indexBuildState":"IndexBuildStarted","ns":"admin.system.version","indexName":"_id_"},"result":0,"ts":{"$date":"2022-02-07T11:07:30.651Z"},"local":{"isSystemUser":true},"remote":{"isSystemUser":true}}
```

the formatting of errors will happen on another PR
