### PR TITLE
DOCSP-26348 Add examples for atlas networking peering azure create

### DIFF
--- a/docs/atlascli/command/atlas-networking-peering-create-azure.txt
+++ b/docs/atlascli/command/atlas-networking-peering-create-azure.txt
@@ -87,3 +87,12 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
+   atlas networking peering create azure --atlasCidrBlock 192.168.0.0/21 --directoryId 56657fdb-ca45-40dc-fr56-77fd8b6d2b37 --subscriptionId 345654f3-77cf-4084-9e06-8943a079ed75 
+   --resourceGroup atlascli-test --region US_EAST_2 --vnet atlascli-test
+

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-create-azure.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-create-azure.txt
@@ -87,3 +87,12 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
+   mongocli atlas networking peering create azure --atlasCidrBlock 192.168.0.0/21 --directoryId 56657fdb-ca45-40dc-fr56-77fd8b6d2b37 --subscriptionId 345654f3-77cf-4084-9e06-8943a079ed75 
+   --resourceGroup atlascli-test --region US_EAST_2 --vnet atlascli-test
+

--- a/internal/cli/atlas/networking/peering/create/azure.go
+++ b/internal/cli/atlas/networking/peering/create/azure.go
@@ -16,6 +16,7 @@ package create
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
@@ -123,7 +124,10 @@ func AzureBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "azure",
 		Short: "Create a connection with Azure.",
-		Args:  require.NoArgs,
+		Example: fmt.Sprintf(`  The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
+  %s networking peering create azure --atlasCidrBlock 192.168.0.0/21 --directoryId 56657fdb-ca45-40dc-fr56-77fd8b6d2b37 --subscriptionId 345654f3-77cf-4084-9e06-8943a079ed75 
+  --resourceGroup atlascli-test --region US_EAST_2 --vnet atlascli-test`, cli.ExampleAtlasEntryPoint()),
+		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,


### PR DESCRIPTION
- [DOCSP-26348](https://jira.mongodb.org/browse/DOCSP-26348) adds example for the network peering azure create command