### PR TITLE
(DOCSP-22762) Adds code blocks to fix build errors from docs files

### DIFF
--- a/docs/atlascli/command/atlas-completion-fish.txt
+++ b/docs/atlascli/command/atlas-completion-fish.txt
@@ -12,17 +12,19 @@ atlas completion fish
    :depth: 1
    :class: singlecol
 
-Generate the autocompletion script for fish
-
 Generate the autocompletion script for the fish shell.
 
 To load completions in your current shell session:
 
-	atlas completion fish | source
+.. code-block::
+
+   atlas completion fish | source
 
 To load completions for every new session, execute once:
 
-	atlas completion fish > ~/.config/fish/completions/atlas.fish
+.. code-block::
+
+   atlas completion fish > ~/.config/fish/completions/atlas.fish
 
 You will need to start a new shell for this setup to take effect.
 

--- a/docs/atlascli/command/atlas-completion-powershell.txt
+++ b/docs/atlascli/command/atlas-completion-powershell.txt
@@ -12,13 +12,13 @@ atlas completion powershell
    :depth: 1
    :class: singlecol
 
-Generate the autocompletion script for powershell
-
 Generate the autocompletion script for powershell.
 
 To load completions in your current shell session:
 
-	atlas completion powershell | Out-String | Invoke-Expression
+.. code-block::
+
+   atlas completion powershell | Out-String | Invoke-Expression
 
 To load completions for every new session, add the output of the above command
 to your powershell profile.

--- a/docs/atlascli/command/atlas-completion-zsh.txt
+++ b/docs/atlascli/command/atlas-completion-zsh.txt
@@ -12,24 +12,28 @@ atlas completion zsh
    :depth: 1
    :class: singlecol
 
-Generate the autocompletion script for zsh
-
 Generate the autocompletion script for the zsh shell.
 
 If shell completion is not already enabled in your environment you will need
 to enable it.  You can execute the following once:
 
-	echo "autoload -U compinit; compinit" >> ~/.zshrc
+.. code-block::
+
+   echo "autoload -U compinit; compinit" >> ~/.zshrc
 
 To load completions for every new session, execute once:
 
 #### Linux:
 
-	atlas completion zsh > "${fpath[1]}/_atlas"
+.. code-block::
+
+   atlas completion zsh > "${fpath[1]}/_atlas"
 
 #### macOS:
 
-	atlas completion zsh > /usr/local/share/zsh/site-functions/_atlas
+.. code-block::
+
+   atlas completion zsh > /usr/local/share/zsh/site-functions/_atlas
 
 You will need to start a new shell for this setup to take effect.
 


### PR DESCRIPTION
## Proposed changes

Fixes build errors from docs files, which appear every time the docs team runs a build in our repo. The fix adds code-block directives above code. Also removes an extra repeat line across these pages.

I did not see any changes required in usage.go, but please let me know if a change to the top of docs files requires changes elsewhere.

X Jira ticket: https://jira.mongodb.org/browse/DOCSP-22762

## Checklist
- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
