### PR TITLE
CLOUDP-136638: Add OM 6.0 E2E tests for MongoCLI

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1053,7 +1053,92 @@ tasks:
       - func: "e2e test"
         vars:
           E2E_TAGS: cloudmanager,remote,sharded
-  # Deploy ops manager and test against it
+  # Deploy ops manager 6.0 and test against it
+  - name: ops_manager_6_0_generic_e2e
+    tags: [ "e2e","ops-manager-50" ]
+    must_have_test_results: true
+    depends_on:
+        - name: compile
+          variant: "code_health"
+          patch_optional: true
+    commands:
+        - func: "clone"
+        - func: "install gotestsum"
+        - func: "build mongocli"
+        - func: "deploy spawn host"
+        - func: ssh-ready
+        - func: "install ops manager"
+          vars:
+            ARCHIVE: ${ops_manager_6_0_archive}
+        - func: "set-up ops manager"
+        - func: "e2e test"
+          vars:
+            E2E_TAGS: om50,generic
+            OM_VERSION: 6.0
+  - name: ops_manager_6_0_iam_e2e
+    tags: [ "e2e","ops-manager-50" ]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "clone"
+      - func: "install gotestsum"
+      - func: "build mongocli"
+      - func: "deploy spawn host"
+      - func: ssh-ready
+      - func: "install ops manager"
+        vars:
+          ARCHIVE: ${ops_manager_6_0_archive}
+      - func: "set-up ops manager"
+      - func: "e2e test"
+        vars:
+          E2E_TAGS: iam,om50
+          OM_VERSION: 6.0
+  - name: ops_manager_6_0_deploy_replica_set_e2e
+    tags: [ "e2e","ops-manager-50" ]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "clone"
+      - func: "install gotestsum"
+      - func: "build mongocli"
+      - func: "deploy spawn host"
+      - func: ssh-ready
+      - func: "install ops manager"
+        vars:
+          ARCHIVE: ${ops_manager_6_0_archive}
+      - func: "set-up ops manager"
+      - func: "install automation agent"
+      - func: "e2e test"
+        vars:
+          E2E_TAGS: om50,remote,replica
+  - name: ops_manager_6_0_deploy_sharded_cluster_e2e
+    tags: [ "e2e","ops-manager-50" ]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "clone"
+      - func: "install gotestsum"
+      - func: "build mongocli"
+      - func: "deploy spawn host"
+      - func: ssh-ready
+      - func: "install ops manager"
+        vars:
+          ARCHIVE: ${ops_manager_6_0_archive}
+      - func: "set-up ops manager"
+      - func: "install automation agent"
+      - func: "e2e test"
+        vars:
+          E2E_TAGS: om50,remote,sharded
+  # Deploy ops manager 5.0 and test against it
   - name: ops_manager_5_0_generic_e2e
     tags: [ "e2e","ops-manager-50" ]
     must_have_test_results: true

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1073,7 +1073,7 @@ tasks:
         - func: "set-up ops manager"
         - func: "e2e test"
           vars:
-            E2E_TAGS: om50,generic
+            E2E_TAGS: om60,generic
             OM_VERSION: 6.0
   - name: ops_manager_6_0_iam_e2e
     tags: [ "e2e","ops-manager-60" ]
@@ -1094,7 +1094,7 @@ tasks:
       - func: "set-up ops manager"
       - func: "e2e test"
         vars:
-          E2E_TAGS: iam,om50
+          E2E_TAGS: iam,om60
           OM_VERSION: 6.0
   - name: ops_manager_6_0_deploy_replica_set_e2e
     tags: [ "e2e","ops-manager-60" ]
@@ -1116,7 +1116,7 @@ tasks:
       - func: "install automation agent"
       - func: "e2e test"
         vars:
-          E2E_TAGS: om50,remote,replica
+          E2E_TAGS: om60,remote,replica
   - name: ops_manager_6_0_deploy_sharded_cluster_e2e
     tags: [ "e2e","ops-manager-60" ]
     must_have_test_results: true
@@ -1137,7 +1137,7 @@ tasks:
       - func: "install automation agent"
       - func: "e2e test"
         vars:
-          E2E_TAGS: om50,remote,sharded
+          E2E_TAGS: om60,remote,sharded
   # Deploy ops manager 5.0 and test against it
   - name: ops_manager_5_0_generic_e2e
     tags: [ "e2e","ops-manager-50" ]

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1055,7 +1055,7 @@ tasks:
           E2E_TAGS: cloudmanager,remote,sharded
   # Deploy ops manager 6.0 and test against it
   - name: ops_manager_6_0_generic_e2e
-    tags: [ "e2e","ops-manager-50" ]
+    tags: [ "e2e","ops-manager-60" ]
     must_have_test_results: true
     depends_on:
         - name: compile
@@ -1076,7 +1076,7 @@ tasks:
             E2E_TAGS: om50,generic
             OM_VERSION: 6.0
   - name: ops_manager_6_0_iam_e2e
-    tags: [ "e2e","ops-manager-50" ]
+    tags: [ "e2e","ops-manager-60" ]
     must_have_test_results: true
     depends_on:
       - name: compile
@@ -1097,7 +1097,7 @@ tasks:
           E2E_TAGS: iam,om50
           OM_VERSION: 6.0
   - name: ops_manager_6_0_deploy_replica_set_e2e
-    tags: [ "e2e","ops-manager-50" ]
+    tags: [ "e2e","ops-manager-60" ]
     must_have_test_results: true
     depends_on:
       - name: compile
@@ -1118,7 +1118,7 @@ tasks:
         vars:
           E2E_TAGS: om50,remote,replica
   - name: ops_manager_6_0_deploy_sharded_cluster_e2e
-    tags: [ "e2e","ops-manager-50" ]
+    tags: [ "e2e","ops-manager-60" ]
     must_have_test_results: true
     depends_on:
       - name: compile
@@ -1466,6 +1466,16 @@ buildvariants:
     tasks:
       - name: ".e2e .cleanup"
         cron: "0 2 * * *" # 2am daily
+  - name: e2e_ops_manager_60
+    display_name: "E2E Ops Manager 6.0 Tests"
+    run_on:
+      - rhel80-small
+    expansions:
+      go_root: "/opt/golang/go1.19"
+      go_bin: "/opt/golang/go1.19/bin"
+      go_base_path: ""
+    tasks:
+      - name: ".ops-manager-60"
   - name: e2e_ops_manager_50
     display_name: "E2E Ops Manager 5.0 Tests"
     run_on:

--- a/test/e2e/cloud_manager/agent_api_keys_test.go
+++ b/test/e2e/cloud_manager/agent_api_keys_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (remote && replica && (cloudmanager || om44 || om50))
+//go:build e2e || (remote && replica && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/agents_test.go
+++ b/test/e2e/cloud_manager/agents_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (remote && replica && (cloudmanager || om44 || om50))
+//go:build e2e || (remote && replica && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/dbusers_test.go
+++ b/test/e2e/cloud_manager/dbusers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (remote && replica && (cloudmanager || om44 || om50))
+//go:build e2e || (remote && replica && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/decryption_aws_test.go
+++ b/test/e2e/cloud_manager/decryption_aws_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (decrypt && (cloudmanager || om44 || om50))
+//go:build e2e || (decrypt && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/decryption_kmip_test.go
+++ b/test/e2e/cloud_manager/decryption_kmip_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (decrypt && (cloudmanager || om44 || om50))
+//go:build e2e || (decrypt && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/decryption_localkey_test.go
+++ b/test/e2e/cloud_manager/decryption_localkey_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (decrypt && (cloudmanager || om44 || om50))
+//go:build e2e || (decrypt && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/test/e2e/cloud_manager/deploy_replica_set_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (remote && replica && (cloudmanager || om44 || om50))
+//go:build e2e || (remote && replica && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/deploy_sharded_cluster_test.go
+++ b/test/e2e/cloud_manager/deploy_sharded_cluster_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (remote && sharded && (cloudmanager || om44 || om50))
+//go:build e2e || (remote && sharded && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/feature_policies_test.go
+++ b/test/e2e/cloud_manager/feature_policies_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (generic && (cloudmanager || om44 || om50))
+//go:build e2e || (generic && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/helper_test.go
+++ b/test/e2e/cloud_manager/helper_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || cloudmanager || om44 || om50
+//go:build e2e || cloudmanager || om50 || om60
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/key_providers_test.go
+++ b/test/e2e/cloud_manager/key_providers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (decrypt && (cloudmanager || om44 || om50))
+//go:build e2e || (decrypt && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/maintenance_test.go
+++ b/test/e2e/cloud_manager/maintenance_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (generic && (cloudmanager || om44 || om50))
+//go:build e2e || (generic && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/cloud_manager/servers_test.go
+++ b/test/e2e/cloud_manager/servers_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (remote && replica && (cloudmanager || om44 || om50))
+//go:build e2e || (remote && replica && (cloudmanager || om50 || om60))
 
 package cloud_manager_test
 

--- a/test/e2e/iam/atlas_users_test.go
+++ b/test/e2e/iam/atlas_users_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (iam && !om44 && !om50)
+//go:build e2e || (iam && !om50 && !om60)
 
 package iam_test
 

--- a/test/e2e/iam/org_api_key_access_list_test.go
+++ b/test/e2e/iam/org_api_key_access_list_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (iam && !om44)
+//go:build e2e || iam
 
 package iam_test
 

--- a/test/e2e/iam/org_invitations_test.go
+++ b/test/e2e/iam/org_invitations_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (iam && !om44)
+//go:build e2e || iam
 
 package iam_test
 

--- a/test/e2e/iam/project_invitations_test.go
+++ b/test/e2e/iam/project_invitations_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (iam && !om44)
+//go:build e2e || iam
 
 package iam_test
 

--- a/test/e2e/iam/project_teams_test.go
+++ b/test/e2e/iam/project_teams_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (iam && !om44 && !om50)
+//go:build e2e || (iam && !om50 && !om60)
 
 package iam_test
 

--- a/test/e2e/iam/team_users_test.go
+++ b/test/e2e/iam/team_users_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (iam && !om44 && !om50)
+//go:build e2e || (iam && !om50 && !om60)
 
 package iam_test
 

--- a/test/e2e/iam/teams_test.go
+++ b/test/e2e/iam/teams_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (iam && !om44 && !om50)
+//go:build e2e || (iam && !om50 && !om60)
 
 package iam_test
 

--- a/test/e2e/ops_manager/version_manifest_test.go
+++ b/test/e2e/ops_manager/version_manifest_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (generic && (om44 || om50))
+//go:build e2e || (generic && (om50 || om60))
 
 package ops_manager_test
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-136638

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

This PR adds e2e tests for OM 6.0:

- adds a new evergreen variant [E2E Ops Manager 6.0 Tests](https://evergreen.mongodb.com/build/mongocli_master_e2e_ops_manager_60_patch_0bab6af3693c0b366873e98ef86ffca1703530e5_63ac1fad2a60ed3b5d0b4f4b_22_12_28_10_51_26)
- adds a new e2e tag: `om60`
- removes the e2e tag `om44` as it is no longer supported