### PR TITLE
(DOCSP-16828) Backfills docs content for globalApiKeys and globalAccessLists commands

### DIFF
--- a/docs/mongocli/command/mongocli-iam-globalAccessLists-create.txt
+++ b/docs/mongocli/command/mongocli-iam-globalAccessLists-create.txt
@@ -12,7 +12,7 @@ mongocli iam globalAccessLists create
    :depth: 1
    :class: singlecol
 
-Create an IP access list for Global API Key.
+Create an IP access list entry for your global API key.
 
 Syntax
 ------
@@ -67,3 +67,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create an access list entry for your global API key to allow access from 192.0.2.0/24:
+   mongocli iam globalAccessLists create --cidr 192.0.2.0/24 --desc "My Global IP" --output json

--- a/docs/mongocli/command/mongocli-iam-globalAccessLists-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-globalAccessLists-delete.txt
@@ -12,7 +12,7 @@ mongocli iam globalAccessLists delete
    :depth: 1
    :class: singlecol
 
-Delete an IP access list from Global API Key.
+Remove the specified IP access list entry for your global API key.
 
 Syntax
 ------
@@ -37,7 +37,7 @@ Arguments
    * - ID
      - string
      - true
-     - Access list identifier.
+     - Unique 24-digit string that identifies the access list entry.
 
 Options
 -------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Remove the IP access list entry with the ID 5f5bad7a57aef32b04ed0210 from the access list for the global API key:
+   mongocli iam globalAccessLists delete 5f5bad7a57aef32b04ed0210

--- a/docs/mongocli/command/mongocli-iam-globalAccessLists-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-globalAccessLists-describe.txt
@@ -12,7 +12,7 @@ mongocli iam globalAccessLists describe
    :depth: 1
    :class: singlecol
 
-Return one Global IP access list entry.
+Return the details for the specified access list entry for your global API key.
 
 Syntax
 ------
@@ -37,7 +37,7 @@ Arguments
    * - ID
      - string
      - true
-     - Access list identifier.
+     - Unique 24-digit string that identifies the access list entry.
 
 Options
 -------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the JSON-formatted details for the access list entry with the ID 5f5bad7a57aef32b04ed0210 from the access list for the global API key:
+   mongocli iam globalAccessLists describe 5f5bad7a57aef32b04ed0210 --output json

--- a/docs/mongocli/command/mongocli-iam-globalAccessLists-list.txt
+++ b/docs/mongocli/command/mongocli-iam-globalAccessLists-list.txt
@@ -12,7 +12,7 @@ mongocli iam globalAccessLists list
    :depth: 1
    :class: singlecol
 
-List Atlas IP access list entries for Global API Key.
+Return all IP access list entries for your global API key.
 
 Syntax
 ------
@@ -67,3 +67,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of all access list entries for the global API key:
+   mongocli iam globalAccessLists list --output json

--- a/docs/mongocli/command/mongocli-iam-globalAccessLists.txt
+++ b/docs/mongocli/command/mongocli-iam-globalAccessLists.txt
@@ -49,10 +49,10 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`mongocli-iam-globalAccessLists-create` - Create an IP access list for Global API Key.
-* :ref:`mongocli-iam-globalAccessLists-delete` - Delete an IP access list from Global API Key.
-* :ref:`mongocli-iam-globalAccessLists-describe` - Return one Global IP access list entry.
-* :ref:`mongocli-iam-globalAccessLists-list` - List Atlas IP access list entries for Global API Key.
+* :ref:`mongocli-iam-globalAccessLists-create` - Create an IP access list entry for your global API key.
+* :ref:`mongocli-iam-globalAccessLists-delete` - Remove the specified IP access list entry for your global API key.
+* :ref:`mongocli-iam-globalAccessLists-describe` - Return the details for the specified access list entry for your global API key.
+* :ref:`mongocli-iam-globalAccessLists-list` - Return all IP access list entries for your global API key.
 
 
 .. toctree::

--- a/docs/mongocli/command/mongocli-iam-globalApiKeys-create.txt
+++ b/docs/mongocli/command/mongocli-iam-globalApiKeys-create.txt
@@ -12,7 +12,7 @@ mongocli iam globalApiKeys create
    :depth: 1
    :class: singlecol
 
-Create a Global API Key.
+Create a global API key for your Ops Manager instance.
 
 Syntax
 ------
@@ -67,3 +67,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Create a global API key that grants GLOBAL_READ_ONLY and GLOBAL_USER_ADMIN access for your Ops Manager instance:
+   mongocli iam globalApiKeys create --desc "My Global API key" --role "GLOBAL_READ_ONLY","GLOBAL_USER_ADMIN" --output json

--- a/docs/mongocli/command/mongocli-iam-globalApiKeys-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-globalApiKeys-delete.txt
@@ -12,7 +12,7 @@ mongocli iam globalApiKeys delete
    :depth: 1
    :class: singlecol
 
-Delete a Global API Key.
+Remove the specified global API key from your Ops Manager instance.
 
 Syntax
 ------
@@ -37,7 +37,7 @@ Arguments
    * - ID
      - string
      - true
-     - Access list identifier.
+     - Unique 24-digit string that identifies the global API key.
 
 Options
 -------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Remove the global API key with the ID 5f5bad7a57aef32b04ed0210 from your Ops Manager instance:
+   mongocli iam globalApiKeys delete 5f5bad7a57aef32b04ed0210

--- a/docs/mongocli/command/mongocli-iam-globalApiKeys-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-globalApiKeys-describe.txt
@@ -12,7 +12,7 @@ mongocli iam globalApiKeys describe
    :depth: 1
    :class: singlecol
 
-Get a specific Global API Key.
+Return the details for the specified global API key for your Ops Manager instance.
 
 Syntax
 ------
@@ -37,7 +37,7 @@ Arguments
    * - ID
      - string
      - true
-     - Access list identifier.
+     - Unique 24-digit string that identifies the global API key.
 
 Options
 -------
@@ -75,3 +75,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return the JSON-formatted details for the global API key with the ID 5f5bad7a57aef32b04ed0210:
+   mongocli iam globalApiKeys describe 5f5bad7a57aef32b04ed0210 --output json

--- a/docs/mongocli/command/mongocli-iam-globalApiKeys-list.txt
+++ b/docs/mongocli/command/mongocli-iam-globalApiKeys-list.txt
@@ -12,7 +12,7 @@ mongocli iam globalApiKeys list
    :depth: 1
    :class: singlecol
 
-List Global API Keys.
+Return all global API keys for your Ops Manager instance.
 
 Syntax
 ------
@@ -67,3 +67,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Return a JSON-formatted list of global API keys:
+   mongocli iam globalApiKeys list --output json

--- a/docs/mongocli/command/mongocli-iam-globalApiKeys-update.txt
+++ b/docs/mongocli/command/mongocli-iam-globalApiKeys-update.txt
@@ -12,7 +12,7 @@ mongocli iam globalApiKeys update
    :depth: 1
    :class: singlecol
 
-Update a Global API Key.
+Modify the roles and description for a global API key.
 
 Syntax
 ------
@@ -37,7 +37,7 @@ Arguments
    * - ID
      - string
      - true
-     - Access list identifier.
+     - Unique 24-digit string that identifies the global API key.
 
 Options
 -------
@@ -83,3 +83,10 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Examples
+--------
+
+.. code-block::
+
+   # Modify the roles and description for the global API key with the ID 5f5bad7a57aef32b04ed0210:
+   mongocli iam globalApiKeys update 5f5bad7a57aef32b04ed0210 --desc "My Sample Global API Key" --role GLOBAL_MONITORING_ADMIN --output json

--- a/docs/mongocli/command/mongocli-iam-globalApiKeys.txt
+++ b/docs/mongocli/command/mongocli-iam-globalApiKeys.txt
@@ -49,11 +49,11 @@ Inherited Options
 Related Commands
 ----------------
 
-* :ref:`mongocli-iam-globalApiKeys-create` - Create a Global API Key.
-* :ref:`mongocli-iam-globalApiKeys-delete` - Delete a Global API Key.
-* :ref:`mongocli-iam-globalApiKeys-describe` - Get a specific Global API Key.
-* :ref:`mongocli-iam-globalApiKeys-list` - List Global API Keys.
-* :ref:`mongocli-iam-globalApiKeys-update` - Update a Global API Key.
+* :ref:`mongocli-iam-globalApiKeys-create` - Create a global API key for your Ops Manager instance.
+* :ref:`mongocli-iam-globalApiKeys-delete` - Remove the specified global API key from your Ops Manager instance.
+* :ref:`mongocli-iam-globalApiKeys-describe` - Return the details for the specified global API key for your Ops Manager instance.
+* :ref:`mongocli-iam-globalApiKeys-list` - Return all global API keys for your Ops Manager instance.
+* :ref:`mongocli-iam-globalApiKeys-update` - Modify the roles and description for a global API key.
 
 
 .. toctree::

--- a/internal/cli/iam/globalaccesslists/create.go
+++ b/internal/cli/iam/globalaccesslists/create.go
@@ -68,7 +68,9 @@ func CreateBuilder() *cobra.Command {
 	opts.Template = createTemplate
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create an IP access list for Global API Key.",
+		Short: "Create an IP access list entry for your global API key.",
+		Example: `  # Create an access list entry for your global API key to allow access from 192.0.2.0/24:
+  mongocli iam globalAccessLists create --cidr 192.0.2.0/24 --desc "My Global IP" --output json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/globalaccesslists/delete.go
+++ b/internal/cli/iam/globalaccesslists/delete.go
@@ -52,11 +52,13 @@ func DeleteBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
-		Short:   "Delete an IP access list from Global API Key.",
+		Short:   "Remove the specified IP access list entry for your global API key.",
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
-			"IDDesc": "Access list identifier.",
+			"IDDesc": "Unique 24-digit string that identifies the access list entry.",
 		},
+		Example: `  # Remove the IP access list entry with the ID 5f5bad7a57aef32b04ed0210 from the access list for the global API key:
+  mongocli iam globalAccessLists delete 5f5bad7a57aef32b04ed0210`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.initStore(cmd.Context())(); err != nil {
 				return err

--- a/internal/cli/iam/globalaccesslists/describe.go
+++ b/internal/cli/iam/globalaccesslists/describe.go
@@ -61,10 +61,12 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <ID>",
 		Aliases: []string{"show"},
 		Args:    require.ExactArgs(1),
-		Short:   "Return one Global IP access list entry.",
+		Short:   "Return the details for the specified access list entry for your global API key.",
 		Annotations: map[string]string{
-			"IDDesc": "Access list identifier.",
+			"IDDesc": "Unique 24-digit string that identifies the access list entry.",
 		},
+		Example: `  # Return the JSON-formatted details for the access list entry with the ID 5f5bad7a57aef32b04ed0210 from the access list for the global API key:
+  mongocli iam globalAccessLists describe 5f5bad7a57aef32b04ed0210 --output json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/globalaccesslists/list.go
+++ b/internal/cli/iam/globalaccesslists/list.go
@@ -62,7 +62,9 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		Short:   "List Atlas IP access list entries for Global API Key.",
+		Short:   "Return all IP access list entries for your global API key.",
+		Example: `  # Return a JSON-formatted list of all access list entries for the global API key:
+  mongocli iam globalAccessLists list --output json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/globalapikeys/create.go
+++ b/internal/cli/iam/globalapikeys/create.go
@@ -69,7 +69,9 @@ func CreateBuilder() *cobra.Command {
 	opts.Template = createTemplate
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create a Global API Key.",
+		Short: "Create a global API key for your Ops Manager instance.",
+		Example: `  # Create a global API key that grants GLOBAL_READ_ONLY and GLOBAL_USER_ADMIN access for your Ops Manager instance:
+  mongocli iam globalApiKeys create --desc "My Global API key" --role "GLOBAL_READ_ONLY","GLOBAL_USER_ADMIN" --output json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/globalapikeys/delete.go
+++ b/internal/cli/iam/globalapikeys/delete.go
@@ -52,11 +52,13 @@ func DeleteBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
-		Short:   "Delete a Global API Key.",
+		Short:   "Remove the specified global API key from your Ops Manager instance.",
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
-			"IDDesc": "Access list identifier.",
+			"IDDesc": "Unique 24-digit string that identifies the global API key.",
 		},
+		Example: `  # Remove the global API key with the ID 5f5bad7a57aef32b04ed0210 from your Ops Manager instance:
+  mongocli iam globalApiKeys delete 5f5bad7a57aef32b04ed0210`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.initStore(cmd.Context())(); err != nil {
 				return err

--- a/internal/cli/iam/globalapikeys/describe.go
+++ b/internal/cli/iam/globalapikeys/describe.go
@@ -59,12 +59,14 @@ func DescribeBuilder() *cobra.Command {
 	opts.Template = describeTemplate
 	cmd := &cobra.Command{
 		Use:     "describe <ID>",
-		Short:   "Get a specific Global API Key.",
+		Short:   "Return the details for the specified global API key for your Ops Manager instance.",
 		Aliases: []string{"show"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
-			"IDDesc": "Access list identifier.",
+			"IDDesc": "Unique 24-digit string that identifies the global API key.",
 		},
+		Example: `  # Return the JSON-formatted details for the global API key with the ID 5f5bad7a57aef32b04ed0210:
+  mongocli iam globalApiKeys describe 5f5bad7a57aef32b04ed0210 --output json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/globalapikeys/list.go
+++ b/internal/cli/iam/globalapikeys/list.go
@@ -61,8 +61,10 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List Global API Keys.",
-		Args:    require.NoArgs,
+		Short:   "Return all global API keys for your Ops Manager instance.",
+		Example: `  # Return a JSON-formatted list of global API keys:
+  mongocli iam globalApiKeys list --output json`,
+		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()

--- a/internal/cli/iam/globalapikeys/update.go
+++ b/internal/cli/iam/globalapikeys/update.go
@@ -68,10 +68,12 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <ID>",
 		Args:  require.ExactArgs(1),
-		Short: "Update a Global API Key.",
+		Short: "Modify the roles and description for a global API key.",
 		Annotations: map[string]string{
-			"IDDesc": "Access list identifier.",
+			"IDDesc": "Unique 24-digit string that identifies the global API key.",
 		},
+		Example: `  # Modify the roles and description for the global API key with the ID 5f5bad7a57aef32b04ed0210:
+  mongocli iam globalApiKeys update 5f5bad7a57aef32b04ed0210 --desc "My Sample Global API Key" --role GLOBAL_MONITORING_ADMIN --output json`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()


### PR DESCRIPTION
## Proposed changes

Backfills docs content for globalApiKeys and globalAccessLists commands.
This is the last PR for [this backfill epic](https://jira.mongodb.org/browse/DOCSP-16432) (however, 2 epics remain for CM and OM specific commands).

_Jira ticket:_ CLOUDP-#

https://jira.mongodb.org/browse/DOCSP-16828
https://jira.mongodb.org/browse/DOCSP-16829
https://jira.mongodb.org/browse/DOCSP-16830
https://jira.mongodb.org/browse/DOCSP-16831
https://jira.mongodb.org/browse/DOCSP-16833
https://jira.mongodb.org/browse/DOCSP-16834
https://jira.mongodb.org/browse/DOCSP-16835
https://jira.mongodb.org/browse/DOCSP-16836
https://jira.mongodb.org/browse/DOCSP-16837


## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
