### PR TITLE
CLOUDP-121631: Changing order to get any closed alert to reduce flakiness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,16 +5,16 @@ this document describes some guidelines necessary to participate in the communit
 
 ## Table of Contents
 
-* [Asking Support Questions](#asking-support-questions)
-* [Feature Requests](#feature-requests)
-* [Reporting Issues](#reporting-issues)
-* [Submitting Patches](#submitting-patches)
-  * [Code Contribution Guidelines](#code-contribution-guidelines)
-  * [Development Setup](#development-setup)
-  * [Building and Testing](#building-and-testing)
-  * [Adding a New Command](#adding-a-new-commands)
-  * [Third Party Dependencies](#third-party-dependencies)
-* [Maintainer's Guide](#maintainers-guide)
+- [Asking Support Questions](#asking-support-questions)
+- [Feature Requests](#feature-requests)
+- [Reporting Issues](#reporting-issues)
+- [Submitting Patches](#submitting-patches)
+  - [Code Contribution Guidelines](#code-contribution-guidelines)
+  - [Development Setup](#development-setup)
+  - [Building and Testing](#building-and-testing)
+  - [Adding a New Command](#adding-a-new-commands)
+  - [Third Party Dependencies](#third-party-dependencies)
+- [Maintainer's Guide](#maintainers-guide)
 
 ## Asking Support Questions
 
@@ -43,21 +43,23 @@ we have a set of guidelines to ensure that all contributions are acceptable.
 
 To make the contribution process as seamless as possible, we ask for the following:
 
-* Fork the repository to work on your changes. Note that code contributions are accepted through pull requests to encourage discussion and allow for a smooth review experience.
-* When you’re ready to create a pull request, be sure to:
-  * Sign the [CLA](https://www.mongodb.com/legal/contributor-agreement).
-  * Have test cases for the new code. If you have questions about how to do this, please ask in your pull request or check the [Building and Testing](#building-and-testing) section.
-  * Run `make fmt`.
-  * Add documentation if you are adding new features or changing functionality.
-  * Confirm that `make check` succeeds. [GitHub Actions](https://github.com/mongodb/mongocli/actions).
+- Fork the repository to work on your changes. Note that code contributions are accepted through pull requests to encourage discussion and allow for a smooth review experience.
+- When you’re ready to create a pull request, be sure to:
+  - Sign the [CLA](https://www.mongodb.com/legal/contributor-agreement).
+  - Have test cases for the new code. If you have questions about how to do this, please ask in your pull request or check the [Building and Testing](#building-and-testing) section.
+  - Run `make fmt`.
+  - Add documentation if you are adding new features or changing functionality.
+  - Confirm that `make check` succeeds. [GitHub Actions](https://github.com/mongodb/mongocli/actions).
 
 ### Development Setup
 
 #### Prerequisite Tools
+
 - [Git](https://git-scm.com/)
-- [Go (at least Go 1.17)](https://golang.org/dl/)
+- [Go (at least Go 1.18)](https://golang.org/dl/)
 
 #### Environment
+
 - Fork the repository.
 - Clone your forked repository locally.
 - We use Go Modules to manage dependencies, so you can develop outside your `$GOPATH`.
@@ -73,7 +75,7 @@ The following is a short list of commands that can be run in the root of the pro
 - Run `E2E_TAGS=e2e,atlas make e2e-test` will run end to end tests against an Atlas instance,
   please make sure to have set `MCLI_*` variables pointing to that instance.
 - Run `E2E_TAGS=cloudmanager,remote,generic make e2e-test` will run end to end tests against an Cloud Manager instance.<br />
-  Please remember to: (a) have a running automation agent, and (b) set MCLI_* variables to point to your Cloud Manager instance.
+  Please remember to: (a) have a running automation agent, and (b) set MCLI\_\* variables to point to your Cloud Manager instance.
 - Run `make build` to generate a local binary in the `./bin` folder.
 
 We provide a git pre-commit hook to format and check the code, to install it run `make link-git-hooks`.
@@ -88,6 +90,7 @@ If you need a new mock please update or add the `//go:generate` instruction to t
 `mongocli` uses [Cobra](https://github.com/spf13/cobra) as a framework for defining commands,
 in addition to this we have defined a basic structure that should be followed.
 For a `mongocli scope newCommand` command, a file `internal/cli/scope/new_command.go` should implement:
+
 - A `ScopeNewCommandOpts` struct which handles the different options for the command.
 - At least a `func (opts *ScopeNewCommandOpts) Run() error` function with the main command logic.
 - A `func ScopeNewCommandBuilder() *cobra.Command` function to put together the expected cobra definition along with the `ScopeNewCommandOpts` logic.
@@ -99,12 +102,13 @@ with the last param being a required argument and the rest handled via flag opti
 For commands that create or modify complex data structures, the use of configuration files is preferred over flag options.
 
 #### How to define flags:
+
 Flags are a way to modify the command, also may be called "options". Flags always have a long version with two dashes (--state) but may also have a shortcut with one dash and one letter (-s).
 
 `mongocli` uses the following types of flags:
 
 - `--flagName value`: this type of flag passes the value to the command. Examples: `--projectId 5efda6aea3f2ed2e7dd6ce05`
-- `--booleanFlag`: this flag represents a boolean and it sets the related variable to true when the flag is used, false otherwise.  Example: `--force`
+- `--booleanFlag`: this flag represents a boolean and it sets the related variable to true when the flag is used, false otherwise. Example: `--force`
 - `--flagName value1,value2,..,valueN`: you will also find flags that accept a list of values. This type of flag can be very useful to represent data structures as `--role roleName1@db,roleName2@db`, `--privilege action@dbName.collection,action2@dbName.collection`, or `--key field:type`.
   As shown in the examples, the standard format used to represent data structures consists of splitting the first value with the second one by at sign `@` or colon `:`, and the second value with the third one by a full stop `.`.
   We recommend using configuration files for complex data structures that require more than three values. For an example of configuration files, see [mongocli atlas cluster create](https://github.com/mongodb/mongocli/blob/f2e6d661a3eb2cfcf9baab5f9e0b1c0f872b8c14/internal/cli/atlas/clusters/create.go#L235).
@@ -112,13 +116,15 @@ Flags are a way to modify the command, also may be called "options". Flags alway
 #### Documentation Requirements
 
 If you are adding a brand new command, or updating a command that has no doc annotations, please define the following doc structures for the command. For more information on all command structs, see [Cobra](https://pkg.go.dev/github.com/spf13/cobra#Command).
+
 - Add `Use` - (Required) Shows the command and arguments if applicable. Will show up in 'help' output.
 - Add `Short` - (Required) Briefly describes the command. Will show up in 'help' output.
 - Add `Example` - (Required) Example of how to use the command. Will show up in 'help' output.
 - Add `Annotations` - If the command has arguments, annotations should be added. They consist of key/value pairs that describe arguments in the command and are added to the generated documentation.
-- Add `Long` - Fully describes the command. Will show up in 'help' output. 
+- Add `Long` - Fully describes the command. Will show up in 'help' output.
 
 Furthermore, after adding the necessary structure, ensure that applicable documentation is generated by running `make gen-docs`.
+
 - Run `make gen-docs`- This generates the documentation for the introduced command.
 - Review the PR with the doc team.
 

--- a/e2e/atlas/alerts_test.go
+++ b/e2e/atlas/alerts_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	open = "OPEN"
+	closed = "CLOSED"
 )
 
 func TestAlerts(t *testing.T) {
@@ -102,7 +102,7 @@ func TestAlerts(t *testing.T) {
 			err := json.Unmarshal(resp, &alert)
 			a.NoError(err)
 			a.Equal(alertID, alert.ID)
-			a.Equal(open, alert.Status)
+			a.Equal(closed, alert.Status)
 		}
 	})
 

--- a/e2e/atlas/alerts_test.go
+++ b/e2e/atlas/alerts_test.go
@@ -39,12 +39,12 @@ func TestAlerts(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// This test should be run before all other tests to grab an alert ID for all others tests
-	t.Run("List with status OPEN", func(t *testing.T) {
+	t.Run("List with status CLOSED", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			alertsEntity,
 			"list",
 			"--status",
-			"OPEN",
+			"CLOSED",
 			"-o=json",
 		)
 
@@ -60,10 +60,12 @@ func TestAlerts(t *testing.T) {
 		}
 	})
 
-	t.Run("List with no status", func(t *testing.T) {
+	t.Run("List with status OPEN", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			alertsEntity,
 			"list",
+			"--status",
+			"OPEN",
 			"-o=json",
 		)
 
@@ -72,12 +74,10 @@ func TestAlerts(t *testing.T) {
 		assert.NoError(t, err, string(resp))
 	})
 
-	t.Run("List with status CLOSED", func(t *testing.T) {
+	t.Run("List with no status", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			alertsEntity,
 			"list",
-			"--status",
-			"CLOSED",
 			"-o=json",
 		)
 


### PR DESCRIPTION
## Proposed changes

Current E2E relies on an open alert being present on the env, which cannot be guaranteed. Changing the tests to instead rely on a closed alert, of which at least 1 should always be present.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
