### PR TITLE
CLOUDP-136376: Example for create bucket using Atlas CLI has typo

### DIFF
--- a/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
@@ -93,5 +93,5 @@ Examples
 .. code-block::
 
    The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
-   $ atlas backup export buckets create test-bucket --cloudProvider AWS --iamRoleID 12345678f901a234dbdb00ca
+   $ atlas backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca
 

--- a/internal/cli/atlas/backup/exports/buckets/create.go
+++ b/internal/cli/atlas/backup/exports/buckets/create.go
@@ -74,7 +74,7 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create <bucketName>",
 		Short: "Create an export destination for Atlas backups using an existing AWS S3 bucket.",
 		Example: fmt.Sprintf(`  The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
-  $ %s backup export buckets create test-bucket --cloudProvider AWS --iamRoleID 12345678f901a234dbdb00ca`, config.BinName()),
+  $ %s backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca`, config.BinName()),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"args":           "bucketName",


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ CLOUDP-136376


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

