### PR TITLE
(DOCSP-28054) Docs for atlas clusters failover shows example for clusters delete

### DIFF
--- a/docs/atlascli/command/atlas-clusters-failover.txt
+++ b/docs/atlascli/command/atlas-clusters-failover.txt
@@ -86,12 +86,5 @@ Examples
 
 .. code-block::
 
-   # Delete a cluster named myCluster after prompting for a confirmation:
-   atlas clusters delete myCluster
-   Are you sure you want to delete: myCluster Y
-   
-   
-.. code-block::
-
-   # Delete a cluster named myCluster without requiring confirmation:
-   atlas clusters delete myCluster --force
+   # Test failover for a cluster named myCluster:
+   atlas clusters failover myCluster

--- a/internal/cli/atlas/clusters/failover.go
+++ b/internal/cli/atlas/clusters/failover.go
@@ -56,12 +56,8 @@ func FailoverBuilder() *cobra.Command {
 		Use:   "failover <clusterName>",
 		Short: "Starts a failover test for the specified cluster in the specified project.",
 		Long:  `Clusters contain a group of hosts that maintain the same data set. A failover test checks how MongoDB Cloud handles the failure of the cluster's primary node. During the test, MongoDB Cloud shuts down the primary node and elects a new primary.`,
-		Example: fmt.Sprintf(`  # Delete a cluster named myCluster after prompting for a confirmation:
-  %[1]s clusters delete myCluster
-  Are you sure you want to delete: myCluster Y
-  
-  # Delete a cluster named myCluster without requiring confirmation:
-  %[1]s clusters delete myCluster --force`, cli.ExampleAtlasEntryPoint()),
+		Example: fmt.Sprintf(`  # Test failover for a cluster named myCluster:
+  %s clusters failover myCluster`, cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Human-readable label that identifies the cluster to start a failover test for.",


### PR DESCRIPTION
## Proposed changes

Fixes incorrect example showing in docs for atlas clusters failover

_Jira ticket:_ 
https://jira.mongodb.org/browse/DOCSP-28054

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
