### PR TITLE
CLOUDP-87997: Add currentIp flag to quickstart and setup

### DIFF
--- a/docs/atlascli/command/atlas-quickstart.txt
+++ b/docs/atlascli/command/atlas-quickstart.txt
@@ -42,6 +42,10 @@ Options
      - string
      - false
      - Name of the cluster.
+   * - --currentIp
+     - 
+     - false
+     - Flag that indicates whether to use the IP Address from the host that is currently executing the command.
    * - -Y, --default
      - 
      - false

--- a/docs/atlascli/command/atlas-setup.txt
+++ b/docs/atlascli/command/atlas-setup.txt
@@ -42,6 +42,10 @@ Options
      - string
      - false
      - Name of the cluster.
+   * - --currentIp
+     - 
+     - false
+     - Flag that indicates whether to use the IP Address from the host that is currently executing the command.
    * - --force
      - 
      - false

--- a/docs/mongocli/command/mongocli-atlas-quickstart.txt
+++ b/docs/mongocli/command/mongocli-atlas-quickstart.txt
@@ -42,6 +42,10 @@ Options
      - string
      - false
      - Name of the cluster.
+   * - --currentIp
+     - 
+     - false
+     - Flag that indicates whether to use the IP Address from the host that is currently executing the command.
    * - -Y, --default
      - 
      - false

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -176,6 +176,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().BoolVar(&qsOpts.SkipSampleData, flag.SkipSampleData, false, usage.SkipSampleData)
 	cmd.Flags().BoolVar(&qsOpts.SkipMongosh, flag.SkipMongosh, false, usage.SkipMongosh)
 	cmd.Flags().BoolVar(&qsOpts.Confirm, flag.Force, false, usage.Force)
+	cmd.Flags().BoolVar(&qsOpts.CurrentIP, flag.CurrentIP, false, usage.CurrentIPSimplified)
 
 	return cmd
 }

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -308,6 +308,7 @@ const (
 	LiveMigrationDropCollections             = "Flag that indicates whether this process should drop existing collections from the destination (Atlas) cluster given in --destinationClusterName before starting the migration of data from the source cluster."
 	LiveMigrationValidationID                = "Unique 24-hexadecimal digit string that identifies the validation job."
 	CurrentIP                                = "Flag that indicates whether to use the IP Address from the host that is currently executing the command. Only applicable for type ipAddress entries. To learn more, see: https://docs.mongodb.com/mongocli/master/command/mongocli-atlas-accessLists-create/."
+	CurrentIPSimplified                      = "Flag that indicates whether to use the IP Address from the host that is currently executing the command."
 	Gov                                      = "Create a default profile for atlas for gov"
 	EncryptedLogFile                         = "Path to the file that contains encrypted audit logs."
 	OutputLogFile                            = "Path to the file where MongoCLI will save the contents of the decrypted audit log. If not specified, MongoCLI writes the contents of the decrypted audit log to stdout."


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-87997](https://jira.mongodb.org/browse/CLOUDP-87997)

### Flag
```shell

➜  mongocli git:(CLOUDP-87997) ✗ atlasdev quickstart --currentIp -P apiKeys
[Default Settings]
Cluster Name:                           Cluster95626
Cloud Provider and Region:              AWS - US_EAST_1
Database Username:                      Cluster95626
Allow connections from (IP Address):    37.228.237.17
? Do you want to set up your first free database in Atlas with default settings (it's free forever)? Yes
We are deploying Cluster95626...
Please store your database authentication access details in a secure location: 
username: Cluster95626 
password: U1declNZQklU

Creating your cluster... [It's safe to 'Ctrl + C']

Creating your cluster... [It's safe to 'Ctrl + C']
Cluster created.
Loading sample data into your cluster... [It's safe to 'Ctrl + C']

[MongoDB Shell (mongosh) is an interactive command line interface to query, update and manage data in the MongoDB database.]
? Do you want to connect to Cluster95626 with MongoDB Shell? [? for help] (Y/n) 


```

### Error handling

```shell

➜  mongocli git:(CLOUDP-87997) atlasdev quickstart --currentIp --accessListIp 1234 -P apiKeys           
Error: cannot use currentIp and accessListIp, please use only one of the flags

➜  mongocli git:(CLOUDP-87997) atlasdev setup --currentIp --accessListIp 1234 -P apiKeys                

you are already authenticated with an API key (Public key: riskfmiy)

run "atlas auth setup --profile <profile_name>" to create a new Atlas account on a new Atlas CLI profile
Error: cannot use currentIp and accessListIp, please use only one of the flags


```
## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
