### PR TITLE
CLOUDP-156746: Add termination protection flags for upgrade

### DIFF
--- a/docs/atlascli/command/atlas-clusters-upgrade.txt
+++ b/docs/atlascli/command/atlas-clusters-upgrade.txt
@@ -52,10 +52,18 @@ Options
      - Type
      - Required
      - Description
+   * - --disableTerminationProtection
+     - 
+     - false
+     - Disables termination protection for your cluster. You can delete a cluster with termination protection disabled.
    * - --diskSizeGB
      - float
      - false
      - Capacity, in gigabytes, of the host's root volume.
+   * - --enableTerminationProtection
+     - 
+     - false
+     - Enables termination protection for your cluster. You can't delete a cluster with termination protection enabled.
    * - -f, --file
      - string
      - false

--- a/internal/cli/atlas/clusters/upgrade.go
+++ b/internal/cli/atlas/clusters/upgrade.go
@@ -35,13 +35,15 @@ const upgradeTemplate = "Upgrading cluster '{{.Name}}'.\n"
 type UpgradeOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
-	name       string
-	mdbVersion string
-	diskSizeGB float64
-	tier       string
-	filename   string
-	fs         afero.Fs
-	store      store.AtlasSharedClusterGetterUpgrader
+	name                         string
+	mdbVersion                   string
+	diskSizeGB                   float64
+	tier                         string
+	filename                     string
+	enableTerminationProtection  bool
+	disableTerminationProtection bool
+	fs                           afero.Fs
+	store                        store.AtlasSharedClusterGetterUpgrader
 }
 
 func (opts *UpgradeOpts) initStore(ctx context.Context) func() error {
@@ -101,6 +103,7 @@ func (opts *UpgradeOpts) patchOpts(out *atlas.Cluster) {
 			}
 		}
 	}
+	out.TerminationProtectionEnabled = cli.ReturnValueForSetting(opts.enableTerminationProtection, opts.disableTerminationProtection)
 
 	AddLabelSharedCluster(out, NewCLILabel())
 }
@@ -140,6 +143,10 @@ func UpgradeBuilder() *cobra.Command {
 	cmd.Flags().Float64Var(&opts.diskSizeGB, flag.DiskSizeGB, 0, usage.DiskSizeGB)
 	cmd.Flags().StringVar(&opts.mdbVersion, flag.MDBVersion, "", usage.MDBVersion)
 	cmd.Flags().StringVarP(&opts.filename, flag.File, flag.FileShort, "", usage.ClusterFilename)
+
+	cmd.Flags().BoolVar(&opts.enableTerminationProtection, flag.EnableTerminationProtection, false, usage.EnableTerminationProtection)
+	cmd.Flags().BoolVar(&opts.disableTerminationProtection, flag.DisableTerminationProtection, false, usage.DisableTerminationProtection)
+	cmd.MarkFlagsMutuallyExclusive(flag.EnableTerminationProtection, flag.DisableTerminationProtection)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/clusters/upgrade_test.go
+++ b/internal/cli/atlas/clusters/upgrade_test.go
@@ -164,6 +164,7 @@ func TestUpgradeBuilder(t *testing.T) {
 		UpgradeBuilder(),
 		0,
 		[]string{flag.Tier, flag.DiskSizeGB, flag.MDBVersion,
+			flag.EnableTerminationProtection, flag.DisableTerminationProtection,
 			flag.File, flag.ProjectID, flag.Output},
 	)
 }

--- a/test/e2e/atlas/clusters_flags_test.go
+++ b/test/e2e/atlas/clusters_flags_test.go
@@ -214,7 +214,7 @@ func TestClustersFlags(t *testing.T) {
 		req.NoError(err, string(resp))
 	})
 
-	t.Run("Delete with fail", func(t *testing.T) {
+	t.Run("Fail Delete for Termination Protection enabled", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			clustersEntity,
 			"delete",

--- a/test/e2e/atlas/clusters_upgrade_test.go
+++ b/test/e2e/atlas/clusters_upgrade_test.go
@@ -51,6 +51,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 			"--tier", tierM2,
 			"--provider", e2eClusterProvider,
 			"--mdbVersion", e2eSharedMDBVer,
+			"--enableTerminationProtection",
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
@@ -61,7 +62,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 		err = json.Unmarshal(resp, &cluster)
 		req.NoError(err)
 
-		ensureSharedCluster(t, cluster, clusterName, e2eSharedMDBVer, tierM2, 2, false)
+		ensureSharedCluster(t, cluster, clusterName, e2eSharedMDBVer, tierM2, 2, true)
 	})
 
 	t.Run("Watch create", func(t *testing.T) {
@@ -76,6 +77,19 @@ func TestSharedClusterUpgrade(t *testing.T) {
 		t.Log(string(resp))
 	})
 
+	t.Run("Fail Delete for Termination Protection", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			clustersEntity,
+			"delete",
+			clusterName,
+			"--force",
+			"--projectId", g.projectID)
+
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		req.Error(err, string(resp))
+	})
+
 	t.Run("Upgrade", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			clustersEntity,
@@ -84,6 +98,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 			"--tier", tierM10,
 			"--diskSizeGB", diskSizeGB40,
 			"--mdbVersion=6.0",
+			"--disableTerminationProtection",
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
This was an outstanding ticket for enabling cluster termination protection through the CLI.
Added flags for cluster termination protection to `upgrade` command. Shared clusters can only be modified through the `upgrade` command. Adding these flags to ensure that users can disable termination protection for clusters created through `quickstart` and `setup` until Atlas confirms this as being the way to do it.

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-156746

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
