### PR TITLE
docs: update examples to use atlas cli

### DIFF
--- a/examples/atlas/create-cluster.md
+++ b/examples/atlas/create-cluster.md
@@ -1,15 +1,139 @@
 # Create a Cluster
 
+## Three member replicaset
+
 To create and get the connection string for a cluster you can do:
 
 ```bash
-mongocli atlas clusters create MyCluster \
+atlas clusters create MyCluster \
   --region EASTERN_US \
   --members 3 \
   --tier M30 \
   --provider GCP \
-  --mdbVersion 4.4 \
+  --mdbVersion 6.0 \
   --diskSizeGB 30 && \
-mongocli atlas clusters watch MyCluster && \
-mongocli atlas clusters describe MyCluster -o go-template="{{.SrvAddress}}"
+atlas clusters watch MyCluster && \
+atlas clusters describe MyCluster -o go-template="{{.SrvAddress}}"
+```
+
+## Multi-Cloud replicaset
+
+Using the following json as an input file
+```json
+{
+    "clusterType": "REPLICASET",
+    "links": [],
+    "name": "multiCloud",
+    "replicationSpecs": [
+      {
+        "numShards": 1,
+        "regionConfigs": [
+          {
+            "analyticsAutoScaling": {
+              "autoIndexing": {
+                "enabled": false
+              },
+              "compute": {
+                "enabled": true,
+                "maxInstanceSize": "M40",
+                "minInstanceSize": "M30",
+                "scaleDownEnabled": true
+              },
+              "diskGB": {
+                "enabled": true
+              }
+            },
+            "analyticsSpecs": {
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "autoScaling": {
+              "autoIndexing": {
+                "enabled": false
+              },
+              "compute": {
+                "enabled": true,
+                "maxInstanceSize": "M40",
+                "minInstanceSize": "M30",
+                "scaleDownEnabled": true
+              },
+              "diskGB": {
+                "enabled": true
+              }
+            },
+            "electableSpecs": {
+              "instanceSize": "M30",
+              "nodeCount": 3
+            },
+            "hiddenSecondarySpecs": {
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "priority": 7,
+            "providerName": "AWS",
+            "readOnlySpecs": {
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "regionName": "US_EAST_1"
+          },
+          {
+            "analyticsAutoScaling": {
+              "autoIndexing": {
+                "enabled": false
+              },
+              "compute": {
+                "enabled": true,
+                "maxInstanceSize": "M40",
+                "minInstanceSize": "M30",
+                "scaleDownEnabled": true
+              },
+              "diskGB": {
+                "enabled": true
+              }
+            },
+            "analyticsSpecs": {
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "autoScaling": {
+              "autoIndexing": {
+                "enabled": false
+              },
+              "compute": {
+                "enabled": true,
+                "maxInstanceSize": "M40",
+                "minInstanceSize": "M30",
+                "scaleDownEnabled": true
+              },
+              "diskGB": {
+                "enabled": true
+              }
+            },
+            "electableSpecs": {
+              "instanceSize": "M30",
+              "nodeCount": 2
+            },
+            "hiddenSecondarySpecs": {
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "priority": 6,
+            "providerName": "GCP",
+            "readOnlySpecs": {
+              "instanceSize": "M30",
+              "nodeCount": 0
+            },
+            "regionName": "EASTERN_US"
+          }
+        ],
+        "zoneName": "Zone 1"
+      }
+    ]
+}
+```
+
+```bash
+atlas clusters create \
+  --file cluster.json
 ```

--- a/examples/atlas/create-recomended-indexes.md
+++ b/examples/atlas/create-recomended-indexes.md
@@ -4,8 +4,8 @@ The performance advisor can recommend indexes, the output of this command can be
 as an input for the create indexes command, which will create an index in a rolling way fashion.
 
 ```bash
-mongocli atlas performanceAdvisor suggestedIndexes ls \
+atlas performanceAdvisor suggestedIndexes ls \
   --processName atlas-00-01.gcp.mongodb.net:27017 \
  | awk 'BEGIN{ORS=" ";}{if (NR!=1){split($2,a,"."); print a[1]; print a[2]; for(i=4;i<=NF-1;++i)printf $i} printf"\n"}' \
- | xargs -n3 sh -c 'echo "Creating index db: $1 collection: $2 index: $3"; mongocli atlas clusters indexes create --clusterName slowQueriesDemo --db $1 --collection $2 --key $3' sh 
+ | xargs -n3 sh -c 'echo "Creating index db: $1 collection: $2 index: $3"; atlas clusters indexes create --clusterName slowQueriesDemo --db $1 --collection $2 --key $3' sh 
 ``` 

--- a/examples/atlas/log-download.md
+++ b/examples/atlas/log-download.md
@@ -4,5 +4,5 @@ You can download and decompress logs by piping the command to gunzip.
 To do this you'll need to output to stdout in the following way: 
 
 ```bash
-mongocli atlas logs download <hostname> mongodb.gz --out - | gunzip
+atlas logs download <hostname> mongodb.gz --out - | gunzip
 ```

--- a/examples/atlas/rename-cluster.md
+++ b/examples/atlas/rename-cluster.md
@@ -8,15 +8,15 @@ however you could deploy a new cluster with the same properties and only change 
 One way to do this with the cli could be:
 
 ```bash
-mongocli atlas cluster describe oldName --output json  > oldcluster.json
-mongocli atlas cluster create newName --file oldcluster.json
-mongocli atlas cluster delete oldName --force
+atlas cluster describe oldName --output json  > oldcluster.json
+atlas cluster create newName --file oldcluster.json
+atlas cluster delete oldName --force
 ```
 
 In case that **zsh** is available to you can even use the following utilities: 
 
 ```zsh
 # ZSH only
-(TMPSUFFIX=.json; mongocli atlas clusters create newName -f =(mongocli atlas clusters describe oldName -o json))
-mongocli atlas cluster delete oldName --force
+(TMPSUFFIX=.json; atlas clusters create newName -f =(atlas clusters describe oldName -o json))
+atlas cluster delete oldName --force
 ```


### PR DESCRIPTION
Update examples to use atlas CLI and add example for multi cloud cluster

I had the json for multicloud cluster laying around and decided to add it here