### PR TITLE
CLOUDP-151494: Export atlas search spec for advanced cluster

### DIFF
--- a/docs/atlascli/command/atlas-kubernetes-config-generate.txt
+++ b/docs/atlascli/command/atlas-kubernetes-config-generate.txt
@@ -48,6 +48,10 @@ Options
      - 
      - false
      - Generate kubernetes secrets with data for projects, users, deployments entities
+   * - --indexFrom
+     - strings
+     - false
+     - Comma-separated list of cluster, database and collection to import index(es) in the following format: <clusterName>.<database>.<collection>.
    * - --orgId
      - string
      - false
@@ -102,3 +106,9 @@ Examples
 
    # Export Project, DatabaseUsers, and Deployment resources for a specific project including connection and integration secrets to a specific namespace:
    atlas kubernetes config generate --projectId=<projectId> --clusterName=<cluster-name-1, cluster-name-2> --includeSecrets --targetNamespace=<namespace>
+
+   
+.. code-block::
+
+   # Export Project, DatabaseUsers resources for a specific project including indexes:
+   atlas kubernetes config generate --projectId=<projectId> --includeSecrets --targetNamespace=<namespace> --indexFrom=<db1>.<collection1>,<db2>.<collection2>

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-isatty v0.0.17
 	github.com/mongodb-forks/digest v1.0.4
 	github.com/mongodb-labs/cobra2snooty v0.12.2
-	github.com/mongodb/mongodb-atlas-kubernetes v1.6.0
+	github.com/mongodb/mongodb-atlas-kubernetes v1.6.2-0.20230131181000-6a09f26b2e64
 	github.com/openlyinc/pointy v1.2.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/mongodb-forks/digest v1.0.4 h1:9FrGTc7MGAchgaQBcXBnEwUM/Oo8obW7OGWxns
 github.com/mongodb-forks/digest v1.0.4/go.mod h1:eHRfgovT+dvSFfltrOa27hy1oR/rcwyDdp5H1ZQxEMA=
 github.com/mongodb-labs/cobra2snooty v0.12.2 h1:elp0tRGcOHixj00+vAvscsGelDVLjeWKBJMwDdpg7bg=
 github.com/mongodb-labs/cobra2snooty v0.12.2/go.mod h1:35BYcRwKG+Lu+bKidg7lw1RT8W4K3zLsExyMLyTZB7U=
-github.com/mongodb/mongodb-atlas-kubernetes v1.6.0 h1:nu5sfE79Yg7560B0RvpJzHzjLiGMufIvlBkYg1ZgZRQ=
-github.com/mongodb/mongodb-atlas-kubernetes v1.6.0/go.mod h1:Xr55jVGTlGiD0jpyxzZk7OVZLI51vLW4v9zMZcZJCO8=
+github.com/mongodb/mongodb-atlas-kubernetes v1.6.2-0.20230131181000-6a09f26b2e64 h1:IIISYyEmYtCJu0EnAxHkZwyGaxFN0uU1JBadk8niAYk=
+github.com/mongodb/mongodb-atlas-kubernetes v1.6.2-0.20230131181000-6a09f26b2e64/go.mod h1:Xr55jVGTlGiD0jpyxzZk7OVZLI51vLW4v9zMZcZJCO8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/internal/cli/atlas/kubernetes/config/generate_test.go
+++ b/internal/cli/atlas/kubernetes/config/generate_test.go
@@ -31,5 +31,6 @@ func TestGenerateBuilder(t *testing.T) {
 			flag.ClusterName,
 			flag.OperatorIncludeSecrets,
 			flag.OperatorTargetNamespace,
+			flag.OperatorIndexFrom,
 		})
 }

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -314,6 +314,7 @@ const (
 	BackupPolicy                              = "policy"                                    // BackupPolicy flag
 	OperatorIncludeSecrets                    = "includeSecrets"                            // OperatorIncludeSecrets flag
 	OperatorTargetNamespace                   = "targetNamespace"                           // OperatorTargetNamespace flag
+	OperatorIndexFrom                         = "indexFrom"                                 // OperatorIndexFrom flag
 	ExportID                                  = "exportId"                                  // ExportID flag
 
 	/* #nosec */

--- a/internal/kubernetes/operator/config_exporter.go
+++ b/internal/kubernetes/operator/config_exporter.go
@@ -42,6 +42,7 @@ type ConfigExporter struct {
 	clusters                []string
 	targetNamespace         string
 	includeSecretsData      bool
+	indexFrom               []string
 	orgID                   string
 	dictionaryForAtlasNames map[string]string
 }
@@ -88,6 +89,11 @@ func (e *ConfigExporter) WithTargetNamespace(namespace string) *ConfigExporter {
 
 func (e *ConfigExporter) WithSecretsData(enabled bool) *ConfigExporter {
 	e.includeSecretsData = enabled
+	return e
+}
+
+func (e *ConfigExporter) WithIndexFrom(indexFrom []string) *ConfigExporter {
+	e.indexFrom = indexFrom
 	return e
 }
 
@@ -174,7 +180,15 @@ func (e *ConfigExporter) exportDeployments(projectName string) ([]runtime.Object
 
 	for _, deploymentName := range e.clusters {
 		// Try advanced cluster first
-		if advancedCluster, err := deployment.BuildAtlasAdvancedDeployment(e.dataProvider, e.projectID, projectName, deploymentName, e.targetNamespace, e.dictionaryForAtlasNames); err == nil {
+		if advancedCluster, err := deployment.BuildAtlasAdvancedDeployment(
+			e.dataProvider,
+			e.projectID,
+			projectName,
+			deploymentName,
+			e.targetNamespace,
+			e.indexFrom,
+			e.dictionaryForAtlasNames,
+		); err == nil {
 			if advancedCluster != nil {
 				// Append deployment to result
 				result = append(result, advancedCluster.Deployment)

--- a/internal/mocks/mock_atlas_operator_cluster_store.go
+++ b/internal/mocks/mock_atlas_operator_cluster_store.go
@@ -109,6 +109,36 @@ func (mr *MockAtlasOperatorClusterStoreMockRecorder) ProjectClusters(arg0, arg1 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProjectClusters", reflect.TypeOf((*MockAtlasOperatorClusterStore)(nil).ProjectClusters), arg0, arg1)
 }
 
+// SearchAnalyzers mocks base method.
+func (m *MockAtlasOperatorClusterStore) SearchAnalyzers(arg0, arg1 string, arg2 *mongodbatlas.ListOptions) ([]*mongodbatlas.SearchAnalyzer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchAnalyzers", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*mongodbatlas.SearchAnalyzer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchAnalyzers indicates an expected call of SearchAnalyzers.
+func (mr *MockAtlasOperatorClusterStoreMockRecorder) SearchAnalyzers(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchAnalyzers", reflect.TypeOf((*MockAtlasOperatorClusterStore)(nil).SearchAnalyzers), arg0, arg1, arg2)
+}
+
+// SearchIndexes mocks base method.
+func (m *MockAtlasOperatorClusterStore) SearchIndexes(arg0, arg1, arg2, arg3 string, arg4 *mongodbatlas.ListOptions) ([]*mongodbatlas.SearchIndex, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchIndexes", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].([]*mongodbatlas.SearchIndex)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchIndexes indicates an expected call of SearchIndexes.
+func (mr *MockAtlasOperatorClusterStoreMockRecorder) SearchIndexes(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchIndexes", reflect.TypeOf((*MockAtlasOperatorClusterStore)(nil).SearchIndexes), arg0, arg1, arg2, arg3, arg4)
+}
+
 // ServerlessInstance mocks base method.
 func (m *MockAtlasOperatorClusterStore) ServerlessInstance(arg0, arg1 string) (*mongodbatlas.Cluster, error) {
 	m.ctrl.T.Helper()

--- a/internal/store/operator.go
+++ b/internal/store/operator.go
@@ -45,6 +45,7 @@ type AtlasOperatorClusterStore interface {
 	ServerlessInstanceDescriber
 	ServerlessPrivateEndpointsLister
 	GlobalClusterDescriber
+	AtlasSearchDescriber
 }
 
 type AtlasAllClustersLister interface {
@@ -52,10 +53,20 @@ type AtlasAllClustersLister interface {
 	ServerlessInstanceLister
 }
 
+type AtlasSearchDescriber interface {
+	SearchIndexLister
+	SearchAnalyzerLister
+}
+
 type AtlasOperatorTeamsStore interface {
 	TeamDescriber
 	ProjectTeamLister
 	TeamUserLister
+}
+
+type AtlasOperatorSearchStore interface {
+	SearchIndexLister
+	SearchAnalyzerLister
 }
 
 type AtlasOperatorGenericStore interface {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -43,6 +43,10 @@ type SearchIndexDeleter interface {
 	DeleteSearchIndex(string, string, string) error
 }
 
+type SearchAnalyzerLister interface {
+	SearchAnalyzers(string, string, *atlas.ListOptions) ([]*atlas.SearchAnalyzer, error)
+}
+
 // SearchIndexes encapsulate the logic to manage different cloud providers.
 func (s *Store) SearchIndexes(projectID, clusterName, dbName, collName string, opts *atlas.ListOptions) ([]*atlas.SearchIndex, error) {
 	switch s.service {
@@ -95,5 +99,15 @@ func (s *Store) DeleteSearchIndex(projectID, clusterName, indexID string) error 
 		return err
 	default:
 		return fmt.Errorf("%w: %s", errUnsupportedService, s.service)
+	}
+}
+
+func (s *Store) SearchAnalyzers(projectID, clusterName string, opts *atlas.ListOptions) ([]*atlas.SearchAnalyzer, error) {
+	switch s.service {
+	case config.CloudService, config.CloudGovService:
+		result, _, err := s.client.(*atlas.Client).Search.ListAnalyzers(s.ctx, projectID, clusterName, opts)
+		return result, err
+	default:
+		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
 	}
 }

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -385,5 +385,6 @@ dbName and collection are required only for built-in roles.`
 	ExporterClusterName                       = "One or more comma separated cluster names to import"
 	OperatorIncludeSecrets                    = "Generate kubernetes secrets with data for projects, users, deployments entities" //nolint:gosec //This is just a message, not a credential
 	OperatorTargetNamespace                   = "Namespaces to use for generated kubernetes entities"
+	OperatorIndexFrom                         = "Comma-separated list of cluster, database and collection to import index(es) in the following format: <clusterName>.<database>.<collection>."
 	ExportID                                  = "Unique string that identifies the AWS S3 bucket to which you export your snapshots."
 )

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -156,14 +156,16 @@ func deleteTeamWithRetry(t *testing.T, teamID string) {
 	t.Helper()
 	deleted := false
 	for attempts := 1; attempts <= maxRetryAttempts; attempts++ {
-		if e := deleteTeam(teamID); e != nil {
-			t.Logf("%d/%d attempts - trying again in %d seconds: unexpected error while deleting the team %q: %v", attempts, maxRetryAttempts, sleepTimeInSeconds, teamID, e)
-			time.Sleep(sleepTimeInSeconds * time.Second)
-		} else {
+		e := deleteTeam(teamID)
+
+		if e == nil {
 			t.Logf("team %q successfully deleted", teamID)
 			deleted = true
 			break
 		}
+
+		t.Logf("%d/%d attempts - trying again in %d seconds: unexpected error while deleting the team %q: %v", attempts, maxRetryAttempts, sleepTimeInSeconds, teamID, e)
+		time.Sleep(sleepTimeInSeconds * time.Second)
 	}
 
 	if !deleted {
@@ -175,14 +177,16 @@ func deleteProjectWithRetry(t *testing.T, projectID string) {
 	t.Helper()
 	deleted := false
 	for attempts := 1; attempts <= maxRetryAttempts; attempts++ {
-		if e := deleteProject(projectID); e != nil {
-			t.Logf("%d/%d attempts - trying again in %d seconds: unexpected error while deleting the project %q: %v", attempts, maxRetryAttempts, sleepTimeInSeconds, projectID, e)
-			time.Sleep(sleepTimeInSeconds * time.Second)
-		} else {
+		e := deleteProject(projectID)
+
+		if e == nil {
 			t.Logf("project %q successfully deleted", projectID)
 			deleted = true
 			break
 		}
+
+		t.Logf("%d/%d attempts - trying again in %d seconds: unexpected error while deleting the project %q: %v", attempts, maxRetryAttempts, sleepTimeInSeconds, projectID, e)
+		time.Sleep(sleepTimeInSeconds * time.Second)
 	}
 
 	if !deleted {

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -79,14 +79,15 @@ func DeleteProjectWithRetry(t *testing.T, projectID string) {
 	t.Helper()
 	deleted := false
 	for attempts := 1; attempts <= maxRetryAttempts; attempts++ {
-		if e := deleteProject(projectID); e != nil {
-			t.Logf("%d/%d attempts - trying again in %d seconds: unexpected error while deleting the project %q: %v", attempts, maxRetryAttempts, sleepTimeInSeconds, projectID, e)
-			time.Sleep(sleepTimeInSeconds * time.Second)
-		} else {
+		e := deleteProject(projectID)
+		if e == nil {
 			t.Logf("project %q successfully deleted", projectID)
 			deleted = true
 			break
 		}
+
+		t.Logf("%d/%d attempts - trying again in %d seconds: unexpected error while deleting the project %q: %v", attempts, maxRetryAttempts, sleepTimeInSeconds, projectID, e)
+		time.Sleep(sleepTimeInSeconds * time.Second)
 	}
 
 	if !deleted {


### PR DESCRIPTION
## Proposed changes

Add the possibility to export indexes and analyzers (Atlas Search features) together with cluster specs.

_Jira ticket:_ CLOUDP-151494

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
