### PR TITLE
(DOCSP-28066) Calls out OM-only property values in atlas config set docs

### DIFF
--- a/docs/atlascli/command/atlas-config-set.txt
+++ b/docs/atlascli/command/atlas-config-set.txt
@@ -37,7 +37,7 @@ Arguments
    * - propertyName
      - string
      - true
-     - Property to set in the profile. Valid values for Atlas CLI and MCLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, valid values for MCLI only are ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.
+     - Property to set in the profile. Valid values for Atlas CLI and MongoDB CLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, values that are only valid for MongoDB CLI include ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.
    * - value
      - string
      - true

--- a/docs/atlascli/command/atlas-config-set.txt
+++ b/docs/atlascli/command/atlas-config-set.txt
@@ -14,9 +14,6 @@ atlas config set
 
 Configure specific properties of a profile.
 
-Configure specific properties of the profile.
-Available properties include: [project_id org_id service public_api_key private_api_key output ops_manager_url base_url ops_manager_ca_certificate ops_manager_skip_verify mongosh_path skip_update_check telemetry_enabled access_token refresh_token].
-
 Syntax
 ------
 
@@ -40,7 +37,7 @@ Arguments
    * - propertyName
      - string
      - true
-     - Property to set in the profile.
+     - Property to set in the profile. Valid values for Atlas CLI and MCLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, valid values for MCLI only are ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.
    * - value
      - string
      - true
@@ -84,5 +81,5 @@ Examples
 .. code-block::
 
   
-   Set Organization ID in the default profile:
+   Set the organization ID in the default profile to 5dd5aaef7a3e5a6c5bd12de4:
    atlas config set org_id 5dd5aaef7a3e5a6c5bd12de4

--- a/docs/mongocli/command/mongocli-config-set.txt
+++ b/docs/mongocli/command/mongocli-config-set.txt
@@ -37,7 +37,7 @@ Arguments
    * - propertyName
      - string
      - true
-     - Property to set in the profile. Valid values for Atlas CLI and MCLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, valid values for MCLI only are ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.
+     - Property to set in the profile. Valid values for Atlas CLI and MongoDB CLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, values that are only valid for MongoDB CLI include ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.
    * - value
      - string
      - true

--- a/docs/mongocli/command/mongocli-config-set.txt
+++ b/docs/mongocli/command/mongocli-config-set.txt
@@ -14,9 +14,6 @@ mongocli config set
 
 Configure specific properties of a profile.
 
-Configure specific properties of the profile.
-Available properties include: [project_id org_id service public_api_key private_api_key output ops_manager_url base_url ops_manager_ca_certificate ops_manager_skip_verify mongosh_path skip_update_check telemetry_enabled access_token refresh_token].
-
 Syntax
 ------
 
@@ -40,7 +37,7 @@ Arguments
    * - propertyName
      - string
      - true
-     - Property to set in the profile.
+     - Property to set in the profile. Valid values for Atlas CLI and MCLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, valid values for MCLI only are ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.
    * - value
      - string
      - true
@@ -83,8 +80,8 @@ Examples
 
 .. code-block::
 
-   # Set Ops Manager Base URL in the profile myProfile:
+   Set the Ops Manager base URL in the profile myProfile to http://localhost:30700/:
    mongocli config set ops_manager_url http://localhost:30700/ -P myProfile
 
-   Set Organization ID in the default profile:
+   Set the organization ID in the default profile to 5dd5aaef7a3e5a6c5bd12de4:
    mongocli config set org_id 5dd5aaef7a3e5a6c5bd12de4

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -71,7 +71,7 @@ func (opts *SetOpts) Run() error {
 
 func mongoCLIExample() string {
 	if config.BinName() == config.MongoCLI {
-		return fmt.Sprintf(`  # Set Ops Manager Base URL in the profile myProfile:
+		return fmt.Sprintf(`  Set the Ops Manager base URL in the profile myProfile to http://localhost:30700/:
   %s config set ops_manager_url http://localhost:30700/ -P myProfile
 `, config.BinName())
 	}
@@ -84,8 +84,6 @@ func SetBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set <propertyName> <value>",
 		Short: "Configure specific properties of a profile.",
-		Long: fmt.Sprintf(`Configure specific properties of the profile.
-Available properties include: %v.`, config.Properties()),
 		Args: func(cmd *cobra.Command, args []string) error {
 			if err := require.ExactArgs(argsN)(cmd, args); err != nil {
 				return err
@@ -96,10 +94,10 @@ Available properties include: %v.`, config.Properties()),
 			return nil
 		},
 		Example: fmt.Sprintf(`  %s
-  Set Organization ID in the default profile:
+  Set the organization ID in the default profile to 5dd5aaef7a3e5a6c5bd12de4:
   %s config set org_id 5dd5aaef7a3e5a6c5bd12de4`, mongoCLIExample(), config.BinName()),
 		Annotations: map[string]string{
-			"propertyNameDesc": "Property to set in the profile.",
+			"propertyNameDesc": "Property to set in the profile. Valid values for Atlas CLI and MCLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, valid values for MCLI only are ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.",
 			"valueDesc":        "Value for the property to set in the profile.",
 		},
 		ValidArgs: config.Properties(),

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -97,7 +97,7 @@ func SetBuilder() *cobra.Command {
   Set the organization ID in the default profile to 5dd5aaef7a3e5a6c5bd12de4:
   %s config set org_id 5dd5aaef7a3e5a6c5bd12de4`, mongoCLIExample(), config.BinName()),
 		Annotations: map[string]string{
-			"propertyNameDesc": "Property to set in the profile. Valid values for Atlas CLI and MCLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, valid values for MCLI only are ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.",
+			"propertyNameDesc": "Property to set in the profile. Valid values for Atlas CLI and MongoDB CLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token. Additionally, values that are only valid for MongoDB CLI include ops_manager_url base_url, ops_manager_ca_certificate, and ops_manager_skip_verify.",
 			"valueDesc":        "Value for the property to set in the profile.",
 		},
 		ValidArgs: config.Properties(),


### PR DESCRIPTION
## Proposed changes

Removes Long text with values for both Atlas CLI and MCLI, adds flag description text that specifies which values are supported for each CLI.

_Jira ticket:_ CLOUDP-#

https://jira.mongodb.org/browse/DOCSP-28066

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code