### PR TITLE
 docs: Backfill docs content for mongocli config commands

### DIFF
--- a/docs/atlascli/command/atlas-config-list.txt
+++ b/docs/atlascli/command/atlas-config-list.txt
@@ -12,7 +12,9 @@ atlas config list
    :depth: 1
    :class: singlecol
 
-List available profiles.
+Return a list of available profiles by name.
+
+If you did not specify a name for your profile, it displays as the default profile.
 
 Syntax
 ------
@@ -56,4 +58,11 @@ Inherited Options
      - string
      - false
      - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+   $ atlas config ls
 

--- a/docs/atlascli/command/atlas-config-rename.txt
+++ b/docs/atlascli/command/atlas-config-rename.txt
@@ -19,7 +19,27 @@ Syntax
 
 .. code-block::
 
-   atlas config rename <oldName> <newName> [options]
+   atlas config rename <oldProfileName> <newProfileName> [options]
+
+Arguments
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - oldProfileName
+     - string
+     - true
+     - Name of the profile to rename.
+   * - newProfileName
+     - string
+     - true
+     - New name of the profile.
 
 Options
 -------
@@ -52,4 +72,12 @@ Inherited Options
      - string
      - false
      - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+   Rename a profile called myProfile to testProfile:
+   $ atlas config rename myProfile testProfile
 

--- a/docs/atlascli/command/atlas-config-set.txt
+++ b/docs/atlascli/command/atlas-config-set.txt
@@ -22,7 +22,27 @@ Syntax
 
 .. code-block::
 
-   atlas config set <property> <value> [options]
+   atlas config set <propertyName> <value> [options]
+
+Arguments
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - propertyName
+     - string
+     - true
+     - Property to set in the profile.
+   * - value
+     - string
+     - true
+     - Value for the property to set in the profile.
 
 Options
 -------
@@ -55,4 +75,17 @@ Inherited Options
      - string
      - false
      - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+
+   Set Ops Manager Base URL in the profile myProfile:
+   $ atlas config set ops_manager_url http://localhost:30700/ -P myProfile
+   Set Organization ID in the default profile:
+   $ atlas config set org_id 5dd5aaef7a3e5a6c5bd12de4
+   Set path for the MongoDB Shell in the default profile:
+   $ atlas config set mongosh_path /usr/local/bin/mongosh
 

--- a/docs/atlascli/command/atlas-config.txt
+++ b/docs/atlascli/command/atlas-config.txt
@@ -59,7 +59,7 @@ Related Commands
 * :ref:`atlas-config-delete` - Delete a profile.
 * :ref:`atlas-config-describe` - Return a specific profile.
 * :ref:`atlas-config-init` - Configure a profile to store access settings for your MongoDB deployment.
-* :ref:`atlas-config-list` - List available profiles.
+* :ref:`atlas-config-list` - Return a list of available profiles by name.
 * :ref:`atlas-config-rename` - Rename a profile.
 * :ref:`atlas-config-set` - Configure specific properties of a profile.
 

--- a/docs/mongocli/command/mongocli-config-list.txt
+++ b/docs/mongocli/command/mongocli-config-list.txt
@@ -12,7 +12,9 @@ mongocli config list
    :depth: 1
    :class: singlecol
 
-List available profiles.
+Return a list of available profiles by name.
+
+If you did not specify a name for your profile, it displays as the default profile.
 
 Syntax
 ------
@@ -56,4 +58,11 @@ Inherited Options
      - string
      - false
      - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+   $ mongocli config ls
 

--- a/docs/mongocli/command/mongocli-config-rename.txt
+++ b/docs/mongocli/command/mongocli-config-rename.txt
@@ -19,7 +19,27 @@ Syntax
 
 .. code-block::
 
-   mongocli config rename <oldName> <newName> [options]
+   mongocli config rename <oldProfileName> <newProfileName> [options]
+
+Arguments
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - oldProfileName
+     - string
+     - true
+     - Name of the profile to rename.
+   * - newProfileName
+     - string
+     - true
+     - New name of the profile.
 
 Options
 -------
@@ -52,4 +72,12 @@ Inherited Options
      - string
      - false
      - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+   Rename a profile called myProfile to testProfile:
+   $ mongocli config rename myProfile testProfile
 

--- a/docs/mongocli/command/mongocli-config-set.txt
+++ b/docs/mongocli/command/mongocli-config-set.txt
@@ -22,7 +22,27 @@ Syntax
 
 .. code-block::
 
-   mongocli config set <property> <value> [options]
+   mongocli config set <propertyName> <value> [options]
+
+Arguments
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - propertyName
+     - string
+     - true
+     - Property to set in the profile.
+   * - value
+     - string
+     - true
+     - Value for the property to set in the profile.
 
 Options
 -------
@@ -55,4 +75,17 @@ Inherited Options
      - string
      - false
      - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+
+   Set Ops Manager Base URL in the profile myProfile:
+   $ mongocli config set ops_manager_url http://localhost:30700/ -P myProfile
+   Set Organization ID in the default profile:
+   $ mongocli config set org_id 5dd5aaef7a3e5a6c5bd12de4
+   Set path for the MongoDB Shell in the default profile:
+   $ mongocli config set mongosh_path /usr/local/bin/mongosh
 

--- a/docs/mongocli/command/mongocli-config.txt
+++ b/docs/mongocli/command/mongocli-config.txt
@@ -14,10 +14,9 @@ mongocli config
 
 Configure a profile to store access settings for your MongoDB deployment.
 
-Configure settings in a user profile.
+You can define the settings that the MongoDB CLI uses to interact with MongoDB services.
 All settings are optional. You can specify settings individually by running: 
 $ mongocli config set --help 
-
 You can also use environment variables (MCLI_*) when running the tool.
 To find out more, see the documentation: https://docs.mongodb.com/mongocli/stable/configure/environment-variables/.
 
@@ -70,22 +69,15 @@ Examples
 .. code-block::
 
 
-   To configure the tool to work with Atlas
+   Configure a profile to interact with Atlas:
    $ mongocli config
-
-   To configure the tool to work with Atlas for Government
+   Configure a profile to interact with Atlas for Government:
    $ mongocli config --service cloudgov
-   $ mongocli config --service gov
    
-   To configure the tool to work with Cloud Manager
+   Configure a profile to interact with Cloud Manager:
    $ mongocli config --service cloud-manager
-   $ mongocli config --service cloudmanager
-   $ mongocli config --service cm
-
-   To configure the tool to work with Ops Manager
+   Configure a profile to interact with Ops Manager:
    $ mongocli config --service ops-manager
-   $ mongocli config --service opsmanager
-   $ mongocli config --service om
 
 
 Related Commands
@@ -93,7 +85,7 @@ Related Commands
 
 * :ref:`mongocli-config-delete` - Delete a profile.
 * :ref:`mongocli-config-describe` - Return a specific profile.
-* :ref:`mongocli-config-list` - List available profiles.
+* :ref:`mongocli-config-list` - Return a list of available profiles by name.
 * :ref:`mongocli-config-rename` - Rename a profile.
 * :ref:`mongocli-config-set` - Configure specific properties of a profile.
 

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -119,29 +119,21 @@ func Builder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Configure a profile to store access settings for your MongoDB deployment.",
-		Long: `Configure settings in a user profile.
+		Long: `You can define the settings that the MongoDB CLI uses to interact with MongoDB services.
 All settings are optional. You can specify settings individually by running: 
 $ mongocli config set --help 
-
 You can also use environment variables (MCLI_*) when running the tool.
 To find out more, see the documentation: https://docs.mongodb.com/mongocli/stable/configure/environment-variables/.`,
 		Example: `
-  To configure the tool to work with Atlas
+  Configure a profile to interact with Atlas:
   $ mongocli config
-
-  To configure the tool to work with Atlas for Government
+  Configure a profile to interact with Atlas for Government:
   $ mongocli config --service cloudgov
-  $ mongocli config --service gov
   
-  To configure the tool to work with Cloud Manager
+  Configure a profile to interact with Cloud Manager:
   $ mongocli config --service cloud-manager
-  $ mongocli config --service cloudmanager
-  $ mongocli config --service cm
-
-  To configure the tool to work with Ops Manager
+  Configure a profile to interact with Ops Manager:
   $ mongocli config --service ops-manager
-  $ mongocli config --service opsmanager
-  $ mongocli config --service om
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opt.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/config/list.go
+++ b/internal/cli/config/list.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
@@ -35,21 +37,23 @@ func (opts *listOpts) Run() error {
 }
 
 func ListBuilder() *cobra.Command {
-	opts := &listOpts{}
-	opts.Template = listTemplate
+	o := &listOpts{}
+	o.Template = listTemplate
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List available profiles.",
+		Short:   "Return a list of available profiles by name.",
+		Long:    "If you did not specify a name for your profile, it displays as the default profile.",
+		Example: fmt.Sprintf("  $ %s config ls", config.BinName()),
 		PreRun: func(cmd *cobra.Command, args []string) {
-			opts.OutWriter = cmd.OutOrStdout()
+			o.OutWriter = cmd.OutOrStdout()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return opts.Run()
+			return o.Run()
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+	cmd.Flags().StringVarP(&o.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
 	return cmd
 }

--- a/internal/cli/config/rename.go
+++ b/internal/cli/config/rename.go
@@ -52,22 +52,30 @@ func (opts *RenameOpts) Run() error {
 		return err
 	}
 
-	fmt.Printf("The profile %v was renamed to %v.\n", opts.oldName, opts.newName)
+	fmt.Printf("The profile %s was renamed to %s.\n", opts.oldName, opts.newName)
 	return nil
 }
 
 func RenameBuilder() *cobra.Command {
 	const argsN = 2
-	opts := &RenameOpts{}
+	o := &RenameOpts{}
 	cmd := &cobra.Command{
-		Use:     "rename <oldName> <newName>",
+		Use:     "rename <oldProfileName> <newProfileName>",
 		Aliases: []string{"mv"},
 		Short:   "Rename a profile.",
-		Args:    require.ExactArgs(argsN),
+		Example: fmt.Sprintf(`  Rename a profile called myProfile to testProfile:
+  $ %s config rename myProfile testProfile`, config.BinName()),
+		Annotations: map[string]string{
+			"args":               "oldProfileName,newProfileName",
+			"requiredArgs":       "oldProfileName,newProfileName",
+			"oldProfileNameDesc": "Name of the profile to rename.",
+			"newProfileNameDesc": "New name of the profile.",
+		},
+		Args: require.ExactArgs(argsN),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.oldName = args[0]
-			opts.newName = args[1]
-			return opts.Run()
+			o.oldName = args[0]
+			o.newName = args[1]
+			return o.Run()
 		},
 	}
 

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -63,7 +63,7 @@ func (opts *SetOpts) Run() error {
 func SetBuilder() *cobra.Command {
 	const argsN = 2
 	cmd := &cobra.Command{
-		Use:   "set <property> <value>",
+		Use:   "set <propertyName> <value>",
 		Short: "Configure specific properties of a profile.",
 		Long: fmt.Sprintf(`Configure specific properties of the profile.
 Available properties include: %v.`, config.Properties()),
@@ -75,6 +75,19 @@ Available properties include: %v.`, config.Properties()),
 				return fmt.Errorf("invalid property: %q", args[0])
 			}
 			return nil
+		},
+		Example: fmt.Sprintf(`
+  Set Ops Manager Base URL in the profile myProfile:
+  $ %[1]s config set ops_manager_url http://localhost:30700/ -P myProfile
+  Set Organization ID in the default profile:
+  $ %[1]s config set org_id 5dd5aaef7a3e5a6c5bd12de4
+  Set path for the MongoDB Shell in the default profile:
+  $ %[1]s config set mongosh_path /usr/local/bin/mongosh`, config.BinName()),
+		Annotations: map[string]string{
+			"args":             "propertyName,value",
+			"requiredArgs":     "propertyName,value",
+			"propertyNameDesc": "Property to set in the profile.",
+			"valueDesc":        "Value for the property to set in the profile.",
 		},
 		ValidArgs: config.Properties(),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Proposed changes

Replaces #833


Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
