### PR TITLE
CLOUDP-131035: Add e2e test for "atlas backup exports buckets" commands

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1250,7 +1250,7 @@ tasks:
           E2E_TAGS: atlas,decrypt
   # export buckets require cloud provider role authentication and a s3 bucket created
   - name: atlas_backups_export_buckets_e2e
-    tags: [ "e2e","buckets","atlas" ]
+    tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
     depends_on:
       - name: compile
@@ -1269,6 +1269,7 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,buckets
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
+          E2E_TEST_BUCKET: ${e2e_test_bucket}
 buildvariants:
   - name: code_health
     display_name: "Code Health"
@@ -1370,8 +1371,8 @@ buildvariants:
       go_base_path: ""
     tasks:
       - name: ".e2e .datalake .atlas"
-  - name: e2e_atlas_backups_export_buckets
-    display_name: "E2E Atlas Backups Tests"
+  - name: e2e_atlas_backups
+    display_name: "E2E Atlas Backup Tests"
     run_on:
       - rhel80-small
     expansions:
@@ -1379,7 +1380,7 @@ buildvariants:
       go_bin: "/opt/golang/go1.18/bin"
       go_base_path: ""
     tasks:
-      - name: ".e2e .buckets .atlas"
+      - name: ".e2e .backup .atlas"
   - name: e2e_cloud_manager_remote
     display_name: "E2E Cloud Manager Remote Host Tests"
     run_on:

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1249,7 +1249,7 @@ tasks:
           AZURE_CLIENT_SECRET: ${logs_decrypt_azure_client_secret}
           E2E_TAGS: atlas,decrypt
   # export buckets require cloud provider role authentication and a s3 bucket created
-  - name: atlas_backups_export_buckets_e2e
+  - name: atlas_backups_e2e
     tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
     depends_on:
@@ -1267,7 +1267,7 @@ tasks:
           MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,buckets
+          E2E_TAGS: atlas,backup
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
 buildvariants:

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1248,6 +1248,27 @@ tasks:
           AZURE_CLIENT_ID: ${logs_decrypt_azure_client_id}
           AZURE_CLIENT_SECRET: ${logs_decrypt_azure_client_secret}
           E2E_TAGS: atlas,decrypt
+  # datalake requires cloud provider role authentication and an s3 bucket created
+  - name: atlas_backups_export_buckets_e2e
+    tags: [ "e2e","buckets","atlas" ]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "clone"
+      - func: "install gotestsum"
+      - func: "e2e test"
+        vars:
+          MCLI_ORG_ID: ${atlas_org_id}
+          MCLI_PROJECT_ID: ${atlas_project_id}
+          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MCLI_SERVICE: cloud
+          E2E_TAGS: atlas,buckets
+          E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
 buildvariants:
   - name: code_health
     display_name: "Code Health"
@@ -1349,6 +1370,16 @@ buildvariants:
       go_base_path: ""
     tasks:
       - name: ".e2e .datalake .atlas"
+  - name: e2e_atlas_backups_export_buckets
+    display_name: "E2E Atlas Backups Tests"
+    run_on:
+      - rhel80-small
+    expansions:
+      go_root: "/opt/golang/go1.18"
+      go_bin: "/opt/golang/go1.18/bin"
+      go_base_path: ""
+    tasks:
+      - name: ".e2e .buckets .atlas"
   - name: e2e_cloud_manager_remote
     display_name: "E2E Cloud Manager Remote Host Tests"
     run_on:

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1248,7 +1248,7 @@ tasks:
           AZURE_CLIENT_ID: ${logs_decrypt_azure_client_id}
           AZURE_CLIENT_SECRET: ${logs_decrypt_azure_client_secret}
           E2E_TAGS: atlas,decrypt
-  # datalake requires cloud provider role authentication and an s3 bucket created
+  # export buckets require cloud provider role authentication and a s3 bucket created
   - name: atlas_backups_export_buckets_e2e
     tags: [ "e2e","buckets","atlas" ]
     must_have_test_results: true

--- a/test/e2e/atlas/backup_export_buckets_test.go
+++ b/test/e2e/atlas/backup_export_buckets_test.go
@@ -35,8 +35,9 @@ func TestExportBuckets(t *testing.T) {
 	const cloudProvider = "AWS"
 	iamRoleID := os.Getenv("E2E_CLOUD_ROLE_ID")
 	bucketName := os.Getenv("E2E_TEST_BUCKET")
-	var bucketID string
 	r.NotEmpty(iamRoleID)
+	r.NotEmpty(bucketName)
+	var bucketID string
 
 	t.Run("Create", func(t *testing.T) {
 		cmd := exec.Command(cliPath,

--- a/test/e2e/atlas/backup_export_buckets_test.go
+++ b/test/e2e/atlas/backup_export_buckets_test.go
@@ -1,0 +1,120 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build e2e || (atlas && buckets)
+
+package atlas_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	atlas "go.mongodb.org/atlas/mongodbatlas"
+	exec "golang.org/x/sys/execabs"
+)
+
+func TestExportBuckets(t *testing.T) {
+	cliPath, err := e2e.AtlasCLIBin()
+	r := require.New(t)
+	r.NoError(err)
+
+	const cloudProvider = "AWS"
+	iamRoleID := os.Getenv("E2E_CLOUD_ROLE_ID")
+	bucketName := os.Getenv("E2E_TEST_BUCKET")
+	var bucketID string
+	r.NotEmpty(iamRoleID)
+
+	t.Run("Create", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			exportsEntity,
+			bucketsEntity,
+			"create",
+			bucketName,
+			"--cloudProvider",
+			cloudProvider,
+			"--iamRoleId",
+			iamRoleID,
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+
+		r.NoError(err, string(resp))
+
+		a := assert.New(t)
+		var exportBucket atlas.CloudProviderSnapshotExportBucket
+		if err = json.Unmarshal(resp, &exportBucket); a.NoError(err) {
+			a.Equal(bucketName, exportBucket.BucketName)
+		}
+		bucketID = exportBucket.ID
+	})
+
+	t.Run("List", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			exportsEntity,
+			bucketsEntity,
+			"list",
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+
+		r.NoError(err, string(resp))
+
+		var r atlas.CloudProviderSnapshotExportBuckets
+		a := assert.New(t)
+		if err = json.Unmarshal(resp, &r); a.NoError(err) {
+			a.NotEmpty(r)
+		}
+	})
+
+	t.Run("Describe", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			exportsEntity,
+			bucketsEntity,
+			"describe",
+			"--bucketId",
+			bucketID,
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+
+		r.NoError(err, string(resp))
+
+		a := assert.New(t)
+		var exportBucket atlas.CloudProviderSnapshotExportBucket
+		if err = json.Unmarshal(resp, &exportBucket); a.NoError(err) {
+			a.Equal(bucketName, exportBucket.BucketName)
+		}
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			exportsEntity,
+			bucketsEntity,
+			"delete",
+			"--bucketId",
+			bucketID,
+			"--force")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+
+		r.NoError(err, string(resp))
+	})
+}

--- a/test/e2e/atlas/backup_test.go
+++ b/test/e2e/atlas/backup_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (atlas && buckets)
+//go:build e2e || (atlas && backup)
 
 package atlas_test
 

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -75,6 +75,9 @@ const (
 	diskSizeGB30                 = "30"
 	projectsEntity               = "projects"
 	settingsEntity               = "settings"
+	backupsEntity                = "backups"
+	exportsEntity                = "exports"
+	bucketsEntity                = "buckets"
 )
 
 // Cluster settings.


### PR DESCRIPTION
## Proposed changes

Adds e2e test for "atlas backup exports buckets" command.

_Jira ticket:_ [CLOUDP-131035](https://jira.mongodb.org/browse/CLOUDP-131035)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code