### PR TITLE
CLOUDP-132456: MongoCLI pagination for endpoint starts with 1 by default

### DIFF
--- a/docs/mongocli/command/mongocli-ops-manager-serverUsage-organizations-hosts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-serverUsage-organizations-hosts-list.txt
@@ -57,7 +57,7 @@ Options
    * - --page
      - int
      - false
-     - Page number. This value defaults to 1.
+     - Page number.
    * - --startDate
      - string
      - true

--- a/docs/mongocli/command/mongocli-ops-manager-serverUsage-projects-hosts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-serverUsage-projects-hosts-list.txt
@@ -53,7 +53,7 @@ Options
    * - --page
      - int
      - false
-     - Page number. This value defaults to 1.
+     - Page number.
    * - --projectId
      - string
      - false

--- a/internal/cli/opsmanager/serverusage/organizations/hosts/list.go
+++ b/internal/cli/opsmanager/serverusage/organizations/hosts/list.go
@@ -88,7 +88,7 @@ func ListBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.startDate, flag.StartDate, "", usage.ServerUsageStartDate)
 	cmd.Flags().StringVar(&opts.endDate, flag.EndDate, "", usage.ServerUsageEndDate)
 
-	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
+	cmd.Flags().IntVar(&opts.PageNum, flag.Page, 0, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
 
 	cmd.Flags().StringVar(&opts.OrgID, flag.OrgID, "", usage.OrgID)

--- a/internal/cli/opsmanager/serverusage/projects/hosts/list.go
+++ b/internal/cli/opsmanager/serverusage/projects/hosts/list.go
@@ -88,7 +88,7 @@ func ListBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.startDate, flag.StartDate, "", usage.ServerUsageStartDate)
 	cmd.Flags().StringVar(&opts.endDate, flag.EndDate, "", usage.ServerUsageEndDate)
 
-	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
+	cmd.Flags().IntVar(&opts.PageNum, flag.Page, 0, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)


### PR DESCRIPTION
_Jira ticket:_ CLOUDP-132456

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

For these APIs the default starting page is zero(0)