### PR TITLE
CLOUDP-127992: Add exponential backoff when watching a cluster

### DIFF
--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -46,7 +46,6 @@ func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 func (opts *WatchOpts) watcher() (bool, error) {
 	result, err := opts.store.AtlasCluster(opts.ConfigProjectID(), opts.name)
 	if opts.previousStatus == "UPDATING" && err != nil {
-		fmt.Println(err.Error())
 		return false, &cli.UpdateError{ErrorCode: "CLUSTER_NOT_FOUND_DURING_UPDATE"}
 	}
 	if err != nil {

--- a/internal/cli/watch_opts.go
+++ b/internal/cli/watch_opts.go
@@ -69,7 +69,7 @@ func (opts *WatchOpts) exponentialBackoff(err error) bool {
 	backoffTimes := []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
 	var atlasErr *atlas.ErrorResponse
 	errorCode := "CLUSTER_NOT_FOUND"
-	if opts.n < 3 && errors.As(err, &atlasErr) && atlasErr.ErrorCode == errorCode {
+	if opts.n < len(backoffTimes) && errors.As(err, &atlasErr) && atlasErr.ErrorCode == errorCode {
 		time.Sleep(backoffTimes[opts.n])
 		opts.n++
 		return true


### PR DESCRIPTION
## Proposed changes

Adds exponential backoff when watching a cluster to avoid a problem when the cluster becomes unavailable for a few seconds during the upgrade process. It happens because the upgrade endpoint logic is as follows:

1. find a cluster to upgrade
2. copy all the data to a new cluster
3. delete the old cluster
4. rename the new cluster

Between steps 3 and 4, there are a few seconds when the cluster with the name that we're watching for is not available. This PR fixes this issue by waiting exponentially to check if the upgrade process is still in progress.

**Important**: This feature will only allow the `watch` command to recover from 404 for up to 7 seconds. If it takes longer for the server to respond, the command needs to be re-run. 

_Jira ticket:_ [CLOUDP-127992](https://jira.mongodb.org/browse/CLOUDP-127992)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code