### PR TITLE
Update alerts e2e tests to not consider alert type

### DIFF
--- a/e2e/atlas/alerts_test.go
+++ b/e2e/atlas/alerts_test.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	open                   = "OPEN"
-	dailyBillOverThreshold = "DAILY_BILL_OVER_THRESHOLD"
+	open = "OPEN"
 )
 
 func TestAlerts(t *testing.T) {
@@ -104,7 +103,6 @@ func TestAlerts(t *testing.T) {
 			a.NoError(err)
 			a.Equal(alertID, alert.ID)
 			a.Equal(open, alert.Status)
-			a.Equal(dailyBillOverThreshold, alert.EventTypeName)
 		}
 	})
 

--- a/e2e/cloud_manager/alerts_test.go
+++ b/e2e/cloud_manager/alerts_test.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	open                        = "OPEN"
-	usersWithoutMultiFactorAuth = "USERS_WITHOUT_MULTI_FACTOR_AUTH"
+	open = "OPEN"
 )
 
 func TestAlerts(t *testing.T) {
@@ -40,11 +39,13 @@ func TestAlerts(t *testing.T) {
 
 	var alertID string
 
-	t.Run("List with no status", func(t *testing.T) {
+	t.Run("List with status OPEN", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			entity,
 			alertsEntity,
 			"list",
+			"--status",
+			open,
 			"-o=json",
 		)
 
@@ -56,7 +57,7 @@ func TestAlerts(t *testing.T) {
 		}
 
 		var alerts mongodbatlas.AlertsResponse
-		if err = json.Unmarshal(resp, &alerts); err != nil {
+		if err := json.Unmarshal(resp, &alerts); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -94,19 +95,13 @@ func TestAlerts(t *testing.T) {
 		if alert.Status != open {
 			t.Errorf("got=%#v\nwant=%#v\n", alert.Status, open)
 		}
-
-		if alert.EventTypeName != usersWithoutMultiFactorAuth {
-			t.Errorf("got=%#v\nwant=%#v\n", alert.EventTypeName, usersWithoutMultiFactorAuth)
-		}
 	})
 
-	t.Run("List with status OPEN", func(t *testing.T) {
+	t.Run("List with no status", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			entity,
 			alertsEntity,
 			"list",
-			"--status",
-			open,
 			"-o=json",
 		)
 
@@ -118,7 +113,7 @@ func TestAlerts(t *testing.T) {
 		}
 
 		var alerts mongodbatlas.AlertsResponse
-		if err := json.Unmarshal(resp, &alerts); err != nil {
+		if err = json.Unmarshal(resp, &alerts); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
This PR fixes the failing alerts tests.

**Proposed changes**: we don't check for the alert type but only its status (we need an open alert to test the acknowled|unacknowled commands)