### PR TITLE
CLOUDP-118459: [cli] quickstart should verify authentication the same as other commands

### DIFF
--- a/internal/cli/atlas/atlas.go
+++ b/internal/cli/atlas/atlas.go
@@ -68,11 +68,6 @@ func Builder() *cobra.Command {
 			if config.Service() == "" {
 				config.SetService(config.CloudService)
 			}
-
-			if cmd.Name() == "quickstart" { // quickstart has its own check
-				return nil
-			}
-
 			return validate.Credentials()
 		},
 		Annotations: map[string]string{

--- a/internal/cli/atlas/quickstart/prompt.go
+++ b/internal/cli/atlas/quickstart/prompt.go
@@ -126,20 +126,6 @@ func newMongoShellQuestionOpenBrowser() survey.Prompt {
 	}
 }
 
-func newAtlasAccountQuestionOpenBrowser() survey.Prompt {
-	return &survey.Confirm{
-		Message: "Do you want to create an Atlas account [This will open www.mongodb.com on your browser]?",
-		Default: true,
-	}
-}
-
-func newProfileDocQuestionOpenBrowser() survey.Prompt {
-	return &survey.Confirm{
-		Message: "Do you want more information to set up your profile [This will open www.mongodb.com on your browser]?",
-		Default: true,
-	}
-}
-
 func newClusterCreateConfirm(clusterName string) survey.Prompt {
 	return &survey.Confirm{
 		Message: fmt.Sprintf("Do you want to create a new cluster %s with the following settings?", clusterName),

--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -207,7 +207,6 @@ func shouldCheckCredentials(cmd *cobra.Command) bool {
 	searchByName := []string{
 		"__complete",
 		"help",
-		"quickstart",
 		figautocomplete.CmdUse,
 	}
 	for _, n := range searchByName {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-118459

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code


```bash
./bin/atlas quickstart -P asdasdasd
Error: this action requires authentication

To log in using your Atlas username and password, run: atlas auth login
To set credentials using API keys, run: atlas config init
```