### PR TITLE
(DOCSP-16849) Backfills docs content for organizations commands

### DIFF
--- a/docs/atlascli/command/atlas-liveMigrations-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-create.txt
@@ -12,8 +12,10 @@ atlas liveMigrations create
    :depth: 1
    :class: singlecol
 
-Create one new migration.
+Create a new push live migration.
 
+To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
 Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax

--- a/docs/atlascli/command/atlas-liveMigrations-cutover.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-cutover.txt
@@ -12,8 +12,10 @@ atlas liveMigrations cutover
    :depth: 1
    :class: singlecol
 
-Start the cutover and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
+Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
 
+To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
 Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax

--- a/docs/atlascli/command/atlas-liveMigrations-describe.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-describe.txt
@@ -12,7 +12,7 @@ atlas liveMigrations describe
    :depth: 1
    :class: singlecol
 
-Return one migration job.
+Return a push live migration job.
 
 Your API Key must have the Organization Owner role to successfully run this command.
 

--- a/docs/atlascli/command/atlas-liveMigrations-link-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-link-create.txt
@@ -12,8 +12,10 @@ atlas liveMigrations link create
    :depth: 1
    :class: singlecol
 
-Create one new link-token.
+Create a new link-token for a push live migration.
 
+To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
 Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax

--- a/docs/atlascli/command/atlas-liveMigrations-link.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-link.txt
@@ -49,7 +49,7 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`atlas-liveMigrations-link-create` - Create one new link-token.
+* :ref:`atlas-liveMigrations-link-create` - Create a new link-token for a push live migration.
 * :ref:`atlas-liveMigrations-link-delete` - Delete one link-token.
 
 

--- a/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
@@ -12,8 +12,10 @@ atlas liveMigrations validation create
    :depth: 1
    :class: singlecol
 
-Create one new validation request.
+Create a new validation request for a push live migration.
 
+To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
 Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax

--- a/docs/atlascli/command/atlas-liveMigrations-validation.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation.txt
@@ -49,7 +49,7 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`atlas-liveMigrations-validation-create` - Create one new validation request.
+* :ref:`atlas-liveMigrations-validation-create` - Create a new validation request for a push live migration.
 * :ref:`atlas-liveMigrations-validation-describe` - Return one validation job.
 
 

--- a/docs/atlascli/command/atlas-liveMigrations.txt
+++ b/docs/atlascli/command/atlas-liveMigrations.txt
@@ -49,9 +49,9 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`atlas-liveMigrations-create` - Create one new migration.
-* :ref:`atlas-liveMigrations-cutover` - Start the cutover and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
-* :ref:`atlas-liveMigrations-describe` - Return one migration job.
+* :ref:`atlas-liveMigrations-create` - Create a new push live migration.
+* :ref:`atlas-liveMigrations-cutover` - Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
+* :ref:`atlas-liveMigrations-describe` - Return a push live migration job.
 * :ref:`atlas-liveMigrations-link` - Manage the link-token for your organization.
 * :ref:`atlas-liveMigrations-validation` - Manage a Live Migration validation job for your project.
 

--- a/docs/atlascli/command/atlas-organizations-delete.txt
+++ b/docs/atlascli/command/atlas-organizations-delete.txt
@@ -12,7 +12,9 @@ atlas organizations delete
    :depth: 1
    :class: singlecol
 
-Delete an organization.
+Remove the specified organization.
+
+Organizations with active projects can't be removed.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - ID
      - string
      - true
-     - Organization identifier.
+     - Unique 24-digit string that identifies the organization.
 
 Options
 -------
@@ -75,3 +77,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Remove the organization with the ID 5e2211c17a3e5a48f5497de3:
+   atlas organizations delete 5e2211c17a3e5a48f5497de3

--- a/docs/atlascli/command/atlas-organizations-describe.txt
+++ b/docs/atlascli/command/atlas-organizations-describe.txt
@@ -12,7 +12,7 @@ atlas organizations describe
    :depth: 1
    :class: singlecol
 
-Describe an organizations.
+Return the details for the specified organizations.
 
 Syntax
 ------
@@ -37,7 +37,7 @@ Arguments
    * - ID
      - string
      - true
-     - Organization identifier.
+     - Unique 24-digit string that identifies the organization.
 
 Options
 -------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the JSON-formatted details for the organization with the ID 5e2211c17a3e5a48f5497de3:
+   atlas organizations describe 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/atlascli/command/atlas-organizations-list.txt
+++ b/docs/atlascli/command/atlas-organizations-list.txt
@@ -12,7 +12,7 @@ atlas organizations list
    :depth: 1
    :class: singlecol
 
-List organizations.
+Return all organizations.
 
 Syntax
 ------
@@ -41,7 +41,7 @@ Options
    * - --includeDeleted
      - 
      - false
-     - If specified, Atlas includes the deleted organizations.
+     - If specified, includes deleted organizations in the list. This option applies only to Ops Manager organizations. You can't return deleted Atlas or Cloud Manager organizations.
    * - --limit
      - int
      - false
@@ -49,7 +49,7 @@ Options
    * - --name
      - string
      - false
-     - Performs a case-insensitive search for organizations which exactly match the specified name.
+     - Performs a case-insensitive search for organizations that exactly match the specified organization name.
    * - -o, --output
      - string
      - false
@@ -75,3 +75,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all organizations:
+   atlas organizations list --output json
+   
+   
+.. code-block::
+
+   # Return a JSON-formatted list that includes the organizations named org1 and Org1, but doesn't return org123:
+   atlas organizations list --name org1 --output json

--- a/docs/atlascli/command/atlas-organizations-users-list.txt
+++ b/docs/atlascli/command/atlas-organizations-users-list.txt
@@ -12,7 +12,7 @@ atlas organizations users list
    :depth: 1
    :class: singlecol
 
-List users in a organization.
+Return all users for an organization.
 
 Syntax
 ------
@@ -71,3 +71,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all users for the organization with the ID 5e2211c17a3e5a48f5497de3:
+   atlas organizations users list --orgId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/atlascli/command/atlas-organizations-users.txt
+++ b/docs/atlascli/command/atlas-organizations-users.txt
@@ -49,7 +49,7 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`atlas-organizations-users-list` - List users in a organization.
+* :ref:`atlas-organizations-users-list` - Return all users for an organization.
 
 
 .. toctree::

--- a/docs/atlascli/command/atlas-organizations.txt
+++ b/docs/atlascli/command/atlas-organizations.txt
@@ -52,10 +52,10 @@ Related Commands
 ----------------
 
 * :ref:`atlas-organizations-apiKeys` - Organization API Keys operations.
-* :ref:`atlas-organizations-delete` - Delete an organization.
-* :ref:`atlas-organizations-describe` - Describe an organizations.
+* :ref:`atlas-organizations-delete` - Remove the specified organization.
+* :ref:`atlas-organizations-describe` - Return the details for the specified organizations.
 * :ref:`atlas-organizations-invitations` - Invitation operations.
-* :ref:`atlas-organizations-list` - List organizations.
+* :ref:`atlas-organizations-list` - Return all organizations.
 * :ref:`atlas-organizations-users` - Manage your Atlas users.
 
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
@@ -12,8 +12,10 @@ mongocli atlas liveMigrations create
    :depth: 1
    :class: singlecol
 
-Create one new migration.
+Create a new push live migration.
 
+To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
 Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-cutover.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-cutover.txt
@@ -12,8 +12,10 @@ mongocli atlas liveMigrations cutover
    :depth: 1
    :class: singlecol
 
-Start the cutover and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
+Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
 
+To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
 Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-describe.txt
@@ -12,7 +12,7 @@ mongocli atlas liveMigrations describe
    :depth: 1
    :class: singlecol
 
-Return one migration job.
+Return a push live migration job.
 
 Your API Key must have the Organization Owner role to successfully run this command.
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-link-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-link-create.txt
@@ -12,8 +12,10 @@ mongocli atlas liveMigrations link create
    :depth: 1
    :class: singlecol
 
-Create one new link-token.
+Create a new link-token for a push live migration.
 
+To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
 Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-link.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-link.txt
@@ -49,7 +49,7 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`mongocli-atlas-liveMigrations-link-create` - Create one new link-token.
+* :ref:`mongocli-atlas-liveMigrations-link-create` - Create a new link-token for a push live migration.
 * :ref:`mongocli-atlas-liveMigrations-link-delete` - Delete one link-token.
 
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
@@ -12,8 +12,10 @@ mongocli atlas liveMigrations validation create
    :depth: 1
    :class: singlecol
 
-Create one new validation request.
+Create a new validation request for a push live migration.
 
+To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
 Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation.txt
@@ -49,7 +49,7 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`mongocli-atlas-liveMigrations-validation-create` - Create one new validation request.
+* :ref:`mongocli-atlas-liveMigrations-validation-create` - Create a new validation request for a push live migration.
 * :ref:`mongocli-atlas-liveMigrations-validation-describe` - Return one validation job.
 
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations.txt
@@ -49,9 +49,9 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`mongocli-atlas-liveMigrations-create` - Create one new migration.
-* :ref:`mongocli-atlas-liveMigrations-cutover` - Start the cutover and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
-* :ref:`mongocli-atlas-liveMigrations-describe` - Return one migration job.
+* :ref:`mongocli-atlas-liveMigrations-create` - Create a new push live migration.
+* :ref:`mongocli-atlas-liveMigrations-cutover` - Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
+* :ref:`mongocli-atlas-liveMigrations-describe` - Return a push live migration job.
 * :ref:`mongocli-atlas-liveMigrations-link` - Manage the link-token for your organization.
 * :ref:`mongocli-atlas-liveMigrations-validation` - Manage a Live Migration validation job for your project.
 

--- a/docs/mongocli/command/mongocli-iam-organizations-create.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-create.txt
@@ -12,7 +12,7 @@ mongocli iam organizations create
    :depth: 1
    :class: singlecol
 
-Create an organization. This command is not available for Atlas. It's available only for Ops Manager and Cloud Manager.
+Create an Ops Manager or Cloud Manager organization. This command is unavailable for Atlas.
 
 Syntax
 ------
@@ -37,7 +37,7 @@ Arguments
    * - name
      - string
      - true
-     - Organization name.
+     - Label that identifies the organization.
 
 Options
 -------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create an Ops Manager organization with the name myOrg:
+   mongocli iam organizations create myOrg --output json

--- a/docs/mongocli/command/mongocli-iam-organizations-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-delete.txt
@@ -12,7 +12,9 @@ mongocli iam organizations delete
    :depth: 1
    :class: singlecol
 
-Delete an organization.
+Remove the specified organization.
+
+Organizations with active projects can't be removed.
 
 Syntax
 ------
@@ -37,7 +39,7 @@ Arguments
    * - ID
      - string
      - true
-     - Organization identifier.
+     - Unique 24-digit string that identifies the organization.
 
 Options
 -------
@@ -75,3 +77,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Remove the organization with the ID 5e2211c17a3e5a48f5497de3:
+   mongocli organizations delete 5e2211c17a3e5a48f5497de3

--- a/docs/mongocli/command/mongocli-iam-organizations-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-describe.txt
@@ -12,7 +12,7 @@ mongocli iam organizations describe
    :depth: 1
    :class: singlecol
 
-Describe an organizations.
+Return the details for the specified organizations.
 
 Syntax
 ------
@@ -37,7 +37,7 @@ Arguments
    * - ID
      - string
      - true
-     - Organization identifier.
+     - Unique 24-digit string that identifies the organization.
 
 Options
 -------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the JSON-formatted details for the organization with the ID 5e2211c17a3e5a48f5497de3:
+   mongocli organizations describe 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/mongocli/command/mongocli-iam-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-list.txt
@@ -12,7 +12,7 @@ mongocli iam organizations list
    :depth: 1
    :class: singlecol
 
-List organizations.
+Return all organizations.
 
 Syntax
 ------
@@ -41,7 +41,7 @@ Options
    * - --includeDeleted
      - 
      - false
-     - If specified, Atlas includes the deleted organizations.
+     - If specified, includes deleted organizations in the list. This option applies only to Ops Manager organizations. You can't return deleted Atlas or Cloud Manager organizations.
    * - --limit
      - int
      - false
@@ -49,7 +49,7 @@ Options
    * - --name
      - string
      - false
-     - Performs a case-insensitive search for organizations which exactly match the specified name.
+     - Performs a case-insensitive search for organizations that exactly match the specified organization name.
    * - -o, --output
      - string
      - false
@@ -75,3 +75,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all organizations:
+   mongocli organizations list --output json
+   
+   
+.. code-block::
+
+   # Return a JSON-formatted list that includes the organizations named org1 and Org1, but doesn't return org123:
+   mongocli organizations list --name org1 --output json

--- a/docs/mongocli/command/mongocli-iam-organizations-users-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-users-list.txt
@@ -12,7 +12,7 @@ mongocli iam organizations users list
    :depth: 1
    :class: singlecol
 
-List users in a organization.
+Return all users for an organization.
 
 Syntax
 ------
@@ -71,3 +71,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all users for the organization with the ID 5e2211c17a3e5a48f5497de3:
+   mongocli organizations users list --orgId 5e2211c17a3e5a48f5497de3 --output json

--- a/docs/mongocli/command/mongocli-iam-organizations-users.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-users.txt
@@ -49,7 +49,7 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`mongocli-iam-organizations-users-list` - List users in a organization.
+* :ref:`mongocli-iam-organizations-users-list` - Return all users for an organization.
 
 
 .. toctree::

--- a/docs/mongocli/command/mongocli-iam-organizations.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations.txt
@@ -52,11 +52,11 @@ Related Commands
 ----------------
 
 * :ref:`mongocli-iam-organizations-apiKeys` - Organization API Keys operations.
-* :ref:`mongocli-iam-organizations-create` - Create an organization. This command is not available for Atlas. It's available only for Ops Manager and Cloud Manager.
-* :ref:`mongocli-iam-organizations-delete` - Delete an organization.
-* :ref:`mongocli-iam-organizations-describe` - Describe an organizations.
+* :ref:`mongocli-iam-organizations-create` - Create an Ops Manager or Cloud Manager organization. This command is unavailable for Atlas.
+* :ref:`mongocli-iam-organizations-delete` - Remove the specified organization.
+* :ref:`mongocli-iam-organizations-describe` - Return the details for the specified organizations.
 * :ref:`mongocli-iam-organizations-invitations` - Invitation operations.
-* :ref:`mongocli-iam-organizations-list` - List organizations.
+* :ref:`mongocli-iam-organizations-list` - Return all organizations.
 * :ref:`mongocli-iam-organizations-users` - Manage your Ops Manager or Cloud Manager users.
 
 

--- a/internal/cli/atlas/livemigrations/create.go
+++ b/internal/cli/atlas/livemigrations/create.go
@@ -59,8 +59,10 @@ func CreateBuilder() *cobra.Command {
 	opts := &CreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create one new migration.",
-		Long:  "Your API Key must have the Organization Owner role to successfully run this command.",
+		Short: "Create a new push live migration.",
+		Long: `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
+Your API Key must have the Organization Owner role to successfully run this command.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),

--- a/internal/cli/atlas/livemigrations/cutover.go
+++ b/internal/cli/atlas/livemigrations/cutover.go
@@ -56,8 +56,10 @@ func CutoverBuilder() *cobra.Command {
 	opts := &CutoverOpts{}
 	cmd := &cobra.Command{
 		Use:   "cutover",
-		Short: "Start the cutover and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.",
-		Long:  "Your API Key must have the Organization Owner role to successfully run this command.",
+		Short: "Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.",
+		Long: `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
+Your API Key must have the Organization Owner role to successfully run this command.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/livemigrations/describe.go
+++ b/internal/cli/atlas/livemigrations/describe.go
@@ -58,7 +58,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe",
 		Aliases: []string{"get"},
-		Short:   "Return one migration job.",
+		Short:   "Return a push live migration job.",
 		Long:    "Your API Key must have the Organization Owner role to successfully run this command.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/livemigrations/link/create.go
+++ b/internal/cli/atlas/livemigrations/link/create.go
@@ -65,8 +65,10 @@ func CreateBuilder() *cobra.Command {
 	opts := &CreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create one new link-token.",
-		Long:  "Your API Key must have the Organization Owner role to successfully run this command.",
+		Short: "Create a new link-token for a push live migration.",
+		Long: `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
+Your API Key must have the Organization Owner role to successfully run this command.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/atlas/livemigrations/validation/create.go
+++ b/internal/cli/atlas/livemigrations/validation/create.go
@@ -59,8 +59,10 @@ func CreateBuilder() *cobra.Command {
 	opts := &CreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create one new validation request.",
-		Long:  "Your API Key must have the Organization Owner role to successfully run this command.",
+		Short: "Create a new validation request for a push live migration.",
+		Long: `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
+		
+Your API Key must have the Organization Owner role to successfully run this command.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),

--- a/internal/cli/iam/organizations/create.go
+++ b/internal/cli/iam/organizations/create.go
@@ -57,13 +57,14 @@ func CreateBuilder() *cobra.Command {
 	opts := new(CreateOpts)
 	opts.Template = createTemplate
 	cmd := &cobra.Command{
-		Use: "create <name>",
-		Short: "Create an organization. This command is not available for Atlas. It's available only" +
-			" for Ops Manager and Cloud Manager.",
-		Args: require.ExactArgs(1),
+		Use:   "create <name>",
+		Short: "Create an Ops Manager or Cloud Manager organization. This command is unavailable for Atlas.",
+		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
-			"nameDesc": "Organization name.",
+			"nameDesc": "Label that identifies the organization.",
 		},
+		Example: `  # Create an Ops Manager organization with the name myOrg:
+  mongocli iam organizations create myOrg --output json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/organizations/delete.go
+++ b/internal/cli/iam/organizations/delete.go
@@ -16,6 +16,7 @@ package organizations
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -51,11 +52,14 @@ func DeleteBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
-		Short:   "Delete an organization.",
+		Short:   "Remove the specified organization.",
+		Long:    "Organizations with active projects can't be removed.",
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
-			"IDDesc": "Organization identifier.",
+			"IDDesc": "Unique 24-digit string that identifies the organization.",
 		},
+		Example: fmt.Sprintf(`  # Remove the organization with the ID 5e2211c17a3e5a48f5497de3:
+  %s organizations delete 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.initStore(cmd.Context())(); err != nil {
 				return err

--- a/internal/cli/iam/organizations/describe.go
+++ b/internal/cli/iam/organizations/describe.go
@@ -16,6 +16,7 @@ package organizations
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -61,10 +62,12 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <ID>",
 		Aliases: []string{"show"},
 		Args:    require.ExactArgs(1),
-		Short:   "Describe an organizations.",
+		Short:   "Return the details for the specified organizations.",
 		Annotations: map[string]string{
-			"IDDesc": "Organization identifier.",
+			"IDDesc": "Unique 24-digit string that identifies the organization.",
 		},
+		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the organization with the ID 5e2211c17a3e5a48f5497de3:
+  %s organizations describe 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/organizations/list.go
+++ b/internal/cli/iam/organizations/list.go
@@ -16,6 +16,7 @@ package organizations
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -70,8 +71,13 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List organizations.",
+		Short:   "Return all organizations.",
 		Args:    require.NoArgs,
+		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all organizations:
+  %[1]s organizations list --output json
+  
+  # Return a JSON-formatted list that includes the organizations named org1 and Org1, but doesn't return org123:
+  %[1]s organizations list --name org1 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/organizations/users/list.go
+++ b/internal/cli/iam/organizations/users/list.go
@@ -16,6 +16,7 @@ package users
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -63,8 +64,10 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List users in a organization.",
+		Short:   "Return all users for an organization.",
 		Args:    require.NoArgs,
+		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all users for the organization with the ID 5e2211c17a3e5a48f5497de3:
+  %s organizations users list --orgId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.PreRunE(

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -150,8 +150,8 @@ dbName and collection are required only for built-in roles.`
 	RoutingKey                                = "Routing key associated with your Splunk On-Call account."
 	IntegrationAPIToken                       = "Your API Token." //nolint:gosec // This is just a message not a credential
 	OrgName                                   = "Your Flowdock organization's name."
-	OrgNameFilter                             = "Performs a case-insensitive search for organizations which exactly match the specified name."
-	OrgIncludeDeleted                         = "If specified, Atlas includes the deleted organizations."
+	OrgNameFilter                             = "Performs a case-insensitive search for organizations that exactly match the specified organization name."
+	OrgIncludeDeleted                         = "If specified, includes deleted organizations in the list. This option applies only to Ops Manager organizations. You can't return deleted Atlas or Cloud Manager organizations."
 	FlowName                                  = "Flowdock Flow name."
 	BlockstoreAssignment                      = "Flag indicating whether this blockstore can be assigned backup jobs."
 	OplogAssignment                           = "Flag indicating whether this oplog can be assigned backup jobs."


### PR DESCRIPTION
## Proposed changes

Backfills docs content for organizations commands. Also addresses one ticket to add more detail to liveMigration commands (but doesn't perform complete backfill/rewrites for those commands).

_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-16849
https://jira.mongodb.org/browse/DOCSP-16850
https://jira.mongodb.org/browse/DOCSP-16851
https://jira.mongodb.org/browse/DOCSP-16852
https://jira.mongodb.org/browse/DOCSP-16853
https://jira.mongodb.org/browse/DOCSP-27330

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
