### PR TITLE
(DOCSP-16595) Backfills content for atlas backups and backups snapshots commands

### DIFF
--- a/docs/atlascli/command/atlas-backups-restores-list.txt
+++ b/docs/atlascli/command/atlas-backups-restores-list.txt
@@ -92,5 +92,5 @@ Examples
 
 .. code-block::
 
-   # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+   # Retrieve the continuous backup restore jobs for the cluster Cluster0:
    atlas backup restore list Cluster0

--- a/docs/atlascli/command/atlas-backups-restores-start.txt
+++ b/docs/atlascli/command/atlas-backups-restores-start.txt
@@ -112,7 +112,7 @@ Examples
 
 .. code-block::
 
-   # The following example creates an automated restore:
+   # Create an automated restore:
    atlas backup restore start automated \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179 \
@@ -122,7 +122,7 @@ Examples
    
 .. code-block::
 
-   # The following example creates a point-in-time restore:
+   # Create a point-in-time restore:
    atlas backup restore start pointInTime \
           --clusterName myDemo \
           --pointInTimeUTCMillis 1588523147 \
@@ -132,7 +132,7 @@ Examples
    
 .. code-block::
 
-   # The following example creates a download restore:
+   # Create a download restore:
    atlas backup restore start download \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179

--- a/docs/atlascli/command/atlas-backups-snapshots-create.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-create.txt
@@ -14,6 +14,8 @@ atlas backups snapshots create
 
 Create a backup snapshot for your project and cluster.
 
+You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.
+
 Syntax
 ------
 
@@ -87,3 +89,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create a backup snapshot for the cluster named myDemo that Atlas retains for 30 days:
+   atlas backups snapshots create myDemo --retention 30

--- a/docs/atlascli/command/atlas-backups-snapshots-create.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-create.txt
@@ -95,4 +95,4 @@ Examples
 .. code-block::
 
    # Create a backup snapshot for the cluster named myDemo that Atlas retains for 30 days:
-   atlas backups snapshots create myDemo --retention 30
+   atlas backups snapshots create myDemo --desc "Daily snapshot" --retention 30

--- a/docs/atlascli/command/atlas-backups-snapshots-delete.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-delete.txt
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Delete the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the cluster named myDemo:
+   atlas backups snapshots delete 5f4007f327a3bd7b6f4103c5 --clusterName myDemo

--- a/docs/atlascli/command/atlas-backups-snapshots-describe.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-describe.txt
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the cluster named myDemo:
+   atlas backups snapshots describe 5f4007f327a3bd7b6f4103c5 --clusterName myDemo

--- a/docs/atlascli/command/atlas-backups-snapshots-watch.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-watch.txt
@@ -89,4 +89,5 @@ Examples
 
 .. code-block::
 
-   atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
+   # Watch for a backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 in the cluster named myDemo to become available:
+   atlas backups snapshots watch 5f4007f327a3bd7b6f4103c5 --clusterName myDemo

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
@@ -92,5 +92,5 @@ Examples
 
 .. code-block::
 
-   # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+   # Retrieve the continuous backup restore jobs for the cluster Cluster0:
    mongocli atlas backup restore list Cluster0

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
@@ -112,7 +112,7 @@ Examples
 
 .. code-block::
 
-   # The following example creates an automated restore:
+   # Create an automated restore:
    mongocli atlas backup restore start automated \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179 \
@@ -122,7 +122,7 @@ Examples
    
 .. code-block::
 
-   # The following example creates a point-in-time restore:
+   # Create a point-in-time restore:
    mongocli atlas backup restore start pointInTime \
           --clusterName myDemo \
           --pointInTimeUTCMillis 1588523147 \
@@ -132,7 +132,7 @@ Examples
    
 .. code-block::
 
-   # The following example creates a download restore:
+   # Create a download restore:
    mongocli atlas backup restore start download \
           --clusterName myDemo \
           --snapshotId 5e7e00128f8ce03996a47179

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-create.txt
@@ -95,4 +95,4 @@ Examples
 .. code-block::
 
    # Create a backup snapshot for the cluster named myDemo that Atlas retains for 30 days:
-   mongocli atlas backups snapshots create myDemo --retention 30
+   mongocli atlas backups snapshots create myDemo --desc "Daily snapshot" --retention 30

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-create.txt
@@ -14,6 +14,8 @@ mongocli atlas backups snapshots create
 
 Create a backup snapshot for your project and cluster.
 
+You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.
+
 Syntax
 ------
 
@@ -87,3 +89,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create a backup snapshot for the cluster named myDemo that Atlas retains for 30 days:
+   mongocli atlas backups snapshots create myDemo --retention 30

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-delete.txt
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Delete the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the cluster named myDemo:
+   mongocli atlas backups snapshots delete 5f4007f327a3bd7b6f4103c5 --clusterName myDemo

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-describe.txt
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the cluster named myDemo:
+   mongocli atlas backups snapshots describe 5f4007f327a3bd7b6f4103c5 --clusterName myDemo

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
@@ -89,4 +89,5 @@ Examples
 
 .. code-block::
 
-   mongocli atlas snapshot watch snapshotIdSample --clusterName clusterNameSample
+   # Watch for a backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 in the cluster named myDemo to become available:
+   mongocli atlas backups snapshots watch 5f4007f327a3bd7b6f4103c5 --clusterName myDemo

--- a/internal/cli/atlas/backup/restores/list.go
+++ b/internal/cli/atlas/backup/restores/list.go
@@ -68,7 +68,7 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve restore jobs.",
 		},
-		Example: fmt.Sprintf(`  # The following example retrieves the continuous backup restore jobs for the cluster Cluster0:
+		Example: fmt.Sprintf(`  # Retrieve the continuous backup restore jobs for the cluster Cluster0:
   %s backup restore list Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -145,21 +145,21 @@ func StartBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"automated|download|pointInTimeDesc": "Type of restore job to create. Accepted values include: automated, download, pointInTime.",
 		},
-		Example: fmt.Sprintf(`  # The following example creates an automated restore:
+		Example: fmt.Sprintf(`  # Create an automated restore:
   %[1]s backup restore start automated \
          --clusterName myDemo \
          --snapshotId 5e7e00128f8ce03996a47179 \
          --targetClusterName myDemo2 \
          --targetProjectId 1a2345b67c8e9a12f3456de7
 
-  # The following example creates a point-in-time restore:
+  # Create a point-in-time restore:
   %[1]s backup restore start pointInTime \
          --clusterName myDemo \
          --pointInTimeUTCMillis 1588523147 \
          --targetClusterName myDemo2 \
          --targetProjectId 1a2345b67c8e9a12f3456de7
   
-  # The following example creates a download restore:
+  # Create a download restore:
   %[1]s backup restore start download \
          --clusterName myDemo \
          --snapshotId 5e7e00128f8ce03996a47179`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/backup/snapshots/create.go
+++ b/internal/cli/atlas/backup/snapshots/create.go
@@ -16,6 +16,7 @@ package snapshots
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/commonerrors"
@@ -73,7 +74,10 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create <clusterName>",
 		Aliases: []string{"take"},
 		Short:   "Create a backup snapshot for your project and cluster.",
+		Long:    "You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.",
 		Args:    require.ExactArgs(1),
+		Example: fmt.Sprintf(`  # Create a backup snapshot for the cluster named myDemo that Atlas retains for 30 days:
+  %s backups snapshots create myDemo --retention 30`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster whose snapshot you want to restore.",
 		},

--- a/internal/cli/atlas/backup/snapshots/create.go
+++ b/internal/cli/atlas/backup/snapshots/create.go
@@ -77,7 +77,7 @@ func CreateBuilder() *cobra.Command {
 		Long:    "You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.",
 		Args:    require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Create a backup snapshot for the cluster named myDemo that Atlas retains for 30 days:
-  %s backups snapshots create myDemo --retention 30`, cli.ExampleAtlasEntryPoint()),
+  %s backups snapshots create myDemo --desc "Daily snapshot" --retention 30`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster whose snapshot you want to restore.",
 		},

--- a/internal/cli/atlas/backup/snapshots/delete.go
+++ b/internal/cli/atlas/backup/snapshots/delete.go
@@ -16,6 +16,7 @@ package snapshots
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/commonerrors"
@@ -56,6 +57,8 @@ func DeleteBuilder() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete a backup snapshot.",
 		Args:    require.ExactArgs(1),
+		Example: fmt.Sprintf(`  # Delete the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the cluster named myDemo:
+  %s backups snapshots delete 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to delete.",
 		},

--- a/internal/cli/atlas/backup/snapshots/describe.go
+++ b/internal/cli/atlas/backup/snapshots/describe.go
@@ -15,6 +15,7 @@ package snapshots
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -61,6 +62,8 @@ func DescribeBuilder() *cobra.Command {
 		Use:   "describe <snapshotId>",
 		Short: "Get a specific snapshot for your project.",
 		Args:  require.ExactArgs(1),
+		Example: fmt.Sprintf(`  # Return the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the cluster named myDemo:
+  %s backups snapshots describe 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to retrieve.",
 		},

--- a/internal/cli/atlas/backup/snapshots/watch.go
+++ b/internal/cli/atlas/backup/snapshots/watch.go
@@ -69,8 +69,9 @@ func WatchBuilder() *cobra.Command {
 Once the snapshot reaches the expected status, the command prints "Snapshot changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource status completes or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
-		Example: fmt.Sprintf(`  %s snapshot watch snapshotIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
-		Args:    require.ExactArgs(1),
+		Example: fmt.Sprintf(`  # Watch for a backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 in the cluster named myDemo to become available:
+  %s backups snapshots watch 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to watch.",
 		},


### PR DESCRIPTION
## Proposed changes

Backfills docs content for atlas backups and atlas backups snapshots commands

_Jira tickets:_ 

https://jira.mongodb.org/browse/DOCSP-16590
https://jira.mongodb.org/browse/DOCSP-16591
https://jira.mongodb.org/browse/DOCSP-16593
https://jira.mongodb.org/browse/DOCSP-16594
https://jira.mongodb.org/browse/DOCSP-16595
https://jira.mongodb.org/browse/DOCSP-16596
https://jira.mongodb.org/browse/DOCSP-16597

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
