### PR TITLE
CLOUDP-155672: cli ops manager clusters don't show default RW concern

### DIFF
--- a/internal/convert/process_config.go
+++ b/internal/convert/process_config.go
@@ -228,6 +228,21 @@ func newReplicaSetProcessConfig(rs *opsmngr.Member, p *opsmngr.Process) *Process
 	if p.Args26.Security != nil {
 		pc.Security = p.Args26.Security
 	}
+	if p.DefaultRWConcern != nil {
+		pc.DefaultRWConcern = &DefaultRWConcern{}
+		if pc.DefaultRWConcern.DefaultReadConcern != nil {
+			pc.DefaultRWConcern.DefaultReadConcern = &DefaultReadConcern{
+				Level: pc.DefaultRWConcern.DefaultReadConcern.Level,
+			}
+		}
+		if pc.DefaultRWConcern.DefaultWriteConcern != nil {
+			pc.DefaultRWConcern.DefaultWriteConcern = &DefaultWriteConcern{
+				W:        pc.DefaultRWConcern.DefaultWriteConcern.W,
+				J:        pc.DefaultRWConcern.DefaultWriteConcern.J,
+				Wtimeout: pc.DefaultRWConcern.DefaultWriteConcern.Wtimeout,
+			}
+		}
+	}
 	return pc
 }
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-155672

We missed a place to copy the settings between the automation config and the internal cluster state 
