### PR TITLE
CLOUDP-118461: Replace exec usage for safe one

### DIFF
--- a/e2e/atlas/access_lists_test.go
+++ b/e2e/atlas/access_lists_test.go
@@ -22,12 +22,11 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestAccessList(t *testing.T) {

--- a/e2e/atlas/access_lists_test.go
+++ b/e2e/atlas/access_lists_test.go
@@ -19,9 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/access_logs_test.go
+++ b/e2e/atlas/access_logs_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestAccessLogs(t *testing.T) {

--- a/e2e/atlas/access_logs_test.go
+++ b/e2e/atlas/access_logs_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/require"

--- a/e2e/atlas/access_roles_test.go
+++ b/e2e/atlas/access_roles_test.go
@@ -20,12 +20,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const aws = "AWS"

--- a/e2e/atlas/access_roles_test.go
+++ b/e2e/atlas/access_roles_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/alert_settings_test.go
+++ b/e2e/atlas/alert_settings_test.go
@@ -18,9 +18,10 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"strconv"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/go-test/deep"
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/alert_settings_test.go
+++ b/e2e/atlas/alert_settings_test.go
@@ -21,12 +21,11 @@ import (
 	"strconv"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/go-test/deep"
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/alerts_test.go
+++ b/e2e/atlas/alerts_test.go
@@ -21,11 +21,10 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/alerts_test.go
+++ b/e2e/atlas/alerts_test.go
@@ -18,9 +18,10 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -22,10 +22,9 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -19,9 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"

--- a/e2e/atlas/clusters_file_test.go
+++ b/e2e/atlas/clusters_file_test.go
@@ -21,13 +21,12 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestClustersFile(t *testing.T) {

--- a/e2e/atlas/clusters_file_test.go
+++ b/e2e/atlas/clusters_file_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/internal/config"

--- a/e2e/atlas/clusters_flags_test.go
+++ b/e2e/atlas/clusters_flags_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestClustersFlags(t *testing.T) {

--- a/e2e/atlas/clusters_flags_test.go
+++ b/e2e/atlas/clusters_flags_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/clusters_m0_test.go
+++ b/e2e/atlas/clusters_m0_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/clusters_m0_test.go
+++ b/e2e/atlas/clusters_m0_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/clusters_sharded_test.go
+++ b/e2e/atlas/clusters_sharded_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestShardedCluster(t *testing.T) {

--- a/e2e/atlas/clusters_sharded_test.go
+++ b/e2e/atlas/clusters_sharded_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/custom_db_roles_test.go
+++ b/e2e/atlas/custom_db_roles_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/custom_db_roles_test.go
+++ b/e2e/atlas/custom_db_roles_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/custom_dns_test.go
+++ b/e2e/atlas/custom_dns_test.go
@@ -20,12 +20,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestCustomDNS(t *testing.T) {

--- a/e2e/atlas/custom_dns_test.go
+++ b/e2e/atlas/custom_dns_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/data_lake_private_endpoint_test.go
+++ b/e2e/atlas/data_lake_private_endpoint_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestDataLakePrivateEndpointsAWS(t *testing.T) {

--- a/e2e/atlas/data_lake_private_endpoint_test.go
+++ b/e2e/atlas/data_lake_private_endpoint_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/data_lake_private_endpoint_test.go
+++ b/e2e/atlas/data_lake_private_endpoint_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/data_lake_test.go
+++ b/e2e/atlas/data_lake_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestDataLakes(t *testing.T) {

--- a/e2e/atlas/data_lake_test.go
+++ b/e2e/atlas/data_lake_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/data_lake_test.go
+++ b/e2e/atlas/data_lake_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/dbusers_certs_test.go
+++ b/e2e/atlas/dbusers_certs_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/internal/cli/atlas/dbusers"
 

--- a/e2e/atlas/dbusers_certs_test.go
+++ b/e2e/atlas/dbusers_certs_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/internal/cli/atlas/dbusers"

--- a/e2e/atlas/dbusers_certs_test.go
+++ b/e2e/atlas/dbusers_certs_test.go
@@ -21,9 +21,8 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/internal/cli/atlas/dbusers"
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/dbusers_test.go
+++ b/e2e/atlas/dbusers_test.go
@@ -26,12 +26,11 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/dbusers_test.go
+++ b/e2e/atlas/dbusers_test.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
 

--- a/e2e/atlas/dbusers_test.go
+++ b/e2e/atlas/dbusers_test.go
@@ -23,9 +23,10 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/decryption_aws_test.go
+++ b/e2e/atlas/decryption_aws_test.go
@@ -18,7 +18,7 @@ package atlas_test
 import (
 	"embed"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/decryption_aws_test.go
+++ b/e2e/atlas/decryption_aws_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 //go:embed decryption/aws/*

--- a/e2e/atlas/decryption_aws_test.go
+++ b/e2e/atlas/decryption_aws_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"embed"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"

--- a/e2e/atlas/decryption_azure_test.go
+++ b/e2e/atlas/decryption_azure_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 //go:embed decryption/azure/*

--- a/e2e/atlas/decryption_azure_test.go
+++ b/e2e/atlas/decryption_azure_test.go
@@ -18,7 +18,7 @@ package atlas_test
 import (
 	"embed"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/decryption_azure_test.go
+++ b/e2e/atlas/decryption_azure_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"embed"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"

--- a/e2e/atlas/decryption_gcp_test.go
+++ b/e2e/atlas/decryption_gcp_test.go
@@ -22,11 +22,10 @@ import (
 	"path"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 //go:embed decryption/gcp/*

--- a/e2e/atlas/decryption_gcp_test.go
+++ b/e2e/atlas/decryption_gcp_test.go
@@ -19,7 +19,7 @@ import (
 	"embed"
 	"io/fs"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"path"
 	"testing"
 

--- a/e2e/atlas/decryption_gcp_test.go
+++ b/e2e/atlas/decryption_gcp_test.go
@@ -19,9 +19,10 @@ import (
 	"embed"
 	"io/fs"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"path"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"

--- a/e2e/atlas/decryption_localkey_test.go
+++ b/e2e/atlas/decryption_localkey_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 //go:embed decryption/localKey/*

--- a/e2e/atlas/decryption_localkey_test.go
+++ b/e2e/atlas/decryption_localkey_test.go
@@ -18,7 +18,7 @@ package atlas_test
 import (
 	"embed"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/decryption_localkey_test.go
+++ b/e2e/atlas/decryption_localkey_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"embed"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"

--- a/e2e/atlas/events_test.go
+++ b/e2e/atlas/events_test.go
@@ -18,9 +18,10 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"

--- a/e2e/atlas/events_test.go
+++ b/e2e/atlas/events_test.go
@@ -21,10 +21,9 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestEvents(t *testing.T) {

--- a/e2e/atlas/events_test.go
+++ b/e2e/atlas/events_test.go
@@ -18,7 +18,7 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
 

--- a/e2e/atlas/helper_test.go
+++ b/e2e/atlas/helper_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/helper_test.go
+++ b/e2e/atlas/helper_test.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/helper_test.go
+++ b/e2e/atlas/helper_test.go
@@ -24,11 +24,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/integrations_test.go
+++ b/e2e/atlas/integrations_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/integrations_test.go
+++ b/e2e/atlas/integrations_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/integrations_test.go
+++ b/e2e/atlas/integrations_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/ldap_test.go
+++ b/e2e/atlas/ldap_test.go
@@ -19,8 +19,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/ldap_test.go
+++ b/e2e/atlas/ldap_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/ldap_test.go
+++ b/e2e/atlas/ldap_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/atlas/live_migrations_test.go
+++ b/e2e/atlas/live_migrations_test.go
@@ -17,8 +17,9 @@ package atlas_test
 
 import (
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/require"

--- a/e2e/atlas/live_migrations_test.go
+++ b/e2e/atlas/live_migrations_test.go
@@ -17,7 +17,7 @@ package atlas_test
 
 import (
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/live_migrations_test.go
+++ b/e2e/atlas/live_migrations_test.go
@@ -19,10 +19,9 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestLinkToken(t *testing.T) {

--- a/e2e/atlas/logs_test.go
+++ b/e2e/atlas/logs_test.go
@@ -18,7 +18,7 @@ package atlas_test
 import (
 	"log"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
 

--- a/e2e/atlas/logs_test.go
+++ b/e2e/atlas/logs_test.go
@@ -21,10 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestLogs(t *testing.T) {

--- a/e2e/atlas/logs_test.go
+++ b/e2e/atlas/logs_test.go
@@ -18,9 +18,10 @@ package atlas_test
 import (
 	"log"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/require"

--- a/e2e/atlas/maintenance_test.go
+++ b/e2e/atlas/maintenance_test.go
@@ -18,7 +18,7 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/maintenance_test.go
+++ b/e2e/atlas/maintenance_test.go
@@ -20,12 +20,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestMaintenanceWindows(t *testing.T) {

--- a/e2e/atlas/maintenance_test.go
+++ b/e2e/atlas/maintenance_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/metrics_test.go
+++ b/e2e/atlas/metrics_test.go
@@ -18,7 +18,7 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/metrics_test.go
+++ b/e2e/atlas/metrics_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestMetrics(t *testing.T) {

--- a/e2e/atlas/metrics_test.go
+++ b/e2e/atlas/metrics_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/require"

--- a/e2e/atlas/online_archives_test.go
+++ b/e2e/atlas/online_archives_test.go
@@ -22,11 +22,10 @@ import (
 	"strings"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestOnlineArchives(t *testing.T) {

--- a/e2e/atlas/online_archives_test.go
+++ b/e2e/atlas/online_archives_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
 

--- a/e2e/atlas/online_archives_test.go
+++ b/e2e/atlas/online_archives_test.go
@@ -19,9 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/performance_advisor_test.go
+++ b/e2e/atlas/performance_advisor_test.go
@@ -19,10 +19,9 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestPerformanceAdvisor(t *testing.T) {

--- a/e2e/atlas/performance_advisor_test.go
+++ b/e2e/atlas/performance_advisor_test.go
@@ -17,7 +17,7 @@ package atlas_test
 
 import (
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/performance_advisor_test.go
+++ b/e2e/atlas/performance_advisor_test.go
@@ -17,8 +17,9 @@ package atlas_test
 
 import (
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/private_endpoint_test.go
+++ b/e2e/atlas/private_endpoint_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 var regionsAWS = []string{

--- a/e2e/atlas/private_endpoint_test.go
+++ b/e2e/atlas/private_endpoint_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/private_endpoint_test.go
+++ b/e2e/atlas/private_endpoint_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/processes_test.go
+++ b/e2e/atlas/processes_test.go
@@ -18,7 +18,7 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/processes_test.go
+++ b/e2e/atlas/processes_test.go
@@ -18,8 +18,9 @@ package atlas_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/processes_test.go
+++ b/e2e/atlas/processes_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestProcesses(t *testing.T) {

--- a/e2e/atlas/search_test.go
+++ b/e2e/atlas/search_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 	"text/template"
 

--- a/e2e/atlas/search_test.go
+++ b/e2e/atlas/search_test.go
@@ -19,9 +19,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
 	"text/template"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/search_test.go
+++ b/e2e/atlas/search_test.go
@@ -22,12 +22,11 @@ import (
 	"testing"
 	"text/template"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestSearch(t *testing.T) {

--- a/e2e/atlas/serverless_test.go
+++ b/e2e/atlas/serverless_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/atlas/serverless_test.go
+++ b/e2e/atlas/serverless_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/atlas/serverless_test.go
+++ b/e2e/atlas/serverless_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestServerless(t *testing.T) {

--- a/e2e/brew/brew_test.go
+++ b/e2e/brew/brew_test.go
@@ -18,7 +18,7 @@ package brew_test
 import (
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
 

--- a/e2e/brew/brew_test.go
+++ b/e2e/brew/brew_test.go
@@ -18,9 +18,10 @@ package brew_test
 import (
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 )

--- a/e2e/brew/brew_test.go
+++ b/e2e/brew/brew_test.go
@@ -21,9 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/cloud_manager/agent_api_keys_test.go
+++ b/e2e/cloud_manager/agent_api_keys_test.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/ops-manager/opsmngr"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/cloud_manager/agent_api_keys_test.go
+++ b/e2e/cloud_manager/agent_api_keys_test.go
@@ -19,7 +19,7 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/cloud_manager/agent_api_keys_test.go
+++ b/e2e/cloud_manager/agent_api_keys_test.go
@@ -19,8 +19,9 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/cloud_manager/agents_test.go
+++ b/e2e/cloud_manager/agents_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/ops-manager/opsmngr"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestAgents(t *testing.T) {

--- a/e2e/cloud_manager/agents_test.go
+++ b/e2e/cloud_manager/agents_test.go
@@ -19,7 +19,7 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/cloud_manager/agents_test.go
+++ b/e2e/cloud_manager/agents_test.go
@@ -19,8 +19,9 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/cloud_manager/alerts_test.go
+++ b/e2e/cloud_manager/alerts_test.go
@@ -19,9 +19,10 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"

--- a/e2e/cloud_manager/alerts_test.go
+++ b/e2e/cloud_manager/alerts_test.go
@@ -22,10 +22,9 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/cloud_manager/alerts_test.go
+++ b/e2e/cloud_manager/alerts_test.go
@@ -19,7 +19,7 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
 

--- a/e2e/cloud_manager/dbusers_test.go
+++ b/e2e/cloud_manager/dbusers_test.go
@@ -21,9 +21,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"

--- a/e2e/cloud_manager/dbusers_test.go
+++ b/e2e/cloud_manager/dbusers_test.go
@@ -24,10 +24,9 @@ import (
 	"strings"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestDBUsersWithFlags(t *testing.T) {

--- a/e2e/cloud_manager/dbusers_test.go
+++ b/e2e/cloud_manager/dbusers_test.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
 

--- a/e2e/cloud_manager/decryption_aws_test.go
+++ b/e2e/cloud_manager/decryption_aws_test.go
@@ -18,7 +18,7 @@ package cloud_manager_test
 import (
 	"embed"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/cloud_manager/decryption_aws_test.go
+++ b/e2e/cloud_manager/decryption_aws_test.go
@@ -18,8 +18,9 @@ package cloud_manager_test
 import (
 	"embed"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"

--- a/e2e/cloud_manager/decryption_aws_test.go
+++ b/e2e/cloud_manager/decryption_aws_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 //go:embed decryption/aws/*

--- a/e2e/cloud_manager/decryption_kmip_test.go
+++ b/e2e/cloud_manager/decryption_kmip_test.go
@@ -25,11 +25,10 @@ import (
 	"path"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 //go:embed decryption/kmip/*

--- a/e2e/cloud_manager/decryption_kmip_test.go
+++ b/e2e/cloud_manager/decryption_kmip_test.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"path"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"

--- a/e2e/cloud_manager/decryption_kmip_test.go
+++ b/e2e/cloud_manager/decryption_kmip_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"path"
 	"testing"
 

--- a/e2e/cloud_manager/decryption_localkey_test.go
+++ b/e2e/cloud_manager/decryption_localkey_test.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"path"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"

--- a/e2e/cloud_manager/decryption_localkey_test.go
+++ b/e2e/cloud_manager/decryption_localkey_test.go
@@ -23,11 +23,10 @@ import (
 	"path"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/e2e/decryption"
 	"github.com/stretchr/testify/require"
+	exec "golang.org/x/sys/execabs"
 )
 
 //go:embed decryption/localKey/*

--- a/e2e/cloud_manager/decryption_localkey_test.go
+++ b/e2e/cloud_manager/decryption_localkey_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"path"
 	"testing"
 

--- a/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/e2e/cloud_manager/deploy_replica_set_test.go
@@ -20,8 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/internal/convert"

--- a/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/e2e/cloud_manager/deploy_replica_set_test.go
@@ -22,10 +22,9 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/internal/convert"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestDeployReplicaSet(t *testing.T) {

--- a/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/e2e/cloud_manager/deploy_replica_set_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/cloud_manager/deploy_sharded_cluster_test.go
+++ b/e2e/cloud_manager/deploy_sharded_cluster_test.go
@@ -19,8 +19,9 @@ package cloud_manager_test
 import (
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 )

--- a/e2e/cloud_manager/deploy_sharded_cluster_test.go
+++ b/e2e/cloud_manager/deploy_sharded_cluster_test.go
@@ -21,9 +21,8 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestDeployCluster(t *testing.T) {

--- a/e2e/cloud_manager/deploy_sharded_cluster_test.go
+++ b/e2e/cloud_manager/deploy_sharded_cluster_test.go
@@ -19,7 +19,7 @@ package cloud_manager_test
 import (
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/cloud_manager/events_test.go
+++ b/e2e/cloud_manager/events_test.go
@@ -19,9 +19,10 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"

--- a/e2e/cloud_manager/events_test.go
+++ b/e2e/cloud_manager/events_test.go
@@ -22,10 +22,9 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestEvents(t *testing.T) {

--- a/e2e/cloud_manager/events_test.go
+++ b/e2e/cloud_manager/events_test.go
@@ -19,7 +19,7 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
 

--- a/e2e/cloud_manager/feature_policies_test.go
+++ b/e2e/cloud_manager/feature_policies_test.go
@@ -20,8 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"

--- a/e2e/cloud_manager/feature_policies_test.go
+++ b/e2e/cloud_manager/feature_policies_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/cloud_manager/feature_policies_test.go
+++ b/e2e/cloud_manager/feature_policies_test.go
@@ -22,10 +22,9 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestFeaturePolicies(t *testing.T) {

--- a/e2e/cloud_manager/helper_test.go
+++ b/e2e/cloud_manager/helper_test.go
@@ -21,10 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"sort"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/internal/convert"

--- a/e2e/cloud_manager/helper_test.go
+++ b/e2e/cloud_manager/helper_test.go
@@ -25,13 +25,12 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/mongodb/mongocli/internal/convert"
 	"github.com/openlyinc/pointy"
 	"go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/cloud_manager/helper_test.go
+++ b/e2e/cloud_manager/helper_test.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"sort"
 	"testing"
 	"time"

--- a/e2e/cloud_manager/key_providers_test.go
+++ b/e2e/cloud_manager/key_providers_test.go
@@ -18,7 +18,7 @@ package cloud_manager_test
 
 import (
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"path"
 	"testing"
 

--- a/e2e/cloud_manager/key_providers_test.go
+++ b/e2e/cloud_manager/key_providers_test.go
@@ -18,9 +18,10 @@ package cloud_manager_test
 
 import (
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"path"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 )

--- a/e2e/cloud_manager/key_providers_test.go
+++ b/e2e/cloud_manager/key_providers_test.go
@@ -21,9 +21,8 @@ import (
 	"path"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestKeyProviders(t *testing.T) {

--- a/e2e/cloud_manager/maintenance_test.go
+++ b/e2e/cloud_manager/maintenance_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
 

--- a/e2e/cloud_manager/maintenance_test.go
+++ b/e2e/cloud_manager/maintenance_test.go
@@ -23,11 +23,10 @@ import (
 	"testing"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/ops-manager/opsmngr"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestMaintenanceWindows(t *testing.T) {

--- a/e2e/cloud_manager/maintenance_test.go
+++ b/e2e/cloud_manager/maintenance_test.go
@@ -20,9 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/cloud_manager/servers_test.go
+++ b/e2e/cloud_manager/servers_test.go
@@ -21,10 +21,9 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestServers(t *testing.T) {

--- a/e2e/cloud_manager/servers_test.go
+++ b/e2e/cloud_manager/servers_test.go
@@ -19,8 +19,9 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"

--- a/e2e/cloud_manager/servers_test.go
+++ b/e2e/cloud_manager/servers_test.go
@@ -19,7 +19,7 @@ package cloud_manager_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/config/autocomplete_test.go
+++ b/e2e/config/autocomplete_test.go
@@ -19,9 +19,8 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
+	exec "golang.org/x/sys/execabs"
 )
 
 const completionEntity = "completion"

--- a/e2e/config/autocomplete_test.go
+++ b/e2e/config/autocomplete_test.go
@@ -17,7 +17,7 @@ package config_test
 
 import (
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/config/autocomplete_test.go
+++ b/e2e/config/autocomplete_test.go
@@ -17,8 +17,9 @@ package config_test
 
 import (
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 )

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -18,9 +18,10 @@ package config_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 )

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -18,7 +18,7 @@ package config_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"strings"
 	"testing"
 

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -21,9 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/iam/atlas_users_test.go
+++ b/e2e/iam/atlas_users_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestUsers(t *testing.T) {

--- a/e2e/iam/atlas_users_test.go
+++ b/e2e/iam/atlas_users_test.go
@@ -18,8 +18,9 @@ package iam_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/atlas_users_test.go
+++ b/e2e/iam/atlas_users_test.go
@@ -18,7 +18,7 @@ package iam_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/helper_test.go
+++ b/e2e/iam/helper_test.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"strconv"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/helper_test.go
+++ b/e2e/iam/helper_test.go
@@ -22,10 +22,9 @@ import (
 	"os"
 	"strconv"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/iam/helper_test.go
+++ b/e2e/iam/helper_test.go
@@ -20,8 +20,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"strconv"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"

--- a/e2e/iam/org_api_key_access_list_test.go
+++ b/e2e/iam/org_api_key_access_list_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/org_api_key_access_list_test.go
+++ b/e2e/iam/org_api_key_access_list_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/org_api_key_access_list_test.go
+++ b/e2e/iam/org_api_key_access_list_test.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestOrgAPIKeyAccessList(t *testing.T) {

--- a/e2e/iam/org_api_keys_test.go
+++ b/e2e/iam/org_api_keys_test.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestOrgAPIKeys(t *testing.T) {

--- a/e2e/iam/org_api_keys_test.go
+++ b/e2e/iam/org_api_keys_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/org_api_keys_test.go
+++ b/e2e/iam/org_api_keys_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/org_invitations_test.go
+++ b/e2e/iam/org_invitations_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/org_invitations_test.go
+++ b/e2e/iam/org_invitations_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/org_invitations_test.go
+++ b/e2e/iam/org_invitations_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/iam/orgs_test.go
+++ b/e2e/iam/orgs_test.go
@@ -18,8 +18,9 @@ package iam_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/orgs_test.go
+++ b/e2e/iam/orgs_test.go
@@ -20,11 +20,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestOrgs(t *testing.T) {

--- a/e2e/iam/orgs_test.go
+++ b/e2e/iam/orgs_test.go
@@ -18,7 +18,7 @@ package iam_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/project_api_keys_test.go
+++ b/e2e/iam/project_api_keys_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/project_api_keys_test.go
+++ b/e2e/iam/project_api_keys_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/project_api_keys_test.go
+++ b/e2e/iam/project_api_keys_test.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestProjectAPIKeys(t *testing.T) {

--- a/e2e/iam/project_invitations_test.go
+++ b/e2e/iam/project_invitations_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/project_invitations_test.go
+++ b/e2e/iam/project_invitations_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/project_invitations_test.go
+++ b/e2e/iam/project_invitations_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/e2e/iam/project_teams_test.go
+++ b/e2e/iam/project_teams_test.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestProjectTeams(t *testing.T) {

--- a/e2e/iam/project_teams_test.go
+++ b/e2e/iam/project_teams_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/project_teams_test.go
+++ b/e2e/iam/project_teams_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/projects_test.go
+++ b/e2e/iam/projects_test.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestProjects(t *testing.T) {

--- a/e2e/iam/projects_test.go
+++ b/e2e/iam/projects_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/projects_test.go
+++ b/e2e/iam/projects_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/team_users_test.go
+++ b/e2e/iam/team_users_test.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestTeamUsers(t *testing.T) {

--- a/e2e/iam/team_users_test.go
+++ b/e2e/iam/team_users_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/team_users_test.go
+++ b/e2e/iam/team_users_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/iam/teams_test.go
+++ b/e2e/iam/teams_test.go
@@ -21,11 +21,10 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestTeams(t *testing.T) {

--- a/e2e/iam/teams_test.go
+++ b/e2e/iam/teams_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/e2e/iam/teams_test.go
+++ b/e2e/iam/teams_test.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"github.com/stretchr/testify/assert"

--- a/e2e/ops_manager/version_manifest_test.go
+++ b/e2e/ops_manager/version_manifest_test.go
@@ -18,8 +18,9 @@ package ops_manager_test
 import (
 	"encoding/json"
 	"os"
-	exec "golang.org/x/sys/execabs"
 	"testing"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"

--- a/e2e/ops_manager/version_manifest_test.go
+++ b/e2e/ops_manager/version_manifest_test.go
@@ -20,10 +20,9 @@ import (
 	"os"
 	"testing"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"
+	exec "golang.org/x/sys/execabs"
 )
 
 func TestVersionManifest(t *testing.T) {

--- a/e2e/ops_manager/version_manifest_test.go
+++ b/e2e/ops_manager/version_manifest_test.go
@@ -18,7 +18,7 @@ package ops_manager_test
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"testing"
 
 	"github.com/mongodb/mongocli/e2e"

--- a/internal/homebrew/homebrew.go
+++ b/internal/homebrew/homebrew.go
@@ -16,8 +16,8 @@ package homebrew
 
 import (
 	"bytes"
-	"os"
 	exec "golang.org/x/sys/execabs"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"

--- a/internal/homebrew/homebrew.go
+++ b/internal/homebrew/homebrew.go
@@ -17,7 +17,7 @@ package homebrew
 import (
 	"bytes"
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"path/filepath"
 	"strings"
 	"time"

--- a/internal/homebrew/homebrew.go
+++ b/internal/homebrew/homebrew.go
@@ -21,11 +21,10 @@ import (
 	"strings"
 	"time"
 
-	exec "golang.org/x/sys/execabs"
-
 	"github.com/mongodb/mongocli/internal/config"
 	"github.com/mongodb/mongocli/internal/file"
 	"github.com/spf13/afero"
+	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/internal/homebrew/homebrew.go
+++ b/internal/homebrew/homebrew.go
@@ -16,11 +16,12 @@ package homebrew
 
 import (
 	"bytes"
-	exec "golang.org/x/sys/execabs"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	exec "golang.org/x/sys/execabs"
 
 	"github.com/mongodb/mongocli/internal/config"
 	"github.com/mongodb/mongocli/internal/file"

--- a/internal/mongosh/mongosh.go
+++ b/internal/mongosh/mongosh.go
@@ -14,8 +14,8 @@
 package mongosh
 
 import (
-	"os"
 	exec "golang.org/x/sys/execabs"
+	"os"
 	"syscall"
 )
 

--- a/internal/mongosh/mongosh.go
+++ b/internal/mongosh/mongosh.go
@@ -15,7 +15,7 @@ package mongosh
 
 import (
 	"os"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"syscall"
 )
 

--- a/internal/mongosh/mongosh.go
+++ b/internal/mongosh/mongosh.go
@@ -14,9 +14,10 @@
 package mongosh
 
 import (
-	exec "golang.org/x/sys/execabs"
 	"os"
 	"syscall"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 func Bin() string {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->
_Jira ticket:_ [CLOUDP-118461](https://jira.mongodb.org/browse/CLOUDP-118461)

There is a vulnerability in os/exec that doesn't affect us for most of the usage in mongocli/atlascli. This PR still updates to the safe exec library option to avoid that we accidentally add changes using that library and inherit that vulnerability.  

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
