### PR TITLE
(DOCSP-26295) Adds the # symbol that cobra2snooty uses to split multi-examples, removes $

### DIFF
--- a/docs/atlascli/command/atlas-accessLists-create.txt
+++ b/docs/atlascli/command/atlas-accessLists-create.txt
@@ -100,5 +100,5 @@ Examples
 
 .. code-block::
 
-   Create IP address access list with the current IP address. Entry is not needed in this case.
-   $ atlas accessList create --currentIP
+   # Create IP address access list with the current IP address. Entry is not needed in this case.
+   atlas accessList create --currentIp

--- a/docs/atlascli/command/atlas-accessLists-describe.txt
+++ b/docs/atlascli/command/atlas-accessLists-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
+   # The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
    atlas accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3

--- a/docs/atlascli/command/atlas-alerts-list.txt
+++ b/docs/atlascli/command/atlas-alerts-list.txt
@@ -80,8 +80,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-   $ atlas alerts list \
+   # This example uses the "atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+   atlas alerts list \
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile

--- a/docs/atlascli/command/atlas-alerts-settings-create.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-create.txt
@@ -176,8 +176,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-   $ atlas alert settings create --event JOINED_GROUP --enabled \
+   # This example uses the "atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+   atlas alert settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305

--- a/docs/atlascli/command/atlas-alerts-settings-list.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-list.txt
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile

--- a/docs/atlascli/command/atlas-auth-login.txt
+++ b/docs/atlascli/command/atlas-auth-login.txt
@@ -68,6 +68,6 @@ Examples
 
 .. code-block::
 
-   To start the interactive login for your MongoDB Atlas account:
-   $ atlas auth login
+   # To start the interactive login for your MongoDB Atlas account:
+   atlas auth login
 

--- a/docs/atlascli/command/atlas-auth-logout.txt
+++ b/docs/atlascli/command/atlas-auth-logout.txt
@@ -64,6 +64,6 @@ Examples
 
 .. code-block::
 
-   To log out from the CLI:
-   $ atlas auth logout
+   # To log out from the CLI:
+   atlas auth logout
 

--- a/docs/atlascli/command/atlas-auth-register.txt
+++ b/docs/atlascli/command/atlas-auth-register.txt
@@ -68,6 +68,6 @@ Examples
 
 .. code-block::
 
-   To start the interactive setup:
-   $ atlas auth register
+   # To start the interactive setup:
+   atlas auth register
 

--- a/docs/atlascli/command/atlas-auth-whoami.txt
+++ b/docs/atlascli/command/atlas-auth-whoami.txt
@@ -60,6 +60,6 @@ Examples
 
 .. code-block::
 
-   See the logged account:
-   $ atlas auth whoami
+   # See the logged account:
+   atlas auth whoami
 

--- a/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
@@ -92,5 +92,5 @@ Examples
 
 .. code-block::
 
-   The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
-   $ atlas backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca
+   # The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
+   atlas backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca

--- a/docs/atlascli/command/atlas-backups-exports-buckets-delete.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-delete.txt
@@ -72,5 +72,5 @@ Examples
 
 .. code-block::
 
-   The following deletes the continuous backup export bucket specified by ID:
-   $ atlas backup exports buckets delete --bucketId dbdb00ca12345678f901a234
+   # The following deletes the continuous backup export bucket specified by ID:
+   atlas backup exports buckets delete --bucketId dbdb00ca12345678f901a234

--- a/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
@@ -72,5 +72,5 @@ Examples
 
 .. code-block::
 
-   The following example returns the continuous backup export bucket specified by ID:
-   $ atlas backup exports buckets describe dbdb00ca12345678f901a234
+   # The following example returns the continuous backup export bucket specified by ID:
+   atlas backup exports buckets describe dbdb00ca12345678f901a234

--- a/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup export buckets:
-   $ atlas backup exports buckets list
+   # The following example retrieves the continuous backup export buckets:
+   atlas backup exports buckets list

--- a/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
-   $ atlas backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test
+   # The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
+   atlas backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test

--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
-   $ atlas backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305
+   # The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
+   atlas backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305

--- a/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
@@ -92,5 +92,5 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup export jobs for the cluster Cluster0:
-   $ atlas backup exports jobs list Cluster0
+   # The following example retrieves the continuous backup export jobs for the cluster Cluster0:
+   atlas backup exports jobs list Cluster0

--- a/docs/atlascli/command/atlas-backups-restores-describe.txt
+++ b/docs/atlascli/command/atlas-backups-restores-describe.txt
@@ -88,5 +88,5 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup restore job for the cluster Cluster0:
-   $ atlas backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0
+   # The following example retrieves the continuous backup restore job for the cluster Cluster0:
+   atlas backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0

--- a/docs/atlascli/command/atlas-backups-restores-list.txt
+++ b/docs/atlascli/command/atlas-backups-restores-list.txt
@@ -92,5 +92,5 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
-   $ atlas backup restore list Cluster0
+   # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+   atlas backup restore list Cluster0

--- a/docs/atlascli/command/atlas-backups-restores-start.txt
+++ b/docs/atlascli/command/atlas-backups-restores-start.txt
@@ -112,21 +112,27 @@ Examples
 
 .. code-block::
 
-   The following example creates an automated restore:
-   $ atlas backup restore start automated \
+   # The following example creates an automated restore:
+   atlas backup restore start automated \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179 \
           --targetClusterName myDemo2 \
           --targetProjectId 1a2345b67c8e9a12f3456de7
 
- The following example creates a point-in-time restore:
-   $ atlas backup restore start pointInTime \
+   
+.. code-block::
+
+   # The following example creates a point-in-time restore:
+   atlas backup restore start pointInTime \
           --clusterName myDemo \
           --pointInTimeUTCMillis 1588523147 \
           --targetClusterName myDemo2 \
           --targetProjectId 1a2345b67c8e9a12f3456de7
    
- The following example creates a download restore:
-   $ atlas backup restore start download \
+   
+.. code-block::
+
+   # The following example creates a download restore:
+   atlas backup restore start download \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179

--- a/docs/atlascli/command/atlas-backups-restores-watch.txt
+++ b/docs/atlascli/command/atlas-backups-restores-watch.txt
@@ -93,5 +93,5 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup restore job for the cluster Cluster0:
-   $ atlas backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0
+   # The following example retrieves the continuous backup restore job for the cluster Cluster0:
+   atlas backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0

--- a/docs/atlascli/command/atlas-backups-schedule-delete.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-delete.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   The following example deletes all backup schedules of the cluster Cluster0:
-   $ atlas backup schedule delete Cluster0
+   # The following example deletes all backup schedules of the cluster Cluster0:
+   atlas backup schedule delete Cluster0

--- a/docs/atlascli/command/atlas-backups-schedule-describe.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   The following example describes the cloud backup schedule for the cluster Cluster0:
-   $ atlas backup schedule describe Cluster0
+   # The following example describes the cloud backup schedule for the cluster Cluster0:
+   atlas backup schedule describe Cluster0

--- a/docs/atlascli/command/atlas-backups-schedule-update.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-update.txt
@@ -120,5 +120,5 @@ Examples
 
 .. code-block::
 
-   Update a snapshot backup policy for a cluster named Cluster0:
-   $ atlas backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7
+   # Update a snapshot backup policy for a cluster named Cluster0:
+   atlas backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7

--- a/docs/atlascli/command/atlas-backups-snapshots-watch.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-watch.txt
@@ -89,4 +89,4 @@ Examples
 
 .. code-block::
 
-   $ atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
+   atlas snapshot watch snapshotIdSample --clusterName clusterNameSample

--- a/docs/atlascli/command/atlas-clusters-advancedSettings-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-advancedSettings-describe.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ atlas clusters advancedSettings describe Cluster0
+   atlas clusters advancedSettings describe Cluster0

--- a/docs/atlascli/command/atlas-clusters-advancedSettings-update.txt
+++ b/docs/atlascli/command/atlas-clusters-advancedSettings-update.txt
@@ -136,8 +136,11 @@ Examples
 
 .. code-block::
 
-   Update the minimum oplog size for a cluster:
-   $ atlas cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
+   # Update the minimum oplog size for a cluster:
+   atlas cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
 
-   Update the minimum TLS protocol version for a cluster:
-   $ atlas cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"
+   
+.. code-block::
+
+   # Update the minimum TLS protocol version for a cluster:
+   atlas cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"

--- a/docs/atlascli/command/atlas-clusters-availableRegions-list.txt
+++ b/docs/atlascli/command/atlas-clusters-availableRegions-list.txt
@@ -76,8 +76,11 @@ Examples
 
 .. code-block::
 
-   List available regions for a given cloud provider and tier:
-   $ atlas cluster availableRegions --provider AWS --tier M50
+   # List available regions for a given cloud provider and tier:
+   atlas cluster availableRegions --provider AWS --tier M50
 
-   List available regions by tier for a given provider:
-   $ atlas cluster availableRegions --provider GCP
+   
+.. code-block::
+
+   # List available regions by tier for a given provider:
+   atlas cluster availableRegions --provider GCP

--- a/docs/atlascli/command/atlas-clusters-create.txt
+++ b/docs/atlascli/command/atlas-clusters-create.txt
@@ -131,17 +131,29 @@ Examples
 
 .. code-block::
 
-   Deploy a free cluster:
-   $ atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
+   # Deploy a free cluster:
+   atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 
-   Deploy a three-member replica set in AWS:
-   $ atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
-
-   Deploy a three-member replica set in AZURE:
-   $ atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
    
-   Deploy a three-member replica set in GCP:
-   $ atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+.. code-block::
 
-   Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-   $ atlas cluster create --projectId <projectId> --file <path/to/file.json>
+   # Deploy a three-member replica set in AWS:
+   atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+
+   
+.. code-block::
+
+   # Deploy a three-member replica set in AZURE:
+   atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+   
+   
+.. code-block::
+
+   # Deploy a three-member replica set in GCP:
+   atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+
+   
+.. code-block::
+
+   # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
+   atlas cluster create --projectId <projectId> --file <path/to/file.json>

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
@@ -89,4 +89,4 @@ Examples
 
 .. code-block::
 
-   $ atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample
+   atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample

--- a/docs/atlascli/command/atlas-clusters-update.txt
+++ b/docs/atlascli/command/atlas-clusters-update.txt
@@ -100,11 +100,17 @@ Examples
 
 .. code-block::
 
-   Update tier for a cluster:
-   $ atlas cluster update <clusterName> --projectId <projectId> --tier M50
+   # Update tier for a cluster:
+   atlas cluster update <clusterName> --projectId <projectId> --tier M50
 
-   Update disk size for a cluster:
-   $ atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+   
+.. code-block::
 
-   Update MongoDB version for a cluster:
-   $ atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+   # Update disk size for a cluster:
+   atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+
+   
+.. code-block::
+
+   # Update MongoDB version for a cluster:
+   atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2

--- a/docs/atlascli/command/atlas-clusters-upgrade.txt
+++ b/docs/atlascli/command/atlas-clusters-upgrade.txt
@@ -100,5 +100,5 @@ Examples
 
 .. code-block::
 
-   The following example upgrades the tier, disk size, and MongoDB version for a cluster:
-   $ atlas cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2
+   # The following example upgrades the tier, disk size, and MongoDB version for a cluster:
+   atlas cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2

--- a/docs/atlascli/command/atlas-clusters-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ atlas cluster watch clusterNameSample
+   atlas cluster watch clusterNameSample

--- a/docs/atlascli/command/atlas-config-delete.txt
+++ b/docs/atlascli/command/atlas-config-delete.txt
@@ -80,8 +80,11 @@ Examples
 
 .. code-block::
 
-   Delete the default profile configuration:
-   $ atlas config delete default
+   # Delete the default profile configuration:
+   atlas config delete default
 
-   Skip the confirmation question and delete the default profile configuration:
-   $ atlas config delete default --force
+   
+.. code-block::
+
+   # Skip the confirmation question and delete the default profile configuration:
+   atlas config delete default --force

--- a/docs/atlascli/command/atlas-config-edit.txt
+++ b/docs/atlascli/command/atlas-config-edit.txt
@@ -62,9 +62,12 @@ Examples
 
 .. code-block::
 
-  
-   To open the config
-   $ atlas config edit
+   #
+   
+.. code-block::
+
+   # To open the config
+   atlas config edit
 
 
 .. toctree::

--- a/docs/atlascli/command/atlas-config-init.txt
+++ b/docs/atlascli/command/atlas-config-init.txt
@@ -64,8 +64,11 @@ Examples
 
 .. code-block::
 
-   To configure the tool to work with Atlas:
-   $ atlas config init
+   # To configure the tool to work with Atlas:
+   atlas config init
 
-   To configure the tool to work with Atlas for Government:
-   $ atlas config init --gov
+   
+.. code-block::
+
+   # To configure the tool to work with Atlas for Government:
+   atlas config init --gov

--- a/docs/atlascli/command/atlas-config-list.txt
+++ b/docs/atlascli/command/atlas-config-list.txt
@@ -66,4 +66,4 @@ Examples
 
 .. code-block::
 
-   $ atlas config ls
+   atlas config ls

--- a/docs/atlascli/command/atlas-config-rename.txt
+++ b/docs/atlascli/command/atlas-config-rename.txt
@@ -80,5 +80,5 @@ Examples
 
 .. code-block::
 
-   Rename a profile called myProfile to testProfile:
-   $ atlas config rename myProfile testProfile
+   # Rename a profile called myProfile to testProfile:
+   atlas config rename myProfile testProfile

--- a/docs/atlascli/command/atlas-config-set.txt
+++ b/docs/atlascli/command/atlas-config-set.txt
@@ -85,4 +85,4 @@ Examples
 
   
    Set Organization ID in the default profile:
-   $ atlas config set org_id 5dd5aaef7a3e5a6c5bd12de4
+   atlas config set org_id 5dd5aaef7a3e5a6c5bd12de4

--- a/docs/atlascli/command/atlas-customDbRoles-create.txt
+++ b/docs/atlascli/command/atlas-customDbRoles-create.txt
@@ -92,4 +92,4 @@ Examples
 
 .. code-block::
 
-   $ atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database
+   atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database

--- a/docs/atlascli/command/atlas-dbusers-create.txt
+++ b/docs/atlascli/command/atlas-dbusers-create.txt
@@ -119,14 +119,23 @@ Examples
 
 .. code-block::
 
-   Create an Atlas database admin user:
-   $ atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
+   # Create an Atlas database admin user:
+   atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
 
-   Create a database user with read/write access to any database:
-   $ atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+   
+.. code-block::
 
-   Create a database user with multiple roles:
-   $ atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+   # Create a database user with read/write access to any database:
+   atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
 
-   Create a database user with multiple scopes:
-   $ atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
+   
+.. code-block::
+
+   # Create a database user with multiple roles:
+   atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+
+   
+.. code-block::
+
+   # Create a database user with multiple scopes:
+   atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>

--- a/docs/atlascli/command/atlas-dbusers-update.txt
+++ b/docs/atlascli/command/atlas-dbusers-update.txt
@@ -100,8 +100,11 @@ Examples
 
 .. code-block::
 
-   Update roles for a database user:
-   $ atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
+   # Update roles for a database user:
+   atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 
-   Update scopes for a database user:
-   $ atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>
+   
+.. code-block::
+
+   # Update scopes for a database user:
+   atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>

--- a/docs/atlascli/command/atlas-metrics-databases-describe.txt
+++ b/docs/atlascli/command/atlas-metrics-databases-describe.txt
@@ -119,5 +119,5 @@ Examples
 
 .. code-block::
 
-   This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
-   $ atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
+   # This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
+   atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H

--- a/docs/atlascli/command/atlas-metrics-databases-list.txt
+++ b/docs/atlascli/command/atlas-metrics-databases-list.txt
@@ -95,5 +95,5 @@ Examples
 
 .. code-block::
 
-   This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   # This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+   atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/atlascli/command/atlas-metrics-disks-describe.txt
+++ b/docs/atlascli/command/atlas-metrics-disks-describe.txt
@@ -119,5 +119,5 @@ Examples
 
 .. code-block::
 
-   This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
+   # This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+   atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H

--- a/docs/atlascli/command/atlas-metrics-disks-list.txt
+++ b/docs/atlascli/command/atlas-metrics-disks-list.txt
@@ -95,5 +95,5 @@ Examples
 
 .. code-block::
 
-   This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   # This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+   atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/atlascli/command/atlas-metrics-processes.txt
+++ b/docs/atlascli/command/atlas-metrics-processes.txt
@@ -115,4 +115,4 @@ Examples
 
 .. code-block::
 
-   $ atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/atlascli/command/atlas-networking-peering-create-azure.txt
+++ b/docs/atlascli/command/atlas-networking-peering-create-azure.txt
@@ -92,6 +92,6 @@ Examples
 
 .. code-block::
 
-   The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
+   # The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
    atlas networking peering create azure --atlasCidrBlock 192.168.0.0/21 --directoryId 56657fdb-ca45-40dc-fr56-77fd8b6d2b37 --subscriptionId 345654f3-77cf-4084-9e06-8943a079ed75 
    --resourceGroup atlascli-test --region US_EAST_2 --vnet atlascli-test

--- a/docs/atlascli/command/atlas-networking-peering-watch.txt
+++ b/docs/atlascli/command/atlas-networking-peering-watch.txt
@@ -89,4 +89,4 @@ Examples
 
 .. code-block::
 
-   $ atlas networking peering watch peeringConnectionSampleId
+   atlas networking peering watch peeringConnectionSampleId

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force
+   atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -88,5 +88,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint aws watch vpce-abcdefg0123456789
+   atlas privateEndpoint aws watch vpce-abcdefg0123456789

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force
+   atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint azure watch vpce-abcdefg0123456789
+   atlas privateEndpoint azure watch vpce-abcdefg0123456789

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
+   atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-create.txt
@@ -72,4 +72,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoints gcp create --region CENTRAL_US
+   atlas privateEndpoints gcp create --region CENTRAL_US

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force
+   atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-describe.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint gcp describe vpce-abcdefg0123456789
+   atlas privateEndpoint gcp describe vpce-abcdefg0123456789

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-create.txt
@@ -96,7 +96,7 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoints gcp interfaces create endpoint-1 \
+   atlas privateEndpoints gcp interfaces create endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd \
    --gcpProjectId mcli-private-endpoints \
    --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-delete.txt
@@ -88,5 +88,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoints gcp interfaces delete endpoint-1 \
+   atlas privateEndpoints gcp interfaces delete endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -88,5 +88,5 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoints gcp interfaces describe endpoint-1 \
+   atlas privateEndpoints gcp interfaces describe endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-list.txt
@@ -76,4 +76,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint gcp ls
+   atlas privateEndpoint gcp ls

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint gcp watch vpce-abcdefg0123456789
+   atlas privateEndpoint gcp watch vpce-abcdefg0123456789

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
+   atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile

--- a/docs/atlascli/command/atlas-processes-describe.txt
+++ b/docs/atlascli/command/atlas-processes-describe.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/atlascli/command/atlas-projects-settings-describe.txt
+++ b/docs/atlascli/command/atlas-projects-settings-describe.txt
@@ -68,5 +68,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas projects settings describe -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas projects settings describe -P myprofile

--- a/docs/atlascli/command/atlas-projects-settings-update.txt
+++ b/docs/atlascli/command/atlas-projects-settings-update.txt
@@ -108,5 +108,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ atlas projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   atlas projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile

--- a/docs/atlascli/command/atlas-quickstart.txt
+++ b/docs/atlascli/command/atlas-quickstart.txt
@@ -114,6 +114,6 @@ Examples
 
 .. code-block::
 
-   Skip setting cluster name, provider or database username by using the command options:
-   $ atlas quickstart --force
-   $ atlas quickstart --clusterName Test --provider GCP --username dbuserTest
+   # Skip setting cluster name, provider or database username by using the command options:
+   atlas quickstart --force
+   atlas quickstart --clusterName Test --provider GCP --username dbuserTest

--- a/docs/atlascli/command/atlas-security-ldap-save.txt
+++ b/docs/atlascli/command/atlas-security-ldap-save.txt
@@ -112,7 +112,7 @@ Examples
 
 .. code-block::
 
-   The following example configures an LDAP server to authenticate and authorize MongoDB users.
+   # The following example configures an LDAP server to authenticate and authorize MongoDB users.
    atlas security ldap save --authenticationEnabled --authorizationEnabled 
    --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername 
    "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com" 

--- a/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ atlas security ldap status watch requestIdSample
+   atlas security ldap status watch requestIdSample

--- a/docs/atlascli/command/atlas-serverless-watch.txt
+++ b/docs/atlascli/command/atlas-serverless-watch.txt
@@ -86,4 +86,4 @@ Examples
 
 .. code-block::
 
-   $ atlas serverless watch instanceNameSample
+   atlas serverless watch instanceNameSample

--- a/docs/atlascli/command/atlas-setup.txt
+++ b/docs/atlascli/command/atlas-setup.txt
@@ -114,5 +114,5 @@ Examples
 
 .. code-block::
 
-   Override default cluster settings like name, provider, or database username by using the command options
-   $ atlas setup --clusterName Test --provider GCP --username dbuserTest
+   # Override default cluster settings like name, provider, or database username by using the command options
+   atlas setup --clusterName Test --provider GCP --username dbuserTest

--- a/docs/atlascli/command/atlas-teams-describe.txt
+++ b/docs/atlascli/command/atlas-teams-describe.txt
@@ -76,10 +76,16 @@ Examples
 
 .. code-block::
 
-  
-   Describe a team by ID
-   $ mongocli iam team(s) describe --id teamId --orgId <orgId>
+   #
+   
+.. code-block::
 
-   Describe a team by Name
-   $ mongocli iam team(s) describe --name teamName --orgId <orgId>
+   # Describe a team by ID
+   mongocli iam team(s) describe --id teamId --orgId <orgId>
+
+   
+.. code-block::
+
+   # Describe a team by Name
+   mongocli iam team(s) describe --name teamName --orgId <orgId>
 

--- a/docs/atlascli/command/atlas-users-describe.txt
+++ b/docs/atlascli/command/atlas-users-describe.txt
@@ -72,10 +72,16 @@ Examples
 
 .. code-block::
 
-  
-   Describe a user by ID
-   $ mongocli iam users describe --id <id>
+   #
+   
+.. code-block::
 
-   Describe a user by username
-   $ mongocli iam users describe --username <username>
+   # Describe a user by ID
+   mongocli iam users describe --id <id>
+
+   
+.. code-block::
+
+   # Describe a user by username
+   mongocli iam users describe --username <username>
 

--- a/docs/atlascli/command/atlas.txt
+++ b/docs/atlascli/command/atlas.txt
@@ -41,9 +41,12 @@ Examples
 
 .. code-block::
 
-  
-   Display the help menu for the config command
-   $ atlas config --help
+   #
+   
+.. code-block::
+
+   # Display the help menu for the config command
+   atlas config --help
 Related Commands
 ----------------
 

--- a/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
@@ -100,5 +100,5 @@ Examples
 
 .. code-block::
 
-   Create IP address access list with the current IP address. Entry is not needed in this case.
-   $ mongocli atlas accessList create --currentIP
+   # Create IP address access list with the current IP address. Entry is not needed in this case.
+   mongocli atlas accessList create --currentIp

--- a/docs/mongocli/command/mongocli-atlas-accessLists-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
+   # The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
    mongocli atlas accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3

--- a/docs/mongocli/command/mongocli-atlas-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-list.txt
@@ -80,8 +80,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts list \
+   # This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts list \
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-create.txt
@@ -176,8 +176,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-   $ mongocli atlas alert settings create --event JOINED_GROUP --enabled \
+   # This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+   mongocli atlas alert settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
@@ -92,5 +92,5 @@ Examples
 
 .. code-block::
 
-   The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
-   $ mongocli atlas backup restore list Cluster0
+   # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+   mongocli atlas backup restore list Cluster0

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
@@ -112,21 +112,27 @@ Examples
 
 .. code-block::
 
-   The following example creates an automated restore:
-   $ mongocli atlas backup restore start automated \
+   # The following example creates an automated restore:
+   mongocli atlas backup restore start automated \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179 \
           --targetClusterName myDemo2 \
           --targetProjectId 1a2345b67c8e9a12f3456de7
 
- The following example creates a point-in-time restore:
-   $ mongocli atlas backup restore start pointInTime \
+   
+.. code-block::
+
+   # The following example creates a point-in-time restore:
+   mongocli atlas backup restore start pointInTime \
           --clusterName myDemo \
           --pointInTimeUTCMillis 1588523147 \
           --targetClusterName myDemo2 \
           --targetProjectId 1a2345b67c8e9a12f3456de7
    
- The following example creates a download restore:
-   $ mongocli atlas backup restore start download \
+   
+.. code-block::
+
+   # The following example creates a download restore:
+   mongocli atlas backup restore start download \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
@@ -89,4 +89,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
+   mongocli atlas snapshot watch snapshotIdSample --clusterName clusterNameSample

--- a/docs/mongocli/command/mongocli-atlas-clusters-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-create.txt
@@ -131,17 +131,29 @@ Examples
 
 .. code-block::
 
-   Deploy a free cluster:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
+   # Deploy a free cluster:
+   mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 
-   Deploy a three-member replica set in AWS:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
-
-   Deploy a three-member replica set in AZURE:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
    
-   Deploy a three-member replica set in GCP:
-   $ mongocli atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+.. code-block::
 
-   Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-   $ mongocli atlas cluster create --projectId <projectId> --file <path/to/file.json>
+   # Deploy a three-member replica set in AWS:
+   mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+
+   
+.. code-block::
+
+   # Deploy a three-member replica set in AZURE:
+   mongocli atlas cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+   
+   
+.. code-block::
+
+   # Deploy a three-member replica set in GCP:
+   mongocli atlas cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+
+   
+.. code-block::
+
+   # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
+   mongocli atlas cluster create --projectId <projectId> --file <path/to/file.json>

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
@@ -89,4 +89,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample
+   mongocli atlas cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample

--- a/docs/mongocli/command/mongocli-atlas-clusters-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-update.txt
@@ -100,11 +100,17 @@ Examples
 
 .. code-block::
 
-   Update tier for a cluster:
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --tier M50
+   # Update tier for a cluster:
+   mongocli atlas cluster update <clusterName> --projectId <projectId> --tier M50
 
-   Update disk size for a cluster:
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+   
+.. code-block::
 
-   Update MongoDB version for a cluster:
-   $ mongocli atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2
+   # Update disk size for a cluster:
+   mongocli atlas cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+
+   
+.. code-block::
+
+   # Update MongoDB version for a cluster:
+   mongocli atlas cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2

--- a/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas cluster watch clusterNameSample
+   mongocli atlas cluster watch clusterNameSample

--- a/docs/mongocli/command/mongocli-atlas-customDbRoles-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDbRoles-create.txt
@@ -92,4 +92,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database
+   mongocli atlas customDbRoles create customRole --privilege FIND@database,UPDATE@database

--- a/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
@@ -119,14 +119,23 @@ Examples
 
 .. code-block::
 
-   Create an Atlas database admin user:
-   $ mongocli atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
+   # Create an Atlas database admin user:
+   mongocli atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
 
-   Create a database user with read/write access to any database:
-   $ mongocli atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+   
+.. code-block::
 
-   Create a database user with multiple roles:
-   $ mongocli atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+   # Create a database user with read/write access to any database:
+   mongocli atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
 
-   Create a database user with multiple scopes:
-   $ mongocli atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
+   
+.. code-block::
+
+   # Create a database user with multiple roles:
+   mongocli atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+
+   
+.. code-block::
+
+   # Create a database user with multiple scopes:
+   mongocli atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>

--- a/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
@@ -100,8 +100,11 @@ Examples
 
 .. code-block::
 
-   Update roles for a database user:
-   $ mongocli atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
+   # Update roles for a database user:
+   mongocli atlas dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 
-   Update scopes for a database user:
-   $ mongocli atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>
+   
+.. code-block::
+
+   # Update scopes for a database user:
+   mongocli atlas dbuser update <username> --scope resourceName:resourceType --projectId <projectId>

--- a/docs/mongocli/command/mongocli-atlas-metrics-databases-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-databases-describe.txt
@@ -119,5 +119,5 @@ Examples
 
 .. code-block::
 
-   This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
-   $ mongocli atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
+   # This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
+   mongocli atlas metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H

--- a/docs/mongocli/command/mongocli-atlas-metrics-databases-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-databases-list.txt
@@ -95,5 +95,5 @@ Examples
 
 .. code-block::
 
-   This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ mongocli atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   # This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+   mongocli atlas metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/mongocli/command/mongocli-atlas-metrics-disks-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-disks-describe.txt
@@ -119,5 +119,5 @@ Examples
 
 .. code-block::
 
-   This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ mongocli atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H
+   # This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+   mongocli atlas metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H

--- a/docs/mongocli/command/mongocli-atlas-metrics-disks-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-disks-list.txt
@@ -95,5 +95,5 @@ Examples
 
 .. code-block::
 
-   This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-   $ mongocli atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   # This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+   mongocli atlas metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
@@ -115,4 +115,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   mongocli atlas metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-create-azure.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-create-azure.txt
@@ -92,6 +92,6 @@ Examples
 
 .. code-block::
 
-   The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
+   # The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
    mongocli atlas networking peering create azure --atlasCidrBlock 192.168.0.0/21 --directoryId 56657fdb-ca45-40dc-fr56-77fd8b6d2b37 --subscriptionId 345654f3-77cf-4084-9e06-8943a079ed75 
    --resourceGroup atlascli-test --region US_EAST_2 --vnet atlascli-test

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
@@ -89,4 +89,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas networking peering watch peeringConnectionSampleId
+   mongocli atlas networking peering watch peeringConnectionSampleId

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force
+   mongocli atlas privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -88,5 +88,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint aws watch vpce-abcdefg0123456789
+   mongocli atlas privateEndpoint aws watch vpce-abcdefg0123456789

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force
+   mongocli atlas privateEndpoint azure delete 0fcd9d80bbafe1607 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint azure watch vpce-abcdefg0123456789
+   mongocli atlas privateEndpoint azure watch vpce-abcdefg0123456789

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
+   mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-create.txt
@@ -72,4 +72,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoints gcp create --region CENTRAL_US
+   mongocli atlas privateEndpoints gcp create --region CENTRAL_US

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force
+   mongocli atlas privateEndpoint gcp delete vpce-abcdefg0123456789 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-describe.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint gcp describe vpce-abcdefg0123456789
+   mongocli atlas privateEndpoint gcp describe vpce-abcdefg0123456789

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-create.txt
@@ -96,7 +96,7 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoints gcp interfaces create endpoint-1 \
+   mongocli atlas privateEndpoints gcp interfaces create endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd \
    --gcpProjectId mcli-private-endpoints \
    --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-delete.txt
@@ -88,5 +88,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoints gcp interfaces delete endpoint-1 \
+   mongocli atlas privateEndpoints gcp interfaces delete endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -88,5 +88,5 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoints gcp interfaces describe endpoint-1 \
+   mongocli atlas privateEndpoints gcp interfaces describe endpoint-1 \
    --endpointServiceId 61eaca605af86411903de1dd

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-list.txt
@@ -76,4 +76,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint gcp ls
+   mongocli atlas privateEndpoint gcp ls

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint gcp watch vpce-abcdefg0123456789
+   mongocli atlas privateEndpoint gcp watch vpce-abcdefg0123456789

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-delete.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force
+   mongocli atlas privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile

--- a/docs/mongocli/command/mongocli-atlas-processes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-processes-describe.txt
@@ -84,4 +84,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
+   mongocli atlas process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017

--- a/docs/mongocli/command/mongocli-atlas-quickstart.txt
+++ b/docs/mongocli/command/mongocli-atlas-quickstart.txt
@@ -114,6 +114,6 @@ Examples
 
 .. code-block::
 
-   Skip setting cluster name, provider or database username by using the command options:
-   $ mongocli atlas quickstart --force
-   $ mongocli atlas quickstart --clusterName Test --provider GCP --username dbuserTest
+   # Skip setting cluster name, provider or database username by using the command options:
+   mongocli atlas quickstart --force
+   mongocli atlas quickstart --clusterName Test --provider GCP --username dbuserTest

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-save.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-save.txt
@@ -112,7 +112,7 @@ Examples
 
 .. code-block::
 
-   The following example configures an LDAP server to authenticate and authorize MongoDB users.
+   # The following example configures an LDAP server to authenticate and authorize MongoDB users.
    mongocli atlas security ldap save --authenticationEnabled --authorizationEnabled 
    --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername 
    "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com" 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
@@ -85,4 +85,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas security ldap status watch requestIdSample
+   mongocli atlas security ldap status watch requestIdSample

--- a/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
@@ -86,4 +86,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli atlas serverless watch instanceNameSample
+   mongocli atlas serverless watch instanceNameSample

--- a/docs/mongocli/command/mongocli-auth-login.txt
+++ b/docs/mongocli/command/mongocli-auth-login.txt
@@ -72,6 +72,6 @@ Examples
 
 .. code-block::
 
-   To start the interactive login for your MongoDB Atlas or Cloud Manager account:
-   $ mongocli auth login
+   # To start the interactive login for your MongoDB Atlas or Cloud Manager account:
+   mongocli auth login
 

--- a/docs/mongocli/command/mongocli-auth-logout.txt
+++ b/docs/mongocli/command/mongocli-auth-logout.txt
@@ -64,6 +64,6 @@ Examples
 
 .. code-block::
 
-   To log out from the CLI:
-   $ mongocli auth logout
+   # To log out from the CLI:
+   mongocli auth logout
 

--- a/docs/mongocli/command/mongocli-auth-whoami.txt
+++ b/docs/mongocli/command/mongocli-auth-whoami.txt
@@ -60,6 +60,6 @@ Examples
 
 .. code-block::
 
-   See the logged account:
-   $ mongocli auth whoami
+   # See the logged account:
+   mongocli auth whoami
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
@@ -80,8 +80,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts list \
+   # This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts list \
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-create.txt
@@ -176,8 +176,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-   $ mongocli atlas alert settings create --event JOINED_GROUP --enabled \
+   # This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+   mongocli atlas alert settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile

--- a/docs/mongocli/command/mongocli-cloud-manager-automation-watch.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-automation-watch.txt
@@ -69,4 +69,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli ops-manager automation watch
+   mongocli ops-manager automation watch

--- a/docs/mongocli/command/mongocli-cloud-manager-clusters-indexes-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-clusters-indexes-create.txt
@@ -136,7 +136,7 @@ Examples
 
 .. code-block::
 
-   The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
+   # The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
    The command uses the default profile.
 
    mongocli om clusters indexes create bedrooms_1 \

--- a/docs/mongocli/command/mongocli-cloud-manager-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-dbusers-create.txt
@@ -84,6 +84,9 @@ Examples
 
 .. code-block::
 
-  
-   Create a user with readWriteAnyDatabase and clusterMonitor access
-   $ mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>
+   #
+   
+.. code-block::
+
+   # Create a user with readWriteAnyDatabase and clusterMonitor access
+   mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>

--- a/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-update.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-update.txt
@@ -86,9 +86,12 @@ Examples
 
 .. code-block::
 
-   Disable user management for a project:
-   $ mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
+   # Disable user management for a project:
+   mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 
-   Update policies from a JSON configuration file:
-   $ mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
+   
+.. code-block::
+
+   # Update policies from a JSON configuration file:
+   mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
 

--- a/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-logs-decrypt.txt
@@ -92,8 +92,14 @@ Examples
 
 .. code-block::
 
-  
- 	For audit logs in BSON format:
-   $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
- 	For audit logs in JSON format:
-   $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json
+   #
+   
+.. code-block::
+
+   # For audit logs in BSON format:
+   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
+   
+.. code-block::
+
+   # For audit logs in JSON format:
+   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json

--- a/docs/mongocli/command/mongocli-cloud-manager-logs-keyProviders-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-logs-keyProviders-list.txt
@@ -69,4 +69,4 @@ Examples
 .. code-block::
 
   
-   $ mongocli ops-manager listKeyProvider --file log.gz
+   mongocli ops-manager listKeyProvider --file log.gz

--- a/docs/mongocli/command/mongocli-config-delete.txt
+++ b/docs/mongocli/command/mongocli-config-delete.txt
@@ -80,8 +80,11 @@ Examples
 
 .. code-block::
 
-   Delete the default profile configuration:
-   $ atlas config delete default
+   # Delete the default profile configuration:
+   atlas config delete default
 
-   Skip the confirmation question and delete the default profile configuration:
-   $ atlas config delete default --force
+   
+.. code-block::
+
+   # Skip the confirmation question and delete the default profile configuration:
+   atlas config delete default --force

--- a/docs/mongocli/command/mongocli-config-edit.txt
+++ b/docs/mongocli/command/mongocli-config-edit.txt
@@ -62,9 +62,12 @@ Examples
 
 .. code-block::
 
-  
-   To open the config
-   $ mongocli config edit
+   #
+   
+.. code-block::
+
+   # To open the config
+   mongocli config edit
 
 
 .. toctree::

--- a/docs/mongocli/command/mongocli-config-list.txt
+++ b/docs/mongocli/command/mongocli-config-list.txt
@@ -66,4 +66,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli config ls
+   mongocli config ls

--- a/docs/mongocli/command/mongocli-config-rename.txt
+++ b/docs/mongocli/command/mongocli-config-rename.txt
@@ -80,5 +80,5 @@ Examples
 
 .. code-block::
 
-   Rename a profile called myProfile to testProfile:
-   $ mongocli config rename myProfile testProfile
+   # Rename a profile called myProfile to testProfile:
+   mongocli config rename myProfile testProfile

--- a/docs/mongocli/command/mongocli-config-set.txt
+++ b/docs/mongocli/command/mongocli-config-set.txt
@@ -85,7 +85,7 @@ Examples
 
   
    Set Ops Manager Base URL in the profile myProfile:
-   $ mongocli config set ops_manager_url http://localhost:30700/ -P myProfile
+   mongocli config set ops_manager_url http://localhost:30700/ -P myProfile
 
    Set Organization ID in the default profile:
-   $ mongocli config set org_id 5dd5aaef7a3e5a6c5bd12de4
+   mongocli config set org_id 5dd5aaef7a3e5a6c5bd12de4

--- a/docs/mongocli/command/mongocli-config.txt
+++ b/docs/mongocli/command/mongocli-config.txt
@@ -70,16 +70,28 @@ Examples
 
 .. code-block::
 
-  
-   Configure a profile to interact with Atlas:
-   $ mongocli config
-   Configure a profile to interact with Atlas for Government:
-   $ mongocli config --service cloudgov
+   #
    
-   Configure a profile to interact with Cloud Manager:
-   $ mongocli config --service cloud-manager
-   Configure a profile to interact with Ops Manager:
-   $ mongocli config --service ops-manager
+.. code-block::
+
+   # Configure a profile to interact with Atlas:
+   mongocli config
+   
+.. code-block::
+
+   # Configure a profile to interact with Atlas for Government:
+   mongocli config --service cloudgov
+   
+   
+.. code-block::
+
+   # Configure a profile to interact with Cloud Manager:
+   mongocli config --service cloud-manager
+   
+.. code-block::
+
+   # Configure a profile to interact with Ops Manager:
+   mongocli config --service ops-manager
 
 Related Commands
 ----------------

--- a/docs/mongocli/command/mongocli-iam-teams-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-describe.txt
@@ -76,10 +76,16 @@ Examples
 
 .. code-block::
 
-  
-   Describe a team by ID
-   $ mongocli iam team(s) describe --id teamId --orgId <orgId>
+   #
+   
+.. code-block::
 
-   Describe a team by Name
-   $ mongocli iam team(s) describe --name teamName --orgId <orgId>
+   # Describe a team by ID
+   mongocli iam team(s) describe --id teamId --orgId <orgId>
+
+   
+.. code-block::
+
+   # Describe a team by Name
+   mongocli iam team(s) describe --name teamName --orgId <orgId>
 

--- a/docs/mongocli/command/mongocli-iam-users-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-users-describe.txt
@@ -72,10 +72,16 @@ Examples
 
 .. code-block::
 
-  
-   Describe a user by ID
-   $ mongocli iam users describe --id <id>
+   #
+   
+.. code-block::
 
-   Describe a user by username
-   $ mongocli iam users describe --username <username>
+   # Describe a user by ID
+   mongocli iam users describe --id <id>
+
+   
+.. code-block::
+
+   # Describe a user by username
+   mongocli iam users describe --username <username>
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
@@ -80,8 +80,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts list \
+   # This example uses the "mongocli atlas alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts list \
      --projectId 5df90590f10fab5e33de2305 \
      -o json \
      --profile myprofile

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-create.txt
@@ -176,8 +176,8 @@ Examples
 
 .. code-block::
 
-   This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-   $ mongocli atlas alert settings create --event JOINED_GROUP --enabled \
+   # This example uses the "mongocli atlas alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+   mongocli atlas alert settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
    --notificationUsername john@example.com \
    -o json --projectId 5df90590f10fab5e33de2305

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   This example uses the profile named "myprofile" for accessing Atlas.
-   $ mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile
+   # This example uses the profile named "myprofile" for accessing Atlas.
+   mongocli atlas alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile

--- a/docs/mongocli/command/mongocli-ops-manager-automation-watch.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-automation-watch.txt
@@ -69,4 +69,4 @@ Examples
 
 .. code-block::
 
-   $ mongocli ops-manager automation watch
+   mongocli ops-manager automation watch

--- a/docs/mongocli/command/mongocli-ops-manager-clusters-indexes-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-clusters-indexes-create.txt
@@ -136,7 +136,7 @@ Examples
 
 .. code-block::
 
-   The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
+   # The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
    The command uses the default profile.
 
    mongocli om clusters indexes create bedrooms_1 \

--- a/docs/mongocli/command/mongocli-ops-manager-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-dbusers-create.txt
@@ -84,6 +84,9 @@ Examples
 
 .. code-block::
 
-  
-   Create a user with readWriteAnyDatabase and clusterMonitor access
-   $ mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>
+   #
+   
+.. code-block::
+
+   # Create a user with readWriteAnyDatabase and clusterMonitor access
+   mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>

--- a/docs/mongocli/command/mongocli-ops-manager-featurePolicies-update.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-featurePolicies-update.txt
@@ -86,9 +86,12 @@ Examples
 
 .. code-block::
 
-   Disable user management for a project:
-   $ mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
+   # Disable user management for a project:
+   mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 
-   Update policies from a JSON configuration file:
-   $ mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
+   
+.. code-block::
+
+   # Update policies from a JSON configuration file:
+   mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
 

--- a/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-logs-decrypt.txt
@@ -92,8 +92,14 @@ Examples
 
 .. code-block::
 
-  
- 	For audit logs in BSON format:
-   $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
- 	For audit logs in JSON format:
-   $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json
+   #
+   
+.. code-block::
+
+   # For audit logs in BSON format:
+   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
+   
+.. code-block::
+
+   # For audit logs in JSON format:
+   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json

--- a/docs/mongocli/command/mongocli-ops-manager-logs-keyProviders-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-logs-keyProviders-list.txt
@@ -69,4 +69,4 @@ Examples
 .. code-block::
 
   
-   $ mongocli ops-manager listKeyProvider --file log.gz
+   mongocli ops-manager listKeyProvider --file log.gz

--- a/docs/mongocli/command/mongocli.txt
+++ b/docs/mongocli/command/mongocli.txt
@@ -41,9 +41,12 @@ Examples
 
 .. code-block::
 
-  
-   Display the help menu for the config command
-   $ mongocli config --help
+   #
+   
+.. code-block::
+
+   # Display the help menu for the config command
+   mongocli config --help
 Related Commands
 ----------------
 

--- a/internal/cli/alerts/list.go
+++ b/internal/cli/alerts/list.go
@@ -74,8 +74,8 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Retrieves all alerts for the specified Atlas project.",
-		Example: fmt.Sprintf(`  This example uses the "%[1]s alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
-  $ %[1]s alerts list \
+		Example: fmt.Sprintf(`  # This example uses the "%[1]s alerts list" command to retrieve all alerts that occurred for the specified project. It uses the profile named "myprofile" for accessing Atlas.
+  %[1]s alerts list \
     --projectId 5df90590f10fab5e33de2305 \
     -o json \
     --profile myprofile`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/alerts/settings/create.go
+++ b/internal/cli/alerts/settings/create.go
@@ -67,8 +67,8 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates one alert configuration in the specified project.",
-		Example: fmt.Sprintf(`  This example uses the "%[1]s alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
-  $ %[1]s alert settings create --event JOINED_GROUP --enabled \
+		Example: fmt.Sprintf(`  # This example uses the "%[1]s alerts settings create" command to create one alert configuration in the specified project. It uses the default profile to access the Atlas project:
+  %[1]s alert settings create --event JOINED_GROUP --enabled \
   --notificationType USER --notificationEmailEnabled \
   --notificationUsername john@example.com \
   -o json --projectId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/alerts/settings/list.go
+++ b/internal/cli/alerts/settings/list.go
@@ -62,8 +62,8 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Returns alert configurations for the specified project.",
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s alerts settings list --projectId 5df90590f10fab5e33de2305 -o json --profile myprofile`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{},
 		Aliases:     []string{"ls"},
 		Args:        require.NoArgs,

--- a/internal/cli/atlas/accesslists/create.go
+++ b/internal/cli/atlas/accesslists/create.go
@@ -138,8 +138,8 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"entryDesc": "The IP address, CIDR address, or AWS security group ID of the access list entry to create.",
 		},
-		Example: fmt.Sprintf(`  Create IP address access list with the current IP address. Entry is not needed in this case.
-  $ %s accessList create --currentIP`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Create IP address access list with the current IP address. Entry is not needed in this case.
+  %s accessList create --currentIp`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/accesslists/describe.go
+++ b/internal/cli/atlas/accesslists/describe.go
@@ -66,7 +66,7 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"entryDesc": "The IP address, CIDR address, or AWS security group ID of the access list entry to retrieve.",
 		},
-		Example: fmt.Sprintf(`  The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
+		Example: fmt.Sprintf(`  # The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
   %s accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/backup/exports/buckets/create.go
+++ b/internal/cli/atlas/backup/exports/buckets/create.go
@@ -73,8 +73,8 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <bucketName>",
 		Short: "Create an export destination for Atlas backups using an existing AWS S3 bucket.",
-		Example: fmt.Sprintf(`  The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
-  $ %s backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca`, config.BinName()),
+		Example: fmt.Sprintf(`  # The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
+  %s backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca`, config.BinName()),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"bucketNameDesc": "Name of the existing S3 bucket that the provided role ID is authorized to access.",

--- a/internal/cli/atlas/backup/exports/buckets/delete.go
+++ b/internal/cli/atlas/backup/exports/buckets/delete.go
@@ -60,8 +60,8 @@ func DeleteBuilder() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a snapshot export bucket.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  The following deletes the continuous backup export bucket specified by ID:
-  $ %s backup exports buckets delete --bucketId dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following deletes the continuous backup export bucket specified by ID:
+  %s backup exports buckets delete --bucketId dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/buckets/describe.go
+++ b/internal/cli/atlas/backup/exports/buckets/describe.go
@@ -62,8 +62,8 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Short:   "Return one snapshot export bucket.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  The following example returns the continuous backup export bucket specified by ID:
-  $ %s backup exports buckets describe dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example returns the continuous backup export bucket specified by ID:
+  %s backup exports buckets describe dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/buckets/list.go
+++ b/internal/cli/atlas/backup/exports/buckets/list.go
@@ -64,8 +64,8 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List cloud backup restore buckets for your project and cluster.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup export buckets:
-  $ %s backup exports buckets list`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup export buckets:
+  %s backup exports buckets list`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/jobs/create.go
+++ b/internal/cli/atlas/backup/exports/jobs/create.go
@@ -80,8 +80,8 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Export one backup snapshot for an M10 or higher Atlas cluster to an existing AWS S3 bucket.",
-		Example: fmt.Sprintf(`  The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
-  $ %s backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test`, config.BinName()),
+		Example: fmt.Sprintf(`  # The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
+  %s backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test`, config.BinName()),
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/backup/exports/jobs/decribe.go
+++ b/internal/cli/atlas/backup/exports/jobs/decribe.go
@@ -64,8 +64,8 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Short:   "Return one cloud backup export job for your project, cluster and bucket.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
-  $ %s backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
+  %s backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/exports/jobs/list.go
+++ b/internal/cli/atlas/backup/exports/jobs/list.go
@@ -68,8 +68,8 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve restore jobs.",
 		},
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup export jobs for the cluster Cluster0:
-  $ %s backup exports jobs list Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup export jobs for the cluster Cluster0:
+  %s backup exports jobs list Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 

--- a/internal/cli/atlas/backup/restores/describe.go
+++ b/internal/cli/atlas/backup/restores/describe.go
@@ -66,8 +66,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"restoreJobIdDesc": "ID of the restore job.",
 		},
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup restore job for the cluster Cluster0:
-  $ %s backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup restore job for the cluster Cluster0:
+  %s backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/restores/list.go
+++ b/internal/cli/atlas/backup/restores/list.go
@@ -68,8 +68,8 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve restore jobs.",
 		},
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
-  $ %s backup restore list Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+  %s backup restore list Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -145,22 +145,22 @@ func StartBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"automated|download|pointInTimeDesc": "Type of restore job to create. Accepted values include: automated, download, pointInTime.",
 		},
-		Example: fmt.Sprintf(`  The following example creates an automated restore:
-  $ %[1]s backup restore start automated \
+		Example: fmt.Sprintf(`  # The following example creates an automated restore:
+  %[1]s backup restore start automated \
          --clusterName myDemo \
          --snapshotId 5e7e00128f8ce03996a47179 \
          --targetClusterName myDemo2 \
          --targetProjectId 1a2345b67c8e9a12f3456de7
 
-The following example creates a point-in-time restore:
-  $ %[1]s backup restore start pointInTime \
+  # The following example creates a point-in-time restore:
+  %[1]s backup restore start pointInTime \
          --clusterName myDemo \
          --pointInTimeUTCMillis 1588523147 \
          --targetClusterName myDemo2 \
          --targetProjectId 1a2345b67c8e9a12f3456de7
   
-The following example creates a download restore:
-  $ %[1]s backup restore start download \
+  # The following example creates a download restore:
+  %[1]s backup restore start download \
          --clusterName myDemo \
          --snapshotId 5e7e00128f8ce03996a47179`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/backup/restores/watch.go
+++ b/internal/cli/atlas/backup/restores/watch.go
@@ -73,8 +73,8 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 		Annotations: map[string]string{
 			"restoreJobIdDesc": "ID of the restore job.",
 		},
-		Example: fmt.Sprintf(`  The following example retrieves the continuous backup restore job for the cluster Cluster0:
-  $ %s backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup restore job for the cluster Cluster0:
+  %s backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/schedule/delete.go
+++ b/internal/cli/atlas/backup/schedule/delete.go
@@ -61,8 +61,8 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster.",
 		},
-		Example: fmt.Sprintf(`  The following example deletes all backup schedules of the cluster Cluster0:
-  $ %s backup schedule delete Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example deletes all backup schedules of the cluster Cluster0:
+  %s backup schedule delete Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/backup/schedule/describe.go
+++ b/internal/cli/atlas/backup/schedule/describe.go
@@ -69,8 +69,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Human-readable label for the cluster.",
 		},
-		Example: fmt.Sprintf(`  The following example describes the cloud backup schedule for the cluster Cluster0:
-  $ %s backup schedule describe Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example describes the cloud backup schedule for the cluster Cluster0:
+  %s backup schedule describe Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/schedule/update.go
+++ b/internal/cli/atlas/backup/schedule/update.go
@@ -349,8 +349,8 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update",
 		Aliases: []string{"updates"},
 		Short:   "Update snapshot backup policies for a cluster.",
-		Example: fmt.Sprintf(`  Update a snapshot backup policy for a cluster named Cluster0:
-  $ %s backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Update a snapshot backup policy for a cluster named Cluster0:
+  %s backup schedule update --clusterName Cluster0 --updateSnapshots --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/snapshots/watch.go
+++ b/internal/cli/atlas/backup/snapshots/watch.go
@@ -69,7 +69,7 @@ func WatchBuilder() *cobra.Command {
 Once the snapshot reaches the expected status, the command prints "Snapshot changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource status completes or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s snapshot watch snapshotIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s snapshot watch snapshotIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to watch.",

--- a/internal/cli/atlas/clusters/advancedsettings/describe.go
+++ b/internal/cli/atlas/clusters/advancedsettings/describe.go
@@ -65,7 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve configuration settings.",
 		},
-		Example: fmt.Sprintf(`  $ %s clusters advancedSettings describe Cluster0`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s clusters advancedSettings describe Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/clusters/advancedsettings/update.go
+++ b/internal/cli/atlas/clusters/advancedsettings/update.go
@@ -136,11 +136,11 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <clusterName>",
 		Short: "Update advanced configuration settings for one cluster.",
-		Example: fmt.Sprintf(`  Update the minimum oplog size for a cluster:
-  $ %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
+		Example: fmt.Sprintf(`  # Update the minimum oplog size for a cluster:
+  %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --oplogSizeMB 1000
 
-  Update the minimum TLS protocol version for a cluster:
-  $ %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"`,
+  # Update the minimum TLS protocol version for a cluster:
+  %[1]s cluster advancedSettings update <clusterName> --projectId <projectId> --minimumEnabledTLSProtocol "TLS1_2"`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/clusters/availableregions/list.go
+++ b/internal/cli/atlas/clusters/availableregions/list.go
@@ -70,11 +70,11 @@ func ListBuilder() *cobra.Command {
 		Short:   "List available regions that Atlas supports for new deployments.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		Example: `  List available regions for a given cloud provider and tier:
-  $ atlas cluster availableRegions --provider AWS --tier M50
+		Example: `  # List available regions for a given cloud provider and tier:
+  atlas cluster availableRegions --provider AWS --tier M50
 
-  List available regions by tier for a given provider:
-  $ atlas cluster availableRegions --provider GCP`,
+  # List available regions by tier for a given provider:
+  atlas cluster availableRegions --provider GCP`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.tier != "" && opts.provider == "" {
 				return fmt.Errorf("tier search also requires a %s flag", flag.Provider)

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -188,20 +188,20 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create one cluster in the specified project.",
 		Long: `To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
 For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.`,
-		Example: fmt.Sprintf(`  Deploy a free cluster:
-  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
+		Example: fmt.Sprintf(`  # Deploy a free cluster:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --tier M0
 
-  Deploy a three-member replica set in AWS:
-  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
+  # Deploy a three-member replica set in AWS:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10
 
-  Deploy a three-member replica set in AZURE:
-  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+  # Deploy a three-member replica set in AZURE:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider AZURE --region US_EAST_2 --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
   
-  Deploy a three-member replica set in GCP:
-  $ %[1]s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
+  # Deploy a three-member replica set in GCP:
+  %[1]s cluster create <clusterName> --projectId <projectId> --provider GCP --region EASTERN_US --members 3 --tier M10  --mdbVersion 5.0 --diskSizeGB 10
 
-  Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
-  $ %[1]s cluster create --projectId <projectId> --file <path/to/file.json>`, cli.ExampleAtlasEntryPoint()),
+  # Deploy a cluster or a multi-cloud cluster from a JSON configuration file:
+  %[1]s cluster create --projectId <projectId> --file <path/to/file.json>`, cli.ExampleAtlasEntryPoint()),
 		Args: require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.filename == "" {

--- a/internal/cli/atlas/clusters/onlinearchive/watch.go
+++ b/internal/cli/atlas/clusters/onlinearchive/watch.go
@@ -71,7 +71,7 @@ func WatchBuilder() *cobra.Command {
 Once the archive reaches the expected status, the command prints "Online archive available."
 If you run the command in the terminal, it blocks the terminal session until the resource status changes to the expected status.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to watch.",

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -126,14 +126,14 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update [clusterName]",
 		Short: "Update a MongoDB Atlas cluster.",
-		Example: fmt.Sprintf(`  Update tier for a cluster:
-  $ %[1]s cluster update <clusterName> --projectId <projectId> --tier M50
+		Example: fmt.Sprintf(`  # Update tier for a cluster:
+  %[1]s cluster update <clusterName> --projectId <projectId> --tier M50
 
-  Update disk size for a cluster:
-  $ %[1]s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
+  # Update disk size for a cluster:
+  %[1]s cluster update <clusterName> --projectId <projectId> --diskSizeGB 20
 
-  Update MongoDB version for a cluster:
-  $ %[1]s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2`,
+  # Update MongoDB version for a cluster:
+  %[1]s cluster update <clusterName> --projectId <projectId> --mdbVersion 4.2`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/clusters/upgrade.go
+++ b/internal/cli/atlas/clusters/upgrade.go
@@ -113,8 +113,8 @@ func UpgradeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade [clusterName]",
 		Short: "Upgrade a MongoDB Atlas cluster's tier, disk size, and/or MongoDB version.",
-		Example: fmt.Sprintf(`  The following example upgrades the tier, disk size, and MongoDB version for a cluster:
-  $ %s cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2`,
+		Example: fmt.Sprintf(`  # The following example upgrades the tier, disk size, and MongoDB version for a cluster:
+  %s cluster upgrade <clusterName> --projectId <projectId> --tier M50 --diskSizeGB 20 --mdbVersion 4.2`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -78,7 +78,7 @@ func WatchBuilder() *cobra.Command {
 Once the cluster reaches the expected state, the command prints "Cluster available."
 If you run the command in the terminal, it blocks the terminal session until the resource state changes to IDLE.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf("  $ %s cluster watch clusterNameSample", cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf("  %s cluster watch clusterNameSample", cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to watch.",

--- a/internal/cli/atlas/config/init.go
+++ b/internal/cli/atlas/config/init.go
@@ -101,11 +101,11 @@ func InitBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Configure a profile to store access settings for your MongoDB deployment.",
-		Example: `  To configure the tool to work with Atlas:
-  $ atlas config init
+		Example: `  # To configure the tool to work with Atlas:
+  atlas config init
 
-  To configure the tool to work with Atlas for Government:
-  $ atlas config init --gov`,
+  # To configure the tool to work with Atlas for Government:
+  atlas config init --gov`,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.OutWriter = cmd.OutOrStdout()
 		},

--- a/internal/cli/atlas/customdbroles/create.go
+++ b/internal/cli/atlas/customdbroles/create.go
@@ -82,7 +82,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create <roleName>",
 		Short:   "Create a custom database role for your project.",
-		Example: fmt.Sprintf(`  $ %s customDbRoles create customRole --privilege FIND@database,UPDATE@database`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s customDbRoles create customRole --privilege FIND@database,UPDATE@database`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"roleNameDesc": "Name of the custom role to create.",

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -173,17 +173,17 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [builtInRole]...",
 		Short: "Create a database user for your project.",
-		Example: fmt.Sprintf(`  Create an Atlas database admin user:
-  $ %[1]s dbuser create atlasAdmin --username <username>  --projectId <projectId>
+		Example: fmt.Sprintf(`  # Create an Atlas database admin user:
+  %[1]s dbuser create atlasAdmin --username <username>  --projectId <projectId>
 
-  Create a database user with read/write access to any database:
-  $ %[1]s dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+  # Create a database user with read/write access to any database:
+  %[1]s dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
 
-  Create a database user with multiple roles:
-  $ %[1]s dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+  # Create a database user with multiple roles:
+  %[1]s dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
 
-  Create a database user with multiple scopes:
-  $ %[1]s dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>`,
+  # Create a database user with multiple scopes:
+  %[1]s dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: cobra.OnlyValidArgs,
 		Annotations: map[string]string{

--- a/internal/cli/atlas/dbusers/update.go
+++ b/internal/cli/atlas/dbusers/update.go
@@ -79,11 +79,11 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <username>",
 		Short: "Update a database user for your project.",
-		Example: fmt.Sprintf(`  Update roles for a database user:
-  $ %[1]s dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
+		Example: fmt.Sprintf(`  # Update roles for a database user:
+  %[1]s dbuser update <username> --role readWriteAnyDatabase --projectId <projectId>
 
-  Update scopes for a database user:
-  $ %[1]s dbuser update <username> --scope resourceName:resourceType --projectId <projectId>`,
+  # Update scopes for a database user:
+  %[1]s dbuser update <username> --scope resourceName:resourceType --projectId <projectId>`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/atlas/logs/decrypt.go
+++ b/internal/cli/atlas/logs/decrypt.go
@@ -98,12 +98,12 @@ func DecryptBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "decrypt",
 		Short: "Decrypts an audit log file with the provided AWS, GCP or Azure key management services.",
-		Example: `  Decrypt using AWS credentials:
-  $ atlas logs decrypt --file /path/to/logFile.json --awsAccessKey <accessKey> --awsSecretAccessKey <secretKey> --awsSessionToken <sessionToken>
-  GCP credentials:
-  $ atlas logs decrypt --file /path/to/logFile.json --gcpServiceAccountKey <serviceAccountKey>
-  Azure credentials:
-  $ atlas logs decrypt --file /path/to/logFile.json --azureClientId <clientId> --azureTenantId <tenantId> --azureSecret <secret>
+		Example: `  # Decrypt using AWS credentials:
+  atlas logs decrypt --file /path/to/logFile.json --awsAccessKey <accessKey> --awsSecretAccessKey <secretKey> --awsSessionToken <sessionToken>
+  # Decrypt using GCP credentials:
+  atlas logs decrypt --file /path/to/logFile.json --gcpServiceAccountKey <serviceAccountKey>
+  # Decrypt using Azure credentials:
+  atlas logs decrypt --file /path/to/logFile.json --azureClientId <clientId> --azureTenantId <tenantId> --azureSecret <secret>
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.initDefaultOut)

--- a/internal/cli/atlas/metrics/databases/describe.go
+++ b/internal/cli/atlas/metrics/databases/describe.go
@@ -75,8 +75,8 @@ $ %s process list`, cli.ExampleAtlasEntryPoint()),
 			"databaseNameDesc":  "Label that identifies the database from which you want to retrieve metrics.",
 		},
 		Example: fmt.Sprintf(
-			`  This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
-  $ %s metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H`,
+			`  # This example retrieves database metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017" 
+  %s metrics database describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H`,
 			cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/metrics/databases/list.go
+++ b/internal/cli/atlas/metrics/databases/list.go
@@ -72,8 +72,8 @@ $ %s process list`, cli.ExampleAtlasEntryPoint()),
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",
 		},
 		Example: fmt.Sprintf(
-			`  This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-  $ %s metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`,
+			`  # This example lists the available databases for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+  %s metrics database ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/metrics/disks/describe.go
+++ b/internal/cli/atlas/metrics/disks/describe.go
@@ -74,8 +74,8 @@ $ %s process list`, cli.ExampleAtlasEntryPoint()),
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",
 			"diskNameDesc":      "Label that identifies the disk or partition from which you want to retrieve metrics.",
 		},
-		Example: fmt.Sprintf(`  This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-  $ %s metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example retrieves disks metrics for the database "testDB" in the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+  %s metrics disk describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/metrics/disks/list.go
+++ b/internal/cli/atlas/metrics/disks/list.go
@@ -73,8 +73,8 @@ $ %s process list`, cli.ExampleAtlasEntryPoint()),
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",
 		},
 		Example: fmt.Sprintf(
-			`  This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
-  $ %s metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
+			`  # This example lists the available disks for the host "atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017"
+  %s metrics disk ls atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/metrics/processes/processes.go
+++ b/internal/cli/atlas/metrics/processes/processes.go
@@ -72,7 +72,7 @@ $ %s process list`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",
 		},
-		Example: fmt.Sprintf(`  $ %s metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s metrics process atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/networking/peering/create/azure.go
+++ b/internal/cli/atlas/networking/peering/create/azure.go
@@ -124,7 +124,7 @@ func AzureBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "azure",
 		Short: "Create a connection with Azure.",
-		Example: fmt.Sprintf(`  The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
+		Example: fmt.Sprintf(`  # The following command creates a peering connection between the Atlas VPC and your Azure VNet for a project using the default profile:
   %s networking peering create azure --atlasCidrBlock 192.168.0.0/21 --directoryId 56657fdb-ca45-40dc-fr56-77fd8b6d2b37 --subscriptionId 345654f3-77cf-4084-9e06-8943a079ed75 
   --resourceGroup atlascli-test --region US_EAST_2 --vnet atlascli-test`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -78,7 +78,7 @@ func WatchBuilder() *cobra.Command {
 Once it reaches the expected state, the command prints "Network peering changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource is available.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s networking peering watch peeringConnectionSampleId`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s networking peering watch peeringConnectionSampleId`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"peerIdDesc": "Network peering connection ID.",

--- a/internal/cli/atlas/privateendpoints/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/delete.go
@@ -58,7 +58,7 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint aws delete vpce-0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/privateendpoints/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe.go
@@ -72,8 +72,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s privateendpoints aws describe 0123456789abcdefghijklmn -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.privateEndpointID = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -68,8 +68,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"interfaceEndpointIdDesc": "Unique identifier of the private endpoint you want to retrieve.",
 		},
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s privateendpoints aws interfaces describe vpce-svc-0123456789abcdefg --endpointServiceId 0123456789abcdefghijklmn -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.privateEndpointID = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/aws/watch.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch.go
@@ -68,7 +68,7 @@ func WatchBuilder() *cobra.Command {
 Once the endpoint reaches the expected state, the command prints "Private endpoint changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s privateEndpoint aws watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint aws watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",

--- a/internal/cli/atlas/privateendpoints/azure/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/delete.go
@@ -58,7 +58,7 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint azure delete 0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint azure delete 0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/privateendpoints/azure/watch.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch.go
@@ -68,7 +68,7 @@ func WatchBuilder() *cobra.Command {
 Once the endpoint reaches the expected state, the command prints "Private endpoint changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s privateEndpoint azure watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint azure watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",

--- a/internal/cli/atlas/privateendpoints/datalake/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/delete.go
@@ -57,7 +57,7 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint dataLake aws delete vpce-0fcd9d80bbafe1607 --force`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
@@ -65,8 +65,8 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.privateEndpointID = args[0]

--- a/internal/cli/atlas/privateendpoints/gcp/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create.go
@@ -71,7 +71,7 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create",
 		Short:   "Create a new GCP private endpoint for your project.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  $ %s privateEndpoints gcp create --region CENTRAL_US`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoints gcp create --region CENTRAL_US`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/privateendpoints/gcp/delete.go
+++ b/internal/cli/atlas/privateendpoints/gcp/delete.go
@@ -60,7 +60,7 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint gcp delete vpce-abcdefg0123456789 --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint gcp delete vpce-abcdefg0123456789 --force`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {

--- a/internal/cli/atlas/privateendpoints/gcp/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe.go
@@ -68,7 +68,7 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint gcp describe vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint gcp describe vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
@@ -100,7 +100,7 @@ func CreateBuilder() *cobra.Command {
 			"endpointGroupIdDesc": "Unique identifier for the endpoint group.",
 		},
 		Example: fmt.Sprintf(
-			`  $ %s privateEndpoints gcp interfaces create endpoint-1 \
+			`  %s privateEndpoints gcp interfaces create endpoint-1 \
   --endpointServiceId 61eaca605af86411903de1dd \
   --gcpProjectId mcli-private-endpoints \
   --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7`,

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/delete.go
@@ -60,7 +60,7 @@ func DeleteBuilder() *cobra.Command {
 			"idDesc": "Unique identifier for the endpoint group.",
 		},
 		Example: fmt.Sprintf(
-			`  $ %s privateEndpoints gcp interfaces delete endpoint-1 \
+			`  %s privateEndpoints gcp interfaces delete endpoint-1 \
   --endpointServiceId 61eaca605af86411903de1dd`,
 			cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
@@ -68,7 +68,7 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"idDesc": "Unique identifier of the private endpoint you want to retrieve.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoints gcp interfaces describe endpoint-1 \
+		Example: fmt.Sprintf(`  %s privateEndpoints gcp interfaces describe endpoint-1 \
   --endpointServiceId 61eaca605af86411903de1dd`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.privateEndpointGroupID = args[0]

--- a/internal/cli/atlas/privateendpoints/gcp/list.go
+++ b/internal/cli/atlas/privateendpoints/gcp/list.go
@@ -63,7 +63,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List GCP private endpoints for your project.",
-		Example: fmt.Sprintf(`  $ %s privateEndpoint gcp ls`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint gcp ls`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/gcp/watch.go
+++ b/internal/cli/atlas/privateendpoints/gcp/watch.go
@@ -71,7 +71,7 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint gcp watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint gcp watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/watch.go
+++ b/internal/cli/atlas/privateendpoints/watch.go
@@ -77,7 +77,7 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 				opts.InitOutput(cmd.OutOrStdout(), "\nPrivate endpoint changes completed.\n"),
 			)
 		},
-		Example: fmt.Sprintf(`  $ %s privateEndpoint watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s privateEndpoint watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()

--- a/internal/cli/atlas/processes/describe.go
+++ b/internal/cli/atlas/processes/describe.go
@@ -62,7 +62,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe <hostname:port>",
 		Short:   "Return the details for the MongoDB process you specify.",
-		Example: fmt.Sprintf(`  $ %s process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s process describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -539,9 +539,9 @@ func Builder() *cobra.Command {
 		Use:   "quickstart",
 		Short: "Create, configure, and connect to an Atlas cluster.",
 		Long:  "This command creates a new cluster, adds your public IP to the atlas access list and creates a db user to access your new MongoDB instance.",
-		Example: fmt.Sprintf(`  Skip setting cluster name, provider or database username by using the command options:
-  $ %[1]s quickstart --force
-  $ %[1]s quickstart --clusterName Test --provider GCP --username dbuserTest`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Skip setting cluster name, provider or database username by using the command options:
+  %[1]s quickstart --force
+  %[1]s quickstart --clusterName Test --provider GCP --username dbuserTest`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRun(cmd.Context(), cmd.OutOrStdout()); err != nil {
 				return err

--- a/internal/cli/atlas/security/ldap/save.go
+++ b/internal/cli/atlas/security/ldap/save.go
@@ -127,7 +127,7 @@ func SaveBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "save",
 		Short: "Save an LDAP configuration.",
-		Example: fmt.Sprintf(` The following example configures an LDAP server to authenticate and authorize MongoDB users.
+		Example: fmt.Sprintf(`  # The following example configures an LDAP server to authenticate and authorize MongoDB users.
   %s security ldap save --authenticationEnabled --authorizationEnabled 
   --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername 
   "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com" 

--- a/internal/cli/atlas/security/ldap/watch.go
+++ b/internal/cli/atlas/security/ldap/watch.go
@@ -69,7 +69,7 @@ func WatchBuilder() *cobra.Command {
 Once the LDAP configuration reaches the expected status, the command prints "LDAP Configuration request completed."
 If you run the command in the terminal, it blocks the terminal session until the resource status succeeds or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s security ldap status watch requestIdSample`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s security ldap status watch requestIdSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"requestIdDesc": "ID of the request to verify an LDAP configuration.",

--- a/internal/cli/atlas/serverless/watch.go
+++ b/internal/cli/atlas/serverless/watch.go
@@ -69,7 +69,7 @@ This command checks the serverless instance's state periodically until the insta
 Once the instance reaches the expected state, the command prints "Instance available."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes idle.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  $ %s serverless watch instanceNameSample`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  %s serverless watch instanceNameSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Name of the instance to watch.",

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -137,8 +137,8 @@ func Builder() *cobra.Command {
 		Use:   "setup",
 		Short: "Register, authenticate, create, and access an Atlas cluster.",
 		Long:  "This command takes you through registration, login, default profile creation, creating your first free tier cluster and connecting to it using MongoDB Shell.",
-		Example: `  Override default cluster settings like name, provider, or database username by using the command options
-  $ atlas setup --clusterName Test --provider GCP --username dbuserTest`,
+		Example: `  # Override default cluster settings like name, provider, or database username by using the command options
+  atlas setup --clusterName Test --provider GCP --username dbuserTest`,
 		Hidden: false,
 		Args:   require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -344,8 +344,8 @@ func LoginBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with MongoDB Atlas.",
-		Example: fmt.Sprintf(`  To start the interactive login for your MongoDB %s account:
-  $ %s auth login
+		Example: fmt.Sprintf(`  # To start the interactive login for your MongoDB %s account:
+  %s auth login
 `, Tool(), config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -77,8 +77,8 @@ func LogoutBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Log out of the CLI.",
-		Example: fmt.Sprintf(`  To log out from the CLI:
-  $ %s auth logout
+		Example: fmt.Sprintf(`  # To log out from the CLI:
+  %s auth logout
 `, config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/auth/register.go
+++ b/internal/cli/auth/register.go
@@ -148,8 +148,8 @@ func RegisterBuilder() *cobra.Command {
 		Use:    "register",
 		Short:  "Register with MongoDB Atlas.",
 		Hidden: false,
-		Example: fmt.Sprintf(`  To start the interactive setup:
-  $ %s auth register
+		Example: fmt.Sprintf(`  # To start the interactive setup:
+  %s auth register
 `, config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := registerPreRun(); err != nil {

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -50,8 +50,8 @@ func WhoAmIBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "Verifies and displays information about your authentication state.",
-		Example: fmt.Sprintf(`  See the logged account:
-  $ %s auth whoami
+		Example: fmt.Sprintf(`  # See the logged account:
+  %s auth whoami
 `, config.BinName()),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			opts.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -123,15 +123,15 @@ $ mongocli config set --help
 You can also use environment variables (MCLI_*) when running the tool.
 To find out more, see the documentation: https://docs.mongodb.com/mongocli/stable/configure/environment-variables/.`,
 		Example: `
-  Configure a profile to interact with Atlas:
-  $ mongocli config
-  Configure a profile to interact with Atlas for Government:
-  $ mongocli config --service cloudgov
+  # Configure a profile to interact with Atlas:
+  mongocli config
+  # Configure a profile to interact with Atlas for Government:
+  mongocli config --service cloudgov
   
-  Configure a profile to interact with Cloud Manager:
-  $ mongocli config --service cloud-manager
-  Configure a profile to interact with Ops Manager:
-  $ mongocli config --service ops-manager
+  # Configure a profile to interact with Cloud Manager:
+  mongocli config --service cloud-manager
+  # Configure a profile to interact with Ops Manager:
+  mongocli config --service ops-manager
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opt.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/config/delete.go
+++ b/internal/cli/config/delete.go
@@ -51,11 +51,11 @@ func DeleteBuilder() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a profile.",
 		Args:    require.ExactArgs(1),
-		Example: `  Delete the default profile configuration:
-  $ atlas config delete default
+		Example: `  # Delete the default profile configuration:
+  atlas config delete default
 
-  Skip the confirmation question and delete the default profile configuration:
-  $ atlas config delete default --force`,
+  # Skip the confirmation question and delete the default profile configuration:
+  atlas config delete default --force`,
 		Annotations: map[string]string{
 			"nameDesc": "Name of the profile.",
 		},

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -49,8 +49,8 @@ func EditBuilder() *cobra.Command {
 		Short: "Opens the config file with the default text editor.",
 		Long:  `Uses the default editor to open the config file. You can use EDITOR or VISUAL envs to change the default.`,
 		Example: fmt.Sprintf(`
-  To open the config
-  $ %s config edit
+  # To open the config
+  %s config edit
 `, config.BinName()),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opt.Run()

--- a/internal/cli/config/list.go
+++ b/internal/cli/config/list.go
@@ -44,7 +44,7 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "Return a list of available profiles by name.",
 		Long:    "If you did not specify a name for your profile, it displays as the default profile.",
-		Example: fmt.Sprintf("  $ %s config ls", config.BinName()),
+		Example: fmt.Sprintf("  %s config ls", config.BinName()),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			o.OutWriter = cmd.OutOrStdout()
 		},

--- a/internal/cli/config/rename.go
+++ b/internal/cli/config/rename.go
@@ -63,8 +63,8 @@ func RenameBuilder() *cobra.Command {
 		Use:     "rename <oldProfileName> <newProfileName>",
 		Aliases: []string{"mv"},
 		Short:   "Rename a profile.",
-		Example: fmt.Sprintf(`  Rename a profile called myProfile to testProfile:
-  $ %s config rename myProfile testProfile`, config.BinName()),
+		Example: fmt.Sprintf(`  # Rename a profile called myProfile to testProfile:
+  %s config rename myProfile testProfile`, config.BinName()),
 		Annotations: map[string]string{
 			"oldProfileNameDesc": "Name of the profile to rename.",
 			"newProfileNameDesc": "New name of the profile.",

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -73,7 +73,7 @@ func mongoCLIExample() string {
 	if config.BinName() == config.MongoCLI {
 		return fmt.Sprintf(`
   Set Ops Manager Base URL in the profile myProfile:
-  $ %s config set ops_manager_url http://localhost:30700/ -P myProfile
+  %s config set ops_manager_url http://localhost:30700/ -P myProfile
 `, config.BinName())
 	}
 
@@ -96,9 +96,9 @@ Available properties include: %v.`, config.Properties()),
 			}
 			return nil
 		},
-		Example: fmt.Sprintf(`%s
+		Example: fmt.Sprintf(`  %s
   Set Organization ID in the default profile:
-  $ %s config set org_id 5dd5aaef7a3e5a6c5bd12de4`, mongoCLIExample(), config.BinName()),
+  %s config set org_id 5dd5aaef7a3e5a6c5bd12de4`, mongoCLIExample(), config.BinName()),
 		Annotations: map[string]string{
 			"propertyNameDesc": "Property to set in the profile.",
 			"valueDesc":        "Value for the property to set in the profile.",

--- a/internal/cli/decryption/list_key_provider.go
+++ b/internal/cli/decryption/list_key_provider.go
@@ -56,7 +56,7 @@ func KeyProvidersListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "Lists all key provider configurations found in the encrypted audit log file.",
 		Example: `
-  $ mongocli ops-manager listKeyProvider --file log.gz`,
+  mongocli ops-manager listKeyProvider --file log.gz`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.InitOutput(cmd.OutOrStdout(), listTmpl),

--- a/internal/cli/events/list.go
+++ b/internal/cli/events/list.go
@@ -102,10 +102,10 @@ func ListBuilder() *cobra.Command {
 		Short: "Return all events for an organization or project.",
 		Deprecated: `  
   To return project events prefer
-  $ mongocli atlas|ops-manager|cloud-manager events projects list [--projectId <projectId>]
+  mongocli atlas|ops-manager|cloud-manager events projects list [--projectId <projectId>]
 
   To return organization events prefer
-  $ mongocli atlas|ops-manager|cloud-manager events organizations list [--orgId <orgId>]
+  mongocli atlas|ops-manager|cloud-manager events organizations list [--orgId <orgId>]
 `,
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,

--- a/internal/cli/iam/projects/settings/describe.go
+++ b/internal/cli/iam/projects/settings/describe.go
@@ -60,8 +60,8 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Retrieve details for settings to the specified project.",
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s projects settings describe -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s projects settings describe -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/iam/projects/settings/update.go
+++ b/internal/cli/iam/projects/settings/update.go
@@ -79,8 +79,8 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update",
 		Aliases: []string{"updates"},
 		Short:   "Updates settings for a project.",
-		Example: fmt.Sprintf(`  This example uses the profile named "myprofile" for accessing Atlas.
-  $ %s projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
+  %s projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			preRun := opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -85,11 +85,11 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Example: `  
-  Describe a team by ID
-  $ mongocli iam team(s) describe --id teamId --orgId <orgId>
+  # Describe a team by ID
+  mongocli iam team(s) describe --id teamId --orgId <orgId>
 
-  Describe a team by Name
-  $ mongocli iam team(s) describe --name teamName --orgId <orgId>
+  # Describe a team by Name
+  mongocli iam team(s) describe --name teamName --orgId <orgId>
 `,
 		Short: "Get a team in an organization.",
 		Args:  require.NoArgs,

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -85,11 +85,11 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Example: `  
-  Describe a user by ID
-  $ mongocli iam users describe --id <id>
+  # Describe a user by ID
+  mongocli iam users describe --id <id>
 
-  Describe a user by username
-  $ mongocli iam users describe --username <username>
+  # Describe a user by username
+  mongocli iam users describe --username <username>
 `,
 		Short: "Get a user by username or id.",
 		Args:  require.NoArgs,

--- a/internal/cli/opsmanager/automation/watch.go
+++ b/internal/cli/opsmanager/automation/watch.go
@@ -72,7 +72,7 @@ func WatchBuilder() *cobra.Command {
 Once the expected status is reached, the command prints "Changes deployed successfully."
 If you run the command in the terminal, it blocks the terminal session until the changes are completed.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: `  $ mongocli ops-manager automation watch`,
+		Example: `  mongocli ops-manager automation watch`,
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/opsmanager/clusters/indexes_create.go
+++ b/internal/cli/opsmanager/clusters/indexes_create.go
@@ -168,7 +168,7 @@ func IndexesCreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"indexNameDesc": "Name of the index to create.",
 		},
-		Example: `  The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
+		Example: `  # The following example creates an index named bedrooms_1 on the listings collection of the realestate database on the replica set repl1. 
   The command uses the default profile.
 
   mongocli om clusters indexes create bedrooms_1 \

--- a/internal/cli/opsmanager/dbusers/create.go
+++ b/internal/cli/opsmanager/dbusers/create.go
@@ -109,8 +109,8 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create",
 		Short: "Create a database user for your project.",
 		Example: `
-  Create a user with readWriteAnyDatabase and clusterMonitor access
-  $ mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>`,
+  # Create a user with readWriteAnyDatabase and clusterMonitor access
+  mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>`,
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/opsmanager/featurepolicies/update.go
+++ b/internal/cli/opsmanager/featurepolicies/update.go
@@ -97,11 +97,11 @@ func UpdateBuilder() *cobra.Command {
 		Use:   "update",
 		Short: "Update feature control policies for your project.",
 		Long:  "Feature Control Policies allow you to enable or disable certain MongoDB features based on your site-specific needs.",
-		Example: `Disable user management for a project:
-  $ mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
+		Example: `  # Disable user management for a project:
+  mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 
-  Update policies from a JSON configuration file:
-  $ mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
+  # Update policies from a JSON configuration file:
+  mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if opts.filename == "" {

--- a/internal/cli/opsmanager/logs/decrypt.go
+++ b/internal/cli/opsmanager/logs/decrypt.go
@@ -92,10 +92,10 @@ func DecryptBuilder() *cobra.Command {
 		Use:   "decrypt",
 		Short: "Decrypts an audit log file with the provided local key file or with a server that supports KMIP.",
 		Example: `
-	For audit logs in BSON format:
-  $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
-	For audit logs in JSON format:
-  $ mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json`,
+  # For audit logs in BSON format:
+  mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
+  # For audit logs in JSON format:
+  mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.initDefaultOut)
 		},

--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -112,8 +112,8 @@ func Builder() *cobra.Command {
 		Short:   "CLI tool to manage MongoDB Atlas",
 		Long:    fmt.Sprintf("Use %s command help for information on a specific command", atlas),
 		Example: `
-  Display the help menu for the config command
-  $ atlas config --help`,
+  # Display the help menu for the config command
+  atlas config --help`,
 		SilenceUsage: true,
 		Annotations: map[string]string{
 			"toc": "true",

--- a/internal/cli/root/mongocli/builder.go
+++ b/internal/cli/root/mongocli/builder.go
@@ -56,8 +56,8 @@ func Builder(profile *string, argsWithoutProg []string) *cobra.Command {
 		Short:   "CLI tool to manage your MongoDB Cloud",
 		Long:    fmt.Sprintf("Use %s command help for information on a specific command", config.ToolName),
 		Example: `
-  Display the help menu for the config command
-  $ mongocli config --help`,
+  # Display the help menu for the config command
+  mongocli config --help`,
 		SilenceUsage: true,
 		Annotations: map[string]string{
 			"toc": "true",

--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -137,7 +137,7 @@ func Builder() *cobra.Command {
 		Use:   "main",
 		Short: "Generate the download center json file",
 		Example: `
-  Generate the download center json file for mongocli
+  # Generate the download center json file for mongocli
   $ main --version 1.23.0 --file mongocli.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Generating JSON: %s\n", opts.fileName)


### PR DESCRIPTION
## Proposed changes

Together with the last PRs merged to cobra2snooty (which automatically split commands by the # sign into new code blocks), this change:

- Adds # before all intro text
- Allow multi-example commands to show each example separately (since cobra2snooty splits them by #)
- Removes the unnecessary $ symbol before commands

I have pulled in the latest cobra2snooty updates from using `go get -u github.com/mongodb-labs/cobra2snooty`
and `go mod tidy`


_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-26295

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added) **N/A**
- [x] I have run `make fmt` and formatted my code
