### PR TITLE
CLOUDP-148788: [AtlasCLI] cutover command is using orgId instead of projectId

### DIFF
--- a/docs/atlascli/command/atlas-liveMigrations-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-create.txt
@@ -56,14 +56,14 @@ Options
      - strings
      - true
      - List of hosts running the MongoDB Agent that can transfer your MongoDB data from the source (Cloud Manager or Ops Manager) to destination (Atlas) deployments. Each live migration process uses its own dedicated migration host.
-   * - --orgId
-     - string
-     - false
-     - Organization ID to use. Overrides the settings in the configuration file or environment variable.
    * - -o, --output
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file.
+   * - --projectId
+     - string
+     - false
+     - Project ID to use. Overrides the settings in the configuration file or environment variable.
    * - --sourceCACertificatePath
      - string
      - false

--- a/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
@@ -56,14 +56,14 @@ Options
      - strings
      - true
      - List of hosts running the MongoDB Agent that can transfer your MongoDB data from the source (Cloud Manager or Ops Manager) to destination (Atlas) deployments. Each live migration process uses its own dedicated migration host.
-   * - --orgId
-     - string
-     - false
-     - Organization ID to use. Overrides the settings in the configuration file or environment variable.
    * - -o, --output
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file.
+   * - --projectId
+     - string
+     - false
+     - Project ID to use. Overrides the settings in the configuration file or environment variable.
    * - --sourceCACertificatePath
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
@@ -56,14 +56,14 @@ Options
      - strings
      - true
      - List of hosts running the MongoDB Agent that can transfer your MongoDB data from the source (Cloud Manager or Ops Manager) to destination (Atlas) deployments. Each live migration process uses its own dedicated migration host.
-   * - --orgId
-     - string
-     - false
-     - Organization ID to use. Overrides the settings in the configuration file or environment variable.
    * - -o, --output
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file.
+   * - --projectId
+     - string
+     - false
+     - Project ID to use. Overrides the settings in the configuration file or environment variable.
    * - --sourceCACertificatePath
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
@@ -56,14 +56,14 @@ Options
      - strings
      - true
      - List of hosts running the MongoDB Agent that can transfer your MongoDB data from the source (Cloud Manager or Ops Manager) to destination (Atlas) deployments. Each live migration process uses its own dedicated migration host.
-   * - --orgId
-     - string
-     - false
-     - Organization ID to use. Overrides the settings in the configuration file or environment variable.
    * - -o, --output
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file.
+   * - --projectId
+     - string
+     - false
+     - Project ID to use. Overrides the settings in the configuration file or environment variable.
    * - --sourceCACertificatePath
      - string
      - false

--- a/internal/cli/atlas/livemigrations/create_test.go
+++ b/internal/cli/atlas/livemigrations/create_test.go
@@ -65,7 +65,7 @@ func TestCreateBuilder(t *testing.T) {
 		CreateBuilder(),
 		0,
 		[]string{
-			flag.OrgID,
+			flag.ProjectID,
 			flag.LiveMigrationSourceClusterName,
 			flag.LiveMigrationSourceProjectID,
 			flag.LiveMigrationSourceUsername,

--- a/internal/cli/atlas/livemigrations/cutover.go
+++ b/internal/cli/atlas/livemigrations/cutover.go
@@ -43,7 +43,7 @@ func (opts *CutoverOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *CutoverOpts) Run() error {
-	r, err := opts.store.CreateLiveMigrationCutover(opts.ConfigOrgID(), opts.liveMigrationID)
+	r, err := opts.store.CreateLiveMigrationCutover(opts.ConfigProjectID(), opts.liveMigrationID)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func CutoverBuilder() *cobra.Command {
 		Long:  "Your API Key must have the Organization Owner role to successfully run this command.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
-				opts.ValidateOrgID,
+				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), cutoverTemplate),
 			)

--- a/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
+++ b/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
@@ -125,9 +125,6 @@ func (opts *LiveMigrationsOpts) Validate() error {
 		return err
 	}
 
-	if opts.SourceManagedAuthentication && opts.SourceUsername != "" {
-		return fmt.Errorf("--%s and --%s are exclusive", flag.LiveMigrationSourceManagedAuthentication, flag.LiveMigrationSourceUsername)
-	}
 	if !opts.SourceManagedAuthentication && opts.SourceUsername == "" {
 		return fmt.Errorf("MongoDB Automation is not managing authentication, --%s must be set", flag.LiveMigrationSourceUsername)
 	}
@@ -151,6 +148,8 @@ func (opts *LiveMigrationsOpts) GenerateFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.DestinationDropEnabled, flag.LiveMigrationDropCollections, false, usage.LiveMigrationDropCollections)
 	cmd.Flags().BoolVar(&opts.Force, flag.Force, false, usage.Force)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+
+	cmd.MarkFlagsMutuallyExclusive(flag.LiveMigrationSourceManagedAuthentication, flag.LiveMigrationSourceUsername)
 
 	_ = cmd.MarkFlagRequired(flag.LiveMigrationSourceClusterName)
 	_ = cmd.MarkFlagRequired(flag.LiveMigrationSourceProjectID)

--- a/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
+++ b/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
@@ -138,7 +138,7 @@ func (opts *LiveMigrationsOpts) Validate() error {
 }
 
 func (opts *LiveMigrationsOpts) GenerateFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&opts.OrgID, flag.OrgID, "", usage.OrgID)
+	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVar(&opts.SourceClusterName, flag.LiveMigrationSourceClusterName, "", usage.LiveMigrationSourceClusterName)
 	cmd.Flags().StringVar(&opts.SourceProjectID, flag.LiveMigrationSourceProjectID, "", usage.LiveMigrationSourceProjectID)
 	cmd.Flags().StringVarP(&opts.SourceUsername, flag.LiveMigrationSourceUsername, flag.UsernameShort, "", usage.LiveMigrationSourceUsername)

--- a/internal/cli/atlas/livemigrations/validation/create_test.go
+++ b/internal/cli/atlas/livemigrations/validation/create_test.go
@@ -64,7 +64,7 @@ func TestCreateBuilder(t *testing.T) {
 		CreateBuilder(),
 		0,
 		[]string{
-			flag.OrgID,
+			flag.ProjectID,
 			flag.LiveMigrationSourceClusterName,
 			flag.LiveMigrationSourceProjectID,
 			flag.LiveMigrationSourceUsername,

--- a/internal/store/live_migrations.go
+++ b/internal/store/live_migrations.go
@@ -32,7 +32,7 @@ type LiveMigrationDescriber interface {
 	LiveMigrationDescribe(string, string) (*atlas.LiveMigration, error)
 }
 
-// LiveMigrationCreate encapsulate the logic to manage different cloud providers.
+// LiveMigrationCreate encapsulates the logic to manage different cloud providers.
 func (s *Store) LiveMigrationCreate(groupID string, liveMigration *atlas.LiveMigration) (*atlas.LiveMigration, error) {
 	switch s.service {
 	case config.CloudService:
@@ -43,7 +43,7 @@ func (s *Store) LiveMigrationCreate(groupID string, liveMigration *atlas.LiveMig
 	}
 }
 
-// LiveMigrationCreate encapsulate the logic to manage different cloud providers.
+// LiveMigrationDescribe encapsulates the logic to manage different cloud providers.
 func (s *Store) LiveMigrationDescribe(groupID, migrationID string) (*atlas.LiveMigration, error) {
 	switch s.service {
 	case config.CloudService:


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-148788

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

This came out in https://jira.mongodb.org/browse/HELP-40211. The cutover command is passing the `orgId` instead of the `projectId`
