### PR TITLE
(DOCSP-24648) Add docs link to config file page

### DIFF
--- a/docs/atlascli/command/atlas-clusters-create.txt
+++ b/docs/atlascli/command/atlas-clusters-create.txt
@@ -68,7 +68,7 @@ Options
    * - -f, --file
      - string
      - false
-     - File name to use, optional file with a json cluster configuration.
+     - File name to use, optional file with a json cluster configuration. To learn more about configuration files for the Atlas CLI, see https://www.mongodb.com/docs/atlas/cli/stable/cluster-config-file/. To learn more about configuration files for MongoCLI, see https://www.mongodb.com/docs/mongocli/stable/reference/mms-cluster-settings-file/.
    * - -h, --help
      - 
      - false

--- a/docs/atlascli/command/atlas-clusters-update.txt
+++ b/docs/atlascli/command/atlas-clusters-update.txt
@@ -57,7 +57,7 @@ Options
    * - -f, --file
      - string
      - false
-     - File name to use, optional file with a json cluster configuration.
+     - File name to use, optional file with a json cluster configuration. To learn more about configuration files for the Atlas CLI, see https://www.mongodb.com/docs/atlas/cli/stable/cluster-config-file/. To learn more about configuration files for MongoCLI, see https://www.mongodb.com/docs/mongocli/stable/reference/mms-cluster-settings-file/.
    * - -h, --help
      - 
      - false

--- a/docs/atlascli/command/atlas-clusters-upgrade.txt
+++ b/docs/atlascli/command/atlas-clusters-upgrade.txt
@@ -57,7 +57,7 @@ Options
    * - -f, --file
      - string
      - false
-     - File name to use, optional file with a json cluster configuration.
+     - File name to use, optional file with a json cluster configuration. To learn more about configuration files for the Atlas CLI, see https://www.mongodb.com/docs/atlas/cli/stable/cluster-config-file/. To learn more about configuration files for MongoCLI, see https://www.mongodb.com/docs/mongocli/stable/reference/mms-cluster-settings-file/.
    * - -h, --help
      - 
      - false

--- a/docs/mongocli/command/mongocli-atlas-clusters-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-create.txt
@@ -68,7 +68,7 @@ Options
    * - -f, --file
      - string
      - false
-     - File name to use, optional file with a json cluster configuration.
+     - File name to use, optional file with a json cluster configuration. To learn more about configuration files for the Atlas CLI, see https://www.mongodb.com/docs/atlas/cli/stable/cluster-config-file/. To learn more about configuration files for MongoCLI, see https://www.mongodb.com/docs/mongocli/stable/reference/mms-cluster-settings-file/.
    * - -h, --help
      - 
      - false

--- a/docs/mongocli/command/mongocli-atlas-clusters-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-update.txt
@@ -57,7 +57,7 @@ Options
    * - -f, --file
      - string
      - false
-     - File name to use, optional file with a json cluster configuration.
+     - File name to use, optional file with a json cluster configuration. To learn more about configuration files for the Atlas CLI, see https://www.mongodb.com/docs/atlas/cli/stable/cluster-config-file/. To learn more about configuration files for MongoCLI, see https://www.mongodb.com/docs/mongocli/stable/reference/mms-cluster-settings-file/.
    * - -h, --help
      - 
      - false

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -108,7 +108,7 @@ dbName and collection are only required for built-in roles.`
 	TeamRole                                  = "Project role you want to assign to the team."
 	MaxDate                                   = "Returns events whose created date is less than or equal to it."
 	MinDate                                   = "Returns events whose created date is greater than or equal to it."
-	ClusterFilename                           = "File name to use, optional file with a json cluster configuration."
+	ClusterFilename                           = "File name to use, optional file with a json cluster configuration. To learn more about configuration files for the Atlas CLI, see https://www.mongodb.com/docs/atlas/cli/stable/cluster-config-file/. To learn more about configuration files for MongoCLI, see https://www.mongodb.com/docs/mongocli/stable/reference/mms-cluster-settings-file/."
 	PoliciesFilename                          = "File name to use, optional file with a json policy configuration."
 	SearchFilename                            = "File name to use, file with a json index configuration."
 	AccessListIps                             = "IP addresses to add to the new user's access list."


### PR DESCRIPTION
## Proposed changes

Adds link to docs page on config files wherever the description of the -f flag appears in docs

_Jira ticket:_ DOCSP-24648

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
