### PR TITLE
CLOUDP-156407: Remove cluster termination protection test

### DIFF
--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -48,7 +48,6 @@ func TestSetup(t *testing.T) {
 			"setup",
 			"--clusterName", clusterName,
 			"--username", dbUserUsername,
-			"--enableTerminationProtection",
 			"--skipMongosh",
 			"--skipSampleData",
 			"--projectId", g.projectID,
@@ -97,37 +96,6 @@ func TestSetup(t *testing.T) {
 		if user.Username != dbUserUsername {
 			t.Fatalf("expected username to match %v, got %v", dbUserUsername, user.Username)
 		}
-	})
-
-	t.Run("Delete with fail", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
-			clustersEntity,
-			"delete",
-			clusterName,
-			"--force",
-			"--projectId", g.projectID,
-		)
-
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		req.Error(err, string(resp))
-	})
-
-	t.Run("Update Termination Protection", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
-			clustersEntity,
-			"update",
-			clusterName,
-			"--disableTerminationProtection",
-			"--projectId", g.projectID,
-			"-o=json")
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
-
-		var cluster mongodbatlas.AdvancedCluster
-		err = json.Unmarshal(resp, &cluster)
-		req.NoError(err)
 	})
 
 	t.Run("DeleteCluster", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Remove cluster termination test from setup e2e test. Will add it back in future PR.

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-154706](https://jira.mongodb.org/browse/CLOUDP-156407)

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
The `update` command cannot be used on shared clusters. Removing this check first, and then will add support for toggling cluster termination protection through the `upgrade` command too, until Atlas team confirms that this is the intended way of dealing with termination protection for shared clusters.
