### PR TITLE
CLOUDP-115072: Adds new select component for fetching options via network

### DIFF
--- a/internal/surveyprompts/select.go
+++ b/internal/surveyprompts/select.go
@@ -1,0 +1,396 @@
+package surveyprompts
+
+import (
+	"errors"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/AlecAivazis/survey/v2/terminal"
+)
+
+// code adapted from https://github.com/AlecAivazis/survey/blob/v2.3.5/select.go
+
+/*
+Select is a prompt that presents a list of various options to the user
+for them to select using the arrow keys and enter. Response type is a string.
+
+	color := ""
+	prompt := &survey.Select{
+		Message: "Choose a color:",
+		Options: []string{"red", "blue", "green"},
+	}
+	survey.AskOne(prompt, &color)
+*/
+type Select struct {
+	survey.Renderer
+	Message       string
+	Options       []string
+	Default       interface{}
+	Help          string
+	PageSize      int
+	VimMode       bool
+	FilterMessage string
+	Filter        func(filter string, value string, index int) bool
+	Description   func(value string, index int) string
+	filter        string
+	selectedIndex int
+	useDefault    bool
+	showingHelp   bool
+}
+
+// SelectTemplateData is the data available to the templates when processing
+type SelectTemplateData struct {
+	Select
+	PageEntries   []core.OptionAnswer
+	SelectedIndex int
+	Answer        string
+	ShowAnswer    bool
+	ShowHelp      bool
+	Description   func(value string, index int) string
+	Config        *survey.PromptConfig
+
+	// These fields are used when rendering an individual option
+	CurrentOpt   core.OptionAnswer
+	CurrentIndex int
+}
+
+// IterateOption sets CurrentOpt and CurrentIndex appropriately so a select option can be rendered individually
+func (s SelectTemplateData) IterateOption(ix int, opt core.OptionAnswer) interface{} {
+	copy := s
+	copy.CurrentIndex = ix
+	copy.CurrentOpt = opt
+	return copy
+}
+
+func (s SelectTemplateData) GetDescription(opt core.OptionAnswer) string {
+	if s.Description == nil {
+		return ""
+	}
+	return s.Description(opt.Value, opt.Index)
+}
+
+var SelectQuestionTemplate = `
+{{- define "option"}}
+    {{- if eq .SelectedIndex .CurrentIndex }}{{color .Config.Icons.SelectFocus.Format }}{{ .Config.Icons.SelectFocus.Text }} {{else}}{{color "default"}}  {{end}}
+    {{- .CurrentOpt.Value}}{{ if ne ($.GetDescription .CurrentOpt) "" }} - {{color "cyan"}}{{ $.GetDescription .CurrentOpt }}{{end}}
+    {{- color "reset"}}
+{{end}}
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
+{{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else}}
+  {{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
+  {{- "\n"}}
+  {{- range $ix, $option := .PageEntries}}
+    {{- template "option" $.IterateOption $ix $option}}
+  {{- end}}
+{{- end}}`
+
+// OnChange is called on every keypress.
+func (s *Select) OnChange(key rune, config *survey.PromptConfig) bool {
+	options := s.filterOptions(config)
+	oldFilter := s.filter
+
+	// if the user pressed the enter key and the index is a valid option
+	if key == terminal.KeyEnter || key == '\n' {
+		// if the selected index is a valid option
+		if len(options) > 0 && s.selectedIndex < len(options) {
+
+			// we're done (stop prompting the user)
+			return true
+		}
+
+		// we're not done (keep prompting)
+		return false
+
+		// if the user pressed the up arrow or 'k' to emulate vim
+	} else if (key == terminal.KeyArrowUp || (s.VimMode && key == 'k')) && len(options) > 0 {
+		s.useDefault = false
+
+		// if we are at the top of the list
+		if s.selectedIndex == 0 {
+			// start from the button
+			s.selectedIndex = len(options) - 1
+		} else {
+			// otherwise we are not at the top of the list so decrement the selected index
+			s.selectedIndex--
+		}
+
+		// if the user pressed down or 'j' to emulate vim
+	} else if (key == terminal.KeyTab || key == terminal.KeyArrowDown || (s.VimMode && key == 'j')) && len(options) > 0 {
+		s.useDefault = false
+		// if we are at the bottom of the list
+		if s.selectedIndex == len(options)-1 {
+			// start from the top
+			s.selectedIndex = 0
+		} else {
+			// increment the selected index
+			s.selectedIndex++
+		}
+		// only show the help message if we have one
+	} else if string(key) == config.HelpInput && s.Help != "" {
+		s.showingHelp = true
+		// if the user wants to toggle vim mode on/off
+	} else if key == terminal.KeyEscape {
+		s.VimMode = !s.VimMode
+		// if the user hits any of the keys that clear the filter
+	} else if key == terminal.KeyDeleteWord || key == terminal.KeyDeleteLine {
+		s.filter = ""
+		// if the user is deleting a character in the filter
+	} else if key == terminal.KeyDelete || key == terminal.KeyBackspace {
+		// if there is content in the filter to delete
+		if s.filter != "" {
+			runeFilter := []rune(s.filter)
+			// subtract a line from the current filter
+			s.filter = string(runeFilter[0 : len(runeFilter)-1])
+			// we removed the last value in the filter
+		}
+	} else if key >= terminal.KeySpace {
+		s.filter += string(key)
+		// make sure vim mode is disabled
+		s.VimMode = false
+		// make sure that we use the current value in the filtered list
+		s.useDefault = false
+	}
+
+	s.FilterMessage = ""
+	if s.filter != "" {
+		s.FilterMessage = " " + s.filter
+	}
+	if oldFilter != s.filter {
+		// filter changed
+		options = s.filterOptions(config)
+		if len(options) > 0 && len(options) <= s.selectedIndex {
+			s.selectedIndex = len(options) - 1
+		}
+	}
+
+	// figure out the options and index to render
+	// figure out the page size
+	pageSize := s.PageSize
+	// if we dont have a specific one
+	if pageSize == 0 {
+		// grab the global value
+		pageSize = config.PageSize
+	}
+
+	// TODO if we have started filtering and were looking at the end of a list
+	// and we have modified the filter then we should move the page back!
+	opts, idx := paginate(pageSize, options, s.selectedIndex)
+
+	tmplData := SelectTemplateData{
+		Select:        *s,
+		SelectedIndex: idx,
+		ShowHelp:      s.showingHelp,
+		Description:   s.Description,
+		PageEntries:   opts,
+		Config:        config,
+	}
+
+	// render the options
+	_ = s.RenderWithCursorOffset(SelectQuestionTemplate, tmplData, opts, idx)
+
+	// keep prompting
+	return false
+}
+
+func (s *Select) filterOptions(config *PromptConfig) []core.OptionAnswer {
+	// the filtered list
+	answers := []core.OptionAnswer{}
+
+	// if there is no filter applied
+	if s.filter == "" {
+		return core.OptionAnswerList(s.Options)
+	}
+
+	// the filter to apply
+	filter := s.Filter
+	if filter == nil {
+		filter = config.Filter
+	}
+
+	//
+	for i, opt := range s.Options {
+		// i the filter says to include the option
+		if filter(s.filter, opt, i) {
+			answers = append(answers, core.OptionAnswer{
+				Index: i,
+				Value: opt,
+			})
+		}
+	}
+
+	// return the list of answers
+	return answers
+}
+
+func (s *Select) Prompt(config *PromptConfig) (interface{}, error) {
+	// if there are no options to render
+	if len(s.Options) == 0 {
+		// we failed
+		return "", errors.New("please provide options to select from")
+	}
+
+	// start off with the first option selected
+	sel := 0
+	// if there is a default
+	if s.Default != "" {
+		// find the choice
+		for i, opt := range s.Options {
+			// if the option corresponds to the default
+			if opt == s.Default {
+				// we found our initial value
+				sel = i
+				// stop looking
+				break
+			}
+		}
+	}
+	// save the selected index
+	s.selectedIndex = sel
+
+	// figure out the page size
+	pageSize := s.PageSize
+	// if we dont have a specific one
+	if pageSize == 0 {
+		// grab the global value
+		pageSize = config.PageSize
+	}
+
+	// figure out the options and index to render
+	opts, idx := paginate(pageSize, core.OptionAnswerList(s.Options), sel)
+
+	cursor := s.NewCursor()
+	cursor.Save()          // for proper cursor placement during selection
+	cursor.Hide()          // hide the cursor
+	defer cursor.Show()    // show the cursor when we're done
+	defer cursor.Restore() // clear any accessibility offsetting on exit
+
+	tmplData := SelectTemplateData{
+		Select:        *s,
+		SelectedIndex: idx,
+		Description:   s.Description,
+		ShowHelp:      s.showingHelp,
+		PageEntries:   opts,
+		Config:        config,
+	}
+
+	// ask the question
+	err := s.RenderWithCursorOffset(SelectQuestionTemplate, tmplData, opts, idx)
+	if err != nil {
+		return "", err
+	}
+
+	// by default, use the default value
+	s.useDefault = true
+
+	rr := s.NewRuneReader()
+	_ = rr.SetTermMode()
+	defer func() {
+		_ = rr.RestoreTermMode()
+	}()
+
+	// start waiting for input
+	for {
+		r, _, err := rr.ReadRune()
+		if err != nil {
+			return "", err
+		}
+		if r == terminal.KeyInterrupt {
+			return "", terminal.InterruptErr
+		}
+		if r == terminal.KeyEndTransmission {
+			break
+		}
+		if s.OnChange(r, config) {
+			break
+		}
+	}
+	options := s.filterOptions(config)
+	s.filter = ""
+	s.FilterMessage = ""
+
+	// the index to report
+	var val string
+	// if we are supposed to use the default value
+	if s.useDefault || s.selectedIndex >= len(options) {
+		// if there is a default value
+		if s.Default != nil {
+			// if the default is a string
+			if defaultString, ok := s.Default.(string); ok {
+				// use the default value
+				val = defaultString
+				// the default value could also be an interpret which is interpretted as the index
+			} else if defaultIndex, ok := s.Default.(int); ok {
+				val = s.Options[defaultIndex]
+			} else {
+				return val, errors.New("default value of select must be an int or string")
+			}
+		} else if len(options) > 0 {
+			// there is no default value so use the first
+			val = options[0].Value
+		}
+		// otherwise the selected index points to the value
+	} else if s.selectedIndex < len(options) {
+		// the
+		val = options[s.selectedIndex].Value
+	}
+
+	// now that we have the value lets go hunt down the right index to return
+	idx = -1
+	for i, optionValue := range s.Options {
+		if optionValue == val {
+			idx = i
+		}
+	}
+
+	return core.OptionAnswer{Value: val, Index: idx}, err
+}
+
+func (s *Select) Cleanup(config *PromptConfig, val interface{}) error {
+	cursor := s.NewCursor()
+	cursor.Restore()
+	return s.Render(
+		SelectQuestionTemplate,
+		SelectTemplateData{
+			Select:      *s,
+			Answer:      val.(core.OptionAnswer).Value,
+			ShowAnswer:  true,
+			Description: s.Description,
+			Config:      config,
+		},
+	)
+}
+
+func paginate(pageSize int, choices []core.OptionAnswer, sel int) ([]core.OptionAnswer, int) {
+	var start, end, cursor int
+
+	if len(choices) < pageSize {
+		// if we dont have enough options to fill a page
+		start = 0
+		end = len(choices)
+		cursor = sel
+	} else if sel < pageSize/2 {
+		// if we are in the first half page
+		start = 0
+		end = pageSize
+		cursor = sel
+	} else if len(choices)-sel-1 < pageSize/2 {
+		// if we are in the last half page
+		start = len(choices) - pageSize
+		end = len(choices)
+		cursor = sel - start
+	} else {
+		// somewhere in the middle
+		above := pageSize / 2
+		below := pageSize - above
+
+		cursor = pageSize / 2
+		start = sel - above
+		end = sel + below
+	}
+
+	// return the subset we care about and the index
+	return choices[start:end], cursor
+}

--- a/internal/surveyprompts/select_network.go
+++ b/internal/surveyprompts/select_network.go
@@ -220,36 +220,6 @@ func (s *SelectNetwork) OnChange(key rune, config *survey.PromptConfig) (bool, e
 	return false, nil
 }
 
-func (s *SelectNetwork) filterOptions(config *survey.PromptConfig) []core.OptionAnswer {
-	// the filtered list
-	answers := []core.OptionAnswer{}
-
-	// if there is no filter applied
-	if s.filter == "" {
-		return core.OptionAnswerList(s.currentOptions)
-	}
-
-	// the filter to apply
-	filter := s.Filter
-	if filter == nil {
-		filter = config.Filter
-	}
-
-	//
-	for i, opt := range s.currentOptions {
-		// i the filter says to include the option
-		if filter(s.filter, opt, i) {
-			answers = append(answers, core.OptionAnswer{
-				Index: i,
-				Value: opt,
-			})
-		}
-	}
-
-	// return the list of answers
-	return answers
-}
-
 func (s *SelectNetwork) findSelectedIndex() (int, error) {
 	if s.Default == "" || s.Default == nil {
 		if err := s.loadNextPage(); err != nil { // load the first page
@@ -349,7 +319,7 @@ func (s *SelectNetwork) Prompt(config *survey.PromptConfig) (interface{}, error)
 			break
 		}
 	}
-	options := s.filterOptions(config)
+	options := core.OptionAnswerList(s.currentOptions)
 	s.filter = ""
 	s.FilterMessage = ""
 

--- a/internal/telemetry/tracker.go
+++ b/internal/telemetry/tracker.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/log"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
+	"github.com/mongodb/mongodb-atlas-cli/internal/surveyprompts"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -234,6 +235,8 @@ func (t *tracker) trackSurvey(p survey.Prompt, response interface{}, e error) er
 	case *survey.Password:
 		options = append(options, withPrompt(v.Message, "password"), withEmpty(castString(response) == ""))
 	case *survey.Select:
+		options = append(options, withPrompt(v.Message, "select"), withDefault(castString(response) == v.Default), withEmpty(castString(response) == ""), withChoice(castString(response)))
+	case *surveyprompts.SelectNetwork:
 		options = append(options, withPrompt(v.Message, "select"), withDefault(castString(response) == v.Default), withEmpty(castString(response) == ""), withChoice(castString(response)))
 	default:
 		return errors.New("unknown survey prompt")


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

This is the first of a few PRs to improve onboarding experience of MongoDB Employees into Atlas CLI

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-115072

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

### Preview

https://user-images.githubusercontent.com/1765216/181204961-5adf0051-5d6c-4486-9e88-852ab5a3a247.mov

### Caveats
If this PR gets merged the following must be considered:
- [survey](https://github.com/AlecAivazis/survey) package upgrades might impact us more given we follow internal practices of components now (things like `github.com/AlecAivazis/survey/v2/core` and `github.com/AlecAivazis/survey/v2/terminal` have been introduced and used)
- code is adapted from the original [Select](https://github.com/AlecAivazis/survey/blob/master/select.go) once Select prompt gets new features we won't
- look and feel is not perfect, work over time might be required to make it look nicer
- currently all Selects are type to filter, this new one is type + press <ENTER> to filter (difference in UX)
- unit tests could not be adapted from original at [here](https://github.com/AlecAivazis/survey/blob/v2.3.5/select_test.go) given the tests are dependent on internal data like `defaultIcons()` and `defaultPromptConfig()`

### Reviewing this PR
First commit is a copy/paste from https://github.com/AlecAivazis/survey/blob/v2.3.5/select.go subsequent commits are adapting original code to our needs.

In this case the purpose is to be able to fetch data from network.

### Steps to test this PR

- Write file `internal/cli/testcmd/cmd.go`
```go
package testcmd

import (
	"context"
	"fmt"
	"strings"
	"time"

	"github.com/AlecAivazis/survey/v2"
	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
	"github.com/mongodb/mongodb-atlas-cli/internal/config"
	"github.com/mongodb/mongodb-atlas-cli/internal/store"
	"github.com/mongodb/mongodb-atlas-cli/internal/surveyprompts"
	"github.com/spf13/cobra"
)

type testOpts struct {
	cli.GlobalOpts
	store store.OrganizationLister
}

func (opts *testOpts) initStore(ctx context.Context) func() error {
	return func() error {
		var err error
		opts.store, err = store.New(store.AuthenticatedPreset(config.Default()), store.WithContext(ctx))
		return err
	}
}

func (opts *testOpts) Run() error {
	fmt.Println("test command")

	var choice string

	pageSize := 7
	options := []string{}
	for page := 0; page < 5; page++ {
		j := pageSize
		if page == 4 {
			j -= 5
		}
		for i := 0; i < j; i++ {
			options = append(options, fmt.Sprintf("Option %v-%v", page, i))
		}
	}

	filteredOptions := func(filter string) []string {
		if filter == "" {
			return options
		}

		results := []string{}

		for _, option := range options {
			if strings.HasPrefix(option, filter) {
				results = append(results, option)
			}
		}

		return results
	}

	if err := survey.AskOne(&surveyprompts.SelectNetwork{
		Message: "Select an option:",
		Options: func(filter string, page int) ([]string, int, error) {
			time.Sleep(3 * time.Second)
			opt := filteredOptions(filter)
			l := len(opt)

			initial := pageSize * page
			final := initial + pageSize
			if final > l {
				final = l
			}
			return opt[initial:final], l, nil
		},
		PageSize: pageSize,
		Description: func(value string, index int) string {
			return fmt.Sprintf("Option %v \"%v\"", index, value)
		},
	}, &choice); err != nil {
		return err
	}

	fmt.Println("You selected:", choice)

	return nil
}

func Builder() *cobra.Command {
	opts := &testOpts{}

	cmd := &cobra.Command{
		Use:    "test",
		Hidden: true,
		Args:   require.NoArgs,
		PreRunE: func(cmd *cobra.Command, args []string) error {
			return opts.PreRunE(
				opts.ValidateProjectID,
				opts.initStore(cmd.Context()),
			)
		},
		RunE: func(cmd *cobra.Command, args []string) error {
			return opts.Run()
		},
	}

	return cmd
}
```
- Update `internal/cli/root/atlas/builder.go`
```diff
--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -56,6 +56,7 @@ import (
        "github.com/mongodb/mongodb-atlas-cli/internal/cli/iam/teams"
        "github.com/mongodb/mongodb-atlas-cli/internal/cli/iam/users"
        "github.com/mongodb/mongodb-atlas-cli/internal/cli/performanceadvisor"
+       "github.com/mongodb/mongodb-atlas-cli/internal/cli/testcmd"
        "github.com/mongodb/mongodb-atlas-cli/internal/config"
        "github.com/mongodb/mongodb-atlas-cli/internal/flag"
        "github.com/mongodb/mongodb-atlas-cli/internal/homebrew"
@@ -215,6 +216,7 @@ func Builder() *cobra.Command {
                whoCmd,
                registerCmd,
                figautocomplete.Builder(),
+               testcmd.Builder(),
        )
 
        rootCmd.PersistentFlags().StringVarP(&profile, flag.Profile, flag.ProfileShort, "", usage.Profile)
```

- `make build-atlascli`
- `atlas test -P [profile]`