### PR TITLE
CLOUDP-134983: [AtlasCLI] Add command to allow customer to open config file on their default editor

### DIFF
--- a/docs/atlascli/command/atlas-config-edit.txt
+++ b/docs/atlascli/command/atlas-config-edit.txt
@@ -12,9 +12,9 @@ atlas config edit
    :depth: 1
    :class: singlecol
 
-Opens the the config with the default text editor.
+Opens the config file with the default text editor.
 
-Uses the default editor to open the tool config file. You can use EDITOR or VISUAL envs to change the default.
+Uses the default editor to open the config file. You can use EDITOR or VISUAL envs to change the default.
 
 Syntax
 ------

--- a/docs/atlascli/command/atlas-config-edit.txt
+++ b/docs/atlascli/command/atlas-config-edit.txt
@@ -1,0 +1,74 @@
+.. _atlas-config-edit:
+
+=================
+atlas config edit
+=================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Opens the the config with the default text editor.
+
+Uses the default editor to open the tool config file. You can use EDITOR or VISUAL envs to change the default.
+
+Syntax
+------
+
+.. code-block::
+
+   atlas config edit [options]
+
+.. Code end marker, please don't delete this comment
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -h, --help
+     - 
+     - false
+     - help for edit
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+
+   To open the config
+   $ atlas config edit
+
+
+
+.. toctree::
+   :titlesonly:
+
+

--- a/docs/atlascli/command/atlas-config.txt
+++ b/docs/atlascli/command/atlas-config.txt
@@ -58,6 +58,7 @@ Related Commands
 
 * :ref:`atlas-config-delete` - Delete a profile.
 * :ref:`atlas-config-describe` - Return a specific profile.
+* :ref:`atlas-config-edit` - Opens the the config with the default text editor.
 * :ref:`atlas-config-init` - Configure a profile to store access settings for your MongoDB deployment.
 * :ref:`atlas-config-list` - Return a list of available profiles by name.
 * :ref:`atlas-config-rename` - Rename a profile.
@@ -69,6 +70,7 @@ Related Commands
 
    delete </command/atlas-config-delete>
    describe </command/atlas-config-describe>
+   edit </command/atlas-config-edit>
    init </command/atlas-config-init>
    list </command/atlas-config-list>
    rename </command/atlas-config-rename>

--- a/docs/atlascli/command/atlas-config.txt
+++ b/docs/atlascli/command/atlas-config.txt
@@ -58,7 +58,7 @@ Related Commands
 
 * :ref:`atlas-config-delete` - Delete a profile.
 * :ref:`atlas-config-describe` - Return a specific profile.
-* :ref:`atlas-config-edit` - Opens the the config with the default text editor.
+* :ref:`atlas-config-edit` - Opens the config file with the default text editor.
 * :ref:`atlas-config-init` - Configure a profile to store access settings for your MongoDB deployment.
 * :ref:`atlas-config-list` - Return a list of available profiles by name.
 * :ref:`atlas-config-rename` - Rename a profile.

--- a/docs/mongocli/command/mongocli-config-edit.txt
+++ b/docs/mongocli/command/mongocli-config-edit.txt
@@ -1,0 +1,74 @@
+.. _mongocli-config-edit:
+
+====================
+mongocli config edit
+====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+Opens the the config with the default text editor.
+
+Uses the default editor to open the tool config file. You can use EDITOR or VISUAL envs to change the default.
+
+Syntax
+------
+
+.. code-block::
+
+   mongocli config edit [options]
+
+.. Code end marker, please don't delete this comment
+
+Options
+-------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -h, --help
+     - 
+     - false
+     - help for edit
+
+Inherited Options
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - -P, --profile
+     - string
+     - false
+     - Profile to use from your configuration file.
+
+Examples
+--------
+
+.. code-block::
+
+
+   To open the config
+   $ mongocli config edit
+
+
+
+.. toctree::
+   :titlesonly:
+
+

--- a/docs/mongocli/command/mongocli-config-edit.txt
+++ b/docs/mongocli/command/mongocli-config-edit.txt
@@ -12,9 +12,9 @@ mongocli config edit
    :depth: 1
    :class: singlecol
 
-Opens the the config with the default text editor.
+Opens the config file with the default text editor.
 
-Uses the default editor to open the tool config file. You can use EDITOR or VISUAL envs to change the default.
+Uses the default editor to open the config file. You can use EDITOR or VISUAL envs to change the default.
 
 Syntax
 ------

--- a/docs/mongocli/command/mongocli-config.txt
+++ b/docs/mongocli/command/mongocli-config.txt
@@ -87,6 +87,7 @@ Related Commands
 
 * :ref:`mongocli-config-delete` - Delete a profile.
 * :ref:`mongocli-config-describe` - Return a specific profile.
+* :ref:`mongocli-config-edit` - Opens the the config with the default text editor.
 * :ref:`mongocli-config-list` - Return a list of available profiles by name.
 * :ref:`mongocli-config-rename` - Rename a profile.
 * :ref:`mongocli-config-set` - Configure specific properties of a profile.
@@ -97,6 +98,7 @@ Related Commands
 
    delete </command/mongocli-config-delete>
    describe </command/mongocli-config-describe>
+   edit </command/mongocli-config-edit>
    list </command/mongocli-config-list>
    rename </command/mongocli-config-rename>
    set </command/mongocli-config-set>

--- a/docs/mongocli/command/mongocli-config.txt
+++ b/docs/mongocli/command/mongocli-config.txt
@@ -87,7 +87,7 @@ Related Commands
 
 * :ref:`mongocli-config-delete` - Delete a profile.
 * :ref:`mongocli-config-describe` - Return a specific profile.
-* :ref:`mongocli-config-edit` - Opens the the config with the default text editor.
+* :ref:`mongocli-config-edit` - Opens the config file with the default text editor.
 * :ref:`mongocli-config-list` - Return a list of available profiles by name.
 * :ref:`mongocli-config-rename` - Rename a profile.
 * :ref:`mongocli-config-set` - Configure specific properties of a profile.

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -47,12 +47,11 @@ func EditBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "Opens the the config with the default text editor.",
-		Long:  `Will use the default editor to open the config file. You can use EDITOR or VISUAL envs to change the default.`,
+		Long:  `Uses the default editor to open the tool config file. You can use EDITOR or VISUAL envs to change the default.`,
 		Example: fmt.Sprintf(`
   To open the config
   $ %s config edit
 `, config.BinName()),
-		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opt.Run()
 		},

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -46,8 +46,8 @@ func EditBuilder() *cobra.Command {
 	opt := &editOpts{}
 	cmd := &cobra.Command{
 		Use:   "edit",
-		Short: "Opens the the config with the default text editor.",
-		Long:  `Uses the default editor to open the tool config file. You can use EDITOR or VISUAL envs to change the default.`,
+		Short: "Opens the config file with the default text editor.",
+		Long:  `Uses the default editor to open the config file. You can use EDITOR or VISUAL envs to change the default.`,
 		Example: fmt.Sprintf(`
   To open the config
   $ %s config edit


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-134983


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

