### PR TITLE
task: improve foliage reporting

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1201,7 +1201,7 @@ tasks:
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
   - name: atlas_cleanup_e2e
-    tags: [ "e2e","cleanup" ]
+    tags: [ "e2e","cleanup", "foliage_infrequent_task" ]
     must_have_test_results: true
     depends_on:
       - name: compile


### PR DESCRIPTION
Cleanup is a cron task, to improve folaige reporting it should be flagged as such 