### PR TITLE
tests: re-enable skipped tests

### DIFF
--- a/test/e2e/cloud_manager/feature_policies_test.go
+++ b/test/e2e/cloud_manager/feature_policies_test.go
@@ -35,7 +35,6 @@ const (
 )
 
 func TestFeaturePolicies(t *testing.T) {
-	t.Skip("Skip until clean up works again", "CLOUDP-152484")
 	n, err := e2e.RandInt(255)
 	require.NoError(t, err)
 

--- a/test/e2e/cloud_manager/maintenance_test.go
+++ b/test/e2e/cloud_manager/maintenance_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestMaintenanceWindows(t *testing.T) {
-	t.Skip("Skip until clean up works again", "CLOUDP-152484")
 	n, err := e2e.RandInt(255)
 	require.NoError(t, err)
 

--- a/test/e2e/iam/project_invitations_test.go
+++ b/test/e2e/iam/project_invitations_test.go
@@ -34,7 +34,6 @@ const (
 )
 
 func TestProjectInvitations(t *testing.T) {
-	t.Skip("Skip until clean up works again", "CLOUDP-152484")
 	cliPath, err := e2e.Bin()
 	require.NoError(t, err)
 

--- a/test/e2e/iam/project_teams_test.go
+++ b/test/e2e/iam/project_teams_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestProjectTeams(t *testing.T) {
-	t.Skip("Skip until clean up works again", "CLOUDP-152484")
 	cliPath, err := e2e.Bin()
 	require.NoError(t, err)
 

--- a/test/e2e/iam/projects_test.go
+++ b/test/e2e/iam/projects_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestProjects(t *testing.T) {
-	t.Skip("Skip until clean up works again", "CLOUDP-152484")
 	cliPath, err := e2e.Bin()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Fix is live and we can re-enable the tests