### PR TITLE
(DOCSP-16571)(DOCSP-16572) Docs backfill for accessLists create and delete commands

### DIFF
--- a/docs/atlascli/command/atlas-accessLists-create.txt
+++ b/docs/atlascli/command/atlas-accessLists-create.txt
@@ -14,6 +14,8 @@ atlas accessLists create
 
 Create an IP access list for your project.
 
+The access list can contain one or more trusted IP addresses, AWS security group IDs, and entries in Classless Inter-Domain Routing (CIDR) notation. You can create one access list per project. Note: the command does not overwrite existing entries in the access list. Instead, it adds the new entries to the list of entries.
+
 Syntax
 ------
 
@@ -100,5 +102,24 @@ Examples
 
 .. code-block::
 
-   # Create IP address access list with the current IP address. Entry is not needed in this case.
+   # Create an IP access list entry using the current IP address. You don't need the entry argument when you use the currentIp flag.:
    atlas accessList create --currentIp
+   
+   
+.. code-block::
+
+   # Create an access list entry for the IP address 192.0.2.15 in the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas accessList create 192.0.2.15 --type ipAddress --projectId 5e2211c17a3e5a48f5497de3 --comment "IP address for app server 2" --output json
+   
+   
+.. code-block::
+
+   # Create an access list entry in CIDR notation for 73.231.201.205/24 in the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas accessList create 73.231.201.205/24 --type cidrBlock --projectId 5e2211c17a3e5a48f5497de3 --output json --comment "CIDR block for servers C - F"
+   
+   
+.. code-block::
+
+   # Create an access list entry for the AWS security group sg-903004f8 in the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas accessList create sg-903004f8 --type awsSecurityGroup
+   --projectId 5e2211c17a3e5a48f5497de3 --output json --comment "AWS Security Group"

--- a/docs/atlascli/command/atlas-accessLists-delete.txt
+++ b/docs/atlascli/command/atlas-accessLists-delete.txt
@@ -14,6 +14,8 @@ atlas accessLists delete
 
 Delete an IP access list from your project.
 
+The command prompts you to confirm the operation when you run the command without the --force option.
+
 Syntax
 ------
 
@@ -84,11 +86,10 @@ Examples
 
 .. code-block::
 
-   # The following command deletes the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation.
+   # Delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation:
    atlas accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3
    
 .. code-block::
 
-   # The following command uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation.
+   # Uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation:
    atlas accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3 --force
- 		

--- a/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
@@ -14,6 +14,8 @@ mongocli atlas accessLists create
 
 Create an IP access list for your project.
 
+The access list can contain one or more trusted IP addresses, AWS security group IDs, and entries in Classless Inter-Domain Routing (CIDR) notation. You can create one access list per project. Note: the command does not overwrite existing entries in the access list. Instead, it adds the new entries to the list of entries.
+
 Syntax
 ------
 
@@ -100,5 +102,24 @@ Examples
 
 .. code-block::
 
-   # Create IP address access list with the current IP address. Entry is not needed in this case.
+   # Create an IP access list entry using the current IP address. You don't need the entry argument when you use the currentIp flag.:
    mongocli atlas accessList create --currentIp
+   
+   
+.. code-block::
+
+   # Create an access list entry for the IP address 192.0.2.15 in the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas accessList create 192.0.2.15 --type ipAddress --projectId 5e2211c17a3e5a48f5497de3 --comment "IP address for app server 2" --output json
+   
+   
+.. code-block::
+
+   # Create an access list entry in CIDR notation for 73.231.201.205/24 in the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas accessList create 73.231.201.205/24 --type cidrBlock --projectId 5e2211c17a3e5a48f5497de3 --output json --comment "CIDR block for servers C - F"
+   
+   
+.. code-block::
+
+   # Create an access list entry for the AWS security group sg-903004f8 in the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas accessList create sg-903004f8 --type awsSecurityGroup
+   --projectId 5e2211c17a3e5a48f5497de3 --output json --comment "AWS Security Group"

--- a/docs/mongocli/command/mongocli-atlas-accessLists-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas accessLists delete
 
 Delete an IP access list from your project.
 
+The command prompts you to confirm the operation when you run the command without the --force option.
+
 Syntax
 ------
 
@@ -84,11 +86,10 @@ Examples
 
 .. code-block::
 
-   # The following command deletes the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation.
+   # Delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation:
    mongocli atlas accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3
    
 .. code-block::
 
-   # The following command uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation.
+   # Uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation:
    mongocli atlas accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3 --force
- 		

--- a/internal/cli/atlas/accesslists/create.go
+++ b/internal/cli/atlas/accesslists/create.go
@@ -134,12 +134,24 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [entry]",
 		Short: "Create an IP access list for your project.",
+		Long:  `The access list can contain one or more trusted IP addresses, AWS security group IDs, and entries in Classless Inter-Domain Routing (CIDR) notation. You can create one access list per project. Note: the command does not overwrite existing entries in the access list. Instead, it adds the new entries to the list of entries.`,
 		Args:  require.MaximumNArgs(1),
 		Annotations: map[string]string{
+			"args":      "entry",
 			"entryDesc": "The IP address, CIDR address, or AWS security group ID of the access list entry to create.",
 		},
-		Example: fmt.Sprintf(`  # Create IP address access list with the current IP address. Entry is not needed in this case.
-  %s accessList create --currentIp`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Create an IP access list entry using the current IP address. You don't need the entry argument when you use the currentIp flag.:
+  %[1]s accessList create --currentIp
+  
+  # Create an access list entry for the IP address 192.0.2.15 in the project with ID 5e2211c17a3e5a48f5497de3:
+  %[1]s accessList create 192.0.2.15 --type ipAddress --projectId 5e2211c17a3e5a48f5497de3 --comment "IP address for app server 2" --output json
+  
+  # Create an access list entry in CIDR notation for 73.231.201.205/24 in the project with ID 5e2211c17a3e5a48f5497de3:
+  %[1]s accessList create 73.231.201.205/24 --type cidrBlock --projectId 5e2211c17a3e5a48f5497de3 --output json --comment "CIDR block for servers C - F"
+  
+  # Create an access list entry for the AWS security group sg-903004f8 in the project with ID 5e2211c17a3e5a48f5497de3:
+  %[1]s accessList create sg-903004f8 --type awsSecurityGroup
+  --projectId 5e2211c17a3e5a48f5497de3 --output json --comment "AWS Security Group"`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/accesslists/delete.go
+++ b/internal/cli/atlas/accesslists/delete.go
@@ -64,8 +64,7 @@ func DeleteBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation:
   %[1]s accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3
   # Uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation:
-  %[1]s accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3 --force
-		`, cli.ExampleAtlasEntryPoint()),
+  %[1]s accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3 --force`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/accesslists/delete.go
+++ b/internal/cli/atlas/accesslists/delete.go
@@ -54,13 +54,16 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <entry>",
 		Aliases: []string{"rm"},
 		Short:   "Delete an IP access list from your project.",
+		Long:    "The command prompts you to confirm the operation when you run the command without the --force option.",
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
-			"entryDesc": "The IP address, CIDR address, or AWS security group ID of the access list entry to delete.",
+			"args":         "entry",
+			"requiredArgs": "entry",
+			"entryDesc":    "The IP address, CIDR address, or AWS security group ID of the access list entry to delete.",
 		},
-		Example: fmt.Sprintf(`  # The following command deletes the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation.
+		Example: fmt.Sprintf(`  # Delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 after prompting for a confirmation:
   %[1]s accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3
-  # The following command uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation.
+  # Uses the --force option to delete the IP address 192.0.2.0 from the access list for the project with ID 5e2211c17a3e5a48f5497de3 without confirmation:
   %[1]s accessLists delete 192.0.2.0 --projectId 5e2211c17a3e5a48f5497de3 --force
 		`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Proposed changes

Backfills docs content for atlas accessLists create and atlas accessLists delete commands.

_Jira ticket:_ 
https://jira.mongodb.org/browse/DOCSP-16571
https://jira.mongodb.org/browse/DOCSP-16572

Closes #[issue number]

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
