### PR TITLE
CLOUDP-149874: Replace export job bucketId with jobId flag

### DIFF
--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -12,7 +12,7 @@ atlas backups exports jobs describe
    :depth: 1
    :class: singlecol
 
-Return one cloud backup export job for your project, cluster and bucket.
+Return one cloud backup export job for your project, cluster and job.
 
 Syntax
 ------
@@ -34,10 +34,6 @@ Options
      - Type
      - Required
      - Description
-   * - --bucketId
-     - string
-     - true
-     - Unique identifier that Atlas assigns to the bucket.
    * - --clusterName
      - string
      - true
@@ -46,6 +42,10 @@ Options
      - 
      - false
      - help for describe
+   * - --jobId
+     - string
+     - true
+     - Unique identifier that Atlas assigns to the job
    * - -o, --output
      - string
      - false
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   # The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
-   atlas backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305
+   # The following example describes the continuous backup export job for the cluster Cluster0 and job 5df90590f10fab5e33de2305:
+   atlas backup exports jobs describe --clusterName Cluster0 --jobId 5df90590f10fab5e33de2305

--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -38,10 +38,10 @@ Options
      - string
      - true
      - Name of the cluster.
-   * - --exportJobId
+   * - --exportId
      - string
      - false
-     - Unique identifier that Atlas assigns to the job
+     - Unique string that identifies the AWS S3 bucket to which you export your snapshots.
    * - -h, --help
      - 
      - false
@@ -76,5 +76,5 @@ Examples
 
 .. code-block::
 
-   # The following example describes the continuous backup export job for the cluster Cluster0 and job 5df90590f10fab5e33de2305:
-   atlas backup exports jobs describe --clusterName Cluster0 --exportJobID 5df90590f10fab5e33de2305
+   # The following example describes the continuous backup export job for the cluster Cluster0 and export job 5df90590f10fab5e33de2305:
+   atlas backup exports jobs describe --clusterName Cluster0 --exportID 5df90590f10fab5e33de2305

--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -40,7 +40,7 @@ Options
      - Name of the cluster.
    * - --exportJobId
      - string
-     - true
+     - false
      - Unique identifier that Atlas assigns to the job
    * - -h, --help
      - 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -38,14 +38,14 @@ Options
      - string
      - true
      - Name of the cluster.
+   * - --exportJobId
+     - string
+     - true
+     - Unique identifier that Atlas assigns to the job
    * - -h, --help
      - 
      - false
      - help for describe
-   * - --jobId
-     - string
-     - true
-     - Unique identifier that Atlas assigns to the job
    * - -o, --output
      - string
      - false
@@ -77,4 +77,4 @@ Examples
 .. code-block::
 
    # The following example describes the continuous backup export job for the cluster Cluster0 and job 5df90590f10fab5e33de2305:
-   atlas backup exports jobs describe --clusterName Cluster0 --jobId 5df90590f10fab5e33de2305
+   atlas backup exports jobs describe --clusterName Cluster0 --exportJobID 5df90590f10fab5e33de2305

--- a/docs/atlascli/command/atlas-backups-exports-jobs.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs.txt
@@ -50,7 +50,7 @@ Related Commands
 ----------------
 
 * :ref:`atlas-backups-exports-jobs-create` - Export one backup snapshot for an M10 or higher Atlas cluster to an existing AWS S3 bucket.
-* :ref:`atlas-backups-exports-jobs-describe` - Return one cloud backup export job for your project, cluster and bucket.
+* :ref:`atlas-backups-exports-jobs-describe` - Return one cloud backup export job for your project, cluster and job.
 * :ref:`atlas-backups-exports-jobs-list` - Return all cloud backup export jobs for your project and cluster.
 
 

--- a/internal/cli/atlas/backup/exports/jobs/decribe.go
+++ b/internal/cli/atlas/backup/exports/jobs/decribe.go
@@ -31,7 +31,7 @@ type DescribeOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
 	clusterName string
-	jobID       string
+	exportJobID string
 	store       store.ExportJobsDescriber
 }
 
@@ -43,12 +43,12 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-var describeTemplate = `ID	EXPORT JOB ID	STATE	SNAPSHOT ID
-{{.ID}}	{{.ExportJobID}}	{{.State}}	{{.SnapshotID}}
+var describeTemplate = `ID	EXPORT BUCKET ID	STATE	SNAPSHOT ID
+{{.ID}}	{{.ExportBucketID}}	{{.State}}	{{.SnapshotID}}
 `
 
 func (opts *DescribeOpts) Run() error {
-	r, err := opts.store.ExportJob(opts.ConfigProjectID(), opts.clusterName, opts.jobID)
+	r, err := opts.store.ExportJob(opts.ConfigProjectID(), opts.clusterName, opts.exportJobID)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (opts *DescribeOpts) Run() error {
 	return opts.Print(r)
 }
 
-// atlas backup(s) export(s) job(s) describe --clusterName <clusterName> --jobID <jobID> [--projectID <projectID>].
+// atlas backup(s) export(s) job(s) describe --clusterName <clusterName> --exportJobID <exportJobID> [--projectID <projectID>].
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
@@ -65,7 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Short:   "Return one cloud backup export job for your project, cluster and job.",
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # The following example describes the continuous backup export job for the cluster Cluster0 and job 5df90590f10fab5e33de2305:
-  %s backup exports jobs describe --clusterName Cluster0 --jobId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
+  %s backup exports jobs describe --clusterName Cluster0 --exportJobID 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
@@ -79,16 +79,16 @@ func DescribeBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.clusterName, flag.ClusterName, "", usage.ClusterName)
-	cmd.Flags().StringVar(&opts.jobID, flag.JobID, "", usage.JobID)
-	cmd.Flags().StringVar(&opts.jobID, flag.BucketID, "", usage.JobID)
+	cmd.Flags().StringVar(&opts.exportJobID, flag.ExportJobID, "", usage.ExportJobID)
+	cmd.Flags().StringVar(&opts.exportJobID, flag.BucketID, "", usage.ExportJobID)
 
 	_ = cmd.MarkFlagRequired(flag.ClusterName)
-	_ = cmd.MarkFlagRequired(flag.JobID)
+	_ = cmd.MarkFlagRequired(flag.ExportJobID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
-	_ = cmd.Flags().MarkDeprecated(flag.BucketID, fmt.Sprintf("please use --%s instead", flag.JobID))
+	_ = cmd.Flags().MarkDeprecated(flag.BucketID, fmt.Sprintf("please use --%s instead", flag.ExportJobID))
 
 	return cmd
 }

--- a/internal/cli/atlas/backup/exports/jobs/decribe.go
+++ b/internal/cli/atlas/backup/exports/jobs/decribe.go
@@ -87,6 +87,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
+	cmd.MarkFlagsMutuallyExclusive(flag.BucketID, flag.ExportJobID)
 	_ = cmd.Flags().MarkDeprecated(flag.BucketID, fmt.Sprintf("please use --%s instead", flag.ExportJobID))
 
 	return cmd

--- a/internal/cli/atlas/backup/exports/jobs/decribe.go
+++ b/internal/cli/atlas/backup/exports/jobs/decribe.go
@@ -83,7 +83,6 @@ func DescribeBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.exportJobID, flag.BucketID, "", usage.ExportJobID)
 
 	_ = cmd.MarkFlagRequired(flag.ClusterName)
-	_ = cmd.MarkFlagRequired(flag.ExportJobID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/backup/exports/jobs/decribe.go
+++ b/internal/cli/atlas/backup/exports/jobs/decribe.go
@@ -31,7 +31,7 @@ type DescribeOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
 	clusterName string
-	bucketID    string
+	jobID       string
 	store       store.ExportJobsDescriber
 }
 
@@ -43,12 +43,12 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-var describeTemplate = `ID	EXPORT BUCKET ID	STATE	SNAPSHOT ID
-{{.ID}}	{{.ExportBucketID}}	{{.State}}	{{.SnapshotID}}
+var describeTemplate = `ID	EXPORT JOB ID	STATE	SNAPSHOT ID
+{{.ID}}	{{.ExportJobID}}	{{.State}}	{{.SnapshotID}}
 `
 
 func (opts *DescribeOpts) Run() error {
-	r, err := opts.store.ExportJob(opts.ConfigProjectID(), opts.clusterName, opts.bucketID)
+	r, err := opts.store.ExportJob(opts.ConfigProjectID(), opts.clusterName, opts.jobID)
 	if err != nil {
 		return err
 	}
@@ -56,16 +56,16 @@ func (opts *DescribeOpts) Run() error {
 	return opts.Print(r)
 }
 
-// atlas backup(s) export(s) job(s) describe --clusterName <clusterName> --bucketID <bucketID> [--projectID <projectID>].
+// atlas backup(s) export(s) job(s) describe --clusterName <clusterName> --jobID <jobID> [--projectID <projectID>].
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
 		Use:     "describe",
 		Aliases: []string{"get"},
-		Short:   "Return one cloud backup export job for your project, cluster and bucket.",
+		Short:   "Return one cloud backup export job for your project, cluster and job.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  # The following example describes the continuous backup export job for the cluster Cluster0 and bucket 5df90590f10fab5e33de2305:
-  %s backup exports jobs describe --clusterName Cluster0 --bucketId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example describes the continuous backup export job for the cluster Cluster0 and job 5df90590f10fab5e33de2305:
+  %s backup exports jobs describe --clusterName Cluster0 --jobId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
@@ -79,13 +79,16 @@ func DescribeBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.clusterName, flag.ClusterName, "", usage.ClusterName)
-	cmd.Flags().StringVar(&opts.bucketID, flag.BucketID, "", usage.BucketID)
+	cmd.Flags().StringVar(&opts.jobID, flag.JobID, "", usage.JobID)
+	cmd.Flags().StringVar(&opts.jobID, flag.BucketID, "", usage.JobID)
 
 	_ = cmd.MarkFlagRequired(flag.ClusterName)
-	_ = cmd.MarkFlagRequired(flag.BucketID)
+	_ = cmd.MarkFlagRequired(flag.JobID)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+
+	_ = cmd.Flags().MarkDeprecated(flag.BucketID, fmt.Sprintf("please use --%s instead", flag.JobID))
 
 	return cmd
 }

--- a/internal/cli/atlas/backup/exports/jobs/decribe.go
+++ b/internal/cli/atlas/backup/exports/jobs/decribe.go
@@ -31,7 +31,7 @@ type DescribeOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
 	clusterName string
-	exportJobID string
+	exportID    string
 	store       store.ExportJobsDescriber
 }
 
@@ -48,7 +48,7 @@ var describeTemplate = `ID	EXPORT BUCKET ID	STATE	SNAPSHOT ID
 `
 
 func (opts *DescribeOpts) Run() error {
-	r, err := opts.store.ExportJob(opts.ConfigProjectID(), opts.clusterName, opts.exportJobID)
+	r, err := opts.store.ExportJob(opts.ConfigProjectID(), opts.clusterName, opts.exportID)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (opts *DescribeOpts) Run() error {
 	return opts.Print(r)
 }
 
-// atlas backup(s) export(s) job(s) describe --clusterName <clusterName> --exportJobID <exportJobID> [--projectID <projectID>].
+// atlas backup(s) export(s) job(s) describe --clusterName <clusterName> --exportID <exportID> [--projectID <projectID>].
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
@@ -64,8 +64,8 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Short:   "Return one cloud backup export job for your project, cluster and job.",
 		Args:    require.NoArgs,
-		Example: fmt.Sprintf(`  # The following example describes the continuous backup export job for the cluster Cluster0 and job 5df90590f10fab5e33de2305:
-  %s backup exports jobs describe --clusterName Cluster0 --exportJobID 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # The following example describes the continuous backup export job for the cluster Cluster0 and export job 5df90590f10fab5e33de2305:
+  %s backup exports jobs describe --clusterName Cluster0 --exportID 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
@@ -79,16 +79,16 @@ func DescribeBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.clusterName, flag.ClusterName, "", usage.ClusterName)
-	cmd.Flags().StringVar(&opts.exportJobID, flag.ExportJobID, "", usage.ExportJobID)
-	cmd.Flags().StringVar(&opts.exportJobID, flag.BucketID, "", usage.ExportJobID)
+	cmd.Flags().StringVar(&opts.exportID, flag.ExportID, "", usage.ExportID)
+	cmd.Flags().StringVar(&opts.exportID, flag.BucketID, "", usage.ExportID)
 
 	_ = cmd.MarkFlagRequired(flag.ClusterName)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
-	cmd.MarkFlagsMutuallyExclusive(flag.BucketID, flag.ExportJobID)
-	_ = cmd.Flags().MarkDeprecated(flag.BucketID, fmt.Sprintf("please use --%s instead", flag.ExportJobID))
+	cmd.MarkFlagsMutuallyExclusive(flag.BucketID, flag.ExportID)
+	_ = cmd.Flags().MarkDeprecated(flag.BucketID, fmt.Sprintf("please use --%s instead", flag.ExportID))
 
 	return cmd
 }

--- a/internal/cli/atlas/backup/exports/jobs/describe_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/describe_test.go
@@ -38,7 +38,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 
 	mockStore.
 		EXPECT().
-		ExportJob(opts.ProjectID, opts.clusterName, opts.bucketID).
+		ExportJob(opts.ProjectID, opts.clusterName, opts.jobID).
 		Return(expected, nil).
 		Times(1)
 
@@ -48,6 +48,20 @@ func TestDescribeOpts_Run(t *testing.T) {
 }
 
 func TestDescribeBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		DescribeBuilder(),
+		0,
+		[]string{
+			flag.ProjectID,
+			flag.ClusterName,
+			flag.JobID,
+			flag.Output,
+		},
+	)
+}
+
+func TestDescribeBuilderWithBucketId(t *testing.T) {
 	test.CmdValidator(
 		t,
 		DescribeBuilder(),

--- a/internal/cli/atlas/backup/exports/jobs/describe_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/describe_test.go
@@ -38,7 +38,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 
 	mockStore.
 		EXPECT().
-		ExportJob(opts.ProjectID, opts.clusterName, opts.jobID).
+		ExportJob(opts.ProjectID, opts.clusterName, opts.exportJobID).
 		Return(expected, nil).
 		Times(1)
 
@@ -55,7 +55,7 @@ func TestDescribeBuilder(t *testing.T) {
 		[]string{
 			flag.ProjectID,
 			flag.ClusterName,
-			flag.JobID,
+			flag.ExportJobID,
 			flag.Output,
 		},
 	)

--- a/internal/cli/atlas/backup/exports/jobs/describe_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/describe_test.go
@@ -38,7 +38,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 
 	mockStore.
 		EXPECT().
-		ExportJob(opts.ProjectID, opts.clusterName, opts.exportJobID).
+		ExportJob(opts.ProjectID, opts.clusterName, opts.exportID).
 		Return(expected, nil).
 		Times(1)
 
@@ -55,7 +55,7 @@ func TestDescribeBuilder(t *testing.T) {
 		[]string{
 			flag.ProjectID,
 			flag.ClusterName,
-			flag.ExportJobID,
+			flag.ExportID,
 			flag.Output,
 		},
 	)

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -312,7 +312,7 @@ const (
 	BackupPolicy                              = "policy"                                    // BackupPolicy flag
 	OperatorIncludeSecrets                    = "includeSecrets"                            // OperatorIncludeSecrets flag
 	OperatorTargetNamespace                   = "targetNamespace"                           // OperatorTargetNamespace flag
-	ExportJobID                               = "exportJobId"                               // ExportJobID flag
+	ExportID                                  = "exportId"                                  // ExportID flag
 
 	/* #nosec */
 	KMIPClientCertificatePassword = "kmipClientCertificatePassword" // KMIPClientCertificatePassword flag

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -312,6 +312,7 @@ const (
 	BackupPolicy                              = "policy"                                    // BackupPolicy flag
 	OperatorIncludeSecrets                    = "includeSecrets"                            // OperatorIncludeSecrets flag
 	OperatorTargetNamespace                   = "targetNamespace"                           // OperatorTargetNamespace flag
+	JobID                                     = "jobId"                                     // JobID flag
 
 	/* #nosec */
 	KMIPClientCertificatePassword = "kmipClientCertificatePassword" // KMIPClientCertificatePassword flag

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -312,7 +312,7 @@ const (
 	BackupPolicy                              = "policy"                                    // BackupPolicy flag
 	OperatorIncludeSecrets                    = "includeSecrets"                            // OperatorIncludeSecrets flag
 	OperatorTargetNamespace                   = "targetNamespace"                           // OperatorTargetNamespace flag
-	JobID                                     = "jobId"                                     // JobID flag
+	ExportJobID                               = "exportJobId"                               // ExportJobID flag
 
 	/* #nosec */
 	KMIPClientCertificatePassword = "kmipClientCertificatePassword" // KMIPClientCertificatePassword flag

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -374,4 +374,5 @@ dbName and collection are only required for built-in roles.`
 	ExporterClusterName                       = "One or more comma separated cluster names to import"
 	OperatorIncludeSecrets                    = "Generate kubernetes secrets with data for projects, users, deployments entities" //nolint:gosec //This is just a message, not a credential
 	OperatorTargetNamespace                   = "Namespaces to use for generated kubernetes entities"
+	JobID                                     = "Unique identifier that Atlas assigns to the job"
 )

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -374,5 +374,5 @@ dbName and collection are only required for built-in roles.`
 	ExporterClusterName                       = "One or more comma separated cluster names to import"
 	OperatorIncludeSecrets                    = "Generate kubernetes secrets with data for projects, users, deployments entities" //nolint:gosec //This is just a message, not a credential
 	OperatorTargetNamespace                   = "Namespaces to use for generated kubernetes entities"
-	ExportJobID                               = "Unique identifier that Atlas assigns to the job"
+	ExportID                                  = "Unique string that identifies the AWS S3 bucket to which you export your snapshots."
 )

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -374,5 +374,5 @@ dbName and collection are only required for built-in roles.`
 	ExporterClusterName                       = "One or more comma separated cluster names to import"
 	OperatorIncludeSecrets                    = "Generate kubernetes secrets with data for projects, users, deployments entities" //nolint:gosec //This is just a message, not a credential
 	OperatorTargetNamespace                   = "Namespaces to use for generated kubernetes entities"
-	JobID                                     = "Unique identifier that Atlas assigns to the job"
+	ExportJobID                               = "Unique identifier that Atlas assigns to the job"
 )


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_  [CLOUDP-149874](https://jira.mongodb.org/browse/CLOUDP-149874)

Following [this related change](https://github.com/mongodb/go-client-mongodb-atlas/pull/331/files) to the go SDK client, the parameter names of the `CloudProviderSnapshotExportJobsServiceOp` GET request `projectID, clusterName, exportJobID string` will correspond to the [public doc](https://www.mongodb.com/docs/atlas/reference/api/cloud-backup/export/get-one-export-job/)
```
GET /groups/{GROUP-ID}/clusters/{CLUSTER-NAME}/backup/exports/{EXPORT-JOB-ID}
```

In this PR, I have updated the references to use `ExportJobID` rather than `bucketId` for consistency with the go client and public docs

- For backwards compatibility, set `bucketId` as an alias for `jobId`, to avoid introducing breaking changes

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

