### PR TITLE
(DOCSP-16652) Backfills docs content for dbusers and dbusers certs commands

### DIFF
--- a/docs/atlascli/command/atlas-dbusers-certs-create.txt
+++ b/docs/atlascli/command/atlas-dbusers-certs-create.txt
@@ -14,6 +14,10 @@ atlas dbusers certs create
 
 Create a new Atlas-managed X.509 certificate for the specified database user.
 
+You can't use this command to create certificates if you are managing your own Certificate Authority (CA) in self-managed X.509 mode.
+		
+The user you specify must authenticate using X.509 certificates.
+
 Syntax
 ------
 
@@ -41,7 +45,7 @@ Options
    * - --monthsUntilExpiration
      - int
      - false
-     - Number of months that the certificate is valid for. This value defaults to 3.
+     - Number of months until the X.509 certificate expires. This value defaults to 3.
    * - -o, --output
      - string
      - false
@@ -71,3 +75,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create an Atlas-managed X.509 certificate that expires in 5 months for a MongoDB user named dbuser for the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas dbusers certs create --username dbuser --monthsUntilExpiration 5 --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/atlascli/command/atlas-dbusers-certs-list.txt
+++ b/docs/atlascli/command/atlas-dbusers-certs-list.txt
@@ -12,7 +12,11 @@ atlas dbusers certs list
    :depth: 1
    :class: singlecol
 
-List of all Atlas-managed, unexpired certificates for a database user.
+Return all Atlas-managed, unexpired certificates for the specified database user.
+
+You can't use this command to return certificates if you are managing your own Certificate Authority (CA) in self-managed X.509 mode.
+		
+The user you specify must authenticate using X.509 certificates.
 
 Syntax
 ------
@@ -79,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all Atlas-managed X.509 certificates for a MongoDB user named dbuser for the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas dbusers certs list dbuser --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/atlascli/command/atlas-dbusers-certs.txt
+++ b/docs/atlascli/command/atlas-dbusers-certs.txt
@@ -50,7 +50,7 @@ Related Commands
 ----------------
 
 * :ref:`atlas-dbusers-certs-create` - Create a new Atlas-managed X.509 certificate for the specified database user.
-* :ref:`atlas-dbusers-certs-list` - List of all Atlas-managed, unexpired certificates for a database user.
+* :ref:`atlas-dbusers-certs-list` - Return all Atlas-managed, unexpired certificates for the specified database user.
 
 
 .. toctree::

--- a/docs/atlascli/command/atlas-dbusers-create.txt
+++ b/docs/atlascli/command/atlas-dbusers-create.txt
@@ -12,7 +12,9 @@ atlas dbusers create
    :depth: 1
    :class: singlecol
 
-Create a database user for your project.
+Create a database user for the specified project.
+
+If you set --ldapType, --x509Type, and --awsIAMType to NONE, Atlas authenticates this user through SCRAM-SHA. To learn more, see https://www.mongodb.com/docs/manual/core/security-scram/.
 
 Syntax
 ------
@@ -53,7 +55,7 @@ Options
    * - --awsIAMType
      - string
      - false
-     - AWS IAM method by which the provided username is authenticated. Valid values are NONE, USER, or ROLE. This value defaults to "NONE".
+     - AWS IAM method by which the provided username is authenticated. Valid values are NONE, USER, or ROLE. If you set this to USER or ROLE, the user authenticates with IAM credentials and doesn't need a password. If you set this to USER or ROLE, you can't set --x509Type or --ldapType to any value other than NONE. This value defaults to "NONE".
    * - --deleteAfter
      - string
      - false
@@ -65,7 +67,7 @@ Options
    * - --ldapType
      - string
      - false
-     - LDAP method by which the provided username is authenticated. Valid values are NONE, USER, or GROUP. This value defaults to "NONE".
+     - LDAP method by which the provided username is authenticated. Valid values are NONE, USER, or GROUP. If you set this to USER or GROUP, the user authenticates with LDAP. If you set this to USER or GROUP, you can't set --x509Type or --awsIAMType to any value other than NONE. This value defaults to "NONE".
    * - -o, --output
      - string
      - false
@@ -81,10 +83,10 @@ Options
    * - --role
      - strings
      - false
-     - User's roles and the databases or collections on which the roles apply.
+     - Comma-separated list that specifies the user's roles and the databases or collections on which the roles apply.
        The roles format is roleName[@dbName[.collection]].
        roleName can either be a built-in role or a custom role.
-       dbName and collection are only required for built-in roles.
+       dbName and collection are required only for built-in roles.
    * - --scope
      - strings
      - false
@@ -96,7 +98,7 @@ Options
    * - --x509Type
      - string
      - false
-     - X.509 method by which the provided username is authenticated.  Valid values are NONE, MANAGED, or CUSTOMER. This value defaults to "NONE".
+     - X.509 method by which the provided username is authenticated.  Valid values are NONE, MANAGED, or CUSTOMER. If you set this to MANAGED the user authenticates with an Atlas-managed X.509 certificate. If you set this to CUSTOMER, the user authenticates with a self-managed X.509 certificate. If you set this to MANAGED or CUSTOMER, you can't set --awsIAMType or --ldapType to any value other than NONE. This value defaults to "NONE".
 
 Inherited Options
 -----------------
@@ -119,23 +121,23 @@ Examples
 
 .. code-block::
 
-   # Create an Atlas database admin user:
-   atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
+   # Create an Atlas database admin user named myAdmin for the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas dbusers create atlasAdmin --username myAdmin  --projectId 5e2211c17a3e5a48f5497de3
 
    
 .. code-block::
 
-   # Create a database user with read/write access to any database:
-   atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+   # Create a database user named myUser with read/write access to any database for the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas dbusers create readWriteAnyDatabase --username myUser --projectId 5e2211c17a3e5a48f5497de3
 
    
 .. code-block::
 
-   # Create a database user with multiple roles:
-   atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+   # Create a database user named myUser with multiple roles for the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas dbusers create --username myUser --role clusterMonitor,backup --projectId 5e2211c17a3e5a48f5497de3
 
    
 .. code-block::
 
-   # Create a database user with multiple scopes:
-   atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
+   # Create a database user named myUser with multiple scopes for the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas dbusers create --username myUser --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId 5e2211c17a3e5a48f5497de3

--- a/docs/atlascli/command/atlas-dbusers.txt
+++ b/docs/atlascli/command/atlas-dbusers.txt
@@ -54,7 +54,7 @@ Related Commands
 ----------------
 
 * :ref:`atlas-dbusers-certs` - Manage Atlas x509 certificates for your database users.
-* :ref:`atlas-dbusers-create` - Create a database user for your project.
+* :ref:`atlas-dbusers-create` - Create a database user for the specified project.
 * :ref:`atlas-dbusers-delete` - Delete a database user for your project.
 * :ref:`atlas-dbusers-describe` - Return a single Atlas database user for your project.
 * :ref:`atlas-dbusers-list` - List Atlas database users for your project.

--- a/docs/mongocli/command/mongocli-atlas-dbusers-certs-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-certs-create.txt
@@ -14,6 +14,10 @@ mongocli atlas dbusers certs create
 
 Create a new Atlas-managed X.509 certificate for the specified database user.
 
+You can't use this command to create certificates if you are managing your own Certificate Authority (CA) in self-managed X.509 mode.
+		
+The user you specify must authenticate using X.509 certificates.
+
 Syntax
 ------
 
@@ -41,7 +45,7 @@ Options
    * - --monthsUntilExpiration
      - int
      - false
-     - Number of months that the certificate is valid for. This value defaults to 3.
+     - Number of months until the X.509 certificate expires. This value defaults to 3.
    * - -o, --output
      - string
      - false
@@ -71,3 +75,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create an Atlas-managed X.509 certificate that expires in 5 months for a MongoDB user named dbuser for the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dbusers certs create --username dbuser --monthsUntilExpiration 5 --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/mongocli/command/mongocli-atlas-dbusers-certs-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-certs-list.txt
@@ -12,7 +12,11 @@ mongocli atlas dbusers certs list
    :depth: 1
    :class: singlecol
 
-List of all Atlas-managed, unexpired certificates for a database user.
+Return all Atlas-managed, unexpired certificates for the specified database user.
+
+You can't use this command to return certificates if you are managing your own Certificate Authority (CA) in self-managed X.509 mode.
+		
+The user you specify must authenticate using X.509 certificates.
 
 Syntax
 ------
@@ -79,3 +83,10 @@ Inherited Options
      - false
      - Profile to use from your configuration file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all Atlas-managed X.509 certificates for a MongoDB user named dbuser for the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dbusers certs list dbuser --projectId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/mongocli/command/mongocli-atlas-dbusers-certs.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-certs.txt
@@ -50,7 +50,7 @@ Related Commands
 ----------------
 
 * :ref:`mongocli-atlas-dbusers-certs-create` - Create a new Atlas-managed X.509 certificate for the specified database user.
-* :ref:`mongocli-atlas-dbusers-certs-list` - List of all Atlas-managed, unexpired certificates for a database user.
+* :ref:`mongocli-atlas-dbusers-certs-list` - Return all Atlas-managed, unexpired certificates for the specified database user.
 
 
 .. toctree::

--- a/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
@@ -12,7 +12,9 @@ mongocli atlas dbusers create
    :depth: 1
    :class: singlecol
 
-Create a database user for your project.
+Create a database user for the specified project.
+
+If you set --ldapType, --x509Type, and --awsIAMType to NONE, Atlas authenticates this user through SCRAM-SHA. To learn more, see https://www.mongodb.com/docs/manual/core/security-scram/.
 
 Syntax
 ------
@@ -53,7 +55,7 @@ Options
    * - --awsIAMType
      - string
      - false
-     - AWS IAM method by which the provided username is authenticated. Valid values are NONE, USER, or ROLE. This value defaults to "NONE".
+     - AWS IAM method by which the provided username is authenticated. Valid values are NONE, USER, or ROLE. If you set this to USER or ROLE, the user authenticates with IAM credentials and doesn't need a password. If you set this to USER or ROLE, you can't set --x509Type or --ldapType to any value other than NONE. This value defaults to "NONE".
    * - --deleteAfter
      - string
      - false
@@ -65,7 +67,7 @@ Options
    * - --ldapType
      - string
      - false
-     - LDAP method by which the provided username is authenticated. Valid values are NONE, USER, or GROUP. This value defaults to "NONE".
+     - LDAP method by which the provided username is authenticated. Valid values are NONE, USER, or GROUP. If you set this to USER or GROUP, the user authenticates with LDAP. If you set this to USER or GROUP, you can't set --x509Type or --awsIAMType to any value other than NONE. This value defaults to "NONE".
    * - -o, --output
      - string
      - false
@@ -81,10 +83,10 @@ Options
    * - --role
      - strings
      - false
-     - User's roles and the databases or collections on which the roles apply.
+     - Comma-separated list that specifies the user's roles and the databases or collections on which the roles apply.
        The roles format is roleName[@dbName[.collection]].
        roleName can either be a built-in role or a custom role.
-       dbName and collection are only required for built-in roles.
+       dbName and collection are required only for built-in roles.
    * - --scope
      - strings
      - false
@@ -96,7 +98,7 @@ Options
    * - --x509Type
      - string
      - false
-     - X.509 method by which the provided username is authenticated.  Valid values are NONE, MANAGED, or CUSTOMER. This value defaults to "NONE".
+     - X.509 method by which the provided username is authenticated.  Valid values are NONE, MANAGED, or CUSTOMER. If you set this to MANAGED the user authenticates with an Atlas-managed X.509 certificate. If you set this to CUSTOMER, the user authenticates with a self-managed X.509 certificate. If you set this to MANAGED or CUSTOMER, you can't set --awsIAMType or --ldapType to any value other than NONE. This value defaults to "NONE".
 
 Inherited Options
 -----------------
@@ -119,23 +121,23 @@ Examples
 
 .. code-block::
 
-   # Create an Atlas database admin user:
-   mongocli atlas dbuser create atlasAdmin --username <username>  --projectId <projectId>
+   # Create an Atlas database admin user named myAdmin for the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dbusers create atlasAdmin --username myAdmin  --projectId 5e2211c17a3e5a48f5497de3
 
    
 .. code-block::
 
-   # Create a database user with read/write access to any database:
-   mongocli atlas dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+   # Create a database user named myUser with read/write access to any database for the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dbusers create readWriteAnyDatabase --username myUser --projectId 5e2211c17a3e5a48f5497de3
 
    
 .. code-block::
 
-   # Create a database user with multiple roles:
-   mongocli atlas dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+   # Create a database user named myUser with multiple roles for the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dbusers create --username myUser --role clusterMonitor,backup --projectId 5e2211c17a3e5a48f5497de3
 
    
 .. code-block::
 
-   # Create a database user with multiple scopes:
-   mongocli atlas dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>
+   # Create a database user named myUser with multiple scopes for the project with ID 5e2211c17a3e5a48f5497de3:
+   mongocli atlas dbusers create --username myUser --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId 5e2211c17a3e5a48f5497de3

--- a/docs/mongocli/command/mongocli-atlas-dbusers.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers.txt
@@ -54,7 +54,7 @@ Related Commands
 ----------------
 
 * :ref:`mongocli-atlas-dbusers-certs` - Manage Atlas x509 certificates for your database users.
-* :ref:`mongocli-atlas-dbusers-create` - Create a database user for your project.
+* :ref:`mongocli-atlas-dbusers-create` - Create a database user for the specified project.
 * :ref:`mongocli-atlas-dbusers-delete` - Delete a database user for your project.
 * :ref:`mongocli-atlas-dbusers-describe` - Return a single Atlas database user for your project.
 * :ref:`mongocli-atlas-dbusers-list` - List Atlas database users for your project.

--- a/internal/cli/atlas/dbusers/certs/create.go
+++ b/internal/cli/atlas/dbusers/certs/create.go
@@ -16,6 +16,7 @@ package certs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -59,7 +60,12 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new Atlas-managed X.509 certificate for the specified database user.",
-		Args:  require.NoArgs,
+		Long: `You can't use this command to create certificates if you are managing your own Certificate Authority (CA) in self-managed X.509 mode.
+		
+The user you specify must authenticate using X.509 certificates.`,
+		Args: require.NoArgs,
+		Example: fmt.Sprintf(`  # Create an Atlas-managed X.509 certificate that expires in 5 months for a MongoDB user named dbuser for the project with ID 5e2211c17a3e5a48f5497de3:
+  %s dbusers certs create --username dbuser --monthsUntilExpiration 5 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/dbusers/certs/list.go
+++ b/internal/cli/atlas/dbusers/certs/list.go
@@ -16,6 +16,7 @@ package certs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -61,11 +62,16 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list <username>",
 		Aliases: []string{"ls"},
-		Short:   "List of all Atlas-managed, unexpired certificates for a database user.",
-		Args:    require.ExactArgs(1),
+		Short:   "Return all Atlas-managed, unexpired certificates for the specified database user.",
+		Long: `You can't use this command to return certificates if you are managing your own Certificate Authority (CA) in self-managed X.509 mode.
+		
+The user you specify must authenticate using X.509 certificates.`,
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"usernameDesc": "Username of the database user for whom you want to list Atlas-managed certificates.",
 		},
+		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all Atlas-managed X.509 certificates for a MongoDB user named dbuser for the project with ID 5e2211c17a3e5a48f5497de3:
+  %s dbusers certs list dbuser --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.username = args[0]
 

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -172,18 +172,19 @@ func CreateBuilder() *cobra.Command {
 	opts := &CreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create [builtInRole]...",
-		Short: "Create a database user for your project.",
-		Example: fmt.Sprintf(`  # Create an Atlas database admin user:
-  %[1]s dbuser create atlasAdmin --username <username>  --projectId <projectId>
+		Short: "Create a database user for the specified project.",
+		Long:  `If you set --ldapType, --x509Type, and --awsIAMType to NONE, Atlas authenticates this user through SCRAM-SHA. To learn more, see https://www.mongodb.com/docs/manual/core/security-scram/.`,
+		Example: fmt.Sprintf(`  # Create an Atlas database admin user named myAdmin for the project with ID 5e2211c17a3e5a48f5497de3:
+  %[1]s dbusers create atlasAdmin --username myAdmin  --projectId 5e2211c17a3e5a48f5497de3
 
-  # Create a database user with read/write access to any database:
-  %[1]s dbuser create readWriteAnyDatabase --username <username> --projectId <projectId>
+  # Create a database user named myUser with read/write access to any database for the project with ID 5e2211c17a3e5a48f5497de3:
+  %[1]s dbusers create readWriteAnyDatabase --username myUser --projectId 5e2211c17a3e5a48f5497de3
 
-  # Create a database user with multiple roles:
-  %[1]s dbuser create --username <username> --role clusterMonitor,backup --projectId <projectId>
+  # Create a database user named myUser with multiple roles for the project with ID 5e2211c17a3e5a48f5497de3:
+  %[1]s dbusers create --username myUser --role clusterMonitor,backup --projectId 5e2211c17a3e5a48f5497de3
 
-  # Create a database user with multiple scopes:
-  %[1]s dbuser create --username <username> --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId <projectId>`,
+  # Create a database user named myUser with multiple scopes for the project with ID 5e2211c17a3e5a48f5497de3:
+  %[1]s dbusers create --username myUser --role clusterMonitor --scope <REPLICA-SET ID>,<storeName> --projectId 5e2211c17a3e5a48f5497de3`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: cobra.OnlyValidArgs,
 		Annotations: map[string]string{

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -75,10 +75,10 @@ const (
 	Mobile                   = "The user's mobile or cell phone number."
 	Period                   = "Duration in ISO 8601 that specifies how far back in the past to retrieve measurements."
 	Roles                    = "User's roles and the databases or collections on which the roles apply."
-	RolesExtended            = `User's roles and the databases or collections on which the roles apply.
+	RolesExtended            = `Comma-separated list that specifies the user's roles and the databases or collections on which the roles apply.
 The roles format is roleName[@dbName[.collection]].
 roleName can either be a built-in role or a custom role.
-dbName and collection are only required for built-in roles.`
+dbName and collection are required only for built-in roles.`
 	Scopes                                    = "Array of clusters and Atlas Data Lakes that this user has access to."
 	DataLakeRole                              = "Amazon Resource Name (ARN) of the role which Atlas Data Lake uses for accessing the data stores."
 	DataLakeRegion                            = "Name of the region to which Atlas Data Lake routes client connections for data processing."
@@ -191,7 +191,7 @@ dbName and collection are only required for built-in roles.`
 	SnapshotDescription                       = "Description of the on-demand snapshot."
 	Database                                  = "Name of the database."
 	DatabaseUser                              = "Username of a database user."
-	MonthsUntilExpiration                     = "Number of months that the certificate is valid for."
+	MonthsUntilExpiration                     = "Number of months until the X.509 certificate expires."
 	Collection                                = "Name of the collection."
 	Append                                    = "The input action and inheritedRoles that will be appended to the existing role."
 	PrivilegeAction                           = "List of actions per database and collection. If no database or collections are provided, cluster scope is assumed."
@@ -297,9 +297,9 @@ dbName and collection are only required for built-in roles.`
 	Provider                                  = "Name of your cloud service provider. Valid values are AWS, AZURE, or GCP."
 	ClusterTypes                              = "Type of the cluster that you want to create. Valid values are REPLICASET or SHARDED."
 	Region                                    = "Physical location of your MongoDB cluster. For a complete list of supported AWS regions, see: https://docs.atlas.mongodb.com/reference/amazon-aws/#amazon-aws. For a complete list of supported Azure regions, see: https://docs.atlas.mongodb.com/reference/microsoft-azure/#microsoft-azure. For a complete list of supported GCP regions, see: https://docs.atlas.mongodb.com/reference/google-gcp/#google-gcp."
-	AWSIAMType                                = "AWS IAM method by which the provided username is authenticated. Valid values are NONE, USER, or ROLE."
-	X509Type                                  = "X.509 method by which the provided username is authenticated.  Valid values are NONE, MANAGED, or CUSTOMER."
-	LDAPType                                  = "LDAP method by which the provided username is authenticated. Valid values are NONE, USER, or GROUP."
+	AWSIAMType                                = "AWS IAM method by which the provided username is authenticated. Valid values are NONE, USER, or ROLE. If you set this to USER or ROLE, the user authenticates with IAM credentials and doesn't need a password. If you set this to USER or ROLE, you can't set --x509Type or --ldapType to any value other than NONE."
+	X509Type                                  = "X.509 method by which the provided username is authenticated.  Valid values are NONE, MANAGED, or CUSTOMER. If you set this to MANAGED the user authenticates with an Atlas-managed X.509 certificate. If you set this to CUSTOMER, the user authenticates with a self-managed X.509 certificate. If you set this to MANAGED or CUSTOMER, you can't set --awsIAMType or --ldapType to any value other than NONE."
+	LDAPType                                  = "LDAP method by which the provided username is authenticated. Valid values are NONE, USER, or GROUP. If you set this to USER or GROUP, the user authenticates with LDAP. If you set this to USER or GROUP, you can't set --x509Type or --awsIAMType to any value other than NONE."
 	DateFormat                                = "Date format for the date field. Valid values are ISODATE, EPOCH_SECONDS, EPOCH_MILLIS, or EPOCH_NANOSECONDS."
 	ServerUsageFormat                         = "Compression format of the resulting report. Valid values are ZIP, TAR, or .GZ."
 	S3AuthMethod                              = "Method used to authorize access to the Amazon S3 bucket specified in s3BucketName. Valid values are KEYS or IAM_ROLE."


### PR DESCRIPTION
## Proposed changes

Backfills docs content for dbusers certs commands and dbusers create command

_Jira ticket:_ CLOUDP-#
https://jira.mongodb.org/browse/DOCSP-16652
https://jira.mongodb.org/browse/DOCSP-16653
https://jira.mongodb.org/browse/DOCSP-16655

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works **N/A**
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added) **N/A**
- [ ] I have run `make fmt` and formatted my code