### PR TITLE
(DOCSP-16574)(DOCSP-16573) Backfill docs content for atlas accessLists list and describe

### DIFF
--- a/docs/atlascli/command/atlas-accessLists-describe.txt
+++ b/docs/atlascli/command/atlas-accessLists-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   # The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
+   # Return the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3:
    atlas accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3

--- a/docs/atlascli/command/atlas-accessLists-list.txt
+++ b/docs/atlascli/command/atlas-accessLists-list.txt
@@ -71,3 +71,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all access list entries for the project with ID 5e1234c17a3e5a48f5497de3:		
+   atlas accessLists list --output json --projectId 5e1234c17a3e5a48f5497de3

--- a/docs/mongocli/command/mongocli-atlas-accessLists-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-describe.txt
@@ -84,5 +84,5 @@ Examples
 
 .. code-block::
 
-   # The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
+   # Return the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3:
    mongocli atlas accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3

--- a/docs/mongocli/command/mongocli-atlas-accessLists-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-list.txt
@@ -71,3 +71,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all access list entries for the project with ID 5e1234c17a3e5a48f5497de3:		
+   atlas accessLists list --output json --projectId 5e1234c17a3e5a48f5497de3

--- a/internal/cli/atlas/accesslists/describe.go
+++ b/internal/cli/atlas/accesslists/describe.go
@@ -66,7 +66,7 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"entryDesc": "The IP address, CIDR address, or AWS security group ID of the access list entry to retrieve.",
 		},
-		Example: fmt.Sprintf(`  # The following example returns the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3.
+		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3:
   %s accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/accesslists/list.go
+++ b/internal/cli/atlas/accesslists/list.go
@@ -64,6 +64,8 @@ func ListBuilder() *cobra.Command {
 		Short:   "List Atlas IP access list entries for your project.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
+		Example: `  # Return a JSON-formatted list of all access list entries for the project with ID 5e1234c17a3e5a48f5497de3:		
+  atlas accessLists list --output json --projectId 5e1234c17a3e5a48f5497de3`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,


### PR DESCRIPTION
## Proposed changes

Backfills missing docs content/exampels for atlas accessLists list and atlas accessLists describe

_Jira ticket:_ 

https://jira.mongodb.org/browse/DOCSP-16574
https://jira.mongodb.org/browse/DOCSP-16573

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
