### PR TITLE
(DOCSP-16646) Backfills docs content for atlas dataLakes commands

### DIFF
--- a/docs/atlascli/command/atlas-dataLakes-create.txt
+++ b/docs/atlascli/command/atlas-dataLakes-create.txt
@@ -39,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas federated database to create.
+     - Name of the federated database instance to create.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-dataLakes-create.txt
+++ b/docs/atlascli/command/atlas-dataLakes-create.txt
@@ -12,7 +12,9 @@ atlas dataLakes create
    :depth: 1
    :class: singlecol
 
-Create a new data lake for your project.
+Create a new federated database instance for your project.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas Data Lake to create.
+     - Name of the Atlas federated database to create.
 
 Options
 -------
@@ -65,11 +67,11 @@ Options
    * - --role
      - string
      - true
-     - Amazon Resource Name (ARN) of the role which Atlas Data Lake uses for accessing the data stores.
+     - Amazon Resource Name (ARN) of the role which Atlas Data Federation uses for accessing the data stores.
    * - --testBucket
      - string
      - true
-     - Name of an Amazon S3 data bucket which Atlas Data Lake uses to validate the provided role.
+     - Name of an Amazon S3 data bucket which Atlas Data Federation uses to validate the provided role.
 
 Inherited Options
 -----------------
@@ -87,3 +89,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create a federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+   atlas dataLakes create myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/atlascli/command/atlas-dataLakes-delete.txt
+++ b/docs/atlascli/command/atlas-dataLakes-delete.txt
@@ -39,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas federated database instance to delete.
+     - Name of the federated database instance to delete.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-dataLakes-delete.txt
+++ b/docs/atlascli/command/atlas-dataLakes-delete.txt
@@ -12,7 +12,9 @@ atlas dataLakes delete
    :depth: 1
    :class: singlecol
 
-Delete a data lake from your project.
+Delete a federated database instance from your project.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas Data Lake to delete.
+     - Name of the Atlas federated database instance to delete.
 
 Options
 -------
@@ -79,3 +81,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Delete the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+   atlas dataLakes delete myFDI --projectId 5e2211c17a3e5a48f5497de3

--- a/docs/atlascli/command/atlas-dataLakes-describe.txt
+++ b/docs/atlascli/command/atlas-dataLakes-describe.txt
@@ -39,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas federated database instance to retrieve.
+     - Name of the federated database instance to retrieve.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-dataLakes-describe.txt
+++ b/docs/atlascli/command/atlas-dataLakes-describe.txt
@@ -12,7 +12,9 @@ atlas dataLakes describe
    :depth: 1
    :class: singlecol
 
-Return a specific data lake.
+Return the details for the specified federated database instance.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas Data Lake to retrieve.
+     - Name of the Atlas federated database instance to retrieve.
 
 Options
 -------
@@ -79,3 +81,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the details for the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+   atlas dataLakes describe myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/atlascli/command/atlas-dataLakes-list.txt
+++ b/docs/atlascli/command/atlas-dataLakes-list.txt
@@ -12,7 +12,9 @@ atlas dataLakes list
    :depth: 1
    :class: singlecol
 
-List Atlas Data Lakes for your project.
+List all Atlas federated database instances for your project.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -63,3 +65,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all federated database instances in the project with the ID 5e2211c17a3e5a48f5497de3:
+   atlas dataLakes list --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/atlascli/command/atlas-dataLakes-list.txt
+++ b/docs/atlascli/command/atlas-dataLakes-list.txt
@@ -12,7 +12,7 @@ atlas dataLakes list
    :depth: 1
    :class: singlecol
 
-List all Atlas federated database instances for your project.
+List all federated database instances for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 

--- a/docs/atlascli/command/atlas-dataLakes-update.txt
+++ b/docs/atlascli/command/atlas-dataLakes-update.txt
@@ -12,7 +12,9 @@ atlas dataLakes update
    :depth: 1
    :class: singlecol
 
-Update a data lake for your project.
+Modify a federated database instance for your project.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas Data Lake to update.
+     - Name of the Atlas federated database instance to update.
 
 Options
 -------
@@ -65,15 +67,15 @@ Options
    * - --region
      - string
      - false
-     - Name of the region to which Atlas Data Lake routes client connections for data processing.
+     - Name of the region to which Atlas Data Federation routes client connections for data processing.
    * - --role
      - string
      - false
-     - Amazon Resource Name (ARN) of the role which Atlas Data Lake uses for accessing the data stores.
+     - Amazon Resource Name (ARN) of the role which Atlas Data Federation uses for accessing the data stores.
    * - --testBucket
      - string
      - false
-     - Name of an Amazon S3 data bucket which Atlas Data Lake uses to validate the provided role.
+     - Name of an Amazon S3 data bucket which Atlas Data Federation uses to validate the provided role.
 
 Inherited Options
 -----------------
@@ -91,3 +93,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Modify the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3 to route client connections to OREGON_USA:
+   atlas dataLakes update myFDI --region OREGON_USA --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/atlascli/command/atlas-dataLakes-update.txt
+++ b/docs/atlascli/command/atlas-dataLakes-update.txt
@@ -39,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas federated database instance to update.
+     - Name of the federated database instance to update.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-dataLakes.txt
+++ b/docs/atlascli/command/atlas-dataLakes.txt
@@ -54,7 +54,7 @@ Related Commands
 * :ref:`atlas-dataLakes-create` - Create a new federated database instance for your project.
 * :ref:`atlas-dataLakes-delete` - Delete a federated database instance from your project.
 * :ref:`atlas-dataLakes-describe` - Return the details for the specified federated database instance.
-* :ref:`atlas-dataLakes-list` - List all Atlas federated database instances for your project.
+* :ref:`atlas-dataLakes-list` - List all federated database instances for your project.
 * :ref:`atlas-dataLakes-update` - Modify a federated database instance for your project.
 
 

--- a/docs/atlascli/command/atlas-dataLakes.txt
+++ b/docs/atlascli/command/atlas-dataLakes.txt
@@ -51,11 +51,11 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`atlas-dataLakes-create` - Create a new data lake for your project.
-* :ref:`atlas-dataLakes-delete` - Delete a data lake from your project.
-* :ref:`atlas-dataLakes-describe` - Return a specific data lake.
-* :ref:`atlas-dataLakes-list` - List Atlas Data Lakes for your project.
-* :ref:`atlas-dataLakes-update` - Update a data lake for your project.
+* :ref:`atlas-dataLakes-create` - Create a new federated database instance for your project.
+* :ref:`atlas-dataLakes-delete` - Delete a federated database instance from your project.
+* :ref:`atlas-dataLakes-describe` - Return the details for the specified federated database instance.
+* :ref:`atlas-dataLakes-list` - List all Atlas federated database instances for your project.
+* :ref:`atlas-dataLakes-update` - Modify a federated database instance for your project.
 
 
 .. toctree::

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-create.txt
@@ -39,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas federated database to create.
+     - Name of the federated database instance to create.
 
 Options
 -------

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-create.txt
@@ -12,7 +12,9 @@ mongocli atlas dataLakes create
    :depth: 1
    :class: singlecol
 
-Create a new data lake for your project.
+Create a new federated database instance for your project.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas Data Lake to create.
+     - Name of the Atlas federated database to create.
 
 Options
 -------
@@ -65,11 +67,11 @@ Options
    * - --role
      - string
      - true
-     - Amazon Resource Name (ARN) of the role which Atlas Data Lake uses for accessing the data stores.
+     - Amazon Resource Name (ARN) of the role which Atlas Data Federation uses for accessing the data stores.
    * - --testBucket
      - string
      - true
-     - Name of an Amazon S3 data bucket which Atlas Data Lake uses to validate the provided role.
+     - Name of an Amazon S3 data bucket which Atlas Data Federation uses to validate the provided role.
 
 Inherited Options
 -----------------
@@ -87,3 +89,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create a federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dataLakes create myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-delete.txt
@@ -39,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas federated database instance to delete.
+     - Name of the federated database instance to delete.
 
 Options
 -------

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-delete.txt
@@ -12,7 +12,9 @@ mongocli atlas dataLakes delete
    :depth: 1
    :class: singlecol
 
-Delete a data lake from your project.
+Delete a federated database instance from your project.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas Data Lake to delete.
+     - Name of the Atlas federated database instance to delete.
 
 Options
 -------
@@ -79,3 +81,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Delete the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dataLakes delete myFDI --projectId 5e2211c17a3e5a48f5497de3

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
@@ -12,7 +12,9 @@ mongocli atlas dataLakes describe
    :depth: 1
    :class: singlecol
 
-Return a specific data lake.
+Return the details for the specified federated database instance.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas Data Lake to retrieve.
+     - Name of the Atlas federated database instance to retrieve.
 
 Options
 -------
@@ -79,3 +81,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the details for the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dataLakes describe myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
@@ -39,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas federated database instance to retrieve.
+     - Name of the federated database instance to retrieve.
 
 Options
 -------

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-list.txt
@@ -12,7 +12,9 @@ mongocli atlas dataLakes list
    :depth: 1
    :class: singlecol
 
-List Atlas Data Lakes for your project.
+List all Atlas federated database instances for your project.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -63,3 +65,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all federated database instances in the project with the ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dataLakes list --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-list.txt
@@ -12,7 +12,7 @@ mongocli atlas dataLakes list
    :depth: 1
    :class: singlecol
 
-List all Atlas federated database instances for your project.
+List all federated database instances for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-update.txt
@@ -39,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas federated database instance to update.
+     - Name of the federated database instance to update.
 
 Options
 -------

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-update.txt
@@ -12,7 +12,9 @@ mongocli atlas dataLakes update
    :depth: 1
    :class: singlecol
 
-Update a data lake for your project.
+Modify a federated database instance for your project.
+
+To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - name
      - string
      - true
-     - Name of the Atlas Data Lake to update.
+     - Name of the Atlas federated database instance to update.
 
 Options
 -------
@@ -65,15 +67,15 @@ Options
    * - --region
      - string
      - false
-     - Name of the region to which Atlas Data Lake routes client connections for data processing.
+     - Name of the region to which Atlas Data Federation routes client connections for data processing.
    * - --role
      - string
      - false
-     - Amazon Resource Name (ARN) of the role which Atlas Data Lake uses for accessing the data stores.
+     - Amazon Resource Name (ARN) of the role which Atlas Data Federation uses for accessing the data stores.
    * - --testBucket
      - string
      - false
-     - Name of an Amazon S3 data bucket which Atlas Data Lake uses to validate the provided role.
+     - Name of an Amazon S3 data bucket which Atlas Data Federation uses to validate the provided role.
 
 Inherited Options
 -----------------
@@ -91,3 +93,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Modify the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3 to route client connections to OREGON_USA:
+   mongocli atlas dataLakes update myFDI --region OREGON_USA --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/mongocli/command/mongocli-atlas-dataLakes.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes.txt
@@ -51,11 +51,11 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`mongocli-atlas-dataLakes-create` - Create a new data lake for your project.
-* :ref:`mongocli-atlas-dataLakes-delete` - Delete a data lake from your project.
-* :ref:`mongocli-atlas-dataLakes-describe` - Return a specific data lake.
-* :ref:`mongocli-atlas-dataLakes-list` - List Atlas Data Lakes for your project.
-* :ref:`mongocli-atlas-dataLakes-update` - Update a data lake for your project.
+* :ref:`mongocli-atlas-dataLakes-create` - Create a new federated database instance for your project.
+* :ref:`mongocli-atlas-dataLakes-delete` - Delete a federated database instance from your project.
+* :ref:`mongocli-atlas-dataLakes-describe` - Return the details for the specified federated database instance.
+* :ref:`mongocli-atlas-dataLakes-list` - List all Atlas federated database instances for your project.
+* :ref:`mongocli-atlas-dataLakes-update` - Modify a federated database instance for your project.
 
 
 .. toctree::

--- a/docs/mongocli/command/mongocli-atlas-dataLakes.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes.txt
@@ -54,7 +54,7 @@ Related Commands
 * :ref:`mongocli-atlas-dataLakes-create` - Create a new federated database instance for your project.
 * :ref:`mongocli-atlas-dataLakes-delete` - Delete a federated database instance from your project.
 * :ref:`mongocli-atlas-dataLakes-describe` - Return the details for the specified federated database instance.
-* :ref:`mongocli-atlas-dataLakes-list` - List all Atlas federated database instances for your project.
+* :ref:`mongocli-atlas-dataLakes-list` - List all federated database instances for your project.
 * :ref:`mongocli-atlas-dataLakes-update` - Modify a federated database instance for your project.
 
 

--- a/internal/cli/atlas/datalake/create.go
+++ b/internal/cli/atlas/datalake/create.go
@@ -16,6 +16,7 @@ package datalake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -74,11 +75,14 @@ func CreateBuilder() *cobra.Command {
 	opts := &CreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create <name>",
-		Short: "Create a new data lake for your project.",
+		Short: "Create a new federated database instance for your project.",
+		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Name of the Atlas Data Lake to create.",
+			"nameDesc": "Name of the Atlas federated database to create.",
 		},
+		Example: fmt.Sprintf(`  # Create a federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+  %s dataLakes create myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/datalake/create.go
+++ b/internal/cli/atlas/datalake/create.go
@@ -79,7 +79,7 @@ func CreateBuilder() *cobra.Command {
 		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Name of the Atlas federated database to create.",
+			"nameDesc": "Name of the federated database instance to create.",
 		},
 		Example: fmt.Sprintf(`  # Create a federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s dataLakes create myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/datalake/delete.go
+++ b/internal/cli/atlas/datalake/delete.go
@@ -16,6 +16,7 @@ package datalake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -52,11 +53,14 @@ func DeleteBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete <name>",
 		Aliases: []string{"rm"},
-		Short:   "Delete a data lake from your project.",
+		Short:   "Delete a federated database instance from your project.",
+		Long:    "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Name of the Atlas Data Lake to delete.",
+			"nameDesc": "Name of the Atlas federated database instance to delete.",
 		},
+		Example: fmt.Sprintf(`  # Delete the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+  %s dataLakes delete myFDI --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err

--- a/internal/cli/atlas/datalake/delete.go
+++ b/internal/cli/atlas/datalake/delete.go
@@ -57,7 +57,7 @@ func DeleteBuilder() *cobra.Command {
 		Long:    "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Name of the Atlas federated database instance to delete.",
+			"nameDesc": "Name of the federated database instance to delete.",
 		},
 		Example: fmt.Sprintf(`  # Delete the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s dataLakes delete myFDI --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -16,6 +16,7 @@ package datalake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -59,11 +60,14 @@ func DescribeBuilder() *cobra.Command {
 	opts := &DescribeOpts{}
 	cmd := &cobra.Command{
 		Use:   "describe <name>",
-		Short: "Return a specific data lake.",
+		Short: "Return the details for the specified federated database instance.",
+		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Name of the Atlas Data Lake to retrieve.",
+			"nameDesc": "Name of the Atlas federated database instance to retrieve.",
 		},
+		Example: fmt.Sprintf(`  # Return the details for the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
+  %s dataLakes describe myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -64,7 +64,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Name of the Atlas federated database instance to retrieve.",
+			"nameDesc": "Name of the federated database instance to retrieve.",
 		},
 		Example: fmt.Sprintf(`  # Return the details for the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s dataLakes describe myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -16,6 +16,7 @@ package datalake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -59,9 +60,12 @@ func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List Atlas Data Lakes for your project.",
+		Short:   "List all Atlas federated database instances for your project.",
+		Long:    "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
+		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all federated database instances in the project with the ID 5e2211c17a3e5a48f5497de3:
+  %s dataLakes list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -60,7 +60,7 @@ func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{
 		Use:     "list",
-		Short:   "List all Atlas federated database instances for your project.",
+		Short:   "List all federated database instances for your project.",
 		Long:    "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,

--- a/internal/cli/atlas/datalake/update.go
+++ b/internal/cli/atlas/datalake/update.go
@@ -93,7 +93,7 @@ func UpdateBuilder() *cobra.Command {
 		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Name of the Atlas federated database instance to update.",
+			"nameDesc": "Name of the federated database instance to update.",
 		},
 		Example: fmt.Sprintf(`  # Modify the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3 to route client connections to OREGON_USA:
   %s dataLakes update myFDI --region OREGON_USA --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/datalake/update.go
+++ b/internal/cli/atlas/datalake/update.go
@@ -17,6 +17,7 @@ package datalake
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -88,11 +89,14 @@ func UpdateBuilder() *cobra.Command {
 	opts := &UpdateOpts{}
 	cmd := &cobra.Command{
 		Use:   "update <name>",
-		Short: "Update a data lake for your project.",
+		Short: "Modify a federated database instance for your project.",
+		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Name of the Atlas Data Lake to update.",
+			"nameDesc": "Name of the Atlas federated database instance to update.",
 		},
+		Example: fmt.Sprintf(`  # Modify the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3 to route client connections to OREGON_USA:
+  %s dataLakes update myFDI --region OREGON_USA --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = args[0]
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -80,9 +80,9 @@ The roles format is roleName[@dbName[.collection]].
 roleName can either be a built-in role or a custom role.
 dbName and collection are only required for built-in roles.`
 	Scopes                                    = "Array of clusters and Atlas Data Lakes that this user has access to."
-	DataLakeRole                              = "Amazon Resource Name (ARN) of the role which Atlas Data Lake uses for accessing the data stores."
-	DataLakeRegion                            = "Name of the region to which Atlas Data Lake routes client connections for data processing."
-	DataLakeTestBucket                        = "Name of an Amazon S3 data bucket which Atlas Data Lake uses to validate the provided role."
+	DataLakeRole                              = "Amazon Resource Name (ARN) of the role which Atlas Data Federation uses for accessing the data stores."
+	DataLakeRegion                            = "Name of the region to which Atlas Data Federation routes client connections for data processing."
+	DataLakeTestBucket                        = "Name of an Amazon S3 data bucket which Atlas Data Federation uses to validate the provided role."
 	PrivateEndpointRegion                     = "Cloud provider region in which you want to create the private endpoint connection."
 	PrivateEndpointProvider                   = "Name of the cloud provider you want to create the private endpoint connection for."
 	Comment                                   = "Optional description or comment for the entry."


### PR DESCRIPTION
## Proposed changes

Backfills docs content for dataLakes commands and updates descriptions and flags to reference Atlas Data Federation

_Jira ticket:_
https://jira.mongodb.org/browse/DOCSP-16646
https://jira.mongodb.org/browse/DOCSP-16647
https://jira.mongodb.org/browse/DOCSP-16648
https://jira.mongodb.org/browse/DOCSP-16649
https://jira.mongodb.org/browse/DOCSP-16650

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works **N/A**
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added) **N/A**
- [x] I have run `make fmt` and formatted my code
