### PR TITLE
CLOUDP-117256: Improve expired code handling

### DIFF
--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -160,6 +161,10 @@ Your code will expire after %.0f minutes.
 	}
 
 	accessToken, _, err := opts.flow.PollToken(ctx, code)
+	var target *atlas.ErrorResponse
+	if errors.As(err, &target) && target.ErrorCode == "DEVICE_AUTHORIZATION_EXPIRED" {
+		return errors.New("authentication timed out")
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-117256

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

```bash
./bin/mongocli login

First, copy your one-time code: DWXF-R48Q

Next, sign in with your browser and enter the code.

Or go to https://account.mongodb.com/account/connect

Your code will expire after 10 minutes.
Error: authentication timed out
```