### PR TITLE
lint: enable extra revive linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters-settings:
     # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: true
     severity: warning
+    max-open-files: 2048
     rules:
       - name: blank-imports
       - name: context-as-argument
@@ -51,6 +52,14 @@ linters-settings:
       - name: unused-parameter
       - name: unreachable-code
       - name: redefines-builtin-id
+      - name: early-return
+      - name: unused-receiver
+      - name: constant-logical-expr
+      - name: confusing-naming
+      - name: unnecessary-stmt
+      - name: imports-blacklist
+        arguments:
+          - "github.com/pkg/errors"
 linters:
   disable-all: true
   enable:
@@ -133,6 +142,7 @@ linters:
   # - wsl: Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
 
 run:
+#  go: '1.17'
   tests: true
   timeout: 5m
   build-tags:

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -49,7 +49,6 @@ type LoginConfig interface {
 const (
 	AlreadyAuthenticatedMsg      = "you are already authenticated with an API key (Public key: %s)"
 	AlreadyAuthenticatedEmailMsg = "you are already authenticated with an email (%s)"
-	LoginMsg                     = `run "atlas auth login" to refresh your session and continue`
 	LoginWithProfileMsg          = `run "atlas auth login --profile <profile_name>"  to authenticate using your Atlas username and password on a new profile`
 	LogoutToLoginAccountMsg      = `run "atlas auth logout" first if you want to login with another Atlas account on the same Atlas CLI profile`
 )
@@ -203,7 +202,7 @@ func hasUserProgrammaticKeys() bool {
 	return config.PublicAPIKey() != "" && config.PrivateAPIKey() != ""
 }
 
-func (opts *LoginOpts) loginPreRun(ctx context.Context) error {
+func loginPreRun(ctx context.Context) error {
 	if hasUserProgrammaticKeys() {
 		msg := fmt.Sprintf(AlreadyAuthenticatedMsg, config.PublicAPIKey())
 		return fmt.Errorf(`%s
@@ -248,7 +247,7 @@ func LoginBuilder() *cobra.Command {
 `, Tool(), config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
-			if err := opts.loginPreRun(cmd.Context()); err != nil {
+			if err := loginPreRun(cmd.Context()); err != nil {
 				return err
 			}
 			return opts.PreRun()

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -135,21 +135,9 @@ Successfully logged in as test@10gen.com.
 `, buf.String())
 }
 
-func Test_registerOpts_LoginPreRun_APIKeys(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	opts := &LoginOpts{
-		flow:       mocks.NewMockAuthenticator(ctrl),
-		config:     mocks.NewMockLoginConfig(ctrl),
-		NoBrowser:  true,
-		SkipConfig: true,
-	}
-	defer ctrl.Finish()
+func TestLoginPreRun(t *testing.T) {
 	ctx := context.TODO()
-	buf := new(bytes.Buffer)
-
-	opts.OutWriter = buf
-
 	config.SetPublicAPIKey("public")
 	config.SetPrivateAPIKey("private")
-	require.ErrorContains(t, opts.loginPreRun(ctx), fmt.Sprintf(AlreadyAuthenticatedMsg, "public"), LoginWithProfileMsg)
+	require.ErrorContains(t, loginPreRun(ctx), fmt.Sprintf(AlreadyAuthenticatedMsg, "public"), LoginWithProfileMsg)
 }

--- a/internal/cli/auth/register.go
+++ b/internal/cli/auth/register.go
@@ -186,7 +186,7 @@ func (opts *registerOpts) PreRun(outWriter io.Writer) error {
 	return opts.login.initFlow()
 }
 
-func (opts *registerOpts) registerPreRun() error {
+func registerPreRun() error {
 	if hasUserProgrammaticKeys() {
 		msg := fmt.Sprintf(AlreadyAuthenticatedMsg, config.PublicAPIKey())
 		return fmt.Errorf(`%s
@@ -213,7 +213,7 @@ func RegisterBuilder() *cobra.Command {
   $ %s auth register
 `, config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := opts.registerPreRun(); err != nil {
+			if err := registerPreRun(); err != nil {
 				return err
 			}
 			return opts.PreRun(cmd.OutOrStdout())

--- a/internal/cli/auth/register_test.go
+++ b/internal/cli/auth/register_test.go
@@ -267,26 +267,8 @@ Your code will expire after 5 minutes.
 `, buf.String())
 }
 
-func Test_registerOpts_RegisterPreRun(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	loginOpts := &LoginOpts{
-		flow:       mocks.NewMockAuthenticator(ctrl),
-		config:     mocks.NewMockLoginConfig(ctrl),
-		NoBrowser:  true,
-		SkipConfig: true,
-	}
-	defer ctrl.Finish()
-	buf := new(bytes.Buffer)
-
-	opts := &registerOpts{
-		login:                loginOpts,
-		regenerateCodePrompt: nil,
-	}
-
-	opts.OutWriter = buf
-	opts.login.OutWriter = buf
-
+func TestRegisterPreRun(t *testing.T) {
 	config.SetPublicAPIKey("public")
 	config.SetPrivateAPIKey("private")
-	require.ErrorContains(t, opts.registerPreRun(), fmt.Sprintf(AlreadyAuthenticatedMsg, "public"), WithProfileMsg)
+	require.ErrorContains(t, registerPreRun(), fmt.Sprintf(AlreadyAuthenticatedMsg, "public"), WithProfileMsg)
 }

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -26,7 +27,7 @@ import (
 type editOpts struct {
 }
 
-func (opts *editOpts) Run() error {
+func (*editOpts) Run() error {
 	editor := defaultEditor
 	if v := os.Getenv("VISUAL"); v != "" {
 		editor = v
@@ -47,10 +48,10 @@ func EditBuilder() *cobra.Command {
 		Use:   "edit",
 		Short: "Opens the the config with the default text editor.",
 		Long:  `Will use the default editor to open the config file. You can use EDITOR or VISUAL envs to change the default.`,
-		Example: `
+		Example: fmt.Sprintf(`
   To open the config
-  $ mongocli config edit
-`,
+  $ %s config edit
+`, config.BinName()),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opt.Run()

--- a/internal/cli/default_setter_opts.go
+++ b/internal/cli/default_setter_opts.go
@@ -252,7 +252,7 @@ func (opts *DefaultSetterOpts) SetUpMongoSHPath() {
 	config.SetMongoShellPath(defaultPath)
 }
 
-func (opts *DefaultSetterOpts) SetUpTelemetryEnabled() {
+func (*DefaultSetterOpts) SetUpTelemetryEnabled() {
 	// Telemetry is enabled by default
 	telemetryEnabled := true
 	if config.IsTelemetryEnabledSet() {
@@ -294,7 +294,7 @@ func omProjects(projects []*opsmngr.Project) (pMap map[string]string, pSlice []s
 	return pMap, pSlice
 }
 
-func (opts *DefaultSetterOpts) DefaultQuestions() []*survey.Question {
+func (*DefaultSetterOpts) DefaultQuestions() []*survey.Question {
 	q := []*survey.Question{
 		{
 			Name: "output",

--- a/internal/cli/global_opts.go
+++ b/internal/cli/global_opts.go
@@ -52,7 +52,7 @@ type cmdOpt func() error
 
 // PreRunE is a function to call before running the command,
 // this will call any additional function pass as a callback.
-func (opts *GlobalOpts) PreRunE(cbs ...cmdOpt) error {
+func (*GlobalOpts) PreRunE(cbs ...cmdOpt) error {
 	for _, f := range cbs {
 		if err := f(); err != nil {
 			return err

--- a/internal/cli/performance_advisor_opts.go
+++ b/internal/cli/performance_advisor_opts.go
@@ -43,7 +43,7 @@ func (opts *PerformanceAdvisorOpts) validateProcessName() error {
 // Atlas: processName is required
 //
 // OM/CM: hostId is required.
-func (opts *PerformanceAdvisorOpts) MarkRequiredFlagsByService(cmd *cobra.Command) func() error {
+func (*PerformanceAdvisorOpts) MarkRequiredFlagsByService(cmd *cobra.Command) func() error {
 	return func() error {
 		if config.IsCloud() {
 			return cmd.MarkFlagRequired(flag.ProcessName)

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -224,7 +224,7 @@ func (p *Profile) Set(name string, value interface{}) {
 }
 
 func SetGlobal(name string, value interface{}) { viper.Set(name, value) }
-func (p *Profile) SetGlobal(name string, value interface{}) {
+func (*Profile) SetGlobal(name string, value interface{}) {
 	SetGlobal(name, value)
 }
 
@@ -432,7 +432,7 @@ func (p *Profile) MongoShellPath() string {
 
 // SetMongoShellPath sets the global MongoDB Shell path.
 func SetMongoShellPath(v string) { Default().SetMongoShellPath(v) }
-func (p *Profile) SetMongoShellPath(v string) {
+func (*Profile) SetMongoShellPath(v string) {
 	SetGlobal(mongoShellPath, v)
 }
 
@@ -444,13 +444,13 @@ func (p *Profile) SkipUpdateCheck() bool {
 
 // SetSkipUpdateCheck sets the global skip update check.
 func SetSkipUpdateCheck(v bool) { Default().SetSkipUpdateCheck(v) }
-func (p *Profile) SetSkipUpdateCheck(v bool) {
+func (*Profile) SetSkipUpdateCheck(v bool) {
 	SetGlobal(skipUpdateCheck, v)
 }
 
 // IsTelemetryEnabledSet return true if telemetry_enabled has been set.
 func IsTelemetryEnabledSet() bool { return Default().IsTelemetryEnabledSet() }
-func (p *Profile) IsTelemetryEnabledSet() bool {
+func (*Profile) IsTelemetryEnabledSet() bool {
 	return viper.IsSet(telemetryEnabled)
 }
 
@@ -465,7 +465,7 @@ func (p *Profile) TelemetryEnabled() bool {
 
 // SetTelemetryEnabled sets the telemetry enabled value.
 func SetTelemetryEnabled(v bool) { Default().SetTelemetryEnabled(v) }
-func (p *Profile) SetTelemetryEnabled(v bool) {
+func (*Profile) SetTelemetryEnabled(v bool) {
 	if ToolName != AtlasCLI || !isTelemetryFeatureFlagSet() {
 		return
 	}

--- a/internal/decryption/keyproviders/kmip.go
+++ b/internal/decryption/keyproviders/kmip.go
@@ -67,8 +67,11 @@ var (
 
 func (ki *KMIPKeyIdentifier) ValidateCredentials() error {
 	if ki.ServerCAFileName == "" || ki.ClientCertificateFileName == "" {
-		fmt.Fprintf(os.Stderr, `No credentials found for resource: KMIP uniqueKeyID="%v" serverNames="%v" serverPort="%v" keyWrapMethod="%v"
+		_, err := fmt.Fprintf(os.Stderr, `No credentials found for resource: KMIP uniqueKeyID="%v" serverNames="%v" serverPort="%v" keyWrapMethod="%v"
 `, ki.UniqueKeyID, strings.Join(ki.ServerNames, "; "), ki.ServerPort, ki.KeyWrapMethod)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := ki.validateServerCA(); err != nil {
@@ -88,7 +91,7 @@ func (ki *KMIPKeyIdentifier) DecryptKey(encryptedKey []byte) ([]byte, error) {
 		return nil, ErrKMIPServerNamesMissing
 	}
 
-	kmipEncryptedKey, err := ki.decodeEncryptedKey(encryptedKey)
+	kmipEncryptedKey, err := decodeEncryptedKey(encryptedKey)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +219,7 @@ func (ki *KMIPKeyIdentifier) decryptWithKeyWrapMethodGet(kmipClient *kmip.Client
 	return decryptedLEK, nil
 }
 
-func (ki *KMIPKeyIdentifier) decodeEncryptedKey(encryptedKey []byte) (*KMIPEncryptedKey, error) {
+func decodeEncryptedKey(encryptedKey []byte) (*KMIPEncryptedKey, error) {
 	var kmipEncryptedKey KMIPEncryptedKey
 	if err := bson.Unmarshal(encryptedKey, &kmipEncryptedKey); err != nil {
 		return nil, err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package store
 
@@ -31,7 +30,7 @@ type auth struct {
 	token    string
 }
 
-func (a auth) Token() (*atlasauth.Token, error) {
+func (auth) Token() (*atlasauth.Token, error) {
 	return nil, nil
 }
 
@@ -87,15 +86,15 @@ type testConfig struct {
 	auth
 }
 
-func (c testConfig) OpsManagerCACertificate() string {
+func (testConfig) OpsManagerCACertificate() string {
 	return ""
 }
 
-func (c testConfig) OpsManagerSkipVerify() string {
+func (testConfig) OpsManagerSkipVerify() string {
 	return "false"
 }
 
-func (c testConfig) Service() string {
+func (testConfig) Service() string {
 	return config.CloudService
 }
 


### PR DESCRIPTION
## Proposed changes

Enabling some extra linters that I find myself repeating on recent PRs

- [early-return](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return)
- [unused-receiver](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver)
- [constant-logical-expr](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#constant-logical-expr)
- [confusing-naming](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#confusing-naming)
- [unnecessary-stmt](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unnecessary-stmt)
- [imports-blacklist](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#imports-blacklist) for github.com/pkg/errors

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments
