### PR TITLE
Adds required role template text to usage.go and populates one command with role text

### DIFF
--- a/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
@@ -14,6 +14,8 @@ atlas backups exports buckets describe
 
 Return one snapshot export bucket.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/internal/cli/atlas/backup/exports/buckets/describe.go
+++ b/internal/cli/atlas/backup/exports/buckets/describe.go
@@ -61,6 +61,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return one snapshot export bucket.",
+		Long:    fmt.Sprintf(`%v %v %v`, usage.RequiredRoleIntro, "Project Read Only", usage.RequiredRoleClose),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup export bucket with the ID dbdb00ca12345678f901a234:
   %s backup exports buckets describe dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -393,4 +393,6 @@ dbName and collection are required only for built-in roles.`
 	OperatorTargetNamespace                   = "Namespaces to use for generated kubernetes entities"
 	OperatorVersion                           = "Version of Atlas Kubernetes Operator to generate resources for."
 	ExportID                                  = "Unique string that identifies the AWS S3 bucket to which you export your snapshots."
+	RequiredRoleIntro                         = "To use this command, you must authenticate with a user account or an API key that has the"
+	RequiredRoleClose                         = "role."
 )


### PR DESCRIPTION
## Proposed changes

Following the conversation on [this cobra2snooty PR](https://github.com/mongodb-labs/cobra2snooty/pull/31), I was thinking of ways we could accomplish two things: 

- Add required roles to the long descriptions (so that the required role also shows up in the CLI). 
- Still standardize text across all commands (to make it easier to change across commands later and prevent errrors)

If this is a good solution, I would be add the Long text portion for all Atlas CLI commands (after existing Long text if applicable). The template text was added to usage.go in this PR (but please let me know if that's not an appropriate use of usage.go).

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
