### PR TITLE
tests: fix tests for audit_log_line_scanner_test

### DIFF
--- a/internal/decryption/audit_log_line_scanner_test.go
+++ b/internal/decryption/audit_log_line_scanner_test.go
@@ -13,115 +13,102 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package decryption
 
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/go-test/deep"
 	"github.com/mongodb/mongodb-atlas-cli/internal/decryption/keyproviders"
+	"github.com/openlyinc/pointy"
 )
 
 func buildExpectedLog() []*AuditLogLine {
 	ts := time.UnixMilli(1647253664552)
-	version := "0.0" //nolint:goconst //simple version comparison unit test
-	compressionMode := "zstd"
 	provider := keyproviders.LocalKey
-	filename := "localKey"
 	encryptedKey, _ := base64.StdEncoding.DecodeString("9Jmg+S67unj4GfLfl4PxmSdo87e1dbtQ0UMrdid7tx7R42XhvtJnoLztSUhYQhWzIne/sNXvPIVl94M9VnXi+g==")
 	mac := "OG/VwMlpPU9ChDmHAQAAAAAAAAAAAAAA"
-	recordType := AuditHeaderRecord
-
 	tsLog := time.UnixMilli(1647253664553)
 	recordTypeLog := AuditLogRecord
-	log := "0QjwufYIydvNuDXTAQAAAAEAAAAAAAAAUZaMkB7yYllyHE8zES4A+BK5HODkhWjTBT9Yq/vwG3Tv8W4kEgED40aDMp8LLQbWzO/gTC+MzGSnHFqer6DgW9T1a7g4GqLlZBmP9WJhYxM+2yDURVsKuoghKlWlosXVGgd1GPD7PexRk8gytjVeFFxYTolPOwbLeek3feaMT1vThflfkAefc+VhUSfxkctX8NKvtY1CLLjrOyzXEG0OOBainbXiybCAyszDC9WdL0Cg8wx5kn4LXQHshFjCWA8GMIWQ8MNU7dmhx1mcEoKGrpdVeP/yQNOxSjkKDrC2o1P0wXigOZ8zRz/W"
 
 	return []*AuditLogLine{
 		{
 			TS:              &ts,
-			Version:         &version,
-			CompressionMode: &compressionMode,
+			Version:         pointy.String("0.0"),
+			CompressionMode: pointy.String("zstd"),
 			KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 				Provider: &provider,
-				Filename: filename,
+				Filename: "localKey",
 			},
 			EncryptedKey:    encryptedKey,
 			MAC:             &mac,
-			AuditRecordType: recordType,
+			AuditRecordType: AuditHeaderRecord,
 		},
 		{
 			TS:              &tsLog,
 			AuditRecordType: recordTypeLog,
-			Log:             &log,
+			Log:             pointy.String("0QjwufYIydvNuDXTAQAAAAEAAAAAAAAAUZaMkB7yYllyHE8zES4A+BK5HODkhWjTBT9Yq/vwG3Tv8W4kEgED40aDMp8LLQbWzO/gTC+MzGSnHFqer6DgW9T1a7g4GqLlZBmP9WJhYxM+2yDURVsKuoghKlWlosXVGgd1GPD7PexRk8gytjVeFFxYTolPOwbLeek3feaMT1vThflfkAefc+VhUSfxkctX8NKvtY1CLLjrOyzXEG0OOBainbXiybCAyszDC9WdL0Cg8wx5kn4LXQHshFjCWA8GMIWQ8MNU7dmhx1mcEoKGrpdVeP/yQNOxSjkKDrC2o1P0wXigOZ8zRz/W"),
 		},
 	}
 }
 
-func deepCompareLogLines(l, r []*AuditLogLine) bool {
-	lJSON, err := json.Marshal(l)
-	if err != nil {
-		return false
-	}
-
-	rJSON, err := json.Marshal(r)
-	if err != nil {
-		return false
-	}
-
-	return bytes.Equal(lJSON, rJSON)
-}
-
 func Test_readAuditLogFile(t *testing.T) {
-	expectedLog := buildExpectedLog()
-
 	inputJSON := []byte(`{"ts":{"$date":{"$numberLong":"1647253664552"}},"auditrecordtype":"header","version":"0.0","compressionmode":"zstd","keystoreidentifier":{"provider":"local","filename":"localKey"},"encryptedkey":{"$binary":{"base64":"9Jmg+S67unj4GfLfl4PxmSdo87e1dbtQ0UMrdid7tx7R42XhvtJnoLztSUhYQhWzIne/sNXvPIVl94M9VnXi+g==","subType":"00"}},"mac":"OG/VwMlpPU9ChDmHAQAAAAAAAAAAAAAA"}
 {"ts":{"$date":{"$numberLong":"1647253664553"}},"log":"0QjwufYIydvNuDXTAQAAAAEAAAAAAAAAUZaMkB7yYllyHE8zES4A+BK5HODkhWjTBT9Yq/vwG3Tv8W4kEgED40aDMp8LLQbWzO/gTC+MzGSnHFqer6DgW9T1a7g4GqLlZBmP9WJhYxM+2yDURVsKuoghKlWlosXVGgd1GPD7PexRk8gytjVeFFxYTolPOwbLeek3feaMT1vThflfkAefc+VhUSfxkctX8NKvtY1CLLjrOyzXEG0OOBainbXiybCAyszDC9WdL0Cg8wx5kn4LXQHshFjCWA8GMIWQ8MNU7dmhx1mcEoKGrpdVeP/yQNOxSjkKDrC2o1P0wXigOZ8zRz/W"}`)
 	inputBSON, _ := base64.StdEncoding.DecodeString(`GQEAAAl0cwAoM/iHfwEAAAJ2ZXJzaW9uAAQAAAAwLjAAAmNvbXByZXNzaW9uTW9kZQAFAAAAenN0ZAADa2V5U3RvcmVJZGVudGlmaWVyADAAAAACcHJvdmlkZXIABgAAAGxvY2FsAAJmaWxlbmFtZQAJAAAAbG9jYWxLZXkAAAVlbmNyeXB0ZWRLZXkAQAAAAAD0maD5Lru6ePgZ8t+Xg/GZJ2jzt7V1u1DRQyt2J3u3HtHjZeG+0megvO1JSFhCFbMid7+w1e88hWX3gz1WdeL6Ak1BQwAhAAAAT0cvVndNbHBQVTlDaERtSEFRQUFBQUFBQUFBQUFBQUEAAmF1ZGl0UmVjb3JkVHlwZQAHAAAAaGVhZGVyAABzAQAACXRzACkz+Id/AQAAAmxvZwBZAQAAMFFqd3VmWUl5ZHZOdURYVEFRQUFBQUVBQUFBQUFBQUFVWmFNa0I3eVlsbHlIRTh6RVM0QStCSzVIT0RraFdqVEJUOVlxL3Z3RzNUdjhXNGtFZ0VENDBhRE1wOExMUWJXek8vZ1RDK016R1NuSEZxZXI2RGdXOVQxYTdnNEdxTGxaQm1QOVdKaFl4TSsyeURVUlZzS3VvZ2hLbFdsb3NYVkdnZDFHUEQ3UGV4Ums4Z3l0alZlRkZ4WVRvbFBPd2JMZWVrM2ZlYU1UMXZUaGZsZmtBZWZjK1ZoVVNmeGtjdFg4Tkt2dFkxQ0xManJPeXpYRUcwT09CYWluYlhpeWJDQXlzekRDOVdkTDBDZzh3eDVrbjRMWFFIc2hGakNXQThHTUlXUThNTlU3ZG1oeDFtY0VvS0dycGRWZVAveVFOT3hTamtLRHJDMm8xUDB3WGlnT1o4elJ6L1cAAA==`)
 
+	expectedLog := buildExpectedLog()
 	testCases := []struct {
+		name           string
 		input          []byte
 		expectedFormat AuditLogFormat
 		expectedLog    []*AuditLogLine
 	}{
 		{
+			name:           "json",
 			input:          inputJSON,
 			expectedFormat: JSON,
 			expectedLog:    expectedLog,
 		},
 		{
+			name:           "bson",
 			input:          inputBSON,
 			expectedFormat: BSON,
 			expectedLog:    expectedLog,
 		},
 	}
-	for _, testCase := range testCases {
-		format, scanner, err := readAuditLogFile(bytes.NewReader(testCase.input))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if testCase.expectedFormat != format {
-			t.Fatalf("expected: %v got: %v", testCase.expectedFormat, format)
-		}
-		var logs []*AuditLogLine
-		for scanner.Scan() {
-			log, err := scanner.AuditLogLine()
+	for _, tt := range testCases {
+		input := tt.input
+		expectedFormat := tt.expectedFormat
+		el := expectedLog
+		t.Run(tt.name, func(t *testing.T) {
+			format, scanner, err := readAuditLogFile(bytes.NewReader(input))
 			if err != nil {
 				t.Fatal(err)
 			}
-			logs = append(logs, log)
-		}
-		if scanner.Err() != nil {
-			t.Fatal(scanner.Err())
-		}
+			if expectedFormat != format {
+				t.Fatalf("expected: %v got: %v", expectedFormat, format)
+			}
+			var logs []*AuditLogLine
+			for scanner.Scan() {
+				log, err2 := scanner.AuditLogLine()
+				if err2 != nil {
+					t.Fatal(err2)
+				}
+				logs = append(logs, log)
+			}
+			if scanner.Err() != nil {
+				t.Fatal(scanner.Err())
+			}
 
-		if !deepCompareLogLines(testCase.expectedLog, logs) {
-			t.Fatalf("expected: %v got: %v", testCase.expectedLog, logs)
-		}
+			if diff := deep.Equal(el, logs); diff != nil {
+				t.Error(diff)
+			}
+		})
 	}
 }
 
@@ -129,59 +116,69 @@ func Test_readAuditLogFile_corruptedBSON(t *testing.T) {
 	expectedLog := buildExpectedLog()
 
 	testCases := []struct {
+		name        string
 		input       string
 		expectErr   bool
 		expectedLog []*AuditLogLine
 	}{
 		{
+			name:      "valid",
 			input:     `GQEAAAl0cwAoM/iHfwEAAAJ2ZXJzaW9uAAQAAAAwLjAAAmNvbXByZXNzaW9uTW9kZQAFAAAAenN0ZAADa2V5U3RvcmVJZGVudGlmaWVyADAAAAACcHJvdmlkZXIABgAAAGxvY2FsAAJmaWxlbmFtZQAJAAAAbG9jYWxLZXkAAAVlbmNyeXB0ZWRLZXkAQAAAAAD0maD5Lru6ePgZ8t+Xg/GZJ2jzt7V1u1DRQyt2J3u3HtHjZeG+0megvO1JSFhCFbMid7+w1e88hWX3gz1WdeL6Ak1BQwAhAAAAT0cvVndNbHBQVTlDaERtSEFRQUFBQUFBQUFBQUFBQUEAAmF1ZGl0UmVjb3JkVHlwZQAHAAAAaGVhZGVyAABzAQAACXRzACkz+Id/AQAAAmxvZwBZAQAAMFFqd3VmWUl5ZHZOdURYVEFRQUFBQUVBQUFBQUFBQUFVWmFNa0I3eVlsbHlIRTh6RVM0QStCSzVIT0RraFdqVEJUOVlxL3Z3RzNUdjhXNGtFZ0VENDBhRE1wOExMUWJXek8vZ1RDK016R1NuSEZxZXI2RGdXOVQxYTdnNEdxTGxaQm1QOVdKaFl4TSsyeURVUlZzS3VvZ2hLbFdsb3NYVkdnZDFHUEQ3UGV4Ums4Z3l0alZlRkZ4WVRvbFBPd2JMZWVrM2ZlYU1UMXZUaGZsZmtBZWZjK1ZoVVNmeGtjdFg4Tkt2dFkxQ0xManJPeXpYRUcwT09CYWluYlhpeWJDQXlzekRDOVdkTDBDZzh3eDVrbjRMWFFIc2hGakNXQThHTUlXUThNTlU3ZG1oeDFtY0VvS0dycGRWZVAveVFOT3hTamtLRHJDMm8xUDB3WGlnT1o4elJ6L1cAAA==`,
 			expectErr: false,
 		},
-		{ // tampered first byte, doc size would be wrong 279 instead of 281
+		{
+			name:      "tampered first byte, doc size would be wrong 279 instead of 281",
 			input:     `FwEAAAl0cwAoM/iHfwEAAAJ2ZXJzaW9uAAQAAAAwLjAAAmNvbXByZXNzaW9uTW9kZQAFAAAAenN0ZAADa2V5U3RvcmVJZGVudGlmaWVyADAAAAACcHJvdmlkZXIABgAAAGxvY2FsAAJmaWxlbmFtZQAJAAAAbG9jYWxLZXkAAAVlbmNyeXB0ZWRLZXkAQAAAAAD0maD5Lru6ePgZ8t+Xg/GZJ2jzt7V1u1DRQyt2J3u3HtHjZeG+0megvO1JSFhCFbMid7+w1e88hWX3gz1WdeL6Ak1BQwAhAAAAT0cvVndNbHBQVTlDaERtSEFRQUFBQUFBQUFBQUFBQUEAAmF1ZGl0UmVjb3JkVHlwZQAHAAAAaGVhZGVyAABzAQAACXRzACkz+Id/AQAAAmxvZwBZAQAAMFFqd3VmWUl5ZHZOdURYVEFRQUFBQUVBQUFBQUFBQUFVWmFNa0I3eVlsbHlIRTh6RVM0QStCSzVIT0RraFdqVEJUOVlxL3Z3RzNUdjhXNGtFZ0VENDBhRE1wOExMUWJXek8vZ1RDK016R1NuSEZxZXI2RGdXOVQxYTdnNEdxTGxaQm1QOVdKaFl4TSsyeURVUlZzS3VvZ2hLbFdsb3NYVkdnZDFHUEQ3UGV4Ums4Z3l0alZlRkZ4WVRvbFBPd2JMZWVrM2ZlYU1UMXZUaGZsZmtBZWZjK1ZoVVNmeGtjdFg4Tkt2dFkxQ0xManJPeXpYRUcwT09CYWluYlhpeWJDQXlzekRDOVdkTDBDZzh3eDVrbjRMWFFIc2hGakNXQThHTUlXUThNTlU3ZG1oeDFtY0VvS0dycGRWZVAveVFOT3hTamtLRHJDMm8xUDB3WGlnT1o4elJ6L1cAAA==`,
 			expectErr: true,
 		},
-		{ // tampered first byte, doc size would be wrong 283 instead of 281
+		{
+			name:      "tampered first byte, doc size would be wrong 283 instead of 281",
 			input:     `GwEAAAl0cwAoM/iHfwEAAAJ2ZXJzaW9uAAQAAAAwLjAAAmNvbXByZXNzaW9uTW9kZQAFAAAAenN0ZAADa2V5U3RvcmVJZGVudGlmaWVyADAAAAACcHJvdmlkZXIABgAAAGxvY2FsAAJmaWxlbmFtZQAJAAAAbG9jYWxLZXkAAAVlbmNyeXB0ZWRLZXkAQAAAAAD0maD5Lru6ePgZ8t+Xg/GZJ2jzt7V1u1DRQyt2J3u3HtHjZeG+0megvO1JSFhCFbMid7+w1e88hWX3gz1WdeL6Ak1BQwAhAAAAT0cvVndNbHBQVTlDaERtSEFRQUFBQUFBQUFBQUFBQUEAAmF1ZGl0UmVjb3JkVHlwZQAHAAAAaGVhZGVyAABzAQAACXRzACkz+Id/AQAAAmxvZwBZAQAAMFFqd3VmWUl5ZHZOdURYVEFRQUFBQUVBQUFBQUFBQUFVWmFNa0I3eVlsbHlIRTh6RVM0QStCSzVIT0RraFdqVEJUOVlxL3Z3RzNUdjhXNGtFZ0VENDBhRE1wOExMUWJXek8vZ1RDK016R1NuSEZxZXI2RGdXOVQxYTdnNEdxTGxaQm1QOVdKaFl4TSsyeURVUlZzS3VvZ2hLbFdsb3NYVkdnZDFHUEQ3UGV4Ums4Z3l0alZlRkZ4WVRvbFBPd2JMZWVrM2ZlYU1UMXZUaGZsZmtBZWZjK1ZoVVNmeGtjdFg4Tkt2dFkxQ0xManJPeXpYRUcwT09CYWluYlhpeWJDQXlzekRDOVdkTDBDZzh3eDVrbjRMWFFIc2hGakNXQThHTUlXUThNTlU3ZG1oeDFtY0VvS0dycGRWZVAveVFOT3hTamtLRHJDMm8xUDB3WGlnT1o4elJ6L1cAAA==`,
 			expectErr: true,
 		},
-		{ // tampered last byte to be 1 instead of 0
+		{
+			name:      "tampered last byte to be 1 instead of 0",
 			input:     `GQEAAAl0cwAoM/iHfwEAAAJ2ZXJzaW9uAAQAAAAwLjAAAmNvbXByZXNzaW9uTW9kZQAFAAAAenN0ZAADa2V5U3RvcmVJZGVudGlmaWVyADAAAAACcHJvdmlkZXIABgAAAGxvY2FsAAJmaWxlbmFtZQAJAAAAbG9jYWxLZXkAAAVlbmNyeXB0ZWRLZXkAQAAAAAD0maD5Lru6ePgZ8t+Xg/GZJ2jzt7V1u1DRQyt2J3u3HtHjZeG+0megvO1JSFhCFbMid7+w1e88hWX3gz1WdeL6Ak1BQwAhAAAAT0cvVndNbHBQVTlDaERtSEFRQUFBQUFBQUFBQUFBQUEAAmF1ZGl0UmVjb3JkVHlwZQAHAAAAaGVhZGVyAABzAQAACXRzACkz+Id/AQAAAmxvZwBZAQAAMFFqd3VmWUl5ZHZOdURYVEFRQUFBQUVBQUFBQUFBQUFVWmFNa0I3eVlsbHlIRTh6RVM0QStCSzVIT0RraFdqVEJUOVlxL3Z3RzNUdjhXNGtFZ0VENDBhRE1wOExMUWJXek8vZ1RDK016R1NuSEZxZXI2RGdXOVQxYTdnNEdxTGxaQm1QOVdKaFl4TSsyeURVUlZzS3VvZ2hLbFdsb3NYVkdnZDFHUEQ3UGV4Ums4Z3l0alZlRkZ4WVRvbFBPd2JMZWVrM2ZlYU1UMXZUaGZsZmtBZWZjK1ZoVVNmeGtjdFg4Tkt2dFkxQ0xManJPeXpYRUcwT09CYWluYlhpeWJDQXlzekRDOVdkTDBDZzh3eDVrbjRMWFFIc2hGakNXQThHTUlXUThNTlU3ZG1oeDFtY0VvS0dycGRWZVAveVFOT3hTamtLRHJDMm8xUDB3WGlnT1o4elJ6L1cAAQ==`,
 			expectErr: true,
 		},
-		{ // tampered ts type from 0x9 UTC datetime to 0x13 decimal128
+		{
+			name:      "tampered ts type from 0x9 UTC datetime to 0x13 decimal128",
 			input:     `GQEAABN0cwAoM/iHfwEAAAJ2ZXJzaW9uAAQAAAAwLjAAAmNvbXByZXNzaW9uTW9kZQAFAAAAenN0ZAADa2V5U3RvcmVJZGVudGlmaWVyADAAAAACcHJvdmlkZXIABgAAAGxvY2FsAAJmaWxlbmFtZQAJAAAAbG9jYWxLZXkAAAVlbmNyeXB0ZWRLZXkAQAAAAAD0maD5Lru6ePgZ8t+Xg/GZJ2jzt7V1u1DRQyt2J3u3HtHjZeG+0megvO1JSFhCFbMid7+w1e88hWX3gz1WdeL6Ak1BQwAhAAAAT0cvVndNbHBQVTlDaERtSEFRQUFBQUFBQUFBQUFBQUEAAmF1ZGl0UmVjb3JkVHlwZQAHAAAAaGVhZGVyAABzAQAACXRzACkz+Id/AQAAAmxvZwBZAQAAMFFqd3VmWUl5ZHZOdURYVEFRQUFBQUVBQUFBQUFBQUFVWmFNa0I3eVlsbHlIRTh6RVM0QStCSzVIT0RraFdqVEJUOVlxL3Z3RzNUdjhXNGtFZ0VENDBhRE1wOExMUWJXek8vZ1RDK016R1NuSEZxZXI2RGdXOVQxYTdnNEdxTGxaQm1QOVdKaFl4TSsyeURVUlZzS3VvZ2hLbFdsb3NYVkdnZDFHUEQ3UGV4Ums4Z3l0alZlRkZ4WVRvbFBPd2JMZWVrM2ZlYU1UMXZUaGZsZmtBZWZjK1ZoVVNmeGtjdFg4Tkt2dFkxQ0xManJPeXpYRUcwT09CYWluYlhpeWJDQXlzekRDOVdkTDBDZzh3eDVrbjRMWFFIc2hGakNXQThHTUlXUThNTlU3ZG1oeDFtY0VvS0dycGRWZVAveVFOT3hTamtLRHJDMm8xUDB3WGlnT1o4elJ6L1cAAA==`,
 			expectErr: true,
 		},
 	}
-	for _, testCase := range testCases {
-		buf, err := base64.StdEncoding.DecodeString(testCase.input)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		format, scanner, err := readAuditLogFile(bytes.NewReader(buf))
-		if err != nil && !testCase.expectErr {
-			t.Fatal(err)
-		}
-		if format != BSON {
-			t.Errorf("expected: BSON got: %v", format)
-		}
-
-		var logs []*AuditLogLine
-		for scanner.Scan() {
-			log, err := scanner.AuditLogLine()
-			if err != nil && !testCase.expectErr {
+	for _, tt := range testCases {
+		input := tt.input
+		expectErr := tt.expectErr
+		t.Run(tt.name, func(t *testing.T) {
+			buf, err := base64.StdEncoding.DecodeString(input)
+			if err != nil {
 				t.Fatal(err)
 			}
-			logs = append(logs, log)
-		}
-		if scanner.Err() != nil && !testCase.expectErr {
-			t.Fatal(scanner.Err())
-		}
 
-		if testCase.expectErr && deepCompareLogLines(expectedLog, logs) {
-			t.Fatal("expected failure but decrypted correctly")
-		}
+			format, scanner, err := readAuditLogFile(bytes.NewReader(buf))
+			if err != nil && !expectErr {
+				t.Fatal(err)
+			}
+			if format != BSON {
+				t.Errorf("expected: BSON got: %v", format)
+			}
+
+			var logs []*AuditLogLine
+			for scanner.Scan() {
+				log, err2 := scanner.AuditLogLine()
+				if err2 != nil && !expectErr {
+					t.Fatal(err2)
+				}
+				logs = append(logs, log)
+			}
+			if scanner.Err() != nil && !expectErr {
+				t.Fatal(scanner.Err())
+			}
+
+			if diff := deep.Equal(expectedLog, logs); expectErr && diff == nil {
+				t.Error("expected failure but decrypted correctly")
+			}
+		})
 	}
 }

--- a/internal/decryption/header_test.go
+++ b/internal/decryption/header_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package decryption
 
@@ -23,17 +22,14 @@ import (
 	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/decryption/keyproviders"
+	"github.com/openlyinc/pointy"
 )
 
 func Test_validateMAC(t *testing.T) {
 	validKey, _ := base64.StdEncoding.DecodeString("pnvb++3sbhxIJdfODOq5uIaUX8yxTuWS95VLgES30FM=")
 	invalidKey, _ := base64.StdEncoding.DecodeString("pnvb++4sbhxIJdfODOq5uIaUX8yxTuWS95VLgES30FM=")
-	validVersion := "0.0"
-	invalidVersion := "0.1"
 	validTimestamp := time.UnixMilli(1644232049921)
 	invalidTimestamp := time.UnixMilli(0)
-	validMAC := "qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA"
-	invalidMAC := "wrongAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 	testCases := []struct {
 		input       HeaderRecord
@@ -43,8 +39,8 @@ func Test_validateMAC(t *testing.T) {
 		{
 			input: HeaderRecord{
 				Timestamp: validTimestamp,
-				Version:   validVersion,
-				MAC:       validMAC,
+				Version:   "0.0",
+				MAC:       "qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA",
 			},
 			inputKey:    validKey,
 			expectedErr: false,
@@ -52,8 +48,8 @@ func Test_validateMAC(t *testing.T) {
 		{
 			input: HeaderRecord{
 				Timestamp: invalidTimestamp,
-				Version:   validVersion,
-				MAC:       validMAC,
+				Version:   "0.0",
+				MAC:       "qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA",
 			},
 			inputKey:    validKey,
 			expectedErr: true,
@@ -61,8 +57,8 @@ func Test_validateMAC(t *testing.T) {
 		{
 			input: HeaderRecord{
 				Timestamp: validTimestamp,
-				Version:   invalidVersion,
-				MAC:       validMAC,
+				Version:   "0.1",
+				MAC:       "qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA",
 			},
 			inputKey:    validKey,
 			expectedErr: true,
@@ -70,8 +66,8 @@ func Test_validateMAC(t *testing.T) {
 		{
 			input: HeaderRecord{
 				Timestamp: validTimestamp,
-				Version:   validVersion,
-				MAC:       invalidMAC,
+				Version:   "0.0",
+				MAC:       "wrongAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 			},
 			inputKey:    validKey,
 			expectedErr: true,
@@ -79,8 +75,8 @@ func Test_validateMAC(t *testing.T) {
 		{
 			input: HeaderRecord{
 				Timestamp: validTimestamp,
-				Version:   validVersion,
-				MAC:       validMAC,
+				Version:   "0.0",
+				MAC:       "qE9fUsGK0EuRrrCRAQAAAAAAAAAAAAAA",
 			},
 			inputKey:    invalidKey,
 			expectedErr: true,
@@ -99,13 +95,9 @@ func Test_validateMAC(t *testing.T) {
 
 func Test_validateHeaderFields(t *testing.T) {
 	ts := time.Now()
-	version := "0.0"
-	compressionMode := "none"
 	invalidCompressionMode := "foo"
 	provider := keyproviders.LocalKey
 	encryptedKey := []byte{0, 1, 2, 3}
-	mac := "mac"
-	recordType := AuditHeaderRecord
 
 	testCases := []struct {
 		input     AuditLogLine
@@ -118,117 +110,117 @@ func Test_validateHeaderFields(t *testing.T) {
 		{
 			input: AuditLogLine{
 				TS:              &ts,
-				Version:         &version,
-				CompressionMode: &compressionMode,
+				Version:         pointy.String("0.0"),
+				CompressionMode: pointy.String("none"),
 				KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 					Provider: &provider,
 				},
 				EncryptedKey:    encryptedKey,
-				MAC:             &mac,
-				AuditRecordType: recordType,
+				MAC:             pointy.String("mac"),
+				AuditRecordType: AuditHeaderRecord,
 			},
 			expectErr: false,
 		},
 		{
 			input: AuditLogLine{
 				TS:              &ts,
-				Version:         &version,
-				CompressionMode: &compressionMode,
+				Version:         pointy.String("0.0"),
+				CompressionMode: pointy.String("none"),
 				KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 					Provider: &provider,
 				},
 				EncryptedKey: encryptedKey,
-				MAC:          &mac,
+				MAC:          pointy.String("mac"),
 			},
 			expectErr: true,
 		},
 		{
 			input: AuditLogLine{
 				TS:              &ts,
-				Version:         &version,
-				CompressionMode: &compressionMode,
+				Version:         pointy.String("0.0"),
+				CompressionMode: pointy.String("none"),
 				KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 					Provider: &provider,
 				},
 				EncryptedKey:    encryptedKey,
-				AuditRecordType: recordType,
+				AuditRecordType: AuditHeaderRecord,
 			},
 			expectErr: true,
 		},
 		{
 			input: AuditLogLine{
 				TS:              &ts,
-				Version:         &version,
-				CompressionMode: &compressionMode,
+				Version:         pointy.String("0.0"),
+				CompressionMode: pointy.String("none"),
 				KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 					Provider: &provider,
 				},
-				MAC:             &mac,
-				AuditRecordType: recordType,
+				MAC:             pointy.String("mac"),
+				AuditRecordType: AuditHeaderRecord,
 			},
 			expectErr: true,
 		},
 		{
 			input: AuditLogLine{
 				TS:              &ts,
-				Version:         &version,
-				CompressionMode: &compressionMode,
-				MAC:             &mac,
+				Version:         pointy.String("0.0"),
+				CompressionMode: pointy.String("none"),
+				MAC:             pointy.String("mac"),
 				EncryptedKey:    encryptedKey,
-				AuditRecordType: recordType,
+				AuditRecordType: AuditHeaderRecord,
 			},
 			expectErr: true,
 		},
 		{
 			input: AuditLogLine{
 				TS:              &ts,
-				CompressionMode: &compressionMode,
+				CompressionMode: pointy.String("none"),
 				KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 					Provider: &provider,
 				},
-				MAC:             &mac,
+				MAC:             pointy.String("mac"),
 				EncryptedKey:    encryptedKey,
-				AuditRecordType: recordType,
+				AuditRecordType: AuditHeaderRecord,
 			},
 			expectErr: true,
 		},
 		{
 			input: AuditLogLine{
-				Version:         &version,
-				CompressionMode: &compressionMode,
+				Version:         pointy.String("0.0"),
+				CompressionMode: pointy.String("none"),
 				KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 					Provider: &provider,
 				},
-				MAC:             &mac,
+				MAC:             pointy.String("mac"),
 				EncryptedKey:    encryptedKey,
-				AuditRecordType: recordType,
+				AuditRecordType: AuditHeaderRecord,
 			},
 			expectErr: true,
 		},
 		{
 			input: AuditLogLine{
 				TS:      &ts,
-				Version: &version,
+				Version: pointy.String("0.0"),
 				KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 					Provider: &provider,
 				},
 				EncryptedKey:    encryptedKey,
-				MAC:             &mac,
-				AuditRecordType: recordType,
+				MAC:             pointy.String("mac"),
+				AuditRecordType: AuditHeaderRecord,
 			},
 			expectErr: true,
 		},
 		{
 			input: AuditLogLine{
 				TS:              &ts,
-				Version:         &version,
+				Version:         pointy.String("0.0"),
 				CompressionMode: &invalidCompressionMode,
 				KeyStoreIdentifier: AuditLogLineKeyStoreIdentifier{
 					Provider: &provider,
 				},
-				MAC:             &mac,
+				MAC:             pointy.String("mac"),
 				EncryptedKey:    encryptedKey,
-				AuditRecordType: recordType,
+				AuditRecordType: AuditHeaderRecord,
 			},
 			expectErr: true,
 		},


### PR DESCRIPTION
Audit logs tests starting failing locally for me. the deep equals we implemented was failing for some reason, i managed to fix this by moving to `github.com/go-test/deep` so the error was probably on the byte generation we were using 

Additional "drive by"s to improve how we were doing matrix test as we were not naming them (which added complexity on debugging the failure) and we were not nesting them in a `t.Run` call back 