### PR TITLE
fix: remove golangci-lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -142,7 +142,7 @@ linters:
   # - wsl: Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
 
 run:
-#  go: '1.17'
+  go: '1.17'
   tests: true
   timeout: 5m
   build-tags:


### PR DESCRIPTION
We don't use any go 1.18 feature (generics) so we can ping the go version in golangci lint to 1.17 and get rid of the following warnings

```
golangci-lint run --fix
WARN [linters context] bodyclose is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] noctx is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] rowserrcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] unparam is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
```