### PR TITLE
CLOUDP-123490: Hidden keep flag

### DIFF
--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -226,7 +226,7 @@ func (opts *Opts) createResources() error {
 
 	if err := opts.createCluster(); err != nil {
 		var target *atlas.ErrorResponse
-		if errors.As(err, &target) && target.ErrorCode == "CANNOT_CREATE_FREE_CLUSTER_VIA_PUBLIC_API" {
+		if errors.As(err, &target) && target.ErrorCode == "CANNOT_CREATE_FREE_CLUSTER_VIA_PUBLIC_API" && strings.Contains(strings.ToLower(target.Detail), ErrFreeClusterAlreadyExists.Error()) {
 			return ErrFreeClusterAlreadyExists
 		}
 		return err

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -229,6 +229,7 @@ func (opts *Opts) createResources() error {
 		if errors.As(err, &target) && target.ErrorCode == "CANNOT_CREATE_FREE_CLUSTER_VIA_PUBLIC_API" {
 			return ErrFreeClusterAlreadyExists
 		}
+		return err
 	}
 	return nil
 }

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -105,6 +105,6 @@ func LogoutBuilder() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
 	cmd.Flags().BoolVar(&opts.keepConfig, "keep", false, usage.Keep)
 
-	cmd.Flags().MarkHidden("keep")
+	_ = cmd.Flags().MarkHidden("keep")
 	return cmd
 }

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -31,9 +31,10 @@ import (
 
 type logoutOpts struct {
 	*cli.DeleteOpts
-	OutWriter io.Writer
-	config    ConfigDeleter
-	flow      Revoker
+	OutWriter  io.Writer
+	config     ConfigDeleter
+	flow       Revoker
+	keepConfig bool
 }
 
 //go:generate mockgen -destination=../../mocks/mock_logout.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/cli/auth Revoker,ConfigDeleter
@@ -58,7 +59,14 @@ func (opts *logoutOpts) Run(ctx context.Context) error {
 		return err
 	}
 
-	return opts.Delete(opts.config.Delete)
+	if !opts.keepConfig {
+		return opts.Delete(opts.config.Delete)
+	}
+	config.SetAccessToken("")
+	config.SetRefreshToken("")
+	config.SetProjectID("")
+	config.SetOrgID("")
+	return config.Save()
 }
 
 func LogoutBuilder() *cobra.Command {
@@ -95,6 +103,8 @@ func LogoutBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
+	cmd.Flags().BoolVar(&opts.keepConfig, "keep", false, usage.Keep)
 
+	cmd.Flags().MarkHidden("keep")
 	return cmd
 }

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -67,3 +67,29 @@ func Test_logoutOpts_Run(t *testing.T) {
 		Times(1)
 	require.NoError(t, opts.Run(ctx))
 }
+
+func Test_logoutOpts_Run_Keep(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockFlow := mocks.NewMockRevoker(ctrl)
+	mockConfig := mocks.NewMockConfigDeleter(ctrl)
+	defer ctrl.Finish()
+	buf := new(bytes.Buffer)
+
+	opts := logoutOpts{
+		OutWriter: buf,
+		config:    mockConfig,
+		flow:      mockFlow,
+		DeleteOpts: &cli.DeleteOpts{
+			Confirm: true,
+		},
+		keepConfig: true,
+	}
+	ctx := context.TODO()
+	mockFlow.
+		EXPECT().
+		RevokeToken(ctx, gomock.Any(), gomock.Any()).
+		Return(nil, nil).
+		Times(1)
+
+	require.NoError(t, opts.Run(ctx))
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -325,4 +325,5 @@ const (
 	DecryptAWSAccessKey                      = "AWS Access Key ID that is part of long-term credentials."
 	DecryptAWSSecretKey                      = "AWS Secret Access Key  that is part of long-term credentials." //nolint:gosec // This is just a message not a credential
 	AWSSessionToken                          = "AWS session token used with temporary security credentials."   //nolint:gosec // This is just a message not a credential
+	Keep                                     = "If specified, skips deleting config file."
 )


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Adds a hidden flag for users who want to keep the config file after logging out.

* Note: Merge only after the Telemetry PR. I don't want to add this to the release.
[CLOUDP-123490)](https://jira.mongodb.org/browse/CLOUDP-123490)
## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [e2e/E2E-TESTS.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/e2e/E2E-TESTS.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
