### PR TITLE
CLOUDP-138980: [AtlasCLI] The atlas customDbRoles list format does not works

### DIFF
--- a/internal/cli/atlas/customdbroles/describe.go
+++ b/internal/cli/atlas/customdbroles/describe.go
@@ -27,7 +27,7 @@ import (
 
 const describeTemplate = `NAME	ACTION	DB	COLLECTION	CLUSTER {{- $roleName := .RoleName }} {{range .Actions}} 
 {{- $actionName := .Action }} {{- range .Resources}}
-{{ $roleName }}	{{ $actionName }}{{if .Db }}	{{ .Db }}{{else}}	N/A{{end}}{{if .Collection }}	{{ .Collection }}{{else if .Cluster}}	N/A{{else}}	ALL COLLECTIONS{{end}}{{if .Cluster}}	{{ .Cluster }}{{else}}	N/A	{{end}}{{end}}{{end}}
+{{ $roleName }}	{{ $actionName }}{{if .DB }}	{{ .DB }}{{else}}	N/A{{end}}{{if .Collection }}	{{ .Collection }}{{else if .Cluster}}	N/A{{else}}	ALL COLLECTIONS{{end}}{{if .Cluster}}	{{ .Cluster }}{{else}}	N/A	{{end}}{{end}}{{end}}
 `
 
 type DescribeOpts struct {

--- a/internal/cli/atlas/customdbroles/list.go
+++ b/internal/cli/atlas/customdbroles/list.go
@@ -28,7 +28,7 @@ import (
 
 const listTemplate = `NAME	ACTION	DB	COLLECTION	CLUSTER {{range .}}{{- $roleName := .RoleName }} {{range .Actions}} 
 {{- $actionName := .Action }} {{- range .Resources}}
-{{ $roleName }}	{{ $actionName }}{{if .Db }}	{{ .Db }}{{else}}	N/A{{end}}{{if .Collection }}	{{ .Collection }}{{else if .Cluster}}	N/A{{else}}	ALL COLLECTIONS{{end}}{{if .Cluster}}	{{ .Cluster }}{{else}}	N/A	{{end}}{{end}}{{end}}{{end}}
+{{ $roleName }}	{{ $actionName }}{{if .DB }}	{{ .DB }}{{else}}	N/A{{end}}{{if .Collection }}	{{ .Collection }}{{else if .Cluster}}	N/A{{else}}	ALL COLLECTIONS{{end}}{{if .Cluster}}	{{ .Cluster }}{{else}}	N/A	{{end}}{{end}}{{end}}{{end}}
 `
 
 type ListOpts struct {

--- a/test/e2e/atlas/custom_db_roles_test.go
+++ b/test/e2e/atlas/custom_db_roles_test.go
@@ -83,6 +83,25 @@ func TestDBRoles(t *testing.T) {
 		assert.NotEmpty(t, roles)
 	})
 
+	t.Run("List default format", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			customDBRoleEntity,
+			"ls")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+	})
+
+	t.Run("Describe default format", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			customDBRoleEntity,
+			"describe",
+			roleName)
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+	})
+
 	t.Run("Describe", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			customDBRoleEntity,

--- a/test/e2e/atlas/custom_db_roles_test.go
+++ b/test/e2e/atlas/custom_db_roles_test.go
@@ -83,7 +83,7 @@ func TestDBRoles(t *testing.T) {
 		assert.NotEmpty(t, roles)
 	})
 
-	t.Run("List default format", func(t *testing.T) {
+	t.Run("List - default format", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			customDBRoleEntity,
 			"ls")
@@ -92,7 +92,7 @@ func TestDBRoles(t *testing.T) {
 		require.NoError(t, err, string(resp))
 	})
 
-	t.Run("Describe default format", func(t *testing.T) {
+	t.Run("Describe - default format", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			customDBRoleEntity,
 			"describe",

--- a/test/e2e/atlas/custom_db_roles_test.go
+++ b/test/e2e/atlas/custom_db_roles_test.go
@@ -83,7 +83,7 @@ func TestDBRoles(t *testing.T) {
 		assert.NotEmpty(t, roles)
 	})
 
-	t.Run("List - default format", func(t *testing.T) {
+	t.Run("List (default format)", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			customDBRoleEntity,
 			"ls")
@@ -92,7 +92,7 @@ func TestDBRoles(t *testing.T) {
 		require.NoError(t, err, string(resp))
 	})
 
-	t.Run("Describe - default format", func(t *testing.T) {
+	t.Run("Describe (default format)", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			customDBRoleEntity,
 			"describe",


### PR DESCRIPTION

<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-138980

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
Issue:
```
atlas customDbRoles list                                                                                                                                                      1.18
Error: template: output:3:38: executing "output" at <.Db>: can't evaluate field Db in type mongodbatlas.Resource
```

Fix:
```
./bin/atlas customDbRoles list                                                                                                                                                1.18
NAME         ACTION                       DB         COLLECTION        CLUSTER
tesr         FIND                         test                         N/A
tesr         INSERT                       test                         N/A
tesr         REMOVE                       test                         N/A
```


- I have added e2e tests to check that the format of the describe and list command is now correct.
  - Example of successful e2e tests: [atlas_generic_e2e](https://evergreen.mongodb.com/task_log_raw/mongocli_master_e2e_generic_atlas_generic_e2e_patch_d610789d6e13749be74d598e5c06af00329a2356_633ed49557e85a72382aeba9_22_10_06_13_14_00/0?type=T#L177)
  - The added e2e tests failed without my changes: [atlas_generic_e2e](https://evergreen.mongodb.com/task_log_raw/mongocli_master_e2e_generic_atlas_generic_e2e_patch_d610789d6e13749be74d598e5c06af00329a2356_633ed2e632f41740f6e59712_22_10_06_13_06_48/0?type=T#L176)


**Next Steps:**
I will open a follow up PR to add e2e tests to check the default format for all the list and describe commands so that we know when the format of a command is broken



