### PR TITLE
CLOUDP-122260: Update atlascli cluster commands description

### DIFF
--- a/docs/atlascli/command/atlas-clusters-create.txt
+++ b/docs/atlascli/command/atlas-clusters-create.txt
@@ -131,15 +131,15 @@ Examples
 
    
    Deploy a three-member replica set in AWS:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+   $ atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
 
    Deploy a three-member replica set in AZURE:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+   $ atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
    
    Deploy a three-member replica set in GCP:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+   $ atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
 
    Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-   $ mongocli atlas cluster create --projectId <projectId> --file <path/to/file.json>
+   $ atlas cluster create --projectId <projectId> --file <path/to/file.json>
 
 

--- a/docs/atlascli/command/atlas-clusters-update.txt
+++ b/docs/atlascli/command/atlas-clusters-update.txt
@@ -100,11 +100,12 @@ Examples
 
 
    Update tier for a cluster
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --tier M50
+   $ atlas cluster update <clusterName> --projectId <projectId> --tier M50
 
    Update disk size for a cluster
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+   $ atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
 
    Update MongoDB version for a cluster
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+   $ atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+
 

--- a/docs/atlascli/command/atlas-clusters-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-watch.txt
@@ -83,5 +83,5 @@ Examples
 
 .. code-block::
 
- $ mongocli atlas cluster watch clusterNameSample
+ $ atlas cluster watch clusterNameSample
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-update.txt
@@ -108,3 +108,4 @@ Examples
    Update MongoDB version for a cluster
    $ mongocli atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
 
+

--- a/internal/cli/atlas/clusters/clusters.go
+++ b/internal/cli/atlas/clusters/clusters.go
@@ -21,12 +21,20 @@ import (
 	"github.com/mongodb/mongocli/internal/cli/atlas/clusters/indexes"
 	"github.com/mongodb/mongocli/internal/cli/atlas/clusters/onlinearchive"
 	"github.com/mongodb/mongocli/internal/cli/atlas/search"
+	"github.com/mongodb/mongocli/internal/config"
 	"github.com/spf13/cobra"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
+var (
+	exampleCmd = "mongocli atlas"
+)
+
 func Builder() *cobra.Command {
 	const use = "clusters"
+	if config.ToolName == config.AtlasCLI {
+		exampleCmd = "atlas"
+	}
 	cmd := &cobra.Command{
 		Use:        use,
 		Aliases:    cli.GenerateAliases(use),

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -17,6 +17,7 @@ package clusters
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/mongodb/mongocli/internal/cli"
 	"github.com/mongodb/mongocli/internal/cli/require"
@@ -31,14 +32,27 @@ import (
 )
 
 const (
-	replicaSet = "REPLICASET"
-	tenant     = "TENANT"
-	atlasM0    = "M0"
-	atlasM2    = "M2"
-	atlasM5    = "M5"
-	zoneName   = "Zone 1"
-	labelKey   = "Infrastructure Tool"
-	labelValue = "mongoCLI"
+	replicaSet    = "REPLICASET"
+	tenant        = "TENANT"
+	atlasM0       = "M0"
+	atlasM2       = "M2"
+	atlasM5       = "M5"
+	zoneName      = "Zone 1"
+	labelKey      = "Infrastructure Tool"
+	labelValue    = "mongoCLI"
+	exampleCreate = `  
+  Deploy a three-member replica set in AWS:
+  $ %s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+
+  Deploy a three-member replica set in AZURE:
+  $ %s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+  
+  Deploy a three-member replica set in GCP:
+  $ %s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+
+  Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
+  $ %s cluster create --projectId <projectId> --file <path/to/file.json>
+`
 )
 
 type CreateOpts struct {
@@ -182,25 +196,14 @@ func CreateBuilder() *cobra.Command {
 	opts := &CreateOpts{
 		fs: afero.NewOsFs(),
 	}
+
 	cmd := &cobra.Command{
 		Use:   "create [name]",
 		Short: "Create one cluster in the specified project.",
 		Long: `To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
 For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.`,
-		Example: `  
-  Deploy a three-member replica set in AWS:
-  $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
-
-  Deploy a three-member replica set in AZURE:
-  $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
-  
-  Deploy a three-member replica set in GCP:
-  $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
-
-  Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-  $ mongocli atlas cluster create --projectId <projectId> --file <path/to/file.json>
-`,
-		Args: require.MaximumNArgs(1),
+		Example: fmt.Sprintf(exampleCreate, exampleCmd, exampleCmd, exampleCmd, exampleCmd),
+		Args:    require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.filename == "" {
 				_ = cmd.MarkFlagRequired(flag.Provider)

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -42,16 +42,16 @@ const (
 	labelValue    = "mongoCLI"
 	exampleCreate = `  
   Deploy a three-member replica set in AWS:
-  $ %s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
 
   Deploy a three-member replica set in AZURE:
-  $ %s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
   
   Deploy a three-member replica set in GCP:
-  $ %s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
 
   Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-  $ %s cluster create --projectId <projectId> --file <path/to/file.json>
+  $ %[1]s cluster create --projectId <projectId> --file <path/to/file.json>
 `
 )
 
@@ -202,7 +202,7 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create one cluster in the specified project.",
 		Long: `To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
 For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.`,
-		Example: fmt.Sprintf(exampleCreate, exampleCmd, exampleCmd, exampleCmd, exampleCmd),
+		Example: fmt.Sprintf(exampleCreate, exampleCmd),
 		Args:    require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.filename == "" {

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -16,6 +16,7 @@ package clusters
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongocli/internal/cli"
 	"github.com/mongodb/mongocli/internal/cli/require"
@@ -27,6 +28,20 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+const (
+	exampleUpdate = `
+  Update tier for a cluster
+  $ %s cluster update <clusterName> --projectId <projectId> --tier M50
+
+  Update disk size for a cluster
+  $ %s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+
+  Update MongoDB version for a cluster
+  $ %s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+`
+	updateTmpl = "Updating cluster '{{.Name}}'.\n"
 )
 
 type UpdateOpts struct {
@@ -48,8 +63,6 @@ func (opts *UpdateOpts) initStore(ctx context.Context) func() error {
 		return err
 	}
 }
-
-var updateTmpl = "Updating cluster '{{.Name}}'.\n"
 
 func (opts *UpdateOpts) Run() error {
 	cluster, err := opts.cluster()
@@ -116,18 +129,10 @@ func UpdateBuilder() *cobra.Command {
 		fs: afero.NewOsFs(),
 	}
 	cmd := &cobra.Command{
-		Use:   "update [clusterName]",
-		Short: "Update a MongoDB cluster.",
-		Example: `
-  Update tier for a cluster
-  $ mongocli atlas cluster update <clusterName> --projectId <projectId> --tier M50
-
-  Update disk size for a cluster
-  $ mongocli atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
-
-  Update MongoDB version for a cluster
-  $ mongocli atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2`,
-		Args: require.MaximumNArgs(1),
+		Use:     "update [clusterName]",
+		Short:   "Update a MongoDB cluster.",
+		Example: fmt.Sprintf(exampleUpdate, exampleCmd, exampleCmd, exampleCmd),
+		Args:    require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				opts.name = args[0]

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -33,13 +33,13 @@ import (
 const (
 	exampleUpdate = `
   Update tier for a cluster
-  $ %s cluster update <clusterName> --projectId <projectId> --tier M50
+  $ %[1]s cluster update <clusterName> --projectId <projectId> --tier M50
 
   Update disk size for a cluster
-  $ %s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+  $ %[1]s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
 
   Update MongoDB version for a cluster
-  $ %s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+  $ %[1]s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
 `
 	updateTmpl = "Updating cluster '{{.Name}}'.\n"
 )
@@ -131,7 +131,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "update [clusterName]",
 		Short:   "Update a MongoDB cluster.",
-		Example: fmt.Sprintf(exampleUpdate, exampleCmd, exampleCmd, exampleCmd),
+		Example: fmt.Sprintf(exampleUpdate, exampleCmd),
 		Args:    require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {

--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -16,6 +16,7 @@ package clusters
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongocli/internal/cli"
 	"github.com/mongodb/mongocli/internal/cli/require"
@@ -25,6 +26,8 @@ import (
 	"github.com/mongodb/mongocli/internal/usage"
 	"github.com/spf13/cobra"
 )
+
+const exampleWatch = "$ %s cluster watch clusterNameSample"
 
 type WatchOpts struct {
 	cli.GlobalOpts
@@ -67,7 +70,7 @@ func WatchBuilder() *cobra.Command {
 Once the cluster reaches the expected state, the command prints "Cluster available."
 If you run the command in the terminal, it blocks the terminal session until the resource state changes to IDLE.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: `$ mongocli atlas cluster watch clusterNameSample`,
+		Example: fmt.Sprintf(exampleWatch, exampleCmd),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"args":            "clusterName",


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-122260

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongocli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongocli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments
**Issue:** Some atlascli cluster commands still have mongocli in their descriptions.

**Fix:**
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
```
./bin/atlas cluster create --help
To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.

Usage:
  atlas clusters create [name] [flags]

Examples:

  Deploy a three-member replica set in AWS:
  $ atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10

  Deploy a three-member replica set in AZURE:
  $ atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10

  Deploy a three-member replica set in GCP:
  $ atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10

  Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
  $ atlas cluster create --projectId <projectId> --file <path/to/file.json>
```