### PR TITLE
DOCSP-26295: Improves examples in autogenerated docs

### DIFF
--- a/docs/atlascli/command/atlas-accessLists-create.txt
+++ b/docs/atlascli/command/atlas-accessLists-create.txt
@@ -102,4 +102,3 @@ Examples
 
    # Create IP address access list with the current IP address. Entry is not needed in this case.
    atlas accessList create --currentIp
-

--- a/docs/atlascli/command/atlas-accessLists-create.txt
+++ b/docs/atlascli/command/atlas-accessLists-create.txt
@@ -100,6 +100,6 @@ Examples
 
 .. code-block::
 
-   Create IP address access list with the current IP address. Entry is not needed in this case.
-   $ atlas accessList create --currentIP
+   # Create IP address access list with the current IP address. Entry is not needed in this case.
+   atlas accessList create --currentIp
 

--- a/docs/atlascli/command/atlas-accessLists-delete.txt
+++ b/docs/atlascli/command/atlas-accessLists-delete.txt
@@ -86,7 +86,9 @@ Examples
 
    # The following command deletes the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation.
    atlas accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3
+   
+.. code-block::
+
    # The following command uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation.
    atlas accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3 --force
  		
-

--- a/docs/atlascli/command/atlas-accessLists-describe.txt
+++ b/docs/atlascli/command/atlas-accessLists-describe.txt
@@ -84,6 +84,5 @@ Examples
 
 .. code-block::
 
-   The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
+    The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
    atlas accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3
-

--- a/docs/atlascli/command/atlas-alerts-list.txt
+++ b/docs/atlascli/command/atlas-alerts-list.txt
@@ -80,8 +80,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-   $ atlas alerts list \
+   # This example uses the "atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+   atlas alerts list \
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile

--- a/docs/atlascli/command/atlas-alerts-list.txt
+++ b/docs/atlascli/command/atlas-alerts-list.txt
@@ -85,4 +85,3 @@ Examples
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile
-

--- a/docs/atlascli/command/atlas-alerts-settings-create.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-create.txt
@@ -176,8 +176,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-   $ atlas alert settings create --event JOINED_GROUP --enabled \
+   # This example uses the "atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+   atlas alert settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305

--- a/docs/atlascli/command/atlas-alerts-settings-create.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-create.txt
@@ -181,4 +181,3 @@ Examples
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305
-

--- a/docs/atlascli/command/atlas-alerts-settings-list.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-list.txt
@@ -76,6 +76,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
 

--- a/docs/atlascli/command/atlas-alerts-settings-list.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-list.txt
@@ -78,4 +78,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
-

--- a/docs/atlascli/command/atlas-auth-login.txt
+++ b/docs/atlascli/command/atlas-auth-login.txt
@@ -68,7 +68,7 @@ Examples
 
 .. code-block::
 
-   To start the interactive login for your MongoDB Atlas account:
-   $ atlas auth login
+   # To start the interactive login for your MongoDB Atlas account:
+   atlas auth login
 
 

--- a/docs/atlascli/command/atlas-auth-login.txt
+++ b/docs/atlascli/command/atlas-auth-login.txt
@@ -71,4 +71,3 @@ Examples
    # To start the interactive login for your MongoDB Atlas account:
    atlas auth login
 
-

--- a/docs/atlascli/command/atlas-auth-logout.txt
+++ b/docs/atlascli/command/atlas-auth-logout.txt
@@ -64,7 +64,7 @@ Examples
 
 .. code-block::
 
-   To log out from the CLI:
-   $ atlas auth logout
+   # To log out from the CLI:
+   atlas auth logout
 
 

--- a/docs/atlascli/command/atlas-auth-logout.txt
+++ b/docs/atlascli/command/atlas-auth-logout.txt
@@ -67,4 +67,3 @@ Examples
    # To log out from the CLI:
    atlas auth logout
 
-

--- a/docs/atlascli/command/atlas-auth-register.txt
+++ b/docs/atlascli/command/atlas-auth-register.txt
@@ -68,7 +68,7 @@ Examples
 
 .. code-block::
 
-   To start the interactive setup:
-   $ atlas auth register
+   # To start the interactive setup:
+   atlas auth register
 
 

--- a/docs/atlascli/command/atlas-auth-register.txt
+++ b/docs/atlascli/command/atlas-auth-register.txt
@@ -71,4 +71,3 @@ Examples
    # To start the interactive setup:
    atlas auth register
 
-

--- a/docs/atlascli/command/atlas-auth-whoami.txt
+++ b/docs/atlascli/command/atlas-auth-whoami.txt
@@ -60,7 +60,7 @@ Examples
 
 .. code-block::
 
-   See the logged account:
-   $ atlas auth whoami
+   # See the logged account:
+   atlas auth whoami
 
 

--- a/docs/atlascli/command/atlas-auth-whoami.txt
+++ b/docs/atlascli/command/atlas-auth-whoami.txt
@@ -63,4 +63,3 @@ Examples
    # See the logged account:
    atlas auth whoami
 
-

--- a/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
@@ -94,4 +94,3 @@ Examples
 
    # The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
    atlas backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca
-

--- a/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
@@ -92,6 +92,6 @@ Examples
 
 .. code-block::
 
-   The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
-   $ atlas backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca
+   # The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
+   atlas backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca
 

--- a/docs/atlascli/command/atlas-backups-exports-buckets-delete.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-delete.txt
@@ -72,6 +72,6 @@ Examples
 
 .. code-block::
 
-   The following deletes the continuous backup export bucket specified by ID:
-   $ atlas backup exports buckets delete --bucketId dbdb00ca12345678f901a234
+   # The following deletes the continuous backup export bucket specified by ID:
+   atlas backup exports buckets delete --bucketId dbdb00ca12345678f901a234
 

--- a/docs/atlascli/command/atlas-backups-exports-buckets-delete.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-delete.txt
@@ -74,4 +74,3 @@ Examples
 
    # The following deletes the continuous backup export bucket specified by ID:
    atlas backup exports buckets delete --bucketId dbdb00ca12345678f901a234
-

--- a/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
@@ -74,4 +74,3 @@ Examples
 
    # The following example returns the continuous backup export bucket specified by ID:
    atlas backup exports buckets describe dbdb00ca12345678f901a234
-

--- a/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
@@ -72,6 +72,6 @@ Examples
 
 .. code-block::
 
-   The following example returns the continuous backup export bucket specified by ID:
-   $ atlas backup exports buckets describe dbdb00ca12345678f901a234
+   # The following example returns the continuous backup export bucket specified by ID:
+   atlas backup exports buckets describe dbdb00ca12345678f901a234
 

--- a/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
@@ -76,6 +76,6 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup export buckets:
-   $ atlas backup exports buckets list
+   # The following example retrieves the continuous backup export buckets:
+   atlas backup exports buckets list
 

--- a/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
@@ -78,4 +78,3 @@ Examples
 
    # The following example retrieves the continuous backup export buckets:
    atlas backup exports buckets list
-

--- a/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
@@ -86,4 +86,3 @@ Examples
 
    # The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
    atlas backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test
-

--- a/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
-   $ atlas backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test
+   # The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
+   atlas backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test
 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -76,6 +76,6 @@ Examples
 
 .. code-block::
 
-   The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
-   $ atlas backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305
+   # The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
+   atlas backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305
 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -78,4 +78,3 @@ Examples
 
    # The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
    atlas backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305
-

--- a/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
@@ -92,6 +92,6 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup export jobs for the cluster Cluster0:
-   $ atlas backup exports jobs list Cluster0
+   # The following example retrieves the continuous backup export jobs for the cluster Cluster0:
+   atlas backup exports jobs list Cluster0
 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
@@ -94,4 +94,3 @@ Examples
 
    # The following example retrieves the continuous backup export jobs for the cluster Cluster0:
    atlas backup exports jobs list Cluster0
-

--- a/docs/atlascli/command/atlas-backups-restores-describe.txt
+++ b/docs/atlascli/command/atlas-backups-restores-describe.txt
@@ -90,4 +90,3 @@ Examples
 
    # The following example retrieves the continuous backup restore job for the cluster Cluster0:
    atlas backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0
-

--- a/docs/atlascli/command/atlas-backups-restores-describe.txt
+++ b/docs/atlascli/command/atlas-backups-restores-describe.txt
@@ -88,6 +88,6 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup restore job for the cluster Cluster0:
-   $ atlas backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0
+   # The following example retrieves the continuous backup restore job for the cluster Cluster0:
+   atlas backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0
 

--- a/docs/atlascli/command/atlas-backups-restores-list.txt
+++ b/docs/atlascli/command/atlas-backups-restores-list.txt
@@ -94,4 +94,3 @@ Examples
 
    # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
    atlas backup restore list Cluster0
-

--- a/docs/atlascli/command/atlas-backups-restores-list.txt
+++ b/docs/atlascli/command/atlas-backups-restores-list.txt
@@ -92,6 +92,6 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
-   $ atlas backup restore list Cluster0
+   # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+   atlas backup restore list Cluster0
 

--- a/docs/atlascli/command/atlas-backups-restores-start.txt
+++ b/docs/atlascli/command/atlas-backups-restores-start.txt
@@ -112,22 +112,10 @@ Examples
 
 .. code-block::
 
-   The following example creates an automated restore:
-   $ atlas backup restore start automated \
-          --clusterName myDemo \
-          --snapshotId 5e7e00128f8ce03996a47179 \
-          --targetClusterName myDemo2 \
-          --targetProjectId 1a2345b67c8e9a12f3456de7
-
- The following example creates a point-in-time restore:
-   $ atlas backup restore start pointInTime \
-          --clusterName myDemo \
-          --pointInTimeUTCMillis 1588523147 \
-          --targetClusterName myDemo2 \
-          --targetProjectId 1a2345b67c8e9a12f3456de7
-   
- The following example creates a download restore:
-   $ atlas backup restore start download \
-          --clusterName myDemo \
-          --snapshotId 5e7e00128f8ce03996a47179
+   # The following example creates an automated restore:
+   atlas backup restore start automated \
+   --clusterName myDemo \
+   --snapshotId 5e7e00128f8ce03996a47179 \
+   --targetClusterName myDemo2 \
+   --targetProjectId 1a2345b67c8e9a12f3456de7
 

--- a/docs/atlascli/command/atlas-backups-restores-start.txt
+++ b/docs/atlascli/command/atlas-backups-restores-start.txt
@@ -119,3 +119,15 @@ Examples
    --targetClusterName myDemo2 \
    --targetProjectId 1a2345b67c8e9a12f3456de7
 
+   # The following example creates a point-in-time restore:
+   atlas backup restore start pointInTime \
+   --clusterName myDemo \
+   --pointInTimeUTCMillis 1588523147 \
+   --targetClusterName myDemo2 \
+   --targetProjectId 1a2345b67c8e9a12f3456de7
+   
+   # The following example creates a download restore:
+   atlas backup restore start download \
+          --clusterName myDemo \
+          --snapshotId 5e7e00128f8ce03996a47179
+

--- a/docs/atlascli/command/atlas-backups-restores-start.txt
+++ b/docs/atlascli/command/atlas-backups-restores-start.txt
@@ -119,6 +119,9 @@ Examples
    --targetClusterName myDemo2 \
    --targetProjectId 1a2345b67c8e9a12f3456de7
 
+   
+.. code-block::
+
    # The following example creates a point-in-time restore:
    atlas backup restore start pointInTime \
    --clusterName myDemo \
@@ -126,8 +129,10 @@ Examples
    --targetClusterName myDemo2 \
    --targetProjectId 1a2345b67c8e9a12f3456de7
    
+   
+.. code-block::
+
    # The following example creates a download restore:
    atlas backup restore start download \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179
-

--- a/docs/atlascli/command/atlas-backups-restores-watch.txt
+++ b/docs/atlascli/command/atlas-backups-restores-watch.txt
@@ -93,6 +93,6 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup restore job for the cluster Cluster0:
-   $ atlas backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0
+   # The following example retrieves the continuous backup restore job for the cluster Cluster0:
+   atlas backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0
 

--- a/docs/atlascli/command/atlas-backups-restores-watch.txt
+++ b/docs/atlascli/command/atlas-backups-restores-watch.txt
@@ -95,4 +95,3 @@ Examples
 
    # The following example retrieves the continuous backup restore job for the cluster Cluster0:
    atlas backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0
-

--- a/docs/atlascli/command/atlas-backups-schedule-delete.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-delete.txt
@@ -86,4 +86,3 @@ Examples
 
    # The following example deletes all backup schedules of the cluster Cluster0:
    atlas backup schedule delete Cluster0
-

--- a/docs/atlascli/command/atlas-backups-schedule-delete.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-delete.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   The following example deletes all backup schedules of the cluster Cluster0:
-   $ atlas backup schedule delete Cluster0
+   # The following example deletes all backup schedules of the cluster Cluster0:
+   atlas backup schedule delete Cluster0
 

--- a/docs/atlascli/command/atlas-backups-schedule-describe.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-describe.txt
@@ -86,4 +86,3 @@ Examples
 
    # The following example describes the cloud backup schedule for the cluster Cluster0:
    atlas backup schedule describe Cluster0
-

--- a/docs/atlascli/command/atlas-backups-schedule-describe.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-describe.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   The following example describes the cloud backup schedule for the cluster Cluster0:
-   $ atlas backup schedule describe Cluster0
+   # The following example describes the cloud backup schedule for the cluster Cluster0:
+   atlas backup schedule describe Cluster0
 

--- a/docs/atlascli/command/atlas-backups-schedule-update.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-update.txt
@@ -122,4 +122,3 @@ Examples
 
    # Update a snapshot backup policy for a cluster named Cluster0:
    atlas backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7
-

--- a/docs/atlascli/command/atlas-backups-schedule-update.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-update.txt
@@ -120,6 +120,6 @@ Examples
 
 .. code-block::
 
-   Update a snapshot backup policy for a cluster named Cluster0:
-   $ atlas backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7
+   # Update a snapshot backup policy for a cluster named Cluster0:
+   atlas backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7
 

--- a/docs/atlascli/command/atlas-backups-snapshots-watch.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-watch.txt
@@ -89,5 +89,4 @@ Examples
 
 .. code-block::
 
-   atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
-
+    atlas snapshot watch snapshotIdSample --clusterName clusterNameSample

--- a/docs/atlascli/command/atlas-backups-snapshots-watch.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-watch.txt
@@ -89,5 +89,5 @@ Examples
 
 .. code-block::
 
-   $ atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
+   atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
 

--- a/docs/atlascli/command/atlas-clusters-advancedSettings-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-advancedSettings-describe.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   atlas clusters advancedSettings describe Cluster0
-
+    atlas clusters advancedSettings describe Cluster0

--- a/docs/atlascli/command/atlas-clusters-advancedSettings-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-advancedSettings-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ atlas clusters advancedSettings describe Cluster0
+   atlas clusters advancedSettings describe Cluster0
 

--- a/docs/atlascli/command/atlas-clusters-advancedSettings-update.txt
+++ b/docs/atlascli/command/atlas-clusters-advancedSettings-update.txt
@@ -139,3 +139,6 @@ Examples
    # Update the minimum oplog size for a cluster:
    atlas cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
 
+   # Update the minimum TLS protocol version for a cluster:
+   atlas cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"
+

--- a/docs/atlascli/command/atlas-clusters-advancedSettings-update.txt
+++ b/docs/atlascli/command/atlas-clusters-advancedSettings-update.txt
@@ -136,9 +136,6 @@ Examples
 
 .. code-block::
 
-   Update the minimum oplog size for a cluster:
-   $ atlas cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
-
-   Update the minimum TLS protocol version for a cluster:
-   $ atlas cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"
+   # Update the minimum oplog size for a cluster:
+   atlas cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
 

--- a/docs/atlascli/command/atlas-clusters-advancedSettings-update.txt
+++ b/docs/atlascli/command/atlas-clusters-advancedSettings-update.txt
@@ -139,6 +139,8 @@ Examples
    # Update the minimum oplog size for a cluster:
    atlas cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
 
+   
+.. code-block::
+
    # Update the minimum TLS protocol version for a cluster:
    atlas cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"
-

--- a/docs/atlascli/command/atlas-clusters-availableRegions-list.txt
+++ b/docs/atlascli/command/atlas-clusters-availableRegions-list.txt
@@ -79,6 +79,8 @@ Examples
    # List available regions for a given cloud provider and tier:
    atlas cluster availableRegions --provider AWS --tier M50
 
+   
+.. code-block::
+
    # List available regions by tier for a given provider:
    atlas cluster availableRegions --provider GCP
-

--- a/docs/atlascli/command/atlas-clusters-availableRegions-list.txt
+++ b/docs/atlascli/command/atlas-clusters-availableRegions-list.txt
@@ -76,9 +76,6 @@ Examples
 
 .. code-block::
 
-   List available regions for a given cloud provider and tier:
-   $ atlas cluster availableRegions --provider AWS --tier M50
-
-   List available regions by tier for a given provider:
-   $ atlas cluster availableRegions --provider GCP
+   # List available regions for a given cloud provider and tier:
+   atlas cluster availableRegions --provider AWS --tier M50
 

--- a/docs/atlascli/command/atlas-clusters-availableRegions-list.txt
+++ b/docs/atlascli/command/atlas-clusters-availableRegions-list.txt
@@ -79,3 +79,6 @@ Examples
    # List available regions for a given cloud provider and tier:
    atlas cluster availableRegions --provider AWS --tier M50
 
+   # List available regions by tier for a given provider:
+   atlas cluster availableRegions --provider GCP
+

--- a/docs/atlascli/command/atlas-clusters-create.txt
+++ b/docs/atlascli/command/atlas-clusters-create.txt
@@ -131,18 +131,6 @@ Examples
 
 .. code-block::
 
-   Deploy a free cluster:
-   $ atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
-
-   Deploy a three-member replica set in AWS:
-   $ atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
-
-   Deploy a three-member replica set in AZURE:
-   $ atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
-   
-   Deploy a three-member replica set in GCP:
-   $ atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
-
-   Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-   $ atlas cluster create --projectId <projectId> --file <path/to/file.json>
+   # Deploy a free cluster:
+   atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 

--- a/docs/atlascli/command/atlas-clusters-create.txt
+++ b/docs/atlascli/command/atlas-clusters-create.txt
@@ -134,15 +134,26 @@ Examples
    # Deploy a free cluster:
    atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 
+   
+.. code-block::
+
    # Deploy a three-member replica set in AWS:
    atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+
+   
+.. code-block::
 
    # Deploy a three-member replica set in AZURE:
    atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
    
+   
+.. code-block::
+
    # Deploy a three-member replica set in GCP:
    atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
 
+   
+.. code-block::
+
    # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
    atlas cluster create --projectId <projectId> --file <path/to/file.json>
-

--- a/docs/atlascli/command/atlas-clusters-create.txt
+++ b/docs/atlascli/command/atlas-clusters-create.txt
@@ -134,3 +134,15 @@ Examples
    # Deploy a free cluster:
    atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 
+   # Deploy a three-member replica set in AWS:
+   atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+
+   # Deploy a three-member replica set in AZURE:
+   atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+   
+   # Deploy a three-member replica set in GCP:
+   atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+
+   # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
+   atlas cluster create --projectId <projectId> --file <path/to/file.json>
+

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
@@ -89,5 +89,5 @@ Examples
 
 .. code-block::
 
-   $ atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample
+   atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
@@ -89,5 +89,4 @@ Examples
 
 .. code-block::
 
-   atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample
-
+    atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample

--- a/docs/atlascli/command/atlas-clusters-update.txt
+++ b/docs/atlascli/command/atlas-clusters-update.txt
@@ -103,3 +103,9 @@ Examples
    # Update tier for a cluster:
    atlas cluster update <clusterName> --projectId <projectId> --tier M50
 
+   # Update disk size for a cluster:
+   atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+
+   # Update MongoDB version for a cluster:
+   atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+

--- a/docs/atlascli/command/atlas-clusters-update.txt
+++ b/docs/atlascli/command/atlas-clusters-update.txt
@@ -100,12 +100,6 @@ Examples
 
 .. code-block::
 
-   Update tier for a cluster:
-   $ atlas cluster update <clusterName> --projectId <projectId> --tier M50
-
-   Update disk size for a cluster:
-   $ atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
-
-   Update MongoDB version for a cluster:
-   $ atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+   # Update tier for a cluster:
+   atlas cluster update <clusterName> --projectId <projectId> --tier M50
 

--- a/docs/atlascli/command/atlas-clusters-update.txt
+++ b/docs/atlascli/command/atlas-clusters-update.txt
@@ -103,9 +103,14 @@ Examples
    # Update tier for a cluster:
    atlas cluster update <clusterName> --projectId <projectId> --tier M50
 
+   
+.. code-block::
+
    # Update disk size for a cluster:
    atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
 
+   
+.. code-block::
+
    # Update MongoDB version for a cluster:
    atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
-

--- a/docs/atlascli/command/atlas-clusters-upgrade.txt
+++ b/docs/atlascli/command/atlas-clusters-upgrade.txt
@@ -102,4 +102,3 @@ Examples
 
    # The following example upgrades the tier, disk size, and MongoDB version for a cluster:
    atlas cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2
-

--- a/docs/atlascli/command/atlas-clusters-upgrade.txt
+++ b/docs/atlascli/command/atlas-clusters-upgrade.txt
@@ -100,6 +100,6 @@ Examples
 
 .. code-block::
 
-   The following example upgrades the tier, disk size, and MongoDB version for a cluster:
-   $ atlas cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2
+   # The following example upgrades the tier, disk size, and MongoDB version for a cluster:
+   atlas cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2
 

--- a/docs/atlascli/command/atlas-clusters-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ atlas cluster watch clusterNameSample
+   atlas cluster watch clusterNameSample
 

--- a/docs/atlascli/command/atlas-clusters-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   atlas cluster watch clusterNameSample
-
+    atlas cluster watch clusterNameSample

--- a/docs/atlascli/command/atlas-config-delete.txt
+++ b/docs/atlascli/command/atlas-config-delete.txt
@@ -80,9 +80,6 @@ Examples
 
 .. code-block::
 
-   Delete the default profile configuration:
-   $ atlas config delete default
-
-   Skip the confirmation question and delete the default profile configuration:
-   $ atlas config delete default --force
+   # Delete the default profile configuration:
+   mongocli config delete default
 

--- a/docs/atlascli/command/atlas-config-delete.txt
+++ b/docs/atlascli/command/atlas-config-delete.txt
@@ -81,5 +81,8 @@ Examples
 .. code-block::
 
    # Delete the default profile configuration:
-   mongocli config delete default
+   atlas config delete default
+
+   # Skip the confirmation question and delete the default profile configuration:
+   atlas config delete default --force
 

--- a/docs/atlascli/command/atlas-config-delete.txt
+++ b/docs/atlascli/command/atlas-config-delete.txt
@@ -83,6 +83,8 @@ Examples
    # Delete the default profile configuration:
    atlas config delete default
 
+   
+.. code-block::
+
    # Skip the confirmation question and delete the default profile configuration:
    atlas config delete default --force
-

--- a/docs/atlascli/command/atlas-config-edit.txt
+++ b/docs/atlascli/command/atlas-config-edit.txt
@@ -62,10 +62,9 @@ Examples
 
 .. code-block::
 
-
+   
    To open the config
    atlas config edit
-
 
 
 .. toctree::

--- a/docs/atlascli/command/atlas-config-edit.txt
+++ b/docs/atlascli/command/atlas-config-edit.txt
@@ -64,7 +64,7 @@ Examples
 
 
    To open the config
-   $ atlas config edit
+   atlas config edit
 
 
 

--- a/docs/atlascli/command/atlas-config-init.txt
+++ b/docs/atlascli/command/atlas-config-init.txt
@@ -64,9 +64,6 @@ Examples
 
 .. code-block::
 
-   To configure the tool to work with Atlas:
-   $ atlas config init
-
-   To configure the tool to work with Atlas for Government:
-   $ atlas config init --gov
+   # To configure the tool to work with Atlas:
+   atlas config init
 

--- a/docs/atlascli/command/atlas-config-init.txt
+++ b/docs/atlascli/command/atlas-config-init.txt
@@ -67,3 +67,6 @@ Examples
    # To configure the tool to work with Atlas:
    atlas config init
 
+   # To configure the tool to work with Atlas for Government:
+   atlas config init --gov
+

--- a/docs/atlascli/command/atlas-config-init.txt
+++ b/docs/atlascli/command/atlas-config-init.txt
@@ -67,6 +67,8 @@ Examples
    # To configure the tool to work with Atlas:
    atlas config init
 
+   
+.. code-block::
+
    # To configure the tool to work with Atlas for Government:
    atlas config init --gov
-

--- a/docs/atlascli/command/atlas-config-list.txt
+++ b/docs/atlascli/command/atlas-config-list.txt
@@ -66,5 +66,4 @@ Examples
 
 .. code-block::
 
-   atlas config ls
-
+    atlas config ls

--- a/docs/atlascli/command/atlas-config-list.txt
+++ b/docs/atlascli/command/atlas-config-list.txt
@@ -66,5 +66,5 @@ Examples
 
 .. code-block::
 
-   $ atlas config ls
+   atlas config ls
 

--- a/docs/atlascli/command/atlas-config-rename.txt
+++ b/docs/atlascli/command/atlas-config-rename.txt
@@ -82,4 +82,3 @@ Examples
 
    # Rename a profile called myProfile to testProfile:
    atlas config rename myProfile testProfile
-

--- a/docs/atlascli/command/atlas-config-rename.txt
+++ b/docs/atlascli/command/atlas-config-rename.txt
@@ -80,6 +80,6 @@ Examples
 
 .. code-block::
 
-   Rename a profile called myProfile to testProfile:
-   $ atlas config rename myProfile testProfile
+   # Rename a profile called myProfile to testProfile:
+   atlas config rename myProfile testProfile
 

--- a/docs/atlascli/command/atlas-config-set.txt
+++ b/docs/atlascli/command/atlas-config-set.txt
@@ -83,9 +83,14 @@ Examples
 
 .. code-block::
 
+   #
+   
+.. code-block::
 
    # Set Ops Manager Base URL in the profile myProfile:
    atlas config set ops_manager_url http://localhost:30700/ -P myProfile
+   
+.. code-block::
+
    # Set Organization ID in the default profile:
    atlas config set org_id 5dd5aaef7a3e5a6c5bd12de4
-

--- a/docs/atlascli/command/atlas-config-set.txt
+++ b/docs/atlascli/command/atlas-config-set.txt
@@ -84,8 +84,6 @@ Examples
 .. code-block::
 
 
-   Set Ops Manager Base URL in the profile myProfile:
-   $ atlas config set ops_manager_url http://localhost:30700/ -P myProfile
-   Set Organization ID in the default profile:
-   $ atlas config set org_id 5dd5aaef7a3e5a6c5bd12de4
+   # Set Ops Manager Base URL in the profile myProfile:
+   atlas config set ops_manager_url http://localhost:30700/ -P myProfile
 

--- a/docs/atlascli/command/atlas-config-set.txt
+++ b/docs/atlascli/command/atlas-config-set.txt
@@ -86,4 +86,6 @@ Examples
 
    # Set Ops Manager Base URL in the profile myProfile:
    atlas config set ops_manager_url http://localhost:30700/ -P myProfile
+   # Set Organization ID in the default profile:
+   atlas config set org_id 5dd5aaef7a3e5a6c5bd12de4
 

--- a/docs/atlascli/command/atlas-customDbRoles-create.txt
+++ b/docs/atlascli/command/atlas-customDbRoles-create.txt
@@ -92,5 +92,4 @@ Examples
 
 .. code-block::
 
-   atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database
-
+    atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database

--- a/docs/atlascli/command/atlas-customDbRoles-create.txt
+++ b/docs/atlascli/command/atlas-customDbRoles-create.txt
@@ -92,5 +92,5 @@ Examples
 
 .. code-block::
 
-   $ atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database
+   atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database
 

--- a/docs/atlascli/command/atlas-dbusers-create.txt
+++ b/docs/atlascli/command/atlas-dbusers-create.txt
@@ -122,12 +122,20 @@ Examples
    # Create an Atlas database admin user:
    atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
 
+   
+.. code-block::
+
    # Create a database user with read/write access to any database:
    atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+
+   
+.. code-block::
 
    # Create a database user with multiple roles:
    atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
 
+   
+.. code-block::
+
    # Create a database user with multiple scopes:
    atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
-

--- a/docs/atlascli/command/atlas-dbusers-create.txt
+++ b/docs/atlascli/command/atlas-dbusers-create.txt
@@ -119,15 +119,6 @@ Examples
 
 .. code-block::
 
-   Create an Atlas database admin user:
-   $ atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
-
-   Create a database user with read/write access to any database:
-   $ atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
-
-   Create a database user with multiple roles:
-   $ atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
-
-   Create a database user with multiple scopes:
-   $ atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
+   # Create an Atlas database admin user:
+   atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
 

--- a/docs/atlascli/command/atlas-dbusers-create.txt
+++ b/docs/atlascli/command/atlas-dbusers-create.txt
@@ -122,3 +122,12 @@ Examples
    # Create an Atlas database admin user:
    atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
 
+   # Create a database user with read/write access to any database:
+   atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+
+   # Create a database user with multiple roles:
+   atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+
+   # Create a database user with multiple scopes:
+   atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
+

--- a/docs/atlascli/command/atlas-dbusers-describe.txt
+++ b/docs/atlascli/command/atlas-dbusers-describe.txt
@@ -91,9 +91,14 @@ Examples
    # The following example returns a MongoDB database user named myDbUser on an Atlas cluster:
    atlas dbuser describe myDbUser --authDB admin --output json
 
+   
+.. code-block::
+
    # The following example returns a MongoDB database user with X.509 authentication on an Atlas cluster. Prepend $external with \ to escape the special-use character.
    atlas dbuser describe CN=ellen@example.com,OU=users,DC=example,DC=com --authDB \$external --output json
 
+   
+.. code-block::
+
    # The following example returns a MongoDB database user with AWS IAM authentication on an Atlas cluster. Prepend $external with \ to escape the special-use character.
    atlas dbuser describe arn:aws:iam::772401394250:user/my-test-user --authDB \$external --output json
-

--- a/docs/atlascli/command/atlas-dbusers-update.txt
+++ b/docs/atlascli/command/atlas-dbusers-update.txt
@@ -103,6 +103,8 @@ Examples
    # Update roles for a database user:
    atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 
+   
+.. code-block::
+
    # Update scopes for a database user:
    atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>
-

--- a/docs/atlascli/command/atlas-dbusers-update.txt
+++ b/docs/atlascli/command/atlas-dbusers-update.txt
@@ -100,9 +100,6 @@ Examples
 
 .. code-block::
 
-   Update roles for a database user:
-   $ atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
-
-   Update scopes for a database user:
-   $ atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>
+   # Update roles for a database user:
+   atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 

--- a/docs/atlascli/command/atlas-dbusers-update.txt
+++ b/docs/atlascli/command/atlas-dbusers-update.txt
@@ -103,3 +103,6 @@ Examples
    # Update roles for a database user:
    atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 
+   # Update scopes for a database user:
+   atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>
+

--- a/docs/atlascli/command/atlas-metrics-databases-describe.txt
+++ b/docs/atlascli/command/atlas-metrics-databases-describe.txt
@@ -15,7 +15,7 @@ atlas metrics databases describe
 Describe database metrics for a database on a specific host.
 
 To retrieve the hostname and port needed for this command, run:
-$ atlas process list
+atlas process list
 
 Syntax
 ------
@@ -120,5 +120,5 @@ Examples
 .. code-block::
 
    This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
-   $ atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
+   atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
 

--- a/docs/atlascli/command/atlas-metrics-databases-describe.txt
+++ b/docs/atlascli/command/atlas-metrics-databases-describe.txt
@@ -119,6 +119,5 @@ Examples
 
 .. code-block::
 
-   This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
+    This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
    atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
-

--- a/docs/atlascli/command/atlas-metrics-databases-list.txt
+++ b/docs/atlascli/command/atlas-metrics-databases-list.txt
@@ -15,7 +15,7 @@ atlas metrics databases list
 List available databases or database metrics for a given host.
 
 To retrieve the hostname and port needed for this command, run:
-$ atlas process list
+atlas process list
 
 Syntax
 ------
@@ -96,5 +96,5 @@ Examples
 .. code-block::
 
    This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
 

--- a/docs/atlascli/command/atlas-metrics-databases-list.txt
+++ b/docs/atlascli/command/atlas-metrics-databases-list.txt
@@ -95,6 +95,5 @@ Examples
 
 .. code-block::
 
-   This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+    This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
    atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
-

--- a/docs/atlascli/command/atlas-metrics-disks-describe.txt
+++ b/docs/atlascli/command/atlas-metrics-disks-describe.txt
@@ -121,4 +121,3 @@ Examples
 
    # This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
    atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
-

--- a/docs/atlascli/command/atlas-metrics-disks-describe.txt
+++ b/docs/atlascli/command/atlas-metrics-disks-describe.txt
@@ -15,7 +15,7 @@ atlas metrics disks describe
 Describe disk partition metrics for a disk partition on a specified host.
 
 To retrieve the hostname and port needed for this command, run:
-$ atlas process list
+atlas process list
 
 Syntax
 ------
@@ -119,6 +119,6 @@ Examples
 
 .. code-block::
 
-   This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
+   # This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+   atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
 

--- a/docs/atlascli/command/atlas-metrics-disks-list.txt
+++ b/docs/atlascli/command/atlas-metrics-disks-list.txt
@@ -15,7 +15,7 @@ atlas metrics disks list
 List available disks or disk partitions for a given host.
 
 To retrieve the hostname and port needed for this command, run:
-$ atlas process list
+atlas process list
 
 Syntax
 ------
@@ -96,5 +96,5 @@ Examples
 .. code-block::
 
    This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
 

--- a/docs/atlascli/command/atlas-metrics-disks-list.txt
+++ b/docs/atlascli/command/atlas-metrics-disks-list.txt
@@ -95,6 +95,5 @@ Examples
 
 .. code-block::
 
-   This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+    This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
    atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
-

--- a/docs/atlascli/command/atlas-metrics-processes.txt
+++ b/docs/atlascli/command/atlas-metrics-processes.txt
@@ -15,7 +15,7 @@ atlas metrics processes
 Get MongoDB process metrics for a given host.
 
 To retrieve the hostname and port needed for this command, run:
-$ atlas process list
+atlas process list
 
 Syntax
 ------
@@ -115,5 +115,5 @@ Examples
 
 .. code-block::
 
-   $ atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
 

--- a/docs/atlascli/command/atlas-metrics-processes.txt
+++ b/docs/atlascli/command/atlas-metrics-processes.txt
@@ -115,5 +115,4 @@ Examples
 
 .. code-block::
 
-   atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
-
+    atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/atlascli/command/atlas-networking-peering-create-aws.txt
+++ b/docs/atlascli/command/atlas-networking-peering-create-aws.txt
@@ -90,4 +90,3 @@ Examples
 
    # The following command creates a peering connection between the Atlas VPC and your AWS VPC for a project using the default profile.
    atlas networking peering create aws --accountId <aws-account-id> --atlasCidrBlock 192.168.0.0/24 --region us-east-1 --routeTableCidrBlock 10.0.0.0/24 --vpcId vpc-078ac381aa90e1e63
-

--- a/docs/atlascli/command/atlas-networking-peering-watch.txt
+++ b/docs/atlascli/command/atlas-networking-peering-watch.txt
@@ -89,5 +89,5 @@ Examples
 
 .. code-block::
 
-   $ atlas networking peering watch peeringConnectionSampleId
+   atlas networking peering watch peeringConnectionSampleId
 

--- a/docs/atlascli/command/atlas-networking-peering-watch.txt
+++ b/docs/atlascli/command/atlas-networking-peering-watch.txt
@@ -89,5 +89,4 @@ Examples
 
 .. code-block::
 
-   atlas networking peering watch peeringConnectionSampleId
-
+    atlas networking peering watch peeringConnectionSampleId

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force
-
+    atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force
+   atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
@@ -86,4 +86,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile
-

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -90,4 +90,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile
-

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -88,6 +88,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint aws watch vpce-abcdefg0123456789
+   atlas privateEndpoint aws watch vpce-abcdefg0123456789
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint aws watch vpce-abcdefg0123456789
-
+    atlas privateEndpoint aws watch vpce-abcdefg0123456789

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force
+   atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force
-
+    atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint azure watch vpce-abcdefg0123456789
+   atlas privateEndpoint azure watch vpce-abcdefg0123456789
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint azure watch vpce-abcdefg0123456789
-
+    atlas privateEndpoint azure watch vpce-abcdefg0123456789

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
-
+    atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
+   atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
 

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -86,4 +86,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
-

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-create.txt
@@ -72,5 +72,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoints gcp create --region CENTRAL_US
-
+    atlas privateEndpoints gcp create --region CENTRAL_US

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-create.txt
@@ -72,5 +72,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoints gcp create --region CENTRAL_US
+   atlas privateEndpoints gcp create --region CENTRAL_US
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force
+   atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force
-
+    atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint gcp describe vpce-abcdefg0123456789
+   atlas privateEndpoint gcp describe vpce-abcdefg0123456789
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-describe.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint gcp describe vpce-abcdefg0123456789
-
+    atlas privateEndpoint gcp describe vpce-abcdefg0123456789

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-create.txt
@@ -96,8 +96,7 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoints gcp interfaces create endpoint-1 \
+    atlas privateEndpoints gcp interfaces create endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd \
    --gcpProjectId mcli-private-endpoints \
    --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7
-

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-create.txt
@@ -96,7 +96,7 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoints gcp interfaces create endpoint-1 \
+   atlas privateEndpoints gcp interfaces create endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd \
    --gcpProjectId mcli-private-endpoints \
    --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-delete.txt
@@ -88,6 +88,5 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoints gcp interfaces delete endpoint-1 \
+    atlas privateEndpoints gcp interfaces delete endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd
-

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-delete.txt
@@ -88,6 +88,6 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoints gcp interfaces delete endpoint-1 \
+   atlas privateEndpoints gcp interfaces delete endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -88,6 +88,5 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoints gcp interfaces describe endpoint-1 \
+    atlas privateEndpoints gcp interfaces describe endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd
-

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -88,6 +88,6 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoints gcp interfaces describe endpoint-1 \
+   atlas privateEndpoints gcp interfaces describe endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-list.txt
@@ -76,5 +76,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint gcp ls
-
+    atlas privateEndpoint gcp ls

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-list.txt
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint gcp ls
+   atlas privateEndpoint gcp ls
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint gcp watch vpce-abcdefg0123456789
-
+    atlas privateEndpoint gcp watch vpce-abcdefg0123456789

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint gcp watch vpce-abcdefg0123456789
+   atlas privateEndpoint gcp watch vpce-abcdefg0123456789
 

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
-
+    atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
+   atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
 

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -86,4 +86,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
-

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
 

--- a/docs/atlascli/command/atlas-processes-describe.txt
+++ b/docs/atlascli/command/atlas-processes-describe.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
-
+    atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/atlascli/command/atlas-processes-describe.txt
+++ b/docs/atlascli/command/atlas-processes-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
 

--- a/docs/atlascli/command/atlas-projects-settings-describe.txt
+++ b/docs/atlascli/command/atlas-projects-settings-describe.txt
@@ -68,6 +68,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas projects settings describe -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas projects settings describe -P myprofile
 

--- a/docs/atlascli/command/atlas-projects-settings-describe.txt
+++ b/docs/atlascli/command/atlas-projects-settings-describe.txt
@@ -70,4 +70,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    atlas projects settings describe -P myprofile
-

--- a/docs/atlascli/command/atlas-projects-settings-update.txt
+++ b/docs/atlascli/command/atlas-projects-settings-update.txt
@@ -110,4 +110,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    atlas projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile
-

--- a/docs/atlascli/command/atlas-projects-settings-update.txt
+++ b/docs/atlascli/command/atlas-projects-settings-update.txt
@@ -108,6 +108,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile
 

--- a/docs/atlascli/command/atlas-quickstart.txt
+++ b/docs/atlascli/command/atlas-quickstart.txt
@@ -114,7 +114,7 @@ Examples
 
 .. code-block::
 
-   Skip setting cluster name, provider or database username by using the command options:
-   $ atlas quickstart --force
-   $ atlas quickstart --clusterName Test --provider GCP --username dbuserTest
+   # Skip setting cluster name, provider or database username by using the command options:
+   atlas quickstart --force
+   atlas quickstart --clusterName Test --provider GCP --username dbuserTest
 

--- a/docs/atlascli/command/atlas-quickstart.txt
+++ b/docs/atlascli/command/atlas-quickstart.txt
@@ -117,4 +117,3 @@ Examples
    # Skip setting cluster name, provider or database username by using the command options:
    atlas quickstart --force
    atlas quickstart --clusterName Test --provider GCP --username dbuserTest
-

--- a/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ atlas security ldap status watch requestIdSample
+   atlas security ldap status watch requestIdSample
 

--- a/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   atlas security ldap status watch requestIdSample
-
+    atlas security ldap status watch requestIdSample

--- a/docs/atlascli/command/atlas-serverless-watch.txt
+++ b/docs/atlascli/command/atlas-serverless-watch.txt
@@ -86,5 +86,4 @@ Examples
 
 .. code-block::
 
-   atlas serverless watch instanceNameSample
-
+    atlas serverless watch instanceNameSample

--- a/docs/atlascli/command/atlas-serverless-watch.txt
+++ b/docs/atlascli/command/atlas-serverless-watch.txt
@@ -86,5 +86,5 @@ Examples
 
 .. code-block::
 
-   $ atlas serverless watch instanceNameSample
+   atlas serverless watch instanceNameSample
 

--- a/docs/atlascli/command/atlas-setup.txt
+++ b/docs/atlascli/command/atlas-setup.txt
@@ -116,4 +116,3 @@ Examples
 
    # Override default cluster settings like name, provider, or database username by using the command options
    $ atlas setup --clusterName Test --provider GCP --username dbuserTest
-

--- a/docs/atlascli/command/atlas-setup.txt
+++ b/docs/atlascli/command/atlas-setup.txt
@@ -114,6 +114,6 @@ Examples
 
 .. code-block::
 
-   Override default cluster settings like name, provider, or database username by using the command options
+   # Override default cluster settings like name, provider, or database username by using the command options
    $ atlas setup --clusterName Test --provider GCP --username dbuserTest
 

--- a/docs/atlascli/command/atlas-teams-describe.txt
+++ b/docs/atlascli/command/atlas-teams-describe.txt
@@ -76,11 +76,16 @@ Examples
 
 .. code-block::
 
+   #
    
+.. code-block::
+
    # Describe a team by ID
    mongocli iam team(s) describe --id teamId --orgId <orgId>
 
+   
+.. code-block::
+
    # Describe a team by Name
    mongocli iam team(s) describe --name teamName --orgId <orgId>
-
 

--- a/docs/atlascli/command/atlas-teams-describe.txt
+++ b/docs/atlascli/command/atlas-teams-describe.txt
@@ -80,3 +80,7 @@ Examples
    # Describe a team by ID
    mongocli iam team(s) describe --id teamId --orgId <orgId>
 
+   # Describe a team by Name
+   mongocli iam team(s) describe --name teamName --orgId <orgId>
+
+

--- a/docs/atlascli/command/atlas-teams-describe.txt
+++ b/docs/atlascli/command/atlas-teams-describe.txt
@@ -77,10 +77,6 @@ Examples
 .. code-block::
 
    
-   Describe a team by ID
-   $ mongocli iam team(s) describe --id teamId --orgId <orgId>
-
-   Describe a team by Name
-   $ mongocli iam team(s) describe --name teamName --orgId <orgId>
-
+   # Describe a team by ID
+   mongocli iam team(s) describe --id teamId --orgId <orgId>
 

--- a/docs/atlascli/command/atlas-users-describe.txt
+++ b/docs/atlascli/command/atlas-users-describe.txt
@@ -76,4 +76,7 @@ Examples
    # Describe a user by ID
    mongocli iam users describe --id <id>
 
+   # Describe a user by username
+   mongocli iam users describe --username <username>
+
 

--- a/docs/atlascli/command/atlas-users-describe.txt
+++ b/docs/atlascli/command/atlas-users-describe.txt
@@ -72,11 +72,16 @@ Examples
 
 .. code-block::
 
+   #
    
+.. code-block::
+
    # Describe a user by ID
    mongocli iam users describe --id <id>
 
+   
+.. code-block::
+
    # Describe a user by username
    mongocli iam users describe --username <username>
-
 

--- a/docs/atlascli/command/atlas-users-describe.txt
+++ b/docs/atlascli/command/atlas-users-describe.txt
@@ -73,10 +73,7 @@ Examples
 .. code-block::
 
    
-   Describe a user by ID
-   $ mongocli iam users describe --id <id>
-
-   Describe a user by username
-   $ mongocli iam users describe --username <username>
+   # Describe a user by ID
+   mongocli iam users describe --id <id>
 
 

--- a/docs/atlascli/command/atlas.txt
+++ b/docs/atlascli/command/atlas.txt
@@ -41,10 +41,9 @@ Examples
 
 .. code-block::
 
-
+   
    Display the help menu for the config command
    $ atlas config --help
-
 Related Commands
 ----------------
 

--- a/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
@@ -100,6 +100,6 @@ Examples
 
 .. code-block::
 
-   Create IP address access list with the current IP address. Entry is not needed in this case.
-   $ mongocli atlas accessList create --currentIP
+   # Create IP address access list with the current IP address. Entry is not needed in this case.
+   mongocli atlas accessList create --currentIp
 

--- a/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
@@ -102,4 +102,3 @@ Examples
 
    # Create IP address access list with the current IP address. Entry is not needed in this case.
    mongocli atlas accessList create --currentIp
-

--- a/docs/mongocli/command/mongocli-atlas-accessLists-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-delete.txt
@@ -86,7 +86,9 @@ Examples
 
    # The following command deletes the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation.
    mongocli atlas accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3
+   
+.. code-block::
+
    # The following command uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation.
    mongocli atlas accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3 --force
  		
-

--- a/docs/mongocli/command/mongocli-atlas-accessLists-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-describe.txt
@@ -84,6 +84,5 @@ Examples
 
 .. code-block::
 
-   The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
+    The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
    mongocli atlas accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3
-

--- a/docs/mongocli/command/mongocli-atlas-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-list.txt
@@ -85,4 +85,3 @@ Examples
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile
-

--- a/docs/mongocli/command/mongocli-atlas-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-list.txt
@@ -80,8 +80,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts list \
+   # This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts list \
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-create.txt
@@ -176,8 +176,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-   $ mongocli atlas alert settings create --event JOINED_GROUP --enabled \
+   # This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+   mongocli atlas alert settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-create.txt
@@ -181,4 +181,3 @@ Examples
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305
-

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
@@ -76,6 +76,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
@@ -78,4 +78,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
-

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
@@ -94,4 +94,3 @@ Examples
 
    # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
    mongocli atlas backup restore list Cluster0
-

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
@@ -92,6 +92,6 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
-   $ mongocli atlas backup restore list Cluster0
+   # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+   mongocli atlas backup restore list Cluster0
 

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
@@ -112,22 +112,10 @@ Examples
 
 .. code-block::
 
-   The following example creates an automated restore:
-   $ mongocli atlas backup restore start automated \
-          --clusterName myDemo \
-          --snapshotId 5e7e00128f8ce03996a47179 \
-          --targetClusterName myDemo2 \
-          --targetProjectId 1a2345b67c8e9a12f3456de7
-
- The following example creates a point-in-time restore:
-   $ mongocli atlas backup restore start pointInTime \
-          --clusterName myDemo \
-          --pointInTimeUTCMillis 1588523147 \
-          --targetClusterName myDemo2 \
-          --targetProjectId 1a2345b67c8e9a12f3456de7
-   
- The following example creates a download restore:
-   $ mongocli atlas backup restore start download \
-          --clusterName myDemo \
-          --snapshotId 5e7e00128f8ce03996a47179
+   # The following example creates an automated restore:
+   mongocli atlas backup restore start automated \
+   --clusterName myDemo \
+   --snapshotId 5e7e00128f8ce03996a47179 \
+   --targetClusterName myDemo2 \
+   --targetProjectId 1a2345b67c8e9a12f3456de7
 

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
@@ -119,3 +119,15 @@ Examples
    --targetClusterName myDemo2 \
    --targetProjectId 1a2345b67c8e9a12f3456de7
 
+   # The following example creates a point-in-time restore:
+   mongocli atlas backup restore start pointInTime \
+   --clusterName myDemo \
+   --pointInTimeUTCMillis 1588523147 \
+   --targetClusterName myDemo2 \
+   --targetProjectId 1a2345b67c8e9a12f3456de7
+   
+   # The following example creates a download restore:
+   mongocli atlas backup restore start download \
+          --clusterName myDemo \
+          --snapshotId 5e7e00128f8ce03996a47179
+

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
@@ -119,6 +119,9 @@ Examples
    --targetClusterName myDemo2 \
    --targetProjectId 1a2345b67c8e9a12f3456de7
 
+   
+.. code-block::
+
    # The following example creates a point-in-time restore:
    mongocli atlas backup restore start pointInTime \
    --clusterName myDemo \
@@ -126,8 +129,10 @@ Examples
    --targetClusterName myDemo2 \
    --targetProjectId 1a2345b67c8e9a12f3456de7
    
+   
+.. code-block::
+
    # The following example creates a download restore:
    mongocli atlas backup restore start download \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179
-

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
@@ -89,5 +89,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
-
+    mongocli atlas snapshot watch snapshotIdSample --clusterName clusterNameSample

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
@@ -89,5 +89,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
+   mongocli atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-create.txt
@@ -134,3 +134,15 @@ Examples
    # Deploy a free cluster:
    mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 
+   # Deploy a three-member replica set in AWS:
+   mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+
+   # Deploy a three-member replica set in AZURE:
+   mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+   
+   # Deploy a three-member replica set in GCP:
+   mongocli atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+
+   # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
+   mongocli atlas cluster create --projectId <projectId> --file <path/to/file.json>
+

--- a/docs/mongocli/command/mongocli-atlas-clusters-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-create.txt
@@ -131,18 +131,6 @@ Examples
 
 .. code-block::
 
-   Deploy a free cluster:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
-
-   Deploy a three-member replica set in AWS:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
-
-   Deploy a three-member replica set in AZURE:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
-   
-   Deploy a three-member replica set in GCP:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
-
-   Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-   $ mongocli atlas cluster create --projectId <projectId> --file <path/to/file.json>
+   # Deploy a free cluster:
+   mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-create.txt
@@ -134,15 +134,26 @@ Examples
    # Deploy a free cluster:
    mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 
+   
+.. code-block::
+
    # Deploy a three-member replica set in AWS:
    mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+
+   
+.. code-block::
 
    # Deploy a three-member replica set in AZURE:
    mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
    
+   
+.. code-block::
+
    # Deploy a three-member replica set in GCP:
    mongocli atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
 
+   
+.. code-block::
+
    # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
    mongocli atlas cluster create --projectId <projectId> --file <path/to/file.json>
-

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
@@ -89,5 +89,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample
-
+    mongocli atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
@@ -89,5 +89,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample
+   mongocli atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-update.txt
@@ -103,3 +103,9 @@ Examples
    # Update tier for a cluster:
    mongocli atlas cluster update <clusterName> --projectId <projectId> --tier M50
 
+   # Update disk size for a cluster:
+   mongocli atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+
+   # Update MongoDB version for a cluster:
+   mongocli atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+

--- a/docs/mongocli/command/mongocli-atlas-clusters-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-update.txt
@@ -103,9 +103,14 @@ Examples
    # Update tier for a cluster:
    mongocli atlas cluster update <clusterName> --projectId <projectId> --tier M50
 
+   
+.. code-block::
+
    # Update disk size for a cluster:
    mongocli atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
 
+   
+.. code-block::
+
    # Update MongoDB version for a cluster:
    mongocli atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
-

--- a/docs/mongocli/command/mongocli-atlas-clusters-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-update.txt
@@ -100,12 +100,6 @@ Examples
 
 .. code-block::
 
-   Update tier for a cluster:
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --tier M50
-
-   Update disk size for a cluster:
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
-
-   Update MongoDB version for a cluster:
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+   # Update tier for a cluster:
+   mongocli atlas cluster update <clusterName> --projectId <projectId> --tier M50
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas cluster watch clusterNameSample
+   mongocli atlas cluster watch clusterNameSample
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas cluster watch clusterNameSample
-
+    mongocli atlas cluster watch clusterNameSample

--- a/docs/mongocli/command/mongocli-atlas-customDbRoles-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDbRoles-create.txt
@@ -92,5 +92,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database
-
+    mongocli atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database

--- a/docs/mongocli/command/mongocli-atlas-customDbRoles-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDbRoles-create.txt
@@ -92,5 +92,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database
+   mongocli atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
@@ -119,15 +119,6 @@ Examples
 
 .. code-block::
 
-   Create an Atlas database admin user:
-   $ mongocli atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
-
-   Create a database user with read/write access to any database:
-   $ mongocli atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
-
-   Create a database user with multiple roles:
-   $ mongocli atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
-
-   Create a database user with multiple scopes:
-   $ mongocli atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
+   # Create an Atlas database admin user:
+   mongocli atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
@@ -122,12 +122,20 @@ Examples
    # Create an Atlas database admin user:
    mongocli atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
 
+   
+.. code-block::
+
    # Create a database user with read/write access to any database:
    mongocli atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+
+   
+.. code-block::
 
    # Create a database user with multiple roles:
    mongocli atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
 
+   
+.. code-block::
+
    # Create a database user with multiple scopes:
    mongocli atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
-

--- a/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
@@ -122,3 +122,12 @@ Examples
    # Create an Atlas database admin user:
    mongocli atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
 
+   # Create a database user with read/write access to any database:
+   mongocli atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+
+   # Create a database user with multiple roles:
+   mongocli atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+
+   # Create a database user with multiple scopes:
+   mongocli atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
+

--- a/docs/mongocli/command/mongocli-atlas-dbusers-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-describe.txt
@@ -91,9 +91,14 @@ Examples
    # The following example returns a MongoDB database user named myDbUser on an Atlas cluster:
    mongocli atlas dbuser describe myDbUser --authDB admin --output json
 
+   
+.. code-block::
+
    # The following example returns a MongoDB database user with X.509 authentication on an Atlas cluster. Prepend $external with \ to escape the special-use character.
    mongocli atlas dbuser describe CN=ellen@example.com,OU=users,DC=example,DC=com --authDB \$external --output json
 
+   
+.. code-block::
+
    # The following example returns a MongoDB database user with AWS IAM authentication on an Atlas cluster. Prepend $external with \ to escape the special-use character.
    mongocli atlas dbuser describe arn:aws:iam::772401394250:user/my-test-user --authDB \$external --output json
-

--- a/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
@@ -103,3 +103,6 @@ Examples
    # Update roles for a database user:
    mongocli atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 
+   # Update scopes for a database user:
+   mongocli atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>
+

--- a/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
@@ -100,9 +100,6 @@ Examples
 
 .. code-block::
 
-   Update roles for a database user:
-   $ mongocli atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
-
-   Update scopes for a database user:
-   $ mongocli atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>
+   # Update roles for a database user:
+   mongocli atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
@@ -103,6 +103,8 @@ Examples
    # Update roles for a database user:
    mongocli atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 
+   
+.. code-block::
+
    # Update scopes for a database user:
    mongocli atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>
-

--- a/docs/mongocli/command/mongocli-atlas-metrics-databases-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-databases-describe.txt
@@ -119,6 +119,5 @@ Examples
 
 .. code-block::
 
-   This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
+    This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
    mongocli atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
-

--- a/docs/mongocli/command/mongocli-atlas-metrics-databases-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-databases-describe.txt
@@ -15,7 +15,7 @@ mongocli atlas metrics databases describe
 Describe database metrics for a database on a specific host.
 
 To retrieve the hostname and port needed for this command, run:
-$ mongocli atlas process list
+mongocli atlas process list
 
 Syntax
 ------
@@ -120,5 +120,5 @@ Examples
 .. code-block::
 
    This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
-   $ mongocli atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
+   mongocli atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
 

--- a/docs/mongocli/command/mongocli-atlas-metrics-databases-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-databases-list.txt
@@ -95,6 +95,5 @@ Examples
 
 .. code-block::
 
-   This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+    This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
    mongocli atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
-

--- a/docs/mongocli/command/mongocli-atlas-metrics-databases-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-databases-list.txt
@@ -15,7 +15,7 @@ mongocli atlas metrics databases list
 List available databases or database metrics for a given host.
 
 To retrieve the hostname and port needed for this command, run:
-$ mongocli atlas process list
+mongocli atlas process list
 
 Syntax
 ------
@@ -96,5 +96,5 @@ Examples
 .. code-block::
 
    This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ mongocli atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   mongocli atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
 

--- a/docs/mongocli/command/mongocli-atlas-metrics-disks-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-disks-describe.txt
@@ -121,4 +121,3 @@ Examples
 
    # This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
    mongocli atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
-

--- a/docs/mongocli/command/mongocli-atlas-metrics-disks-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-disks-describe.txt
@@ -15,7 +15,7 @@ mongocli atlas metrics disks describe
 Describe disk partition metrics for a disk partition on a specified host.
 
 To retrieve the hostname and port needed for this command, run:
-$ mongocli atlas process list
+mongocli atlas process list
 
 Syntax
 ------
@@ -119,6 +119,6 @@ Examples
 
 .. code-block::
 
-   This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ mongocli atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
+   # This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+   mongocli atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
 

--- a/docs/mongocli/command/mongocli-atlas-metrics-disks-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-disks-list.txt
@@ -95,6 +95,5 @@ Examples
 
 .. code-block::
 
-   This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+    This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
    mongocli atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
-

--- a/docs/mongocli/command/mongocli-atlas-metrics-disks-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-disks-list.txt
@@ -15,7 +15,7 @@ mongocli atlas metrics disks list
 List available disks or disk partitions for a given host.
 
 To retrieve the hostname and port needed for this command, run:
-$ mongocli atlas process list
+mongocli atlas process list
 
 Syntax
 ------
@@ -96,5 +96,5 @@ Examples
 .. code-block::
 
    This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ mongocli atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   mongocli atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
 

--- a/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
@@ -115,5 +115,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
-
+    mongocli atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
@@ -15,7 +15,7 @@ mongocli atlas metrics processes
 Get MongoDB process metrics for a given host.
 
 To retrieve the hostname and port needed for this command, run:
-$ mongocli atlas process list
+mongocli atlas process list
 
 Syntax
 ------
@@ -115,5 +115,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   mongocli atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
 

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-create-aws.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-create-aws.txt
@@ -90,4 +90,3 @@ Examples
 
    # The following command creates a peering connection between the Atlas VPC and your AWS VPC for a project using the default profile.
    mongocli atlas networking peering create aws --accountId <aws-account-id> --atlasCidrBlock 192.168.0.0/24 --region us-east-1 --routeTableCidrBlock 10.0.0.0/24 --vpcId vpc-078ac381aa90e1e63
-

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
@@ -89,5 +89,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas networking peering watch peeringConnectionSampleId
-
+    mongocli atlas networking peering watch peeringConnectionSampleId

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
@@ -89,5 +89,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas networking peering watch peeringConnectionSampleId
+   mongocli atlas networking peering watch peeringConnectionSampleId
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force
-
+    mongocli atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force
+   mongocli atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
@@ -86,4 +86,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    mongocli atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile
-

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -88,6 +88,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -90,4 +90,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    mongocli atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile
-

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint aws watch vpce-abcdefg0123456789
-
+    mongocli atlas privateEndpoint aws watch vpce-abcdefg0123456789

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint aws watch vpce-abcdefg0123456789
+   mongocli atlas privateEndpoint aws watch vpce-abcdefg0123456789
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force
+   mongocli atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force
-
+    mongocli atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint azure watch vpce-abcdefg0123456789
+   mongocli atlas privateEndpoint azure watch vpce-abcdefg0123456789
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint azure watch vpce-abcdefg0123456789
-
+    mongocli atlas privateEndpoint azure watch vpce-abcdefg0123456789

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
-
+    mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
+   mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -86,4 +86,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
-

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-create.txt
@@ -72,5 +72,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoints gcp create --region CENTRAL_US
-
+    mongocli atlas privateEndpoints gcp create --region CENTRAL_US

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-create.txt
@@ -72,5 +72,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoints gcp create --region CENTRAL_US
+   mongocli atlas privateEndpoints gcp create --region CENTRAL_US
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force
-
+    mongocli atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force
+   mongocli atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint gcp describe vpce-abcdefg0123456789
+   mongocli atlas privateEndpoint gcp describe vpce-abcdefg0123456789
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-describe.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint gcp describe vpce-abcdefg0123456789
-
+    mongocli atlas privateEndpoint gcp describe vpce-abcdefg0123456789

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-create.txt
@@ -96,8 +96,7 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoints gcp interfaces create endpoint-1 \
+    mongocli atlas privateEndpoints gcp interfaces create endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd \
    --gcpProjectId mcli-private-endpoints \
    --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7
-

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-create.txt
@@ -96,7 +96,7 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoints gcp interfaces create endpoint-1 \
+   mongocli atlas privateEndpoints gcp interfaces create endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd \
    --gcpProjectId mcli-private-endpoints \
    --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-delete.txt
@@ -88,6 +88,6 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoints gcp interfaces delete endpoint-1 \
+   mongocli atlas privateEndpoints gcp interfaces delete endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-delete.txt
@@ -88,6 +88,5 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoints gcp interfaces delete endpoint-1 \
+    mongocli atlas privateEndpoints gcp interfaces delete endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd
-

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -88,6 +88,6 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoints gcp interfaces describe endpoint-1 \
+   mongocli atlas privateEndpoints gcp interfaces describe endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -88,6 +88,5 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoints gcp interfaces describe endpoint-1 \
+    mongocli atlas privateEndpoints gcp interfaces describe endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd
-

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-list.txt
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint gcp ls
+   mongocli atlas privateEndpoint gcp ls
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-list.txt
@@ -76,5 +76,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint gcp ls
-
+    mongocli atlas privateEndpoint gcp ls

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint gcp watch vpce-abcdefg0123456789
+   mongocli atlas privateEndpoint gcp watch vpce-abcdefg0123456789
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint gcp watch vpce-abcdefg0123456789
-
+    mongocli atlas privateEndpoint gcp watch vpce-abcdefg0123456789

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-delete.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
-
+    mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
+   mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -84,6 +84,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -86,4 +86,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
-

--- a/docs/mongocli/command/mongocli-atlas-processes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-processes-describe.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
-
+    mongocli atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/mongocli/command/mongocli-atlas-processes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-processes-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   mongocli atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
 

--- a/docs/mongocli/command/mongocli-atlas-quickstart.txt
+++ b/docs/mongocli/command/mongocli-atlas-quickstart.txt
@@ -114,7 +114,7 @@ Examples
 
 .. code-block::
 
-   Skip setting cluster name, provider or database username by using the command options:
-   $ mongocli atlas quickstart --force
-   $ mongocli atlas quickstart --clusterName Test --provider GCP --username dbuserTest
+   # Skip setting cluster name, provider or database username by using the command options:
+   mongocli atlas quickstart --force
+   mongocli atlas quickstart --clusterName Test --provider GCP --username dbuserTest
 

--- a/docs/mongocli/command/mongocli-atlas-quickstart.txt
+++ b/docs/mongocli/command/mongocli-atlas-quickstart.txt
@@ -117,4 +117,3 @@ Examples
    # Skip setting cluster name, provider or database username by using the command options:
    mongocli atlas quickstart --force
    mongocli atlas quickstart --clusterName Test --provider GCP --username dbuserTest
-

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
@@ -85,5 +85,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas security ldap status watch requestIdSample
+   mongocli atlas security ldap status watch requestIdSample
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
@@ -85,5 +85,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas security ldap status watch requestIdSample
-
+    mongocli atlas security ldap status watch requestIdSample

--- a/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
@@ -86,5 +86,4 @@ Examples
 
 .. code-block::
 
-   mongocli atlas serverless watch instanceNameSample
-
+    mongocli atlas serverless watch instanceNameSample

--- a/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
@@ -86,5 +86,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas serverless watch instanceNameSample
+   mongocli atlas serverless watch instanceNameSample
 

--- a/docs/mongocli/command/mongocli-auth-login.txt
+++ b/docs/mongocli/command/mongocli-auth-login.txt
@@ -72,7 +72,7 @@ Examples
 
 .. code-block::
 
-   To start the interactive login for your MongoDB Atlas or Cloud Manager account:
-   $ mongocli auth login
+   # To start the interactive login for your MongoDB Atlas or Cloud Manager account:
+   mongocli auth login
 
 

--- a/docs/mongocli/command/mongocli-auth-login.txt
+++ b/docs/mongocli/command/mongocli-auth-login.txt
@@ -75,4 +75,3 @@ Examples
    # To start the interactive login for your MongoDB Atlas or Cloud Manager account:
    mongocli auth login
 
-

--- a/docs/mongocli/command/mongocli-auth-logout.txt
+++ b/docs/mongocli/command/mongocli-auth-logout.txt
@@ -64,7 +64,7 @@ Examples
 
 .. code-block::
 
-   To log out from the CLI:
-   $ mongocli auth logout
+   # To log out from the CLI:
+   mongocli auth logout
 
 

--- a/docs/mongocli/command/mongocli-auth-logout.txt
+++ b/docs/mongocli/command/mongocli-auth-logout.txt
@@ -67,4 +67,3 @@ Examples
    # To log out from the CLI:
    mongocli auth logout
 
-

--- a/docs/mongocli/command/mongocli-auth-whoami.txt
+++ b/docs/mongocli/command/mongocli-auth-whoami.txt
@@ -60,7 +60,7 @@ Examples
 
 .. code-block::
 
-   See the logged account:
-   $ mongocli auth whoami
+   # See the logged account:
+   mongocli auth whoami
 
 

--- a/docs/mongocli/command/mongocli-auth-whoami.txt
+++ b/docs/mongocli/command/mongocli-auth-whoami.txt
@@ -63,4 +63,3 @@ Examples
    # See the logged account:
    mongocli auth whoami
 
-

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
@@ -85,4 +85,3 @@ Examples
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile
-

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
@@ -80,8 +80,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts list \
+   # This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts list \
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-create.txt
@@ -176,8 +176,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-   $ mongocli atlas alert settings create --event JOINED_GROUP --enabled \
+   # This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+   mongocli atlas alert settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-create.txt
@@ -181,4 +181,3 @@ Examples
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305
-

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
@@ -76,6 +76,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
@@ -78,4 +78,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
-

--- a/docs/mongocli/command/mongocli-cloud-manager-automation-watch.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-automation-watch.txt
@@ -69,5 +69,4 @@ Examples
 
 .. code-block::
 
-   mongocli ops-manager automation watch
-
+    mongocli ops-manager automation watch

--- a/docs/mongocli/command/mongocli-cloud-manager-automation-watch.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-automation-watch.txt
@@ -69,5 +69,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli ops-manager automation watch
+   mongocli ops-manager automation watch
 

--- a/docs/mongocli/command/mongocli-cloud-manager-clusters-indexes-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-clusters-indexes-create.txt
@@ -142,4 +142,3 @@ Examples
    mongocli om clusters indexes create bedrooms_1 \
      --collectionName listings --db realestate --key bedrooms:1 \
      --rsName repl1
-

--- a/docs/mongocli/command/mongocli-cloud-manager-clusters-indexes-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-clusters-indexes-create.txt
@@ -136,7 +136,7 @@ Examples
 
 .. code-block::
 
-   The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
+   # The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
    The command uses the default profile.
 
    mongocli om clusters indexes create bedrooms_1 \

--- a/docs/mongocli/command/mongocli-cloud-manager-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-dbusers-create.txt
@@ -84,7 +84,9 @@ Examples
 
 .. code-block::
 
+   #
+   
+.. code-block::
 
    # Create a user with readWriteAnyDatabase and clusterMonitor access
    mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>
-

--- a/docs/mongocli/command/mongocli-cloud-manager-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-dbusers-create.txt
@@ -85,6 +85,6 @@ Examples
 .. code-block::
 
 
-   Create a user with readWriteAnyDatabase and clusterMonitor access
-   $ mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>
+   # Create a user with readWriteAnyDatabase and clusterMonitor access
+   mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>
 

--- a/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-update.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-update.txt
@@ -89,3 +89,7 @@ Examples
    # Disable user management for a project:
    mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 
+   # Update policies from a JSON configuration file:
+   mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
+
+

--- a/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-update.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-update.txt
@@ -86,10 +86,6 @@ Examples
 
 .. code-block::
 
- Disable user management for a project:
-   $ mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
-
-   Update policies from a JSON configuration file:
-   $ mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
-
+   # Disable user management for a project:
+   mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 

--- a/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-update.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-update.txt
@@ -89,7 +89,9 @@ Examples
    # Disable user management for a project:
    mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 
+   
+.. code-block::
+
    # Update policies from a JSON configuration file:
    mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
-
 

--- a/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
@@ -92,9 +92,6 @@ Examples
 
 .. code-block::
 
-
- 	For audit logs in BSON format:
-   $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
- 	For audit logs in JSON format:
-   $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json
+   # For audit logs in BSON format:
+   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
 

--- a/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
@@ -92,6 +92,9 @@ Examples
 
 .. code-block::
 
+
    # For audit logs in BSON format:
    mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
+ 	For audit logs in JSON format:
+   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json
 

--- a/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
@@ -92,9 +92,11 @@ Examples
 
 .. code-block::
 
+   #
+   
+.. code-block::
 
    # For audit logs in BSON format:
    mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
  	For audit logs in JSON format:
    mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json
-

--- a/docs/mongocli/command/mongocli-cloud-manager-logs-keyProviders-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-logs-keyProviders-list.txt
@@ -68,6 +68,5 @@ Examples
 
 .. code-block::
 
-
+   
    mongocli ops-manager listKeyProvider --file log.gz
-

--- a/docs/mongocli/command/mongocli-cloud-manager-logs-keyProviders-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-logs-keyProviders-list.txt
@@ -69,5 +69,5 @@ Examples
 .. code-block::
 
 
-   $ mongocli ops-manager listKeyProvider --file log.gz
+   mongocli ops-manager listKeyProvider --file log.gz
 

--- a/docs/mongocli/command/mongocli-config-delete.txt
+++ b/docs/mongocli/command/mongocli-config-delete.txt
@@ -80,9 +80,6 @@ Examples
 
 .. code-block::
 
-   Delete the default profile configuration:
-   $ atlas config delete default
-
-   Skip the confirmation question and delete the default profile configuration:
-   $ atlas config delete default --force
+   # Delete the default profile configuration:
+   mongocli config delete default
 

--- a/docs/mongocli/command/mongocli-config-delete.txt
+++ b/docs/mongocli/command/mongocli-config-delete.txt
@@ -81,5 +81,8 @@ Examples
 .. code-block::
 
    # Delete the default profile configuration:
-   mongocli config delete default
+   atlas config delete default
+
+   # Skip the confirmation question and delete the default profile configuration:
+   atlas config delete default --force
 

--- a/docs/mongocli/command/mongocli-config-delete.txt
+++ b/docs/mongocli/command/mongocli-config-delete.txt
@@ -83,6 +83,8 @@ Examples
    # Delete the default profile configuration:
    atlas config delete default
 
+   
+.. code-block::
+
    # Skip the confirmation question and delete the default profile configuration:
    atlas config delete default --force
-

--- a/docs/mongocli/command/mongocli-config-edit.txt
+++ b/docs/mongocli/command/mongocli-config-edit.txt
@@ -64,7 +64,7 @@ Examples
 
 
    To open the config
-   $ mongocli config edit
+   mongocli config edit
 
 
 

--- a/docs/mongocli/command/mongocli-config-edit.txt
+++ b/docs/mongocli/command/mongocli-config-edit.txt
@@ -62,10 +62,9 @@ Examples
 
 .. code-block::
 
-
+   
    To open the config
    mongocli config edit
-
 
 
 .. toctree::

--- a/docs/mongocli/command/mongocli-config-list.txt
+++ b/docs/mongocli/command/mongocli-config-list.txt
@@ -66,5 +66,4 @@ Examples
 
 .. code-block::
 
-   mongocli config ls
-
+    mongocli config ls

--- a/docs/mongocli/command/mongocli-config-list.txt
+++ b/docs/mongocli/command/mongocli-config-list.txt
@@ -66,5 +66,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli config ls
+   mongocli config ls
 

--- a/docs/mongocli/command/mongocli-config-rename.txt
+++ b/docs/mongocli/command/mongocli-config-rename.txt
@@ -80,6 +80,6 @@ Examples
 
 .. code-block::
 
-   Rename a profile called myProfile to testProfile:
-   $ mongocli config rename myProfile testProfile
+   # Rename a profile called myProfile to testProfile:
+   mongocli config rename myProfile testProfile
 

--- a/docs/mongocli/command/mongocli-config-rename.txt
+++ b/docs/mongocli/command/mongocli-config-rename.txt
@@ -82,4 +82,3 @@ Examples
 
    # Rename a profile called myProfile to testProfile:
    mongocli config rename myProfile testProfile
-

--- a/docs/mongocli/command/mongocli-config-set.txt
+++ b/docs/mongocli/command/mongocli-config-set.txt
@@ -83,9 +83,14 @@ Examples
 
 .. code-block::
 
+   #
+   
+.. code-block::
 
    # Set Ops Manager Base URL in the profile myProfile:
    mongocli config set ops_manager_url http://localhost:30700/ -P myProfile
+   
+.. code-block::
+
    # Set Organization ID in the default profile:
    mongocli config set org_id 5dd5aaef7a3e5a6c5bd12de4
-

--- a/docs/mongocli/command/mongocli-config-set.txt
+++ b/docs/mongocli/command/mongocli-config-set.txt
@@ -86,4 +86,6 @@ Examples
 
    # Set Ops Manager Base URL in the profile myProfile:
    mongocli config set ops_manager_url http://localhost:30700/ -P myProfile
+   # Set Organization ID in the default profile:
+   mongocli config set org_id 5dd5aaef7a3e5a6c5bd12de4
 

--- a/docs/mongocli/command/mongocli-config-set.txt
+++ b/docs/mongocli/command/mongocli-config-set.txt
@@ -84,8 +84,6 @@ Examples
 .. code-block::
 
 
-   Set Ops Manager Base URL in the profile myProfile:
-   $ mongocli config set ops_manager_url http://localhost:30700/ -P myProfile
-   Set Organization ID in the default profile:
-   $ mongocli config set org_id 5dd5aaef7a3e5a6c5bd12de4
+   # Set Ops Manager Base URL in the profile myProfile:
+   mongocli config set ops_manager_url http://localhost:30700/ -P myProfile
 

--- a/docs/mongocli/command/mongocli-config.txt
+++ b/docs/mongocli/command/mongocli-config.txt
@@ -70,7 +70,7 @@ Examples
 
 .. code-block::
 
-
+   
    Configure a profile to interact with Atlas:
    $ mongocli config
    Configure a profile to interact with Atlas for Government:
@@ -80,7 +80,6 @@ Examples
    $ mongocli config --service cloud-manager
    Configure a profile to interact with Ops Manager:
    $ mongocli config --service ops-manager
-
 
 Related Commands
 ----------------

--- a/docs/mongocli/command/mongocli-iam-teams-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-describe.txt
@@ -76,11 +76,16 @@ Examples
 
 .. code-block::
 
+   #
    
+.. code-block::
+
    # Describe a team by ID
    mongocli iam team(s) describe --id teamId --orgId <orgId>
 
+   
+.. code-block::
+
    # Describe a team by Name
    mongocli iam team(s) describe --name teamName --orgId <orgId>
-
 

--- a/docs/mongocli/command/mongocli-iam-teams-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-describe.txt
@@ -80,3 +80,7 @@ Examples
    # Describe a team by ID
    mongocli iam team(s) describe --id teamId --orgId <orgId>
 
+   # Describe a team by Name
+   mongocli iam team(s) describe --name teamName --orgId <orgId>
+
+

--- a/docs/mongocli/command/mongocli-iam-teams-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-describe.txt
@@ -77,10 +77,6 @@ Examples
 .. code-block::
 
    
-   Describe a team by ID
-   $ mongocli iam team(s) describe --id teamId --orgId <orgId>
-
-   Describe a team by Name
-   $ mongocli iam team(s) describe --name teamName --orgId <orgId>
-
+   # Describe a team by ID
+   mongocli iam team(s) describe --id teamId --orgId <orgId>
 

--- a/docs/mongocli/command/mongocli-iam-users-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-users-describe.txt
@@ -76,4 +76,7 @@ Examples
    # Describe a user by ID
    mongocli iam users describe --id <id>
 
+   # Describe a user by username
+   mongocli iam users describe --username <username>
+
 

--- a/docs/mongocli/command/mongocli-iam-users-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-users-describe.txt
@@ -72,11 +72,16 @@ Examples
 
 .. code-block::
 
+   #
    
+.. code-block::
+
    # Describe a user by ID
    mongocli iam users describe --id <id>
 
+   
+.. code-block::
+
    # Describe a user by username
    mongocli iam users describe --username <username>
-
 

--- a/docs/mongocli/command/mongocli-iam-users-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-users-describe.txt
@@ -73,10 +73,7 @@ Examples
 .. code-block::
 
    
-   Describe a user by ID
-   $ mongocli iam users describe --id <id>
-
-   Describe a user by username
-   $ mongocli iam users describe --username <username>
+   # Describe a user by ID
+   mongocli iam users describe --id <id>
 
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
@@ -85,4 +85,3 @@ Examples
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile
-

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
@@ -80,8 +80,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts list \
+   # This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts list \
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-create.txt
@@ -176,8 +176,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-   $ mongocli atlas alert settings create --event JOINED_GROUP --enabled \
+   # This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+   mongocli atlas alert settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-create.txt
@@ -181,4 +181,3 @@ Examples
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305
-

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
@@ -76,6 +76,6 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
@@ -78,4 +78,3 @@ Examples
 
    # This example uses the profile named "myprofile" for accessing Atlas.
    mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
-

--- a/docs/mongocli/command/mongocli-ops-manager-automation-watch.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-automation-watch.txt
@@ -69,5 +69,4 @@ Examples
 
 .. code-block::
 
-   mongocli ops-manager automation watch
-
+    mongocli ops-manager automation watch

--- a/docs/mongocli/command/mongocli-ops-manager-automation-watch.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-automation-watch.txt
@@ -69,5 +69,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli ops-manager automation watch
+   mongocli ops-manager automation watch
 

--- a/docs/mongocli/command/mongocli-ops-manager-clusters-indexes-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-clusters-indexes-create.txt
@@ -142,4 +142,3 @@ Examples
    mongocli om clusters indexes create bedrooms_1 \
      --collectionName listings --db realestate --key bedrooms:1 \
      --rsName repl1
-

--- a/docs/mongocli/command/mongocli-ops-manager-clusters-indexes-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-clusters-indexes-create.txt
@@ -136,7 +136,7 @@ Examples
 
 .. code-block::
 
-   The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
+   # The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
    The command uses the default profile.
 
    mongocli om clusters indexes create bedrooms_1 \

--- a/docs/mongocli/command/mongocli-ops-manager-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-dbusers-create.txt
@@ -84,7 +84,9 @@ Examples
 
 .. code-block::
 
+   #
+   
+.. code-block::
 
    # Create a user with readWriteAnyDatabase and clusterMonitor access
    mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>
-

--- a/docs/mongocli/command/mongocli-ops-manager-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-dbusers-create.txt
@@ -85,6 +85,6 @@ Examples
 .. code-block::
 
 
-   Create a user with readWriteAnyDatabase and clusterMonitor access
-   $ mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>
+   # Create a user with readWriteAnyDatabase and clusterMonitor access
+   mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>
 

--- a/docs/mongocli/command/mongocli-ops-manager-featurePolicies-update.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-featurePolicies-update.txt
@@ -89,3 +89,7 @@ Examples
    # Disable user management for a project:
    mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 
+   # Update policies from a JSON configuration file:
+   mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
+
+

--- a/docs/mongocli/command/mongocli-ops-manager-featurePolicies-update.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-featurePolicies-update.txt
@@ -86,10 +86,6 @@ Examples
 
 .. code-block::
 
- Disable user management for a project:
-   $ mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
-
-   Update policies from a JSON configuration file:
-   $ mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
-
+   # Disable user management for a project:
+   mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 

--- a/docs/mongocli/command/mongocli-ops-manager-featurePolicies-update.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-featurePolicies-update.txt
@@ -89,7 +89,9 @@ Examples
    # Disable user management for a project:
    mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 
+   
+.. code-block::
+
    # Update policies from a JSON configuration file:
    mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
-
 

--- a/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
@@ -92,9 +92,6 @@ Examples
 
 .. code-block::
 
-
- 	For audit logs in BSON format:
-   $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
- 	For audit logs in JSON format:
-   $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json
+   # For audit logs in BSON format:
+   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
 

--- a/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
@@ -92,6 +92,9 @@ Examples
 
 .. code-block::
 
+
    # For audit logs in BSON format:
    mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
+ 	For audit logs in JSON format:
+   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json
 

--- a/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
@@ -92,9 +92,11 @@ Examples
 
 .. code-block::
 
+   #
+   
+.. code-block::
 
    # For audit logs in BSON format:
    mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
  	For audit logs in JSON format:
    mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json
-

--- a/docs/mongocli/command/mongocli-ops-manager-logs-keyProviders-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-logs-keyProviders-list.txt
@@ -68,6 +68,5 @@ Examples
 
 .. code-block::
 
-
+   
    mongocli ops-manager listKeyProvider --file log.gz
-

--- a/docs/mongocli/command/mongocli-ops-manager-logs-keyProviders-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-logs-keyProviders-list.txt
@@ -69,5 +69,5 @@ Examples
 .. code-block::
 
 
-   $ mongocli ops-manager listKeyProvider --file log.gz
+   mongocli ops-manager listKeyProvider --file log.gz
 

--- a/docs/mongocli/command/mongocli-ops-manager-serverUsage-download.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-serverUsage-download.txt
@@ -84,5 +84,4 @@ Examples
 
 .. code-block::
 
-   mongocli ops-manager serverUsage download --endDate 2022-12-12 --startDate 2022-01-01
-
+    mongocli ops-manager serverUsage download --endDate 2022-12-12 --startDate 2022-01-01

--- a/docs/mongocli/command/mongocli.txt
+++ b/docs/mongocli/command/mongocli.txt
@@ -41,10 +41,9 @@ Examples
 
 .. code-block::
 
-
+   
    Display the help menu for the config command
    $ mongocli config --help
-
 Related Commands
 ----------------
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/klauspost/compress v1.15.12
 	github.com/mattn/go-isatty v0.0.16
 	github.com/mongodb-forks/digest v1.0.4
-	github.com/mongodb-labs/cobra2snooty v0.11.0
+	github.com/mongodb-labs/cobra2snooty v0.12.0
 	github.com/openlyinc/pointy v1.2.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mongodb-forks/digest v1.0.4 h1:9FrGTc7MGAchgaQBcXBnEwUM/Oo8obW7OGWxnsSvZ64=
 github.com/mongodb-forks/digest v1.0.4/go.mod h1:eHRfgovT+dvSFfltrOa27hy1oR/rcwyDdp5H1ZQxEMA=
-github.com/mongodb-labs/cobra2snooty v0.11.0 h1:wwxU9OE0ayemPlnHQPHcClPcvL/ALtoBtfP5CBx1FnM=
-github.com/mongodb-labs/cobra2snooty v0.11.0/go.mod h1:GZIm50ATfP1kgLzFKa9OH6oY96A0aNLR8UssrzLn2uI=
+github.com/mongodb-labs/cobra2snooty v0.12.0 h1:JjdKU8Zh3QFwBuFuS0WKBPObyASp8MzuQ1d3UL5hrqE=
+github.com/mongodb-labs/cobra2snooty v0.12.0/go.mod h1:35BYcRwKG+Lu+bKidg7lw1RT8W4K3zLsExyMLyTZB7U=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/internal/cli/alerts/list.go
+++ b/internal/cli/alerts/list.go
@@ -74,8 +74,8 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Retrieves all alerts for the specified Atlas project.",
-		Example: fmt.Sprintf(`  This example uses the "%[1]s alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-  $ %[1]s alerts list \
+		Example: fmt.Sprintf(`  # This example uses the "%[1]s alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+  %[1]s alerts list \
     --projectId 5df90590f10fab5e33de2305 \
     -o json \
     --profile myprofile`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/alerts/settings/create.go
+++ b/internal/cli/alerts/settings/create.go
@@ -67,8 +67,8 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates one alert configuration in the specified project.",
-		Example: fmt.Sprintf(`  This example uses the "%[1]s alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-  $ %[1]s alert settings create --event JOINED_GROUP --enabled \
+		Example: fmt.Sprintf(`  # This example uses the "%[1]s alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+  %[1]s alert settings create --event JOINED_GROUP --enabled \
   --notificationType USER --notificationEmailEnabled \
   --notificationUsername john@example.com \
   -o json --projectId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/alerts/settings/list.go
+++ b/internal/cli/alerts/settings/list.go
@@ -62,8 +62,8 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Returns alert configurations for the specified project.",
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{},
 		Aliases:     []string{"ls"},
 		Args:        require.NoArgs,

--- a/internal/cli/atlas/accesslists/create.go
+++ b/internal/cli/atlas/accesslists/create.go
@@ -138,8 +138,8 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"entryDesc": "The IP address, CIDR address, or AWS security group ID of the access list entry to create.",
 		},
-		Example: fmt.Sprintf(`  Create IP address access list with the current IP address. Entry is not needed in this case.
-  $ %s accessList create --currentIP`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Create IP address access list with the current IP address. Entry is not needed in this case.
+  %s accessList create --currentIp`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/buckets/create.go
+++ b/internal/cli/atlas/backup/exports/buckets/create.go
@@ -73,8 +73,8 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <bucketName>",
 		Short: "Create an export destination for Atlas backups using an existing AWS S3 bucket.",
-		Example: fmt.Sprintf(`  The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
-  $ %s backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca`, config.BinName()),
+		Example: fmt.Sprintf(`  # The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
+  %s backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca`, config.BinName()),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"bucketNameDesc": "Name of the existing S3 bucket that the provided role ID is authorized to access.",

--- a/internal/cli/atlas/backup/exports/buckets/delete.go
+++ b/internal/cli/atlas/backup/exports/buckets/delete.go
@@ -60,8 +60,8 @@ func DeleteBuilder() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a snapshot export bucket.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  The following deletes the continuous backup export bucket specified by ID:
-  $ %s backup exports buckets delete --bucketId dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following deletes the continuous backup export bucket specified by ID:
+  %s backup exports buckets delete --bucketId dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/buckets/describe.go
+++ b/internal/cli/atlas/backup/exports/buckets/describe.go
@@ -62,8 +62,8 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Short:   "Return one snapshot export bucket.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  The following example returns the continuous backup export bucket specified by ID:
-  $ %s backup exports buckets describe dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example returns the continuous backup export bucket specified by ID:
+  %s backup exports buckets describe dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/buckets/list.go
+++ b/internal/cli/atlas/backup/exports/buckets/list.go
@@ -64,8 +64,8 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List cloud backup restore buckets for your project and cluster.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup export buckets:
-  $ %s backup exports buckets list`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup export buckets:
+  %s backup exports buckets list`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/jobs/create.go
+++ b/internal/cli/atlas/backup/exports/jobs/create.go
@@ -80,8 +80,8 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Export one backup snapshot for an M10 or higher Atlas cluster to an existing AWS S3 bucket.",
-		Example: fmt.Sprintf(`  The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
-  $ %s backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test`, config.BinName()),
+		Example: fmt.Sprintf(`  # The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
+  %s backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test`, config.BinName()),
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/backup/exports/jobs/decribe.go
+++ b/internal/cli/atlas/backup/exports/jobs/decribe.go
@@ -64,8 +64,8 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Short:   "Return one cloud backup export job for your project, cluster and bucket.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
-  $ %s backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
+  %s backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/jobs/list.go
+++ b/internal/cli/atlas/backup/exports/jobs/list.go
@@ -68,8 +68,8 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve restore jobs.",
 		},
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup export jobs for the cluster Cluster0:
-  $ %s backup exports jobs list Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup export jobs for the cluster Cluster0:
+  %s backup exports jobs list Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 

--- a/internal/cli/atlas/backup/restores/describe.go
+++ b/internal/cli/atlas/backup/restores/describe.go
@@ -66,8 +66,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"restoreJobIdDesc": "ID of the restore job.",
 		},
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup restore job for the cluster Cluster0:
-  $ %s backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup restore job for the cluster Cluster0:
+  %s backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/restores/list.go
+++ b/internal/cli/atlas/backup/restores/list.go
@@ -68,8 +68,8 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve restore jobs.",
 		},
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
-  $ %s backup restore list Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+  %s backup restore list Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -144,25 +144,23 @@ func StartBuilder() *cobra.Command {
 		ValidArgs: []string{automatedRestore, downloadRestore, pointInTimeRestore},
 		Annotations: map[string]string{
 			"automated|download|pointInTimeDesc": "Type of restore job to create. Accepted values include: automated, download, pointInTime.",
+			"Example2": fmt.Sprintf(`  # The following example creates a point-in-time restore:
+  %[1]s backup restore start pointInTime \
+  --clusterName myDemo \
+  --pointInTimeUTCMillis 1588523147 \
+  --targetClusterName myDemo2 \
+  --targetProjectId 1a2345b67c8e9a12f3456de7`, cli.ExampleAtlasEntryPoint()),
+			"Example3": fmt.Sprintf(`  # The following example creates a download restore:
+  %[1]s backup restore start download \
+  --clusterName myDemo \
+  --snapshotId 5e7e00128f8ce03996a47179`, cli.ExampleAtlasEntryPoint()),
 		},
-		Example: fmt.Sprintf(`  The following example creates an automated restore:
-  $ %[1]s backup restore start automated \
-         --clusterName myDemo \
-         --snapshotId 5e7e00128f8ce03996a47179 \
-         --targetClusterName myDemo2 \
-         --targetProjectId 1a2345b67c8e9a12f3456de7
-
-The following example creates a point-in-time restore:
-  $ %[1]s backup restore start pointInTime \
-         --clusterName myDemo \
-         --pointInTimeUTCMillis 1588523147 \
-         --targetClusterName myDemo2 \
-         --targetProjectId 1a2345b67c8e9a12f3456de7
-  
-The following example creates a download restore:
-  $ %[1]s backup restore start download \
-         --clusterName myDemo \
-         --snapshotId 5e7e00128f8ce03996a47179`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example creates an automated restore:
+  %[1]s backup restore start automated \
+  --clusterName myDemo \
+  --snapshotId 5e7e00128f8ce03996a47179 \
+  --targetClusterName myDemo2 \
+  --targetProjectId 1a2345b67c8e9a12f3456de7`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.method = args[0]
 

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -144,23 +144,25 @@ func StartBuilder() *cobra.Command {
 		ValidArgs: []string{automatedRestore, downloadRestore, pointInTimeRestore},
 		Annotations: map[string]string{
 			"automated|download|pointInTimeDesc": "Type of restore job to create. Accepted values include: automated, download, pointInTime.",
-			"Example2": fmt.Sprintf(`  # The following example creates a point-in-time restore:
-  %[1]s backup restore start pointInTime \
-  --clusterName myDemo \
-  --pointInTimeUTCMillis 1588523147 \
-  --targetClusterName myDemo2 \
-  --targetProjectId 1a2345b67c8e9a12f3456de7`, cli.ExampleAtlasEntryPoint()),
-			"Example3": fmt.Sprintf(`  # The following example creates a download restore:
-  %[1]s backup restore start download \
-  --clusterName myDemo \
-  --snapshotId 5e7e00128f8ce03996a47179`, cli.ExampleAtlasEntryPoint()),
 		},
 		Example: fmt.Sprintf(`  # The following example creates an automated restore:
   %[1]s backup restore start automated \
   --clusterName myDemo \
   --snapshotId 5e7e00128f8ce03996a47179 \
   --targetClusterName myDemo2 \
-  --targetProjectId 1a2345b67c8e9a12f3456de7`, cli.ExampleAtlasEntryPoint()),
+  --targetProjectId 1a2345b67c8e9a12f3456de7
+
+  # The following example creates a point-in-time restore:
+  %[1]s backup restore start pointInTime \
+  --clusterName myDemo \
+  --pointInTimeUTCMillis 1588523147 \
+  --targetClusterName myDemo2 \
+  --targetProjectId 1a2345b67c8e9a12f3456de7
+  
+  # The following example creates a download restore:
+  %[1]s backup restore start download \
+         --clusterName myDemo \
+         --snapshotId 5e7e00128f8ce03996a47179`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.method = args[0]
 

--- a/internal/cli/atlas/backup/restores/watch.go
+++ b/internal/cli/atlas/backup/restores/watch.go
@@ -73,8 +73,8 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 		Annotations: map[string]string{
 			"restoreJobIdDesc": "ID of the restore job.",
 		},
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup restore job for the cluster Cluster0:
-  $ %s backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup restore job for the cluster Cluster0:
+  %s backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/schedule/delete.go
+++ b/internal/cli/atlas/backup/schedule/delete.go
@@ -61,8 +61,8 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster.",
 		},
-		Example: fmt.Sprintf(`  The following example deletes all backup schedules of the cluster Cluster0:
-  $ %s backup schedule delete Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example deletes all backup schedules of the cluster Cluster0:
+  %s backup schedule delete Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/backup/schedule/describe.go
+++ b/internal/cli/atlas/backup/schedule/describe.go
@@ -69,8 +69,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Human-readable label for the cluster.",
 		},
-		Example: fmt.Sprintf(`  The following example describes the cloud backup schedule for the cluster Cluster0:
-  $ %s backup schedule describe Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example describes the cloud backup schedule for the cluster Cluster0:
+  %s backup schedule describe Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/schedule/update.go
+++ b/internal/cli/atlas/backup/schedule/update.go
@@ -349,8 +349,8 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update",
 		Aliases: []string{"updates"},
 		Short:   "Update snapshot backup policies for a cluster.",
-		Example: fmt.Sprintf(`  Update a snapshot backup policy for a cluster named Cluster0:
-  $ %s backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Update a snapshot backup policy for a cluster named Cluster0:
+  %s backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/snapshots/watch.go
+++ b/internal/cli/atlas/backup/snapshots/watch.go
@@ -69,7 +69,7 @@ func WatchBuilder() *cobra.Command {
 Once the snapshot reaches the expected status, the command prints "Snapshot changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource status completes or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s snapshot watch snapshotIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s snapshot watch snapshotIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to watch.",

--- a/internal/cli/atlas/clusters/advancedsettings/describe.go
+++ b/internal/cli/atlas/clusters/advancedsettings/describe.go
@@ -65,7 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve configuration settings.",
 		},
-		Example: fmt.Sprintf(`  $ %s clusters advancedSettings describe Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s clusters advancedSettings describe Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/clusters/advancedsettings/update.go
+++ b/internal/cli/atlas/clusters/advancedsettings/update.go
@@ -136,11 +136,8 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <clusterName>",
 		Short: "Update advanced configuration settings for one cluster.",
-		Example: fmt.Sprintf(`  Update the minimum oplog size for a cluster:
-  $ %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
-
-  Update the minimum TLS protocol version for a cluster:
-  $ %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"`,
+		Example: fmt.Sprintf(`  # Update the minimum oplog size for a cluster:
+  %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -158,6 +155,8 @@ func UpdateBuilder() *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to update.",
+			"Example2": fmt.Sprintf(`  # Update the minimum TLS protocol version for a cluster:
+  %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"`, cli.ExampleAtlasEntryPoint()),
 		},
 	}
 

--- a/internal/cli/atlas/clusters/advancedsettings/update.go
+++ b/internal/cli/atlas/clusters/advancedsettings/update.go
@@ -137,7 +137,10 @@ func UpdateBuilder() *cobra.Command {
 		Use:   "update <clusterName>",
 		Short: "Update advanced configuration settings for one cluster.",
 		Example: fmt.Sprintf(`  # Update the minimum oplog size for a cluster:
-  %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000`,
+  %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
+
+  # Update the minimum TLS protocol version for a cluster:
+  %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -155,8 +158,6 @@ func UpdateBuilder() *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to update.",
-			"Example2": fmt.Sprintf(`  # Update the minimum TLS protocol version for a cluster:
-  %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"`, cli.ExampleAtlasEntryPoint()),
 		},
 	}
 

--- a/internal/cli/atlas/clusters/availableregions/list.go
+++ b/internal/cli/atlas/clusters/availableregions/list.go
@@ -70,12 +70,11 @@ func ListBuilder() *cobra.Command {
 		Short:   "List available regions that Atlas supports for new deployments.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		Annotations: map[string]string{
-			"Example2": `  # List available regions by tier for a given provider:
-  atlas cluster availableRegions --provider GCP`,
-		},
 		Example: `  # List available regions for a given cloud provider and tier:
-  atlas cluster availableRegions --provider AWS --tier M50`,
+  atlas cluster availableRegions --provider AWS --tier M50
+
+  # List available regions by tier for a given provider:
+  atlas cluster availableRegions --provider GCP`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.tier != "" && opts.provider == "" {
 				return fmt.Errorf("tier search also requires a %s flag", flag.Provider)

--- a/internal/cli/atlas/clusters/availableregions/list.go
+++ b/internal/cli/atlas/clusters/availableregions/list.go
@@ -70,11 +70,12 @@ func ListBuilder() *cobra.Command {
 		Short:   "List available regions that Atlas supports for new deployments.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		Example: `  List available regions for a given cloud provider and tier:
-  $ atlas cluster availableRegions --provider AWS --tier M50
-
-  List available regions by tier for a given provider:
-  $ atlas cluster availableRegions --provider GCP`,
+		Annotations: map[string]string{
+			"Example2": `  # List available regions by tier for a given provider:
+  atlas cluster availableRegions --provider GCP`,
+		},
+		Example: `  # List available regions for a given cloud provider and tier:
+  atlas cluster availableRegions --provider AWS --tier M50`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.tier != "" && opts.provider == "" {
 				return fmt.Errorf("tier search also requires a %s flag", flag.Provider)

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -188,20 +188,8 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create one cluster in the specified project.",
 		Long: `To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
 For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.`,
-		Example: fmt.Sprintf(`  Deploy a free cluster:
-  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
-
-  Deploy a three-member replica set in AWS:
-  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
-
-  Deploy a three-member replica set in AZURE:
-  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
-  
-  Deploy a three-member replica set in GCP:
-  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
-
-  Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-  $ %[1]s cluster create --projectId <projectId> --file <path/to/file.json>`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Deploy a free cluster:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0`, cli.ExampleAtlasEntryPoint()),
 		Args: require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.filename == "" {
@@ -225,6 +213,14 @@ For full control of your deployment, or to create multi-cloud clusters, provide 
 		},
 		Annotations: map[string]string{
 			"nameDesc": "Name of the cluster. The cluster name cannot be changed after the cluster is created. Cluster name can contain ASCII letters, numbers, and hyphens.",
+			"Example2": fmt.Sprintf(`  # Deploy a three-member replica set in AWS:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10`, cli.ExampleAtlasEntryPoint()),
+			"Example3": fmt.Sprintf(`  # Deploy a three-member replica set in AZURE:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10`, cli.ExampleAtlasEntryPoint()),
+			"Example4": fmt.Sprintf(`  # Deploy a three-member replica set in GCP:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10`, cli.ExampleAtlasEntryPoint()),
+			"Example5": fmt.Sprintf(`  # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
+  %[1]s cluster create --projectId <projectId> --file <path/to/file.json>`, cli.ExampleAtlasEntryPoint()),
 		},
 	}
 

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -189,7 +189,19 @@ func CreateBuilder() *cobra.Command {
 		Long: `To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
 For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.`,
 		Example: fmt.Sprintf(`  # Deploy a free cluster:
-  %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0`, cli.ExampleAtlasEntryPoint()),
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
+
+  # Deploy a three-member replica set in AWS:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+
+  # Deploy a three-member replica set in AZURE:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+  
+  # Deploy a three-member replica set in GCP:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+
+  # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
+  %[1]s cluster create --projectId <projectId> --file <path/to/file.json>`, cli.ExampleAtlasEntryPoint()),
 		Args: require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.filename == "" {
@@ -213,14 +225,6 @@ For full control of your deployment, or to create multi-cloud clusters, provide 
 		},
 		Annotations: map[string]string{
 			"nameDesc": "Name of the cluster. The cluster name cannot be changed after the cluster is created. Cluster name can contain ASCII letters, numbers, and hyphens.",
-			"Example2": fmt.Sprintf(`  # Deploy a three-member replica set in AWS:
-  %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10`, cli.ExampleAtlasEntryPoint()),
-			"Example3": fmt.Sprintf(`  # Deploy a three-member replica set in AZURE:
-  %[1]s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10`, cli.ExampleAtlasEntryPoint()),
-			"Example4": fmt.Sprintf(`  # Deploy a three-member replica set in GCP:
-  %[1]s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10`, cli.ExampleAtlasEntryPoint()),
-			"Example5": fmt.Sprintf(`  # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-  %[1]s cluster create --projectId <projectId> --file <path/to/file.json>`, cli.ExampleAtlasEntryPoint()),
 		},
 	}
 

--- a/internal/cli/atlas/clusters/onlinearchive/watch.go
+++ b/internal/cli/atlas/clusters/onlinearchive/watch.go
@@ -71,7 +71,7 @@ func WatchBuilder() *cobra.Command {
 Once the archive reaches the expected status, the command prints "Online archive available."
 If you run the command in the terminal, it blocks the terminal session until the resource status changes to the expected status.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to watch.",

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -127,7 +127,13 @@ func UpdateBuilder() *cobra.Command {
 		Use:   "update [clusterName]",
 		Short: "Update a MongoDB Atlas cluster.",
 		Example: fmt.Sprintf(`  # Update tier for a cluster:
-  %[1]s cluster update <clusterName> --projectId <projectId> --tier M50`,
+  %[1]s cluster update <clusterName> --projectId <projectId> --tier M50
+
+  # Update disk size for a cluster:
+  %[1]s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+
+  # Update MongoDB version for a cluster:
+  %[1]s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -145,10 +151,6 @@ func UpdateBuilder() *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to update.",
-			"Example2": fmt.Sprintf(`  # Update disk size for a cluster:
-  %[1]s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20`, cli.ExampleAtlasEntryPoint()),
-			"Example3": fmt.Sprintf(`  # Update MongoDB version for a cluster:
-  %[1]s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2`, cli.ExampleAtlasEntryPoint()),
 		},
 	}
 

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -126,14 +126,8 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update [clusterName]",
 		Short: "Update a MongoDB Atlas cluster.",
-		Example: fmt.Sprintf(`  Update tier for a cluster:
-  $ %[1]s cluster update <clusterName> --projectId <projectId> --tier M50
-
-  Update disk size for a cluster:
-  $ %[1]s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
-
-  Update MongoDB version for a cluster:
-  $ %[1]s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2`,
+		Example: fmt.Sprintf(`  # Update tier for a cluster:
+  %[1]s cluster update <clusterName> --projectId <projectId> --tier M50`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -151,6 +145,10 @@ func UpdateBuilder() *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to update.",
+			"Example2": fmt.Sprintf(`  # Update disk size for a cluster:
+  %[1]s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20`, cli.ExampleAtlasEntryPoint()),
+			"Example3": fmt.Sprintf(`  # Update MongoDB version for a cluster:
+  %[1]s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2`, cli.ExampleAtlasEntryPoint()),
 		},
 	}
 

--- a/internal/cli/atlas/clusters/upgrade.go
+++ b/internal/cli/atlas/clusters/upgrade.go
@@ -113,8 +113,8 @@ func UpgradeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade [clusterName]",
 		Short: "Upgrade a MongoDB Atlas cluster's tier, disk size, and/or MongoDB version.",
-		Example: fmt.Sprintf(`  The following example upgrades the tier, disk size, and MongoDB version for a cluster:
-  $ %s cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2`,
+		Example: fmt.Sprintf(`  # The following example upgrades the tier, disk size, and MongoDB version for a cluster:
+  %s cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -78,7 +78,7 @@ func WatchBuilder() *cobra.Command {
 Once the cluster reaches the expected state, the command prints "Cluster available."
 If you run the command in the terminal, it blocks the terminal session until the resource state changes to IDLE.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf("  $ %s cluster watch clusterNameSample", cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf("  %s cluster watch clusterNameSample", cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to watch.",

--- a/internal/cli/atlas/config/init.go
+++ b/internal/cli/atlas/config/init.go
@@ -101,11 +101,8 @@ func InitBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Configure a profile to store access settings for your MongoDB deployment.",
-		Example: `  To configure the tool to work with Atlas:
-  $ atlas config init
-
-  To configure the tool to work with Atlas for Government:
-  $ atlas config init --gov`,
+		Example: `  # To configure the tool to work with Atlas:
+  atlas config init`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.OutWriter = cmd.OutOrStdout()
 		},
@@ -113,6 +110,10 @@ func InitBuilder() *cobra.Command {
 			return opts.Run(cmd.Context())
 		},
 		Args: require.NoArgs,
+		Annotations: map[string]string{
+			"Example2": `  # To configure the tool to work with Atlas for Government:
+  atlas config init --gov`,
+		},
 	}
 	cmd.Flags().BoolVar(&opts.gov, flag.Gov, false, usage.Gov)
 

--- a/internal/cli/atlas/config/init.go
+++ b/internal/cli/atlas/config/init.go
@@ -102,7 +102,10 @@ func InitBuilder() *cobra.Command {
 		Use:   "init",
 		Short: "Configure a profile to store access settings for your MongoDB deployment.",
 		Example: `  # To configure the tool to work with Atlas:
-  atlas config init`,
+  atlas config init
+
+  # To configure the tool to work with Atlas for Government:
+  atlas config init --gov`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.OutWriter = cmd.OutOrStdout()
 		},
@@ -110,10 +113,6 @@ func InitBuilder() *cobra.Command {
 			return opts.Run(cmd.Context())
 		},
 		Args: require.NoArgs,
-		Annotations: map[string]string{
-			"Example2": `  # To configure the tool to work with Atlas for Government:
-  atlas config init --gov`,
-		},
 	}
 	cmd.Flags().BoolVar(&opts.gov, flag.Gov, false, usage.Gov)
 

--- a/internal/cli/atlas/customdbroles/create.go
+++ b/internal/cli/atlas/customdbroles/create.go
@@ -82,7 +82,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create <roleName>",
 		Short:   "Create a custom database role for your project.",
-		Example: fmt.Sprintf(`  $ %s customDbRoles create customRole --privilege FIND@database,UPDATE@database`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s customDbRoles create customRole --privilege FIND@database,UPDATE@database`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"roleNameDesc": "Name of the custom role to create.",

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -173,21 +173,18 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [builtInRole]...",
 		Short: "Create a database user for your project.",
-		Example: fmt.Sprintf(`  Create an Atlas database admin user:
-  $ %[1]s dbuser create atlasAdmin --username <username>  --projectId <projectId>
-
-  Create a database user with read/write access to any database:
-  $ %[1]s dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
-
-  Create a database user with multiple roles:
-  $ %[1]s dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
-
-  Create a database user with multiple scopes:
-  $ %[1]s dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>`,
+		Example: fmt.Sprintf(`  # Create an Atlas database admin user:
+  %[1]s dbuser create atlasAdmin --username <username>  --projectId <projectId>`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: cobra.OnlyValidArgs,
 		Annotations: map[string]string{
 			"builtInRoleDesc": "Atlas built-in role that you want to assign to the user.",
+			"Example2": fmt.Sprintf(`  # Create a database user with read/write access to any database:
+  %[1]s dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>`, cli.ExampleAtlasEntryPoint()),
+			"Example3": fmt.Sprintf(`  # Create a database user with multiple roles:
+  %[1]s dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>`, cli.ExampleAtlasEntryPoint()),
+			"Example4": fmt.Sprintf(`  # Create a database user with multiple scopes:
+  %[1]s dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>`, cli.ExampleAtlasEntryPoint()),
 		},
 		ValidArgs: []string{"atlasAdmin", "readWriteAnyDatabase", "readAnyDatabase", "clusterMonitor", "backup", "dbAdminAnyDatabase", "enableSharding"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -174,17 +174,20 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create [builtInRole]...",
 		Short: "Create a database user for your project.",
 		Example: fmt.Sprintf(`  # Create an Atlas database admin user:
-  %[1]s dbuser create atlasAdmin --username <username>  --projectId <projectId>`,
+  %[1]s dbuser create atlasAdmin --username <username>  --projectId <projectId>
+
+  # Create a database user with read/write access to any database:
+  %[1]s dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+
+  # Create a database user with multiple roles:
+  %[1]s dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+
+  # Create a database user with multiple scopes:
+  %[1]s dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: cobra.OnlyValidArgs,
 		Annotations: map[string]string{
 			"builtInRoleDesc": "Atlas built-in role that you want to assign to the user.",
-			"Example2": fmt.Sprintf(`  # Create a database user with read/write access to any database:
-  %[1]s dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>`, cli.ExampleAtlasEntryPoint()),
-			"Example3": fmt.Sprintf(`  # Create a database user with multiple roles:
-  %[1]s dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>`, cli.ExampleAtlasEntryPoint()),
-			"Example4": fmt.Sprintf(`  # Create a database user with multiple scopes:
-  %[1]s dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>`, cli.ExampleAtlasEntryPoint()),
 		},
 		ValidArgs: []string{"atlasAdmin", "readWriteAnyDatabase", "readAnyDatabase", "clusterMonitor", "backup", "dbAdminAnyDatabase", "enableSharding"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/dbusers/update.go
+++ b/internal/cli/atlas/dbusers/update.go
@@ -79,15 +79,14 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <username>",
 		Short: "Update a database user for your project.",
-		Example: fmt.Sprintf(`  Update roles for a database user:
-  $ %[1]s dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
-
-  Update scopes for a database user:
-  $ %[1]s dbuser update <username> --scope resourceName:resourceType --projectId <projectId>`,
+		Example: fmt.Sprintf(`  # Update roles for a database user:
+  %[1]s dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"usernameDesc": "Username to update in the MongoDB database.",
+			"Example2": fmt.Sprintf(`  # Update scopes for a database user:
+  %[1]s dbuser update <username> --scope resourceName:resourceType --projectId <projectId>`, cli.ExampleAtlasEntryPoint()),
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/dbusers/update.go
+++ b/internal/cli/atlas/dbusers/update.go
@@ -80,13 +80,14 @@ func UpdateBuilder() *cobra.Command {
 		Use:   "update <username>",
 		Short: "Update a database user for your project.",
 		Example: fmt.Sprintf(`  # Update roles for a database user:
-  %[1]s dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>`,
+  %[1]s dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
+
+  # Update scopes for a database user:
+  %[1]s dbuser update <username> --scope resourceName:resourceType --projectId <projectId>`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"usernameDesc": "Username to update in the MongoDB database.",
-			"Example2": fmt.Sprintf(`  # Update scopes for a database user:
-  %[1]s dbuser update <username> --scope resourceName:resourceType --projectId <projectId>`, cli.ExampleAtlasEntryPoint()),
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/logs/decrypt.go
+++ b/internal/cli/atlas/logs/decrypt.go
@@ -98,13 +98,14 @@ func DecryptBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decrypt",
 		Short: "Decrypts an audit log file with the provided AWS, GCP or Azure key management services.",
-		Example: `  Decrypt using AWS credentials:
-  $ atlas logs decrypt --file /path/to/logFile.json --awsAccessKey <accessKey> --awsSecretAccessKey <secretKey> --awsSessionToken <sessionToken>
-  GCP credentials:
-  $ atlas logs decrypt --file /path/to/logFile.json --gcpServiceAccountKey <serviceAccountKey>
-  Azure credentials:
-  $ atlas logs decrypt --file /path/to/logFile.json --azureClientId <clientId> --azureTenantId <tenantId> --azureSecret <secret>
-`,
+		Example: `  # Decrypt using AWS credentials:
+  atlas logs decrypt --file /path/to/logFile.json --awsAccessKey <accessKey> --awsSecretAccessKey <secretKey> --awsSessionToken <sessionToken>`,
+		Annotations: map[string]string{
+			"Example2": fmt.Sprintf(`  # Decrypt using GCP credentials:
+  atlas logs decrypt --file /path/to/logFile.json --gcpServiceAccountKey <serviceAccountKey>`, cli.ExampleAtlasEntryPoint()),
+			"Example3": fmt.Sprintf(`  # Decrypt using Azure credentials:
+  atlas logs decrypt --file /path/to/logFile.json --azureClientId <clientId> --azureTenantId <tenantId> --azureSecret <secret>`, cli.ExampleAtlasEntryPoint()),
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.initDefaultOut)
 		},

--- a/internal/cli/atlas/logs/decrypt.go
+++ b/internal/cli/atlas/logs/decrypt.go
@@ -99,13 +99,12 @@ func DecryptBuilder() *cobra.Command {
 		Use:   "decrypt",
 		Short: "Decrypts an audit log file with the provided AWS, GCP or Azure key management services.",
 		Example: `  # Decrypt using AWS credentials:
-  atlas logs decrypt --file /path/to/logFile.json --awsAccessKey <accessKey> --awsSecretAccessKey <secretKey> --awsSessionToken <sessionToken>`,
-		Annotations: map[string]string{
-			"Example2": fmt.Sprintf(`  # Decrypt using GCP credentials:
-  atlas logs decrypt --file /path/to/logFile.json --gcpServiceAccountKey <serviceAccountKey>`, cli.ExampleAtlasEntryPoint()),
-			"Example3": fmt.Sprintf(`  # Decrypt using Azure credentials:
-  atlas logs decrypt --file /path/to/logFile.json --azureClientId <clientId> --azureTenantId <tenantId> --azureSecret <secret>`, cli.ExampleAtlasEntryPoint()),
-		},
+  atlas logs decrypt --file /path/to/logFile.json --awsAccessKey <accessKey> --awsSecretAccessKey <secretKey> --awsSessionToken <sessionToken>
+  # Decrypts using GCP credentials:
+  atlas logs decrypt --file /path/to/logFile.json --gcpServiceAccountKey <serviceAccountKey>
+  # Decrypts using Azure credentials:
+  atlas logs decrypt --file /path/to/logFile.json --azureClientId <clientId> --azureTenantId <tenantId> --azureSecret <secret>
+`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.initDefaultOut)
 		},

--- a/internal/cli/atlas/metrics/databases/describe.go
+++ b/internal/cli/atlas/metrics/databases/describe.go
@@ -67,7 +67,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "describe <hostname:port> <databaseName>",
 		Long: fmt.Sprintf(`To retrieve the hostname and port needed for this command, run:
-$ %s process list`, cli.ExampleAtlasEntryPoint()),
+%s process list`, cli.ExampleAtlasEntryPoint()),
 		Short: "Describe database metrics for a database on a specific host.",
 		Args:  require.ExactArgs(argsN),
 		Annotations: map[string]string{
@@ -76,7 +76,7 @@ $ %s process list`, cli.ExampleAtlasEntryPoint()),
 		},
 		Example: fmt.Sprintf(
 			`  This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
-  $ %s metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H`,
+  %s metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H`,
 			cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/metrics/databases/list.go
+++ b/internal/cli/atlas/metrics/databases/list.go
@@ -65,7 +65,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "list <hostname:port>",
 		Long: fmt.Sprintf(`To retrieve the hostname and port needed for this command, run:
-$ %s process list`, cli.ExampleAtlasEntryPoint()),
+%s process list`, cli.ExampleAtlasEntryPoint()),
 		Short:   "List available databases or database metrics for a given host.",
 		Aliases: []string{"ls"},
 		Annotations: map[string]string{
@@ -73,7 +73,7 @@ $ %s process list`, cli.ExampleAtlasEntryPoint()),
 		},
 		Example: fmt.Sprintf(
 			`  This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-  $ %s metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`,
+  %s metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/metrics/disks/describe.go
+++ b/internal/cli/atlas/metrics/disks/describe.go
@@ -67,15 +67,15 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "describe <hostname:port> <diskName>",
 		Long: fmt.Sprintf(`To retrieve the hostname and port needed for this command, run:
-$ %s process list`, cli.ExampleAtlasEntryPoint()),
+%s process list`, cli.ExampleAtlasEntryPoint()),
 		Short: "Describe disk partition metrics for a disk partition on a specified host.",
 		Args:  require.ExactArgs(argsN),
 		Annotations: map[string]string{
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",
 			"diskNameDesc":      "Label that identifies the disk or partition from which you want to retrieve metrics.",
 		},
-		Example: fmt.Sprintf(`  This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-  $ %s metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+  %s metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/metrics/disks/list.go
+++ b/internal/cli/atlas/metrics/disks/list.go
@@ -65,7 +65,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "list <hostname:port>",
 		Long: fmt.Sprintf(`To retrieve the hostname and port needed for this command, run:
-$ %s process list`, cli.ExampleAtlasEntryPoint()),
+%s process list`, cli.ExampleAtlasEntryPoint()),
 		Short:   "List available disks or disk partitions for a given host.",
 		Aliases: []string{"ls"},
 		Args:    require.ExactArgs(1),
@@ -74,7 +74,7 @@ $ %s process list`, cli.ExampleAtlasEntryPoint()),
 		},
 		Example: fmt.Sprintf(
 			`  This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-  $ %s metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
+  %s metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/metrics/processes/processes.go
+++ b/internal/cli/atlas/metrics/processes/processes.go
@@ -66,13 +66,13 @@ func Builder() *cobra.Command {
 		Use:   "processes <hostname:port>",
 		Short: "Get MongoDB process metrics for a given host.",
 		Long: fmt.Sprintf(`To retrieve the hostname and port needed for this command, run:
-$ %s process list`, cli.ExampleAtlasEntryPoint()),
+%s process list`, cli.ExampleAtlasEntryPoint()),
 		Aliases: []string{"process"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",
 		},
-		Example: fmt.Sprintf(`  $ %s metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -78,7 +78,7 @@ func WatchBuilder() *cobra.Command {
 Once it reaches the expected state, the command prints "Network peering changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource is available.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s networking peering watch peeringConnectionSampleId`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s networking peering watch peeringConnectionSampleId`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"peerIdDesc": "Network peering connection ID.",

--- a/internal/cli/atlas/privateendpoints/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/delete.go
@@ -58,7 +58,7 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/privateendpoints/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe.go
@@ -72,8 +72,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.privateEndpointID = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -68,8 +68,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"interfaceEndpointIdDesc": "Unique identifier of the private endpoint you want to retrieve.",
 		},
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.privateEndpointID = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/aws/watch.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch.go
@@ -68,7 +68,7 @@ func WatchBuilder() *cobra.Command {
 Once the endpoint reaches the expected state, the command prints "Private endpoint changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s privateEndpoint aws watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint aws watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",

--- a/internal/cli/atlas/privateendpoints/azure/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/delete.go
@@ -58,7 +58,7 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint azure delete 0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint azure delete 0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/privateendpoints/azure/watch.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch.go
@@ -68,7 +68,7 @@ func WatchBuilder() *cobra.Command {
 Once the endpoint reaches the expected state, the command prints "Private endpoint changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s privateEndpoint azure watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint azure watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",

--- a/internal/cli/atlas/privateendpoints/datalake/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/delete.go
@@ -57,7 +57,7 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
@@ -65,8 +65,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.privateEndpointID = args[0]

--- a/internal/cli/atlas/privateendpoints/gcp/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create.go
@@ -71,7 +71,7 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create",
 		Short:   "Create a new GCP private endpoint for your project.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  $ %s privateEndpoints gcp create --region CENTRAL_US`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoints gcp create --region CENTRAL_US`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/privateendpoints/gcp/delete.go
+++ b/internal/cli/atlas/privateendpoints/gcp/delete.go
@@ -60,7 +60,7 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint gcp delete vpce-abcdefg0123456789 --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint gcp delete vpce-abcdefg0123456789 --force`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {

--- a/internal/cli/atlas/privateendpoints/gcp/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe.go
@@ -68,7 +68,7 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint gcp describe vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint gcp describe vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
@@ -100,7 +100,7 @@ func CreateBuilder() *cobra.Command {
 			"endpointGroupIdDesc": "Unique identifier for the endpoint group.",
 		},
 		Example: fmt.Sprintf(
-			`  $ %s privateEndpoints gcp interfaces create endpoint-1 \
+			`  %s privateEndpoints gcp interfaces create endpoint-1 \
   --endpointServiceId 61eaca605af86411903de1dd \
   --gcpProjectId mcli-private-endpoints \
   --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7`,

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/delete.go
@@ -60,7 +60,7 @@ func DeleteBuilder() *cobra.Command {
 			"idDesc": "Unique identifier for the endpoint group.",
 		},
 		Example: fmt.Sprintf(
-			`  $ %s privateEndpoints gcp interfaces delete endpoint-1 \
+			`  %s privateEndpoints gcp interfaces delete endpoint-1 \
   --endpointServiceId 61eaca605af86411903de1dd`,
 			cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
@@ -68,7 +68,7 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"idDesc": "Unique identifier of the private endpoint you want to retrieve.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoints gcp interfaces describe endpoint-1 \
+		Example: fmt.Sprintf(`  %s privateEndpoints gcp interfaces describe endpoint-1 \
   --endpointServiceId 61eaca605af86411903de1dd`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.privateEndpointGroupID = args[0]

--- a/internal/cli/atlas/privateendpoints/gcp/list.go
+++ b/internal/cli/atlas/privateendpoints/gcp/list.go
@@ -63,7 +63,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List GCP private endpoints for your project.",
-		Example: fmt.Sprintf(`  $ %s privateEndpoint gcp ls`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint gcp ls`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/gcp/watch.go
+++ b/internal/cli/atlas/privateendpoints/gcp/watch.go
@@ -71,7 +71,7 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint gcp watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint gcp watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/watch.go
+++ b/internal/cli/atlas/privateendpoints/watch.go
@@ -77,7 +77,7 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 				opts.InitOutput(cmd.OutOrStdout(), "\nPrivate endpoint changes completed.\n"),
 			)
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()

--- a/internal/cli/atlas/processes/describe.go
+++ b/internal/cli/atlas/processes/describe.go
@@ -62,7 +62,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe <hostname:port>",
 		Short:   "Return the details for the MongoDB process you specify.",
-		Example: fmt.Sprintf(`  $ %s process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -539,9 +539,9 @@ func Builder() *cobra.Command {
 		Use:   "quickstart",
 		Short: "Create, configure, and connect to an Atlas cluster.",
 		Long:  "This command creates a new cluster, adds your public IP to the atlas access list and creates a db user to access your new MongoDB instance.",
-		Example: fmt.Sprintf(`  Skip setting cluster name, provider or database username by using the command options:
-  $ %[1]s quickstart --force
-  $ %[1]s quickstart --clusterName Test --provider GCP --username dbuserTest`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Skip setting cluster name, provider or database username by using the command options:
+  %[1]s quickstart --force
+  %[1]s quickstart --clusterName Test --provider GCP --username dbuserTest`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRun(cmd.Context(), cmd.OutOrStdout()); err != nil {
 				return err

--- a/internal/cli/atlas/security/ldap/watch.go
+++ b/internal/cli/atlas/security/ldap/watch.go
@@ -69,7 +69,7 @@ func WatchBuilder() *cobra.Command {
 Once the LDAP configuration reaches the expected status, the command prints "LDAP Configuration request completed."
 If you run the command in the terminal, it blocks the terminal session until the resource status succeeds or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s security ldap status watch requestIdSample`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s security ldap status watch requestIdSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"requestIdDesc": "ID of the request to verify an LDAP configuration.",

--- a/internal/cli/atlas/serverless/watch.go
+++ b/internal/cli/atlas/serverless/watch.go
@@ -69,7 +69,7 @@ This command checks the serverless instance's state periodically until the insta
 Once the instance reaches the expected state, the command prints "Instance available."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes idle.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s serverless watch instanceNameSample`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s serverless watch instanceNameSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Name of the instance to watch.",

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -137,7 +137,7 @@ func Builder() *cobra.Command {
 		Use:   "setup",
 		Short: "Register, authenticate, create, and access an Atlas cluster.",
 		Long:  "This command takes you through registration, login, default profile creation, creating your first free tier cluster and connecting to it using MongoDB Shell.",
-		Example: `  Override default cluster settings like name, provider, or database username by using the command options
+		Example: `  # Override default cluster settings like name, provider, or database username by using the command options
   $ atlas setup --clusterName Test --provider GCP --username dbuserTest`,
 		Hidden: false,
 		Args:   require.NoArgs,

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -344,8 +344,8 @@ func LoginBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with MongoDB Atlas.",
-		Example: fmt.Sprintf(`  To start the interactive login for your MongoDB %s account:
-  $ %s auth login
+		Example: fmt.Sprintf(`  # To start the interactive login for your MongoDB %s account:
+  %s auth login
 `, Tool(), config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -77,8 +77,8 @@ func LogoutBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Log out of the CLI.",
-		Example: fmt.Sprintf(`  To log out from the CLI:
-  $ %s auth logout
+		Example: fmt.Sprintf(`  # To log out from the CLI:
+  %s auth logout
 `, config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/auth/register.go
+++ b/internal/cli/auth/register.go
@@ -148,8 +148,8 @@ func RegisterBuilder() *cobra.Command {
 		Use:    "register",
 		Short:  "Register with MongoDB Atlas.",
 		Hidden: false,
-		Example: fmt.Sprintf(`  To start the interactive setup:
-  $ %s auth register
+		Example: fmt.Sprintf(`  # To start the interactive setup:
+  %s auth register
 `, config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := registerPreRun(); err != nil {

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -50,8 +50,8 @@ func WhoAmIBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "Verifies and displays information about your authentication state.",
-		Example: fmt.Sprintf(`  See the logged account:
-  $ %s auth whoami
+		Example: fmt.Sprintf(`  # See the logged account:
+  %s auth whoami
 `, config.BinName()),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/config/delete.go
+++ b/internal/cli/config/delete.go
@@ -52,11 +52,12 @@ func DeleteBuilder() *cobra.Command {
 		Short:   "Delete a profile.",
 		Args:    require.ExactArgs(1),
 		Example: `  # Delete the default profile configuration:
-  mongocli config delete default`,
+  atlas config delete default
+
+  # Skip the confirmation question and delete the default profile configuration:
+  atlas config delete default --force`,
 		Annotations: map[string]string{
 			"nameDesc": "Name of the profile.",
-			"Example2": `  # Skip the confirmation question and delete the default profile configuration:
-  mongocli config delete default --force`,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.Entry = args[0]

--- a/internal/cli/config/delete.go
+++ b/internal/cli/config/delete.go
@@ -51,13 +51,12 @@ func DeleteBuilder() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a profile.",
 		Args:    require.ExactArgs(1),
-		Example: `  Delete the default profile configuration:
-  $ atlas config delete default
-
-  Skip the confirmation question and delete the default profile configuration:
-  $ atlas config delete default --force`,
+		Example: `  # Delete the default profile configuration:
+  mongocli config delete default`,
 		Annotations: map[string]string{
 			"nameDesc": "Name of the profile.",
+			"Example2": `  # Skip the confirmation question and delete the default profile configuration:
+  mongocli config delete default --force`,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.Entry = args[0]

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -50,7 +50,7 @@ func EditBuilder() *cobra.Command {
 		Long:  `Uses the default editor to open the config file. You can use EDITOR or VISUAL envs to change the default.`,
 		Example: fmt.Sprintf(`
   To open the config
-  $ %s config edit
+  %s config edit
 `, config.BinName()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opt.Run()

--- a/internal/cli/config/list.go
+++ b/internal/cli/config/list.go
@@ -44,7 +44,7 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "Return a list of available profiles by name.",
 		Long:    "If you did not specify a name for your profile, it displays as the default profile.",
-		Example: fmt.Sprintf("  $ %s config ls", config.BinName()),
+		Example: fmt.Sprintf("  %s config ls", config.BinName()),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			o.OutWriter = cmd.OutOrStdout()
 		},

--- a/internal/cli/config/rename.go
+++ b/internal/cli/config/rename.go
@@ -63,8 +63,8 @@ func RenameBuilder() *cobra.Command {
 		Use:     "rename <oldProfileName> <newProfileName>",
 		Aliases: []string{"mv"},
 		Short:   "Rename a profile.",
-		Example: fmt.Sprintf(`  Rename a profile called myProfile to testProfile:
-  $ %s config rename myProfile testProfile`, config.BinName()),
+		Example: fmt.Sprintf(`  # Rename a profile called myProfile to testProfile:
+  %s config rename myProfile testProfile`, config.BinName()),
 		Annotations: map[string]string{
 			"oldProfileNameDesc": "Name of the profile to rename.",
 			"newProfileNameDesc": "New name of the profile.",

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -87,12 +87,12 @@ Available properties include: %v.`, config.Properties()),
 		},
 		Example: fmt.Sprintf(`
   # Set Ops Manager Base URL in the profile myProfile:
-  %[1]s config set ops_manager_url http://localhost:30700/ -P myProfile`, config.BinName()),
+  %[1]s config set ops_manager_url http://localhost:30700/ -P myProfile
+  # Set Organization ID in the default profile:
+  %[1]s config set org_id 5dd5aaef7a3e5a6c5bd12de4`, config.BinName()),
 		Annotations: map[string]string{
 			"propertyNameDesc": "Property to set in the profile.",
 			"valueDesc":        "Value for the property to set in the profile.",
-			"Example2": fmt.Sprintf(`  # Set Organization ID in the default profile:
-  %[1]s config set org_id 5dd5aaef7a3e5a6c5bd12de4`, cli.ExampleAtlasEntryPoint()),
 		},
 		ValidArgs: config.Properties(),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -86,13 +86,13 @@ Available properties include: %v.`, config.Properties()),
 			return nil
 		},
 		Example: fmt.Sprintf(`
-  Set Ops Manager Base URL in the profile myProfile:
-  $ %[1]s config set ops_manager_url http://localhost:30700/ -P myProfile
-  Set Organization ID in the default profile:
-  $ %[1]s config set org_id 5dd5aaef7a3e5a6c5bd12de4`, config.BinName()),
+  # Set Ops Manager Base URL in the profile myProfile:
+  %[1]s config set ops_manager_url http://localhost:30700/ -P myProfile`, config.BinName()),
 		Annotations: map[string]string{
 			"propertyNameDesc": "Property to set in the profile.",
 			"valueDesc":        "Value for the property to set in the profile.",
+			"Example2": fmt.Sprintf(`  # Set Organization ID in the default profile:
+  %[1]s config set org_id 5dd5aaef7a3e5a6c5bd12de4`, cli.ExampleAtlasEntryPoint()),
 		},
 		ValidArgs: config.Properties(),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/decryption/list_key_provider.go
+++ b/internal/cli/decryption/list_key_provider.go
@@ -56,7 +56,7 @@ func KeyProvidersListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "Lists all key provider configurations found in the encrypted audit log file.",
 		Example: `
-  $ mongocli ops-manager listKeyProvider --file log.gz`,
+  mongocli ops-manager listKeyProvider --file log.gz`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.InitOutput(cmd.OutOrStdout(), listTmpl),

--- a/internal/cli/iam/projects/settings/describe.go
+++ b/internal/cli/iam/projects/settings/describe.go
@@ -60,8 +60,8 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Retrieve details for settings to the specified project.",
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s projects settings describe -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s projects settings describe -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/iam/projects/settings/update.go
+++ b/internal/cli/iam/projects/settings/update.go
@@ -79,8 +79,8 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update",
 		Aliases: []string{"updates"},
 		Short:   "Updates settings for a project.",
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			preRun := opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -85,14 +85,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Example: `  
-  Describe a team by ID
-  $ mongocli iam team(s) describe --id teamId --orgId <orgId>
-
-  Describe a team by Name
-  $ mongocli iam team(s) describe --name teamName --orgId <orgId>
-`,
+  # Describe a team by ID
+  mongocli iam team(s) describe --id teamId --orgId <orgId>`,
 		Short: "Get a team in an organization.",
 		Args:  require.NoArgs,
+		Annotations: map[string]string{
+			"Example2": `  # Describe a team by Name
+  mongocli iam team(s) describe --name teamName --orgId <orgId>`,
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -86,13 +86,13 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Example: `  
   # Describe a team by ID
-  mongocli iam team(s) describe --id teamId --orgId <orgId>`,
+  mongocli iam team(s) describe --id teamId --orgId <orgId>
+
+  # Describe a team by Name
+  mongocli iam team(s) describe --name teamName --orgId <orgId>
+`,
 		Short: "Get a team in an organization.",
 		Args:  require.NoArgs,
-		Annotations: map[string]string{
-			"Example2": `  # Describe a team by Name
-  mongocli iam team(s) describe --name teamName --orgId <orgId>`,
-		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -87,13 +87,12 @@ func DescribeBuilder() *cobra.Command {
 		Example: `  
   # Describe a user by ID
   mongocli iam users describe --id <id>
+
+  # Describe a user by username
+  mongocli iam users describe --username <username>
 `,
 		Short: "Get a user by username or id.",
 		Args:  require.NoArgs,
-		Annotations: map[string]string{
-			"Example2": `  # Describe a user by username
-  mongocli iam users describe --username <username>`,
-		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prerun.ExecuteE(
 				opts.initStore(cmd.Context()),

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -85,14 +85,15 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Example: `  
-  Describe a user by ID
-  $ mongocli iam users describe --id <id>
-
-  Describe a user by username
-  $ mongocli iam users describe --username <username>
+  # Describe a user by ID
+  mongocli iam users describe --id <id>
 `,
 		Short: "Get a user by username or id.",
 		Args:  require.NoArgs,
+		Annotations: map[string]string{
+			"Example2": `  # Describe a user by username
+  mongocli iam users describe --username <username>`,
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prerun.ExecuteE(
 				opts.initStore(cmd.Context()),

--- a/internal/cli/opsmanager/automation/watch.go
+++ b/internal/cli/opsmanager/automation/watch.go
@@ -72,7 +72,7 @@ func WatchBuilder() *cobra.Command {
 Once the expected status is reached, the command prints "Changes deployed successfully."
 If you run the command in the terminal, it blocks the terminal session until the changes are completed.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: `  $ mongocli ops-manager automation watch`,
+		Example: `  mongocli ops-manager automation watch`,
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/opsmanager/clusters/indexes_create.go
+++ b/internal/cli/opsmanager/clusters/indexes_create.go
@@ -168,7 +168,7 @@ func IndexesCreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"indexNameDesc": "Name of the index to create.",
 		},
-		Example: `  The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
+		Example: `  # The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
   The command uses the default profile.
 
   mongocli om clusters indexes create bedrooms_1 \

--- a/internal/cli/opsmanager/dbusers/create.go
+++ b/internal/cli/opsmanager/dbusers/create.go
@@ -109,8 +109,8 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create",
 		Short: "Create a database user for your project.",
 		Example: `
-  Create a user with readWriteAnyDatabase and clusterMonitor access
-  $ mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>`,
+  # Create a user with readWriteAnyDatabase and clusterMonitor access
+  mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>`,
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/opsmanager/featurepolicies/update.go
+++ b/internal/cli/opsmanager/featurepolicies/update.go
@@ -16,6 +16,7 @@ package featurepolicies
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
@@ -97,12 +98,12 @@ func UpdateBuilder() *cobra.Command {
 		Use:   "update",
 		Short: "Update feature control policies for your project.",
 		Long:  "Feature Control Policies allow you to enable or disable certain MongoDB features based on your site-specific needs.",
-		Example: `Disable user management for a project:
-  $ mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
-
-  Update policies from a JSON configuration file:
-  $ mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
-`,
+		Example: `  # Disable user management for a project:
+  mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT`,
+		Annotations: map[string]string{
+			"Example2": fmt.Sprintf(`  # Update policies from a JSON configuration file:
+  mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>`, cli.ExampleAtlasEntryPoint()),
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.filename == "" {
 				_ = cmd.MarkFlagRequired(flag.Name)

--- a/internal/cli/opsmanager/featurepolicies/update.go
+++ b/internal/cli/opsmanager/featurepolicies/update.go
@@ -16,7 +16,6 @@ package featurepolicies
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
@@ -99,11 +98,11 @@ func UpdateBuilder() *cobra.Command {
 		Short: "Update feature control policies for your project.",
 		Long:  "Feature Control Policies allow you to enable or disable certain MongoDB features based on your site-specific needs.",
 		Example: `  # Disable user management for a project:
-  mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT`,
-		Annotations: map[string]string{
-			"Example2": fmt.Sprintf(`  # Update policies from a JSON configuration file:
-  mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>`, cli.ExampleAtlasEntryPoint()),
-		},
+  mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
+
+  # Update policies from a JSON configuration file:
+  mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
+`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.filename == "" {
 				_ = cmd.MarkFlagRequired(flag.Name)

--- a/internal/cli/opsmanager/logs/decrypt.go
+++ b/internal/cli/opsmanager/logs/decrypt.go
@@ -91,12 +91,11 @@ func DecryptBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decrypt",
 		Short: "Decrypts an audit log file with the provided local key file or with a server that supports KMIP.",
-		Example: `  # For audit logs in BSON format:
-  mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json`,
-		Annotations: map[string]string{
-			"Example2": `  # For audit logs in JSON format:
+		Example: `
+  # For audit logs in BSON format:
+  mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
+	For audit logs in JSON format:
   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json`,
-		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.initDefaultOut)
 		},

--- a/internal/cli/opsmanager/logs/decrypt.go
+++ b/internal/cli/opsmanager/logs/decrypt.go
@@ -91,11 +91,12 @@ func DecryptBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decrypt",
 		Short: "Decrypts an audit log file with the provided local key file or with a server that supports KMIP.",
-		Example: `
-	For audit logs in BSON format:
-  $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
-	For audit logs in JSON format:
-  $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json`,
+		Example: `  # For audit logs in BSON format:
+  mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json`,
+		Annotations: map[string]string{
+			"Example2": `  # For audit logs in JSON format:
+  mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json`,
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.initDefaultOut)
 		},


### PR DESCRIPTION
**This PR must be rebased/merged after this PR merges: https://github.com/mongodb-labs/cobra2snooty/pull/26**

## Proposed changes

This PR would make a few improvements to the autogenerated examples:

- The intro sentences would be commented out, so they won't interfere with running commands
- The $ was removed before commands for the same reason
- Files with multiple examples now show them in separate code blocks due to changes in the cobra2snooty file and the addition of the #'s

The accompanying PR (https://github.com/mongodb-labs/cobra2snooty/pull/26) updated cobra2snooty.go to split the examples using the # symbol.

I rebased and tested this against the updated cobra2snooty file and it worked correctly.

The following files have more than one example, which makes them good candidates for spot checking changes:
atlas backups restores start
atlas clusters advancedSettings update
atlas clusters available regions list
atlas clusters create
atlas clusters update
atlas config init
atlas config rename
atlas dbusers create
atlas dbusers update
atlas logs decrypt
cli config delete
cli config set
cli iam teams describe
cli iam users describe
cli opsmgr feature policies update
cli opsmgr logs decrypt

_Jira ticket:_ https://jira.mongodb.org/browse/DOCSP-26295

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code