### PR TITLE
CLOUDP-162861: Remove unnnecessary new constructors from the auth pkg

### DIFF
--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -143,10 +143,6 @@ type Flow interface {
 	Run() error
 }
 
-func NewQuickstartFlow(qsOpts *Opts) Flow {
-	return qsOpts
-}
-
 func NewQuickstartOpts(loginOpts *auth.LoginOpts) *Opts {
 	labelValue := atlasCLILabelValue
 	if config.ToolName == config.MongoCLI {
@@ -154,7 +150,7 @@ func NewQuickstartOpts(loginOpts *auth.LoginOpts) *Opts {
 	}
 	return &Opts{
 		loginOpts:  loginOpts,
-		login:      auth.NewLoginFlow(loginOpts),
+		login:      loginOpts, // FIXME: CLOUDP-162860 two logins?
 		LabelKey:   labelKey,
 		LabelValue: labelValue,
 	}

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -83,7 +83,7 @@ This command will help you
 	return opts.quickstart.Run()
 }
 
-func (opts *Opts) PreRun(ctx context.Context) error {
+func (opts *Opts) PreRun(ctx context.Context) {
 	opts.skipRegister = true
 	opts.skipLogin = true
 
@@ -109,8 +109,6 @@ func (opts *Opts) PreRun(ctx context.Context) error {
 		opts.skipRegister = false
 	default:
 	}
-
-	return nil
 }
 
 // Builder
@@ -129,8 +127,8 @@ func Builder() *cobra.Command {
 	qsOpts.LabelValue = labelValue
 	opts := &Opts{
 		register:   auth.NewRegisterFlow(loginOpts),
-		login:      auth.NewLoginFlow(loginOpts),
-		quickstart: quickstart.NewQuickstartFlow(qsOpts),
+		login:      loginOpts,
+		quickstart: qsOpts,
 	}
 
 	cmd := &cobra.Command{
@@ -144,9 +142,7 @@ func Builder() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			// setup pre run
-			if err := opts.PreRun(cmd.Context()); err != nil {
-				return err
-			}
+			opts.PreRun(cmd.Context())
 
 			// registration pre run if applicable
 			if !opts.skipRegister {

--- a/internal/cli/atlas/setup/setup_cmd_test.go
+++ b/internal/cli/atlas/setup/setup_cmd_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package setup
 
@@ -120,7 +119,8 @@ func Test_setupOpts_RunWithAPIKeys(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	require.NoError(t, opts.PreRun(ctx))
+	// FIXME: CLOUDP-162860 side effect dependant test
+	opts.PreRun(ctx)
 	require.NoError(t, opts.Run(ctx))
 	assert.Equal(t, `
 You are already authenticated with an API key (Public key: publicKey).
@@ -168,7 +168,8 @@ func Test_setupOpts_RunSkipRegister(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	require.NoError(t, opts.PreRun(ctx))
+	// FIXME: CLOUDP-162860 side effect dependant test
+	opts.PreRun(ctx)
 	assert.Equal(t, opts.skipRegister, true)
 	require.NoError(t, opts.Run(ctx))
 }

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -48,12 +48,12 @@ type LoginConfig interface {
 }
 
 const (
-	AlreadyAuthenticatedError      = "you are already authenticated with an API key (Public key: %s)"
+	alreadyAuthenticatedError      = "you are already authenticated with an API key (Public key: %s)"
 	AlreadyAuthenticatedMsg        = "You are already authenticated with an API key (Public key: %s)."
-	AlreadyAuthenticatedEmailError = "you are already authenticated with an account (%s)"
+	alreadyAuthenticatedEmailError = "you are already authenticated with an account (%s)"
 	AlreadyAuthenticatedEmailMsg   = "You are already authenticated with an account (%s)."
-	LoginWithProfileMsg            = `run "atlas auth login --profile <profile_name>"  to authenticate using your Atlas username and password on a new profile`
-	LogoutToLoginAccountMsg        = `run "atlas auth logout" first if you want to login with another Atlas account on the same Atlas CLI profile`
+	loginWithProfileMsg            = `run "atlas auth login --profile <profile_name>"  to authenticate using your Atlas username and password on a new profile`
+	logoutToLoginAccountMsg        = `run "atlas auth logout" first if you want to login with another Atlas account on the same Atlas CLI profile`
 )
 
 var (
@@ -104,10 +104,6 @@ func (c *confirmPrompt) confirm() (response bool, err error) {
 type LoginFlow interface {
 	Run(ctx context.Context) error
 	PreRun() error
-}
-
-func NewLoginFlow(opts *LoginOpts) LoginFlow {
-	return opts
 }
 
 func (opts *LoginOpts) initFlow() error {
@@ -309,18 +305,18 @@ func hasUserProgrammaticKeys() bool {
 
 func loginPreRun(ctx context.Context) error {
 	if hasUserProgrammaticKeys() {
-		msg := fmt.Sprintf(AlreadyAuthenticatedError, config.PublicAPIKey())
+		msg := fmt.Sprintf(alreadyAuthenticatedError, config.PublicAPIKey())
 		return fmt.Errorf(`%s
 
-%s`, msg, LoginWithProfileMsg)
+%s`, msg, loginWithProfileMsg)
 	}
 
 	if account, err := AccountWithAccessToken(); err == nil {
 		if err := cli.RefreshToken(ctx); err == nil && validate.Token() == nil {
-			msg := fmt.Sprintf(AlreadyAuthenticatedEmailError, account)
+			msg := fmt.Sprintf(alreadyAuthenticatedEmailError, account)
 			return fmt.Errorf(`%s
 
-%s`, msg, LogoutToLoginAccountMsg)
+%s`, msg, logoutToLoginAccountMsg)
 		}
 	}
 	return nil
@@ -334,7 +330,7 @@ func (opts *LoginOpts) PreRun() error {
 	return opts.initFlow()
 }
 
-func Tool() string {
+func tool() string {
 	if config.ToolName == config.MongoCLI {
 		return "Atlas or Cloud Manager"
 	}
@@ -349,7 +345,7 @@ func LoginBuilder() *cobra.Command {
 		Short: "Authenticate with MongoDB Atlas.",
 		Example: fmt.Sprintf(`  # To start the interactive login for your MongoDB %s account:
   %s auth login
-`, Tool(), config.BinName()),
+`, tool(), config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			if err := loginPreRun(cmd.Context()); err != nil {

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -161,7 +161,7 @@ func TestLoginPreRun(t *testing.T) {
 	ctx := context.TODO()
 	config.SetPublicAPIKey("public")
 	config.SetPrivateAPIKey("private")
-	require.ErrorContains(t, loginPreRun(ctx), fmt.Sprintf(AlreadyAuthenticatedError, "public"), LoginWithProfileMsg)
+	require.ErrorContains(t, loginPreRun(ctx), fmt.Sprintf(alreadyAuthenticatedError, "public"), loginWithProfileMsg)
 }
 
 func Test_loginOpts_oauthFlow(t *testing.T) {

--- a/internal/cli/auth/register.go
+++ b/internal/cli/auth/register.go
@@ -39,19 +39,15 @@ type registerOpts struct {
 	login *LoginOpts
 }
 
-func newRegisterOpts(l *LoginOpts) *registerOpts {
-	return &registerOpts{
-		login: l,
-	}
-}
-
 type RegisterFlow interface {
 	Run(ctx context.Context) error
 	PreRun(outWriter io.Writer) error
 }
 
 func NewRegisterFlow(l *LoginOpts) RegisterFlow {
-	return newRegisterOpts(l)
+	return &registerOpts{
+		login: l,
+	}
 }
 
 func (opts *registerOpts) Run(ctx context.Context) error {
@@ -127,14 +123,14 @@ func (opts *registerOpts) PreRun(outWriter io.Writer) error {
 
 func registerPreRun() error {
 	if hasUserProgrammaticKeys() {
-		msg := fmt.Sprintf(AlreadyAuthenticatedError, config.PublicAPIKey())
+		msg := fmt.Sprintf(alreadyAuthenticatedError, config.PublicAPIKey())
 		return fmt.Errorf(`%s
 
 %s`, msg, WithProfileMsg)
 	}
 
 	if account, err := AccountWithAccessToken(); err == nil {
-		msg := fmt.Sprintf(AlreadyAuthenticatedEmailError, account)
+		msg := fmt.Sprintf(alreadyAuthenticatedEmailError, account)
 		return fmt.Errorf(`%s
 
 %s`, msg, WithProfileMsg)
@@ -143,7 +139,9 @@ func registerPreRun() error {
 }
 
 func RegisterBuilder() *cobra.Command {
-	opts := newRegisterOpts(NewLoginOpts())
+	opts := &registerOpts{
+		login: NewLoginOpts(),
+	}
 	cmd := &cobra.Command{
 		Use:    "register",
 		Short:  "Register with MongoDB Atlas.",

--- a/internal/cli/auth/register_test.go
+++ b/internal/cli/auth/register_test.go
@@ -139,5 +139,5 @@ func TestRegisterPreRun(t *testing.T) {
 	t.Cleanup(test.CleanupConfig)
 	config.SetPublicAPIKey("public")
 	config.SetPrivateAPIKey("private")
-	require.ErrorContains(t, registerPreRun(), fmt.Sprintf(AlreadyAuthenticatedError, "public"), WithProfileMsg)
+	require.ErrorContains(t, registerPreRun(), fmt.Sprintf(alreadyAuthenticatedError, "public"), WithProfileMsg)
 }

--- a/internal/cli/refresher_opts.go
+++ b/internal/cli/refresher_opts.go
@@ -54,10 +54,9 @@ func (opts *RefresherOpts) RefreshAccessToken(ctx context.Context) error {
 		var target *atlas.ErrorResponse
 		if errors.As(err, &target) && target.ErrorCode == "INVALID_REFRESH_TOKEN" {
 			return fmt.Errorf(
-				"%w\n\nTo login, run: %s %s",
+				"%w\n\nTo login, run: %s auth login",
 				ErrInvalidRefreshToken,
-				config.BinName(),
-				"auth login")
+				config.BinName())
 		}
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-162861


Trying to clean up auth login/register and setup is becoming too complected due to a big amount of technical debt and inter-dependency, starting small with a small clean up of unnecessary methods that expose a lot of the issues I'm seeing

I'll pause trying to fix the unit tests deleting config files after this PR since it's becoming bigger and I have other tickets to look at  


