### PR TITLE
CLOUDP-123153: Cleanup help text to remove mongocli for atlas specific commands

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.45.2
+          version: v1.46.2

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
-GOLANGCI_VERSION=v1.45.2
+GOLANGCI_VERSION=v1.46.2
 COVERAGE=coverage.out
 
 MCLI_SOURCE_FILES?=./cmd/mongocli

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -124,7 +124,7 @@ func mongoCLIConfigFilePath() (configPath string, err error) {
 		return configPath, nil
 	}
 
-	if configDir, err := config.OldMongoCLIConfigHome(); err == nil {
+	if configDir, err := config.OldMongoCLIConfigHome(); err == nil { //nolint:staticcheck // Deprecated before fully removing support in the future
 		configPath = fmt.Sprintf("%s/mongocli.toml", configDir)
 	}
 

--- a/cmd/mongocli/mongocli.go
+++ b/cmd/mongocli/mongocli.go
@@ -54,7 +54,7 @@ func updateMongoCLIConfigPath() {
 		return
 	}
 
-	oldMongoCLIConfigHome, err := config.OldMongoCLIConfigHome()
+	oldMongoCLIConfigHome, err := config.OldMongoCLIConfigHome() //nolint:staticcheck // Deprecated before fully removing support in the future
 	if err != nil {
 		return
 	}

--- a/internal/cli/atlas/logs/logs.go
+++ b/internal/cli/atlas/logs/logs.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// MongoCLIBuilder is to split "mongocli atlas logs" and "atlascli logs".
+// MongoCLIBuilder is to split "mongocli atlas logs" and "atlas logs".
 func MongoCLIBuilder() *cobra.Command {
 	const use = "logs"
 	cmd := &cobra.Command{

--- a/internal/cli/atlas/quickstart/access_list_setup.go
+++ b/internal/cli/atlas/quickstart/access_list_setup.go
@@ -18,9 +18,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
-
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	atlas "go.mongodb.org/atlas/mongodbatlas"

--- a/internal/cli/atlas/quickstart/access_list_setup.go
+++ b/internal/cli/atlas/quickstart/access_list_setup.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
@@ -60,7 +62,8 @@ func (opts *Opts) askAccessListOptions() error {
 }
 
 func (opts *Opts) newProjectIPAccessList() []*atlas.ProjectIPAccessList {
-	const accessListComment = "IP added with mongocli atlas quickstart"
+	var accessListComment = fmt.Sprintf("IP added with %s quickstart", cli.ExampleAtlasEntryPoint())
+
 	accessListArray := make([]*atlas.ProjectIPAccessList, len(opts.IPAddresses))
 	for i, addr := range opts.IPAddresses {
 		accessList := &atlas.ProjectIPAccessList{

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -65,7 +65,9 @@ Creating your cluster... [It's safe to 'Ctrl + C']
 `
 const quickstartTemplateIPNotFound = `
 We could not find your public IP address. To add your IP address run:
-  mongocli atlas accesslist create`
+  %s accesslist create
+
+`
 
 var ErrFreeClusterAlreadyExists = errors.New("this project already has another free cluster")
 
@@ -150,7 +152,7 @@ func (opts *Opts) Run() error {
 		if publicIP := store.IPAddress(); publicIP != "" {
 			opts.IPAddresses = []string{publicIP}
 		} else {
-			_, _ = fmt.Fprintln(os.Stderr, quickstartTemplateIPNotFound)
+			_, _ = fmt.Fprintf(os.Stderr, quickstartTemplateIPNotFound, cli.ExampleAtlasEntryPoint())
 		}
 	}
 
@@ -361,7 +363,7 @@ func (opts *Opts) newDefaultValues() (*quickstart, error) {
 		if publicIP := store.IPAddress(); publicIP != "" {
 			values.IPAddresses = []string{publicIP}
 		} else {
-			_, _ = fmt.Fprintln(os.Stderr, quickstartTemplateIPNotFound)
+			_, _ = fmt.Fprintf(os.Stderr, quickstartTemplateIPNotFound, cli.ExampleAtlasEntryPoint())
 		}
 	}
 


### PR DESCRIPTION
Improvement for some examples that are given as part of commands, to ensure the correct cli (mongocli/atlas cli) help text is returned.

Example in quickstart:
```
atlas quickstart

We could not find your public IP address. To add your IP address run:
  atlas accesslist create
...
```

_Jira ticket:_ CLOUDP-123153

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

