### PR TITLE
(DOCSP-16617) Backfills docs content for 5 onlineArchives commands

### DIFF
--- a/docs/atlascli/command/atlas-clusters-onlineArchives-delete.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-delete.txt
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Delete an online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+   atlas clusters onlineArchives delete 5f189832e26ec075e10c32d3 --clusterName myCluster

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-describe.txt
@@ -12,7 +12,7 @@ atlas clusters onlineArchives describe
    :depth: 1
    :class: singlecol
 
-Describe an online archive for a cluster.
+Return the details for one online archive you specify.
 
 Syntax
 ------
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the JSON-formatted details for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+   atlas clusters onlineArchives describe 5f189832e26ec075e10c32d3 --clusterName myCluster --output json

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-list.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-list.txt
@@ -12,7 +12,7 @@ atlas clusters onlineArchives list
    :depth: 1
    :class: singlecol
 
-List online archives for a cluster.
+List all online archives for a cluster.
 
 Syntax
 ------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of online archives for the cluster named myCluster:
+   atlas clusters onlineArchives list --clusterName myCluster --output json

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-pause.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-pause.txt
@@ -12,7 +12,7 @@ atlas clusters onlineArchives pause
    :depth: 1
    :class: singlecol
 
-Pause an online archive from a cluster.
+Pause the online archive for a cluster.
 
 Syntax
 ------
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Pause the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+   atlas clusters onlineArchives pause 5f189832e26ec075e10c32d3 --clusterName myCluster --output json

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-update.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-update.txt
@@ -12,7 +12,7 @@ atlas clusters onlineArchives update
    :depth: 1
    :class: singlecol
 
-Update an online archive for a cluster.
+Modify the archiving rule for the online archive for a cluster.
 
 Syntax
 ------
@@ -87,3 +87,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Update the archiving rule to archive after 5 days for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+   atlas clusters onlineArchives update 5f189832e26ec075e10c32d3 --clusterName --archiveAfter 5 myCluster --output json

--- a/docs/atlascli/command/atlas-clusters-onlineArchives.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives.txt
@@ -51,11 +51,11 @@ Related Commands
 
 * :ref:`atlas-clusters-onlineArchives-create` - Create an online archive for a collection in the cluster you specify.
 * :ref:`atlas-clusters-onlineArchives-delete` - Delete an online archive from a cluster.
-* :ref:`atlas-clusters-onlineArchives-describe` - Describe an online archive for a cluster.
-* :ref:`atlas-clusters-onlineArchives-list` - List online archives for a cluster.
-* :ref:`atlas-clusters-onlineArchives-pause` - Pause an online archive from a cluster.
+* :ref:`atlas-clusters-onlineArchives-describe` - Return the details for one online archive you specify.
+* :ref:`atlas-clusters-onlineArchives-list` - List all online archives for a cluster.
+* :ref:`atlas-clusters-onlineArchives-pause` - Pause the online archive for a cluster.
 * :ref:`atlas-clusters-onlineArchives-start` - Start a paused online archive from a cluster.
-* :ref:`atlas-clusters-onlineArchives-update` - Update an online archive for a cluster.
+* :ref:`atlas-clusters-onlineArchives-update` - Modify the archiving rule for the online archive for a cluster.
 * :ref:`atlas-clusters-onlineArchives-watch` - Watch for an archive to be available.
 
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-delete.txt
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Delete an online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+   mongocli atlas clusters onlineArchives delete 5f189832e26ec075e10c32d3 --clusterName myCluster

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-describe.txt
@@ -12,7 +12,7 @@ mongocli atlas clusters onlineArchives describe
    :depth: 1
    :class: singlecol
 
-Describe an online archive for a cluster.
+Return the details for one online archive you specify.
 
 Syntax
 ------
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the JSON-formatted details for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+   mongocli atlas clusters onlineArchives describe 5f189832e26ec075e10c32d3 --clusterName myCluster --output json

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-list.txt
@@ -12,7 +12,7 @@ mongocli atlas clusters onlineArchives list
    :depth: 1
    :class: singlecol
 
-List online archives for a cluster.
+List all online archives for a cluster.
 
 Syntax
 ------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of online archives for the cluster named myCluster:
+   mongocli atlas clusters onlineArchives list --clusterName myCluster --output json

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-pause.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-pause.txt
@@ -12,7 +12,7 @@ mongocli atlas clusters onlineArchives pause
    :depth: 1
    :class: singlecol
 
-Pause an online archive from a cluster.
+Pause the online archive for a cluster.
 
 Syntax
 ------
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Pause the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+   mongocli atlas clusters onlineArchives pause 5f189832e26ec075e10c32d3 --clusterName myCluster --output json

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-update.txt
@@ -12,7 +12,7 @@ mongocli atlas clusters onlineArchives update
    :depth: 1
    :class: singlecol
 
-Update an online archive for a cluster.
+Modify the archiving rule for the online archive for a cluster.
 
 Syntax
 ------
@@ -87,3 +87,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Update the archiving rule to archive after 5 days for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+   mongocli atlas clusters onlineArchives update 5f189832e26ec075e10c32d3 --clusterName --archiveAfter 5 myCluster --output json

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives.txt
@@ -51,11 +51,11 @@ Related Commands
 
 * :ref:`mongocli-atlas-clusters-onlineArchives-create` - Create an online archive for a collection in the cluster you specify.
 * :ref:`mongocli-atlas-clusters-onlineArchives-delete` - Delete an online archive from a cluster.
-* :ref:`mongocli-atlas-clusters-onlineArchives-describe` - Describe an online archive for a cluster.
-* :ref:`mongocli-atlas-clusters-onlineArchives-list` - List online archives for a cluster.
-* :ref:`mongocli-atlas-clusters-onlineArchives-pause` - Pause an online archive from a cluster.
+* :ref:`mongocli-atlas-clusters-onlineArchives-describe` - Return the details for one online archive you specify.
+* :ref:`mongocli-atlas-clusters-onlineArchives-list` - List all online archives for a cluster.
+* :ref:`mongocli-atlas-clusters-onlineArchives-pause` - Pause the online archive for a cluster.
 * :ref:`mongocli-atlas-clusters-onlineArchives-start` - Start a paused online archive from a cluster.
-* :ref:`mongocli-atlas-clusters-onlineArchives-update` - Update an online archive for a cluster.
+* :ref:`mongocli-atlas-clusters-onlineArchives-update` - Modify the archiving rule for the online archive for a cluster.
 * :ref:`mongocli-atlas-clusters-onlineArchives-watch` - Watch for an archive to be available.
 
 

--- a/internal/cli/atlas/clusters/onlinearchive/delete.go
+++ b/internal/cli/atlas/clusters/onlinearchive/delete.go
@@ -16,6 +16,7 @@ package onlinearchive
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -59,6 +60,8 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to delete.",
 		},
+		Example: fmt.Sprintf(`  # Delete an online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+  %s clusters onlineArchives delete 5f189832e26ec075e10c32d3 --clusterName myCluster`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/clusters/onlinearchive/describe.go
+++ b/internal/cli/atlas/clusters/onlinearchive/describe.go
@@ -16,6 +16,7 @@ package onlinearchive
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -61,11 +62,13 @@ func DescribeBuilder() *cobra.Command {
 	opts := &DescribeOpts{}
 	cmd := &cobra.Command{
 		Use:   "describe <archiveId>",
-		Short: "Describe an online archive for a cluster.",
+		Short: "Return the details for one online archive you specify.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to retrieve.",
 		},
+		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+  %s clusters onlineArchives describe 5f189832e26ec075e10c32d3 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/clusters/onlinearchive/list.go
+++ b/internal/cli/atlas/clusters/onlinearchive/list.go
@@ -16,6 +16,7 @@ package onlinearchive
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -61,9 +62,11 @@ func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List online archives for a cluster.",
+		Short:   "List all online archives for a cluster.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
+		Example: fmt.Sprintf(`  # Return a JSON-formatted list of online archives for the cluster named myCluster:
+  %s clusters onlineArchives list --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/clusters/onlinearchive/pause.go
+++ b/internal/cli/atlas/clusters/onlinearchive/pause.go
@@ -16,6 +16,7 @@ package onlinearchive
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -64,11 +65,13 @@ func PauseBuilder() *cobra.Command {
 	opts := &PauseOpts{}
 	cmd := &cobra.Command{
 		Use:   "pause <archiveId>",
-		Short: "Pause an online archive from a cluster.",
+		Short: "Pause the online archive for a cluster.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to pause.",
 		},
+		Example: fmt.Sprintf(`  # Pause the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+  %s clusters onlineArchives pause 5f189832e26ec075e10c32d3 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/clusters/onlinearchive/update.go
+++ b/internal/cli/atlas/clusters/onlinearchive/update.go
@@ -16,6 +16,7 @@ package onlinearchive
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -71,11 +72,13 @@ func UpdateBuilder() *cobra.Command {
 	opts := &UpdateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update <archiveId>",
-		Short: "Update an online archive for a cluster.",
+		Short: "Modify the archiving rule for the online archive for a cluster.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to update.",
 		},
+		Example: fmt.Sprintf(`  # Update the archiving rule to archive after 5 days for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
+  %s clusters onlineArchives update 5f189832e26ec075e10c32d3 --clusterName --archiveAfter 5 myCluster --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,


### PR DESCRIPTION
## Proposed changes

Backfills content for onlineArchives commands (less create, which was part of a previous PR)

_Jira ticket:_
https://jira.mongodb.org/browse/DOCSP-16617
https://jira.mongodb.org/browse/DOCSP-16618
https://jira.mongodb.org/browse/DOCSP-16619
https://jira.mongodb.org/browse/DOCSP-16620
https://jira.mongodb.org/browse/DOCSP-16621

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works **N/A**
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added) **N/A**
- [ ] I have run `make fmt` and formatted my code
