### PR TITLE
HELP-37776: [Atlas CLI] prompt error with garbage characters in tty

### DIFF
--- a/docs/atlascli/command/atlas-liveMigrations-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-create.txt
@@ -44,6 +44,10 @@ Options
      - 
      - false
      - Flag that indicates whether this process should drop existing collections from the destination (Atlas) cluster given in --destinationClusterName before starting the migration of data from the source cluster.
+   * - --force
+     - 
+     - false
+     - If specified, skips asking for confirmation before proceeding with a requested action.
    * - -h, --help
      - 
      - false

--- a/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
@@ -44,6 +44,10 @@ Options
      - 
      - false
      - Flag that indicates whether this process should drop existing collections from the destination (Atlas) cluster given in --destinationClusterName before starting the migration of data from the source cluster.
+   * - --force
+     - 
+     - false
+     - If specified, skips asking for confirmation before proceeding with a requested action.
    * - -h, --help
      - 
      - false

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
@@ -44,6 +44,10 @@ Options
      - 
      - false
      - Flag that indicates whether this process should drop existing collections from the destination (Atlas) cluster given in --destinationClusterName before starting the migration of data from the source cluster.
+   * - --force
+     - 
+     - false
+     - If specified, skips asking for confirmation before proceeding with a requested action.
    * - -h, --help
      - 
      - false

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
@@ -44,6 +44,10 @@ Options
      - 
      - false
      - Flag that indicates whether this process should drop existing collections from the destination (Atlas) cluster given in --destinationClusterName before starting the migration of data from the source cluster.
+   * - --force
+     - 
+     - false
+     - If specified, skips asking for confirmation before proceeding with a requested action.
    * - -h, --help
      - 
      - false

--- a/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
+++ b/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
@@ -32,16 +32,17 @@ type LiveMigrationsOpts struct {
 	cli.OutputOpts
 	cli.InputOpts
 	cli.GlobalOpts
-	DestinationClusterName      string
-	DestinationDropEnabled      bool
 	MigrationHosts              []string
 	SourceCACertificatePath     string
 	SourceClusterName           string
 	SourceProjectID             string
-	SourceSSL                   bool
-	SourceManagedAuthentication bool
 	SourceUsername              string
 	SourcePassword              string
+	DestinationClusterName      string
+	SourceSSL                   bool
+	SourceManagedAuthentication bool
+	Force                       bool
+	DestinationDropEnabled      bool
 }
 
 func (opts *LiveMigrationsOpts) NewCreateRequest() *mongodbatlas.LiveMigration {
@@ -65,7 +66,7 @@ func (opts *LiveMigrationsOpts) NewCreateRequest() *mongodbatlas.LiveMigration {
 }
 
 func (opts *LiveMigrationsOpts) askDestinationDropConfirm() error {
-	if !opts.DestinationDropEnabled {
+	if opts.Force || !opts.DestinationDropEnabled {
 		return nil
 	}
 	confirmDrop := false
@@ -148,6 +149,7 @@ func (opts *LiveMigrationsOpts) GenerateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&opts.DestinationClusterName, flag.ClusterName, "", usage.LiveMigrationDestinationClusterName)
 	cmd.Flags().StringSliceVar(&opts.MigrationHosts, flag.LiveMigrationHost, []string{}, usage.LiveMigrationHostEntries)
 	cmd.Flags().BoolVar(&opts.DestinationDropEnabled, flag.LiveMigrationDropCollections, false, usage.LiveMigrationDropCollections)
+	cmd.Flags().BoolVar(&opts.Force, flag.Force, false, usage.Force)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
 	_ = cmd.MarkFlagRequired(flag.LiveMigrationSourceClusterName)

--- a/internal/cli/atlas/livemigrations/validation/create.go
+++ b/internal/cli/atlas/livemigrations/validation/create.go
@@ -54,7 +54,7 @@ func (opts *CreateOpts) Run() error {
 	return opts.Print(r)
 }
 
-// mongocli atlas liveMigrations|lm validation create --clusterName clusterName --migrationHosts hosts --sourceClusterName clusterName --sourceProjectId projectId [--sourceSSL] [--sourceCACertificatePath path] [--sourceManagedAuthentication] [--sourceUsername userName] [--sourcePassword password] [--drop] [--projectId projectId].
+// mongocli atlas liveMigrations|lm validation create --clusterName clusterName --migrationHosts hosts --sourceClusterName clusterName --sourceProjectId projectId [--sourceSSL] [--sourceCACertificatePath path] [--sourceManagedAuthentication] [--sourceUsername userName] [--sourcePassword password] [--drop] [--force] [--projectId projectId].
 func CreateBuilder() *cobra.Command {
 	opts := &CreateOpts{}
 	cmd := &cobra.Command{
@@ -75,6 +75,5 @@ func CreateBuilder() *cobra.Command {
 	}
 
 	opts.GenerateFlags(cmd)
-
 	return cmd
 }

--- a/internal/cli/atlas/livemigrations/validation/create_test.go
+++ b/internal/cli/atlas/livemigrations/validation/create_test.go
@@ -75,6 +75,7 @@ func TestCreateBuilder(t *testing.T) {
 			flag.ClusterName,
 			flag.LiveMigrationHost,
 			flag.LiveMigrationDropCollections,
+			flag.Force,
 		},
 	)
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [HELP-37776](https://jira.mongodb.org/browse/HELP-37776)

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

**Description:**
This PR adds the **--force** flag to `atlascli livemigrations create` to skip the confirmation prompt when `--drop` is provided


**Without --force**
```
 atlas liveMigrations validation create --clusterName "quartermaster-sandbox" --migrationHost cmhqa3-qmdata1016.cmhqa3.indeed.net --sourceCACertificatePath "/etc/pki/ca-trust/source/anchors/Indeed-Second-Certificate-Authority.crt" --sourceClusterName "context" --sourceProjectId 623b483b48614d5ebc80720f --sourceUsername "mms-automation" --sourcePassword "xxx" --drop
? Are you sure you want to drop the destination collections? (y/N) n
```

**With --force**
```
./bin/atlas livemigrations create --clusterName "quartermaster-sandbox" --migrationHost cmhqa3-qmdata1016.cmhqa3.indeed.net --sourceCACertificatePath "/etc/pki/ca-trust/source/anchors/Indeed-Second-Certificate-Authority.crt" --sourceClusterName "context" --sourceProjectId 623b483b48614d5ebc80720f --sourceUsername "mms-automation" --sourcePassword "xxx" --drop --force
ID                          PROJECT ID                  SOURCE    PROJECT ID                  STATUS
623b483b48614d5ebc80720f    743b483b48614d5ebc80720f    context   623b483b48614d5ebc80720f    PENDING
```