### PR TITLE
fix: allow help commands in atlas

### DIFF
--- a/e2e/brew/brew_test.go
+++ b/e2e/brew/brew_test.go
@@ -61,10 +61,17 @@ func TestMongoCLIConfig(t *testing.T) {
 			t.Fatalf("expected error, resp: %v", string(resp))
 		}
 		got := strings.TrimSpace(string(resp))
-		want := errorMessage
 
-		if !strings.HasPrefix(got, want) {
-			t.Errorf("want '%s'; got '%s'\n", want, got)
+		if !strings.HasPrefix(got, errorMessage) {
+			t.Errorf("want '%s'; got '%s'\n", errorMessage, got)
+		}
+	})
+
+	t.Run("help", func(t *testing.T) {
+		cmd := exec.Command(cliPath, "help")
+		cmd.Env = append(os.Environ(), tempDirEnv)
+		if resp, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("unexpected error, resp: %v", string(resp))
 		}
 	})
 }
@@ -100,10 +107,17 @@ func TestAtlasCLIConfig(t *testing.T) {
 			t.Fatalf("expected error, resp: %v", string(resp))
 		}
 		got := strings.TrimSpace(string(resp))
-		want := errorMessage
 
-		if !strings.HasPrefix(got, want) {
-			t.Errorf("want '%s'; got '%s'\n", want, got)
+		if !strings.HasPrefix(got, errorMessage) {
+			t.Errorf("want '%s'; got '%s'\n", errorMessage, got)
+		}
+	})
+
+	t.Run("help", func(t *testing.T) {
+		cmd := exec.Command(cliPath, "help")
+		cmd.Env = append(os.Environ(), tempDirEnv)
+		if resp, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("unexpected error, resp: %v", string(resp))
 		}
 	})
 }

--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -204,26 +204,26 @@ func shouldSetService(cmd *cobra.Command) bool {
 }
 
 func shouldCheckCredentials(cmd *cobra.Command) bool {
-	if cmd.Name() == figautocomplete.CmdUse { // figautocomplete command does not require credentials
-		return false
+	searchByName := []string{
+		"help",
+		"quickstart",
+		figautocomplete.CmdUse,
 	}
-
-	if strings.HasPrefix(cmd.CommandPath(), fmt.Sprintf("%s %s", atlas, "completion")) { // completion commands do not require credentials
-		return false
+	for _, n := range searchByName {
+		if cmd.Name() == n {
+			return false
+		}
 	}
-
-	if cmd.Name() == "quickstart" { // quickstart has its own check
-		return false
+	searchByPath := []string{
+		fmt.Sprintf("%s %s", atlas, "completion"), // completion commands do not require credentials
+		fmt.Sprintf("%s %s", atlas, "config"),     // user wants to set credentials
+		fmt.Sprintf("%s %s", atlas, "auth"),       // user wants to set credentials
 	}
-
-	if strings.HasPrefix(cmd.CommandPath(), fmt.Sprintf("%s %s", atlas, "config")) { // user wants to set credentials
-		return false
+	for _, p := range searchByPath {
+		if strings.HasPrefix(cmd.CommandPath(), p) {
+			return false
+		}
 	}
-
-	if strings.HasPrefix(cmd.CommandPath(), fmt.Sprintf("%s %s", atlas, "auth")) { // user wants to set credentials
-		return false
-	}
-
 	return true
 }
 


### PR DESCRIPTION
## Proposed changes

running `atlas help` used to require credentials 

