### PR TITLE
CLOUDP-126655: golangci-lint isn't properly installed by Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,24 +44,23 @@ export GO111MODULE := on
 export MCLI_E2E_BINARY
 export ATLAS_E2E_BINARY
 
-.PHONY: setupgolangcilint
-setupgolangcilint:  ## Install golangci-lint
-	@echo "==> Installing golangci-lint..."
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
-
 .PHONY: deps
 deps:  ## Download go module dependencies
 	@echo "==> Installing go.mod dependencies..."
 	go mod download
 	go mod tidy
 
-.PHONY: setup
-setup: deps setupgolangcilint ## Set up dev env
+.PHONY: devtools
+devtools:  ## Install dev tools
 	@echo "==> Installing dev tools..."
 	go install github.com/google/addlicense@latest
 	go install github.com/golang/mock/mockgen@latest
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/google/go-licenses@latest
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
+
+.PHONY: setup
+setup: deps devtools ## Set up dev env
 
 .PHONY: link-git-hooks
 link-git-hooks: ## Install git hooks

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ setup: deps setupgolangcilint ## Set up dev env
 	go install github.com/google/addlicense@latest
 	go install github.com/golang/mock/mockgen@latest
 	go install golang.org/x/tools/cmd/goimports@latest
+	go install github.com/google/go-licenses@latest
 
 .PHONY: link-git-hooks
 link-git-hooks: ## Install git hooks

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ INTEGRATION_TAGS?=integration
 E2E_TAGS?=e2e
 E2E_TIMEOUT?=60m
 
-export PATH := ./bin:$(PATH)
+export PATH := $(shell go env GOPATH)/bin:$(PATH)
+export SHELL := env PATH=$(PATH) /bin/bash
 export GO111MODULE := on
 export MCLI_E2E_BINARY
 export ATLAS_E2E_BINARY
@@ -44,7 +45,7 @@ export ATLAS_E2E_BINARY
 .PHONY: setupgolangcilint
 setupgolangcilint:  ## Install golangci-lint
 	@echo "==> Installing golangci-lint..."
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
 
 .PHONY: deps
 deps:  ## Download go module dependencies
@@ -95,10 +96,12 @@ gen-mocks: ## Generate mocks
 .PHONY: gen-docs
 gen-docs: gen-docs-mongocli gen-docs-atlascli ## Generate docs for commands
 
+.PHONY: gen-docs-mongocli
 gen-docs-mongocli: ## Generate docs for mongocli commands
 	@echo "==> Generating docs for mongocli"
 	go run ./tools/mongoclidocs/main.go
 
+.PHONY: gen-docs-atlascli
 gen-docs-atlascli: ## Generate docs for atlascli commands
 	@echo "==> Generating docs for atlascli"
 	go run ./tools/atlasclidocs/main.go
@@ -109,6 +112,7 @@ build: build-mongocli ## Generate a binary for mongocli
 .PHONY: build-all
 build-all: build-mongocli build-atlascli ## Generate a binary for both CLIs
 
+.PHONY: build-mongocli
 build-mongocli: ## Generate a mongocli binary in ./bin
 	@echo "==> Building $(MCLI_BINARY_NAME) binary"
 	go build -ldflags "$(MCLI_LINKER_FLAGS)" -o $(MCLI_DESTINATION) $(MCLI_SOURCE_FILES)
@@ -121,10 +125,12 @@ build-atlascli: ## Generate a atlascli binary in ./bin
 .PHONY: build-debug
 build-debug: build-mongocli-debug build-atlascli-debug ## Generate binaries in ./bin for debugging both CLIs
 
+.PHONY: build-mongocli-debug
 build-mongocli-debug: ## Generate a binary in ./bin for debugging mongocli
 	@echo "==> Building $(MCLI_BINARY_NAME) binary for debugging"
 	go build -gcflags="$(DEBUG_FLAGS)" -ldflags "$(MCLI_LINKER_FLAGS)" -o $(MCLI_DESTINATION) $(MCLI_SOURCE_FILES)
 
+.PHONY: build-atlascli-debug
 build-atlascli-debug: ## Generate a binary in ./bin for debugging atlascli
 	@echo "==> Building $(ATLAS_BINARY_NAME) binary for debugging"
 	go build -gcflags="$(DEBUG_FLAGS)" -ldflags "$(ATLAS_LINKER_FLAGS)" -o $(ATLAS_DESTINATION) $(ATLAS_SOURCE_FILES)
@@ -148,11 +154,13 @@ unit-test: ## Run unit-tests
 .PHONY: install
 install: install-mongocli install-atlascli ## Install binaries in $GOPATH/bin for both CLIs
 
+.PHONY: install-mongocli
 install-mongocli: ## Install mongocli binary in $GOPATH/bin
 	@echo "==> Installing $(MCLI_BINARY_NAME) to $(MCLI_INSTALL_PATH)"
 	go install -ldflags "$(MCLI_LINKER_FLAGS)" $(MCLI_SOURCE_FILES)
 	@echo "==> Done..."
 
+.PHONY: install-atlascli
 install-atlascli: ## Install atlascli binary in $GOPATH/bin
 	@echo "==> Installing $(ATLAS_BINARY_NAME) to $(ATLAS_INSTALL_PATH)"
 	go install -ldflags "$(ATLAS_LINKER_FLAGS)" $(ATLAS_SOURCE_FILES)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ E2E_TAGS?=e2e
 E2E_TIMEOUT?=60m
 
 export PATH := $(shell go env GOPATH)/bin:$(PATH)
-export SHELL := env PATH=$(PATH) /bin/bash
+ifneq ($(OS),Windows_NT)
+	export SHELL := env PATH=$(PATH) /bin/bash
+endif
 export GO111MODULE := on
 export MCLI_E2E_BINARY
 export ATLAS_E2E_BINARY

--- a/build/ci/check-licenses.sh
+++ b/build/ci/check-licenses.sh
@@ -17,9 +17,6 @@
 
 set -Eeou pipefail
 
-export GOPATH="${workdir:?}"
-export PATH="$GOPATH/bin:$PATH"
-
 go install github.com/google/addlicense@latest
 
 find_files() {

--- a/build/ci/check-licenses.sh
+++ b/build/ci/check-licenses.sh
@@ -17,8 +17,6 @@
 
 set -Eeou pipefail
 
-go install github.com/google/addlicense@latest
-
 find_files() {
   find . -not \( \
     \( \

--- a/build/ci/evergreen-generate-tasks.sh
+++ b/build/ci/evergreen-generate-tasks.sh
@@ -17,7 +17,4 @@
 
 set -Eeou pipefail
 
-export GOPATH="${workdir:?}"
-export PATH="$GOPATH/bin:$PATH"
-
 go run tools/evergreen/main.go -tool_name "${tool_name:?}" > tasks.json

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -19,17 +19,18 @@ pre_error_fails_task: true
 
 variables:
   - &go_env
-      XDG_CONFIG_HOME: ${workdir}
+      XDG_CONFIG_HOME: ${go_base_path}${workdir}
       GO111MODULE: "on"
       GOROOT: ${go_root}
-      GOPATH: ${workdir}
-      ADD_PATH: "${go_bin}:${workdir}/bin:${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
+      GOPATH: ${go_base_path}${workdir}
+      ADD_PATH: "${go_bin}:${go_base_path}${workdir}/bin:${go_base_path}${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
   - &go_options
     add_to_path:
       - ${go_bin}
-      - ${workdir}/bin
-      - ${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
+      - ${go_base_path}${workdir}/bin
+      - ${go_base_path}${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
     include_expansions_in_env:
+      - go_base_path
       - workdir
     working_dir: src/github.com/mongodb/mongodb-atlas-cli
     env:
@@ -101,6 +102,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - go_base_path
           - workdir
           - MCLI_ORG_ID
           - MCLI_PROJECT_ID
@@ -185,6 +187,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - go_base_path
           - workdir
           - ops_manager_service
         binary: ./set-up-ops-manager.sh
@@ -195,6 +198,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - go_base_path
           - workdir
           - cloud_manager_service
           - revision
@@ -344,7 +348,7 @@ tasks:
         type: test
         params:
           env:
-            XDG_CONFIG_HOME: ${workdir}
+            XDG_CONFIG_HOME: ${go_base_path}${workdir}
           script: |
             set -Eeou pipefail
             mkdir "$XDG_CONFIG_HOME/mongocli"
@@ -1231,6 +1235,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: .code_health
   - name: e2e_generic
@@ -1240,6 +1245,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .generic"
   - name: e2e_required
@@ -1249,6 +1255,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .required"
   - name: e2e_interactive
@@ -1258,6 +1265,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .interactive"
   - name: e2e_atlas_clusters
@@ -1267,6 +1275,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .clusters .atlas"
   - name: e2e_decryption
@@ -1276,6 +1285,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .decrypt"
   - name: e2e_atlas_gov_clusters
@@ -1285,6 +1295,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .clusters .atlasgov"
   - name: e2e_atlas_networking
@@ -1294,6 +1305,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .networking .atlas"
   - name: e2e_atlas_live_migrations
@@ -1303,6 +1315,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .livemigrations .atlas"
   - name: e2e_atlas_datalake
@@ -1312,6 +1325,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .datalake .atlas"
   - name: e2e_cloud_manager_remote
@@ -1321,6 +1335,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".e2e .clusters .cloudmanager"
   - name: e2e_ops_manager_44
@@ -1330,6 +1345,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".ops-manager-44"
   - name: e2e_ops_manager_50
@@ -1339,6 +1355,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: ".ops-manager-50"
   - name: snyk
@@ -1348,6 +1365,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: .snyk
 include:

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -338,8 +338,8 @@ tasks:
         params:
           script: |
             set -Eeou pipefail
-            mkdir mongocli
-            cat <<EOF > mongocli/config.toml
+            mkdir "$XDG_CONFIG_HOME/mongocli"
+            cat <<EOF > "$XDG_CONFIG_HOME/mongocli/config.toml"
             [e2e]
               org_id = "5e429e7706822c6eac4d5971"
               public_api_key = "AAUMGJXA"

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -231,13 +231,12 @@ functions:
           set -Eeou pipefail
           export PATH="$ADD_PATH:$PATH"
           curl -sfL https://github.com/gotestyourself/gotestsum/releases/download/v${gotestsum_ver}/gotestsum_${gotestsum_ver}_linux_amd64.tar.gz | tar zx
-  "install golangci-lint":
+  "install dev tools":
     - command: subprocess.exec
       type: setup
       params:
         <<: *go_options
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        command: make setupgolangcilint
+        command: make devtools
   "install snyk":
     - command: shell.exec
       type: setup
@@ -321,7 +320,7 @@ tasks:
     tags: ["code_health"]
     commands:
       - func: "clone"
-      - func: "install golangci-lint"
+      - func: "install dev tools"
       - func: "lint"
   - name: snyk_scan
     tags: ["snyk"]
@@ -333,6 +332,7 @@ tasks:
     tags: ["code_health"]
     commands:
       - func: "clone"
+      - func: "install dev tools"
       - func: "check license header"
   - name: config_e2e
     tags: ["e2e","generic"]

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -18,6 +18,12 @@ command_type: system
 pre_error_fails_task: true
 
 variables:
+  - &go_env
+      XDG_CONFIG_HOME: ${workdir}
+      GO111MODULE: "on"
+      GOROOT: ${go_root}
+      GOPATH: ${workdir}
+      ADD_PATH: "${go_bin}:${workdir}/bin:${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
   - &go_options
     add_to_path:
       - ${go_bin}
@@ -27,11 +33,7 @@ variables:
       - workdir
     working_dir: src/github.com/mongodb/mongodb-atlas-cli
     env:
-      XDG_CONFIG_HOME: ${workdir}
-      GO111MODULE: "on"
-      GOROOT: ${go_root}
-      GOPATH: ${workdir}
-      ADD_PATH: "${go_bin}:${workdir}/bin:${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
+      <<: *go_env
 functions:
   "clone":
     - command: git.get_project
@@ -70,6 +72,7 @@ functions:
       params:
         <<: *go_options
         env:
+          <<: *go_env
           TEST_CMD: gotestsum --junitfile unit-tests.xml --
         command: make integration-test
   "generate html coverage":
@@ -98,6 +101,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - workdir
           - MCLI_ORG_ID
           - MCLI_PROJECT_ID
           - MCLI_PRIVATE_API_KEY
@@ -120,6 +124,7 @@ functions:
           - AZURE_CLIENT_SECRET
           - revision
         env:
+          <<: *go_env
           MCLI_SKIP_UPDATE_CHECK: "yes"
           TEST_CMD: gotestsum --junitfile e2e-tests.xml --format standard-verbose --
         command: make e2e-test
@@ -180,6 +185,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - workdir
           - ops_manager_service
         binary: ./set-up-ops-manager.sh
         args: ['-h', 'hosts.json']
@@ -188,14 +194,14 @@ functions:
       type: setup
       params:
         <<: *go_options
-        add_to_path:
-          - ../../bin
         include_expansions_in_env:
+          - workdir
           - cloud_manager_service
           - revision
         binary: ./set-up-cloud-manager.sh
         args: ['-h', 'hosts.json']
         env:
+          <<: *go_env
           MCLI_ORG_ID: ${cloud_manager_org_id}
           MCLI_PROJECT_ID: ${cloud_manager_project_id}
           MCLI_PRIVATE_API_KEY: ${cloud_manager_private_api_key}
@@ -260,6 +266,7 @@ functions:
         binary: ./install.sh
         args: ["-h", "hosts.json"]
         env:
+          <<: *go_env
           KMIP_CA: ${logs_decrypt_kmip_ca}
           KMIP_CERT: ${logs_decrypt_kmip_cert}
 post:

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -19,8 +19,19 @@ pre_error_fails_task: true
 
 variables:
   - &go_options
-    GO111MODULE: "on"
-    GOROOT: ${go_root}
+    add_to_path:
+      - ${go_bin}
+      - ${workdir}/bin
+      - ${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
+    include_expansions_in_env:
+      - workdir
+    working_dir: src/github.com/mongodb/mongodb-atlas-cli
+    env:
+      XDG_CONFIG_HOME: ${workdir}
+      GO111MODULE: "on"
+      GOROOT: ${go_root}
+      GOPATH: ${workdir}
+      ADD_PATH: "${go_bin}:${workdir}/bin:${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
 functions:
   "clone":
     - command: git.get_project
@@ -31,68 +42,44 @@ functions:
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        env:
-          <<: *go_options
+        <<: *go_options
         command: make build-all
   "build mongocli":
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        env:
-          <<: *go_options
+        <<: *go_options
         command: make build-mongocli
   "build atlascli":
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        env:
-          <<: *go_options
+        <<: *go_options
         command: make build-atlascli
   "unit-test":
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
+        <<: *go_options
         env:
           TEST_CMD: gotestsum --junitfile unit-tests.xml --
-          <<: *go_options
         command: make unit-test
   "integration-test":
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
+        <<: *go_options
         env:
           TEST_CMD: gotestsum --junitfile unit-tests.xml --
-          <<: *go_options
         command: make integration-test
   "generate html coverage":
     - command: shell.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        env:
-          <<: *go_options
+        <<: *go_options
         script: |
           set -Eeou pipefail
-
-          export GOROOT="${go_root}"
-          export PATH="./bin:$GOROOT/bin:$PATH"
+          export PATH="$ADD_PATH:$PATH"
           go tool cover -html=coverage.out -o coverage.html
   "upload html coverage":
     - command: s3.put
@@ -109,8 +96,7 @@ functions:
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
+        <<: *go_options
         include_expansions_in_env:
           - MCLI_ORG_ID
           - MCLI_PROJECT_ID
@@ -133,12 +119,9 @@ functions:
           - AZURE_CLIENT_ID
           - AZURE_CLIENT_SECRET
           - revision
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
         env:
           MCLI_SKIP_UPDATE_CHECK: "yes"
-          XDG_CONFIG_HOME: ${workdir}
           TEST_CMD: gotestsum --junitfile e2e-tests.xml --format standard-verbose --
-          <<: *go_options
         command: make e2e-test
   "deploy spawn host":
     - command: shell.exec
@@ -195,30 +178,24 @@ functions:
     - command: subprocess.exec
       type: setup
       params:
-        add_to_path:
-          - ${go_bin}
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli/build/ci
+        <<: *go_options
         include_expansions_in_env:
           - ops_manager_service
         binary: ./set-up-ops-manager.sh
         args: ['-h', 'hosts.json']
-        env:
-          XDG_CONFIG_HOME: ${workdir}
   "set-up cloud manager":
     - command: subprocess.exec
       type: setup
       params:
+        <<: *go_options
         add_to_path:
-          - ${go_bin}
           - ../../bin
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli/build/ci
         include_expansions_in_env:
           - cloud_manager_service
           - revision
         binary: ./set-up-cloud-manager.sh
         args: ['-h', 'hosts.json']
         env:
-          XDG_CONFIG_HOME: ${workdir}
           MCLI_ORG_ID: ${cloud_manager_org_id}
           MCLI_PROJECT_ID: ${cloud_manager_project_id}
           MCLI_PRIVATE_API_KEY: ${cloud_manager_private_api_key}
@@ -229,26 +206,26 @@ functions:
     - command: shell.exec
       type: test
       params:
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
+        <<: *go_options
         script: |
           set -Eeou pipefail
-
-          export GOROOT="${go_root}"
-          export PATH="./bin:$GOROOT/bin:$PATH"
+          export PATH="$ADD_PATH:$PATH"
           golangci-lint run --out-format junit-xml > lint-tests.xml
   "install gotestsum":
     - command: shell.exec
       type: setup
       params:
+        <<: *go_options
         working_dir: src/github.com/mongodb/mongodb-atlas-cli/bin
         script: |
           set -Eeou pipefail
-
+          export PATH="$ADD_PATH:$PATH"
           curl -sfL https://github.com/gotestyourself/gotestsum/releases/download/v${gotestsum_ver}/gotestsum_${gotestsum_ver}_linux_amd64.tar.gz | tar zx
   "install golangci-lint":
     - command: subprocess.exec
       type: setup
       params:
+        <<: *go_options
         working_dir: src/github.com/mongodb/mongodb-atlas-cli
         command: make setupgolangcilint
   "install snyk":
@@ -278,28 +255,21 @@ functions:
     - command: subprocess.exec
       type: setup
       params:
-        add_to_path:
-          - ${go_bin}
-          - ../../bin
+        <<: *go_options
         working_dir: /src/github.com/mongodb/mongodb-atlas-cli/build/ci/kmip
         binary: ./install.sh
         args: ["-h", "hosts.json"]
         env:
-          XDG_CONFIG_HOME: ${workdir}
           KMIP_CA: ${logs_decrypt_kmip_ca}
           KMIP_CERT: ${logs_decrypt_kmip_cert}
 post:
   - command: subprocess.exec
     type: setup
     params:
-      add_to_path:
-        - ${go_bin}
-        - ../../bin
+      <<: *go_options
       working_dir: src/github.com/mongodb/mongodb-atlas-cli/build/ci
       binary: ./clean-up-cloud-manager.sh
       args: ['-h', 'hosts.json']
-      env:
-        XDG_CONFIG_HOME: ${workdir}
   - command: attach.xunit_results
     params:
       files: ["src/github.com/mongodb/mongodb-atlas-cli/*.xml"]

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -336,6 +336,8 @@ tasks:
       - command: shell.exec
         type: test
         params:
+          env:
+            XDG_CONFIG_HOME: ${workdir}
           script: |
             set -Eeou pipefail
             mkdir "$XDG_CONFIG_HOME/mongocli"

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -1,4 +1,10 @@
 variables:
+  - &go_env
+      XDG_CONFIG_HOME: ${workdir}
+      GO111MODULE: "on"
+      GOROOT: ${go_root}
+      GOPATH: ${workdir}
+      ADD_PATH: "${go_bin}:${workdir}/bin:${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
   - &go_options
     add_to_path:
       - ${go_bin}
@@ -8,11 +14,7 @@ variables:
       - workdir
     working_dir: src/github.com/mongodb/mongodb-atlas-cli
     env:
-      XDG_CONFIG_HOME: ${workdir}
-      GO111MODULE: "on"
-      GOROOT: ${go_root}
-      GOPATH: ${workdir}
-      ADD_PATH: "${go_bin}:${workdir}/bin:${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
+      <<: *go_env
 functions:
   "install goreleaser":
     - command: shell.exec
@@ -62,6 +64,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - workdir
           - notary_service_key_id
           - notary_service_secret
           - notary_service_url
@@ -91,11 +94,15 @@ functions:
         <<: *go_options
         working_dir: src/github.com/mongodb/mongodb-atlas-cli
         add_to_path:
+          - ${go_bin}
+          - ${workdir}/bin
+          - ${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
           - "/cygdrive/c/Program Files/go-msi"
           - "/cygdrive/c/wixtools/bin"
         include_expansions_in_env:
           - workdir
         env:
+          <<: *go_env
           TOOL_NAME: ${TOOL_NAME}
         command: bash.exe -c build/package/generate-msi.sh
   "rename pkg":
@@ -104,6 +111,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - workdir
           - unstable
           - latest_deb
           - latest_rpm
@@ -132,6 +140,7 @@ functions:
         <<: *go_options
         working_dir: src/github.com/mongodb/mongodb-atlas-cli/dist
         include_expansions_in_env:
+          - workdir
           - FEED_FILE_NAME
           - TOOL_NAME
         binary: ../build/package/generate-download-archive-manifest.sh
@@ -159,6 +168,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - workdir
           - barque_url
           - distro
           - edition
@@ -173,6 +183,7 @@ functions:
           - signing_auth_token_50
           - tool_name
         env:
+          <<: *go_env
           NOTARY_KEY_NAME: ${notary_key_name|server-4.4}
           BARQUE_USERNAME: ${barque_user}
           BARQUE_API_KEY: ${barque_api_key}
@@ -205,6 +216,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - workdir
           - tool_name
         binary: build/ci/evergreen-generate-tasks.sh
     - command: s3.put

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -286,6 +286,7 @@ tasks:
         patch_optional: true
     commands:
       - func: "clone"
+      - func: "install dev tools"
       - func: "generate notices"
       - func: "install goreleaser"
       - func: "install macos notarization service"
@@ -550,6 +551,7 @@ tasks:
         variant: "release_mongocli_msi"
     commands:
       - func: "clone"
+      - func: "install dev tools"
       - func: "generate notices"
       - func: "install goreleaser"
       - func: "install macos notarization service"
@@ -615,6 +617,7 @@ tasks:
         variant: "release_atlascli_msi"
     commands:
       - func: "clone"
+      - func: "install dev tools"
       - func: "generate notices"
       - func: "install goreleaser"
       - func: "install macos notarization service"

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -1,8 +1,18 @@
 variables:
   - &go_options
-    GO111MODULE: "on"
-    GOROOT: ${go_root}
-
+    add_to_path:
+      - ${go_bin}
+      - ${workdir}/bin
+      - ${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
+    include_expansions_in_env:
+      - workdir
+    working_dir: src/github.com/mongodb/mongodb-atlas-cli
+    env:
+      XDG_CONFIG_HOME: ${workdir}
+      GO111MODULE: "on"
+      GOROOT: ${go_root}
+      GOPATH: ${workdir}
+      ADD_PATH: "${go_bin}:${workdir}/bin:${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
 functions:
   "install goreleaser":
     - command: shell.exec
@@ -38,33 +48,19 @@ functions:
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        include_expansions_in_env:
-          - workdir
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        env:
-          <<: *go_options
+        <<: *go_options
         binary: build/ci/check-licenses.sh
   "generate notices":
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        include_expansions_in_env:
-          - workdir
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        env:
-          <<: *go_options
+        <<: *go_options
         binary: build/package/generate-notices.sh
   "package":
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
+        <<: *go_options
         include_expansions_in_env:
           - notary_service_key_id
           - notary_service_secret
@@ -75,8 +71,6 @@ functions:
           - changelog_file
           - github_token
           - unstable
-        env:
-          <<: *go_options
         binary: build/package/package.sh
   "install go-msi":
     - command: subprocess.exec
@@ -94,23 +88,21 @@ functions:
     - command: subprocess.exec
       type: test
       params:
+        <<: *go_options
         working_dir: src/github.com/mongodb/mongodb-atlas-cli
         add_to_path:
-          - ${go_bin}
           - "/cygdrive/c/Program Files/go-msi"
           - "/cygdrive/c/wixtools/bin"
         include_expansions_in_env:
           - workdir
         env:
-          <<: *go_options
           TOOL_NAME: ${TOOL_NAME}
         command: bash.exe -c build/package/generate-msi.sh
   "rename pkg":
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
+        <<: *go_options
         include_expansions_in_env:
           - unstable
           - latest_deb
@@ -118,9 +110,6 @@ functions:
           - package_name
           - meta_package_name
           - tool_name
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        env:
-          <<: *go_options
         binary: build/package/rename-pkg.sh
   "send slack notification":
     - command: subprocess.exec
@@ -140,14 +129,11 @@ functions:
     - command: subprocess.exec
       type: test
       params:
+        <<: *go_options
         working_dir: src/github.com/mongodb/mongodb-atlas-cli/dist
         include_expansions_in_env:
           - FEED_FILE_NAME
           - TOOL_NAME
-        add_to_path:
-          - ${go_bin}
-        env:
-          <<: *go_options
         binary: ../build/package/generate-download-archive-manifest.sh
   "upload dist":
     - command: s3.put
@@ -171,6 +157,7 @@ functions:
     - command: subprocess.exec
       type: test
       params:
+        <<: *go_options
         include_expansions_in_env:
           - barque_url
           - distro
@@ -185,11 +172,7 @@ functions:
           - signing_auth_token_46
           - signing_auth_token_50
           - tool_name
-        add_to_path:
-          - ./bin
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
         env:
-          <<: *go_options
           NOTARY_KEY_NAME: ${notary_key_name|server-4.4}
           BARQUE_USERNAME: ${barque_user}
           BARQUE_API_KEY: ${barque_api_key}
@@ -220,14 +203,9 @@ functions:
     - command: subprocess.exec
       type: test
       params:
-        add_to_path:
-          - ${go_bin}
+        <<: *go_options
         include_expansions_in_env:
           - tool_name
-          - workdir
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        env:
-          <<: *go_options
         binary: build/ci/evergreen-generate-tasks.sh
     - command: s3.put
       params:

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -1,16 +1,17 @@
 variables:
   - &go_env
-      XDG_CONFIG_HOME: ${workdir}
+      XDG_CONFIG_HOME: ${go_base_path}${workdir}
       GO111MODULE: "on"
       GOROOT: ${go_root}
-      GOPATH: ${workdir}
-      ADD_PATH: "${go_bin}:${workdir}/bin:${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
+      GOPATH: ${go_base_path}${workdir}
+      ADD_PATH: "${go_bin}:${go_base_path}${workdir}/bin:${go_base_path}${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin"
   - &go_options
     add_to_path:
       - ${go_bin}
-      - ${workdir}/bin
-      - ${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
+      - ${go_base_path}${workdir}/bin
+      - ${go_base_path}${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
     include_expansions_in_env:
+      - go_base_path
       - workdir
     working_dir: src/github.com/mongodb/mongodb-atlas-cli
     env:
@@ -64,6 +65,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - go_base_path
           - workdir
           - notary_service_key_id
           - notary_service_secret
@@ -95,11 +97,12 @@ functions:
         working_dir: src/github.com/mongodb/mongodb-atlas-cli
         add_to_path:
           - ${go_bin}
-          - ${workdir}/bin
-          - ${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
+          - ${go_base_path}${workdir}/bin
+          - ${go_base_path}${workdir}/src/github.com/mongodb/mongodb-atlas-cli/bin
           - "/cygdrive/c/Program Files/go-msi"
           - "/cygdrive/c/wixtools/bin"
         include_expansions_in_env:
+          - go_base_path
           - workdir
         env:
           <<: *go_env
@@ -111,6 +114,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - go_base_path
           - workdir
           - unstable
           - latest_deb
@@ -140,6 +144,7 @@ functions:
         <<: *go_options
         working_dir: src/github.com/mongodb/mongodb-atlas-cli/dist
         include_expansions_in_env:
+          - go_base_path
           - workdir
           - FEED_FILE_NAME
           - TOOL_NAME
@@ -168,6 +173,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - go_base_path
           - workdir
           - barque_url
           - distro
@@ -216,6 +222,7 @@ functions:
       params:
         <<: *go_options
         include_expansions_in_env:
+          - go_base_path
           - workdir
           - tool_name
         binary: build/ci/evergreen-generate-tasks.sh
@@ -1368,6 +1375,7 @@ buildvariants:
     expansions:
       go_root: "c:\\golang\\go1.18"
       go_bin: "c:\\golang\\go1.18/bin"
+      go_base_path: "c:"
       tool_name: "mongocli"
     tasks:
       - name: package_msi
@@ -1378,6 +1386,7 @@ buildvariants:
     expansions:
       go_root: "c:\\golang\\go1.18"
       go_bin: "c:\\golang\\go1.18/bin"
+      go_base_path: "c:"
       tool_name: "atlascli"
     tasks:
       - name: package_msi
@@ -1388,6 +1397,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
       server_version: "4.4.0-rc3"
       goreleaser_file: "build/package/.mongocli.goreleaser.yml"
       package_name: "mongocli"
@@ -1401,6 +1411,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
       server_version: "4.4.0-rc3"
       goreleaser_file: "build/package/.atlascli.goreleaser.yml"
       package_name: "mongodb-atlas-cli"
@@ -1415,6 +1426,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
       server_version: "4.4.0-rc3"
     tasks:
       - name: .push
@@ -1427,6 +1439,7 @@ buildvariants:
     expansions:
       go_root: "c:\\golang\\go1.18"
       go_bin: "c:\\golang\\go1.18/bin"
+      go_base_path: "c:"
       tool_name: "mongocli"
     tasks:
       - name: release_msi
@@ -1437,6 +1450,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: release_mongocli
   - name: release_atlascli_github
@@ -1446,6 +1460,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     tasks:
       - name: release_atlascli
   - name: release_atlascli_msi
@@ -1455,6 +1470,7 @@ buildvariants:
     expansions:
       go_root: "c:\\golang\\go1.18"
       go_bin: "c:\\golang\\go1.18/bin"
+      go_base_path: "c:"
       tool_name: "atlascli"
     tasks:
       - name: release_msi
@@ -1527,6 +1543,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     run_on:
       - ubuntu1804-small
     tasks:
@@ -1536,6 +1553,7 @@ buildvariants:
     expansions:
       go_root: "/opt/golang/go1.18"
       go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
     run_on:
       - ubuntu1804-small
     tasks:

--- a/build/package/generate-notices.sh
+++ b/build/package/generate-notices.sh
@@ -17,9 +17,6 @@
 
 set -Eeou pipefail
 
-export GOPATH="${workdir:?}"
-export PATH="$GOPATH/bin:$PATH"
-
 go install github.com/google/go-licenses@latest
 
 go-licenses save "github.com/mongodb/mongodb-atlas-cli/cmd/mongocli" --save_path=third_party_notices

--- a/build/package/generate-notices.sh
+++ b/build/package/generate-notices.sh
@@ -17,8 +17,6 @@
 
 set -Eeou pipefail
 
-go install github.com/google/go-licenses@latest
-
 go-licenses save "github.com/mongodb/mongodb-atlas-cli/cmd/mongocli" --save_path=third_party_notices
 # For HCL, a dependency of viper, go-license adds the source code with restricted permissions, this is a problem for some linux users
 sudo chmod -R 755 ./third_party_notices


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

golangci-lint isn't properly installed by Makefile, this PR changes the install location to be `$GOPATH/bin` instead of `/path/to/mongodb-atlas-cli/bin` and adds it to `$PATH` when running commands.

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-126655

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
This PR changes:

- the installation directory of golangci-lint to be in GOPATH (`go env GOPATH`) which makes it globally available
- added missing tool into `make setup` (`github.com/google/go-licenses`)
- made GOPATH consistent across all tasks in evergreen