### PR TITLE
CLOUDP-161161: [Atlas CLI] Add support for --curentIp on API access list for organizations

### DIFF
--- a/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-create.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-create.txt
@@ -44,6 +44,10 @@ Options
      - strings
      - false
      - Access list entry in CIDR notation to be added for your API key. To add more than one entry, you can specify each entry with a separate cidr flag or specify all the entries as a comma-separated list using one cidr flag. You can't set both cidr and ip in the same command.
+   * - --currentIp
+     - 
+     - false
+     - Flag that adds the IP address from the host that is currently executing the command to the access list. Only applicable for type ipAddress entries. You don't need the entry argument when you use the currentIp option.
    * - -h, --help
      - 
      - false

--- a/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-delete.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-delete.txt
@@ -19,7 +19,7 @@ Syntax
 
 .. code-block::
 
-   atlas organizations apiKeys accessLists delete <ID> [options]
+   atlas organizations apiKeys accessLists delete <entry> [options]
 
 .. Code end marker, please don't delete this comment
 
@@ -34,7 +34,7 @@ Arguments
      - Type
      - Required
      - Description
-   * - ID
+   * - entry
      - string
      - true
      - IP or CIDR address that you want to remove from the access list. If the entry includes a subnet mask, such as 192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-create.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-create.txt
@@ -44,6 +44,10 @@ Options
      - strings
      - false
      - Access list entry in CIDR notation to be added for your API key. To add more than one entry, you can specify each entry with a separate cidr flag or specify all the entries as a comma-separated list using one cidr flag. You can't set both cidr and ip in the same command.
+   * - --currentIp
+     - 
+     - false
+     - Flag that adds the IP address from the host that is currently executing the command to the access list. Only applicable for type ipAddress entries. You don't need the entry argument when you use the currentIp option.
    * - -h, --help
      - 
      - false

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-delete.txt
@@ -19,7 +19,7 @@ Syntax
 
 .. code-block::
 
-   mongocli iam organizations apiKeys accessLists delete <ID> [options]
+   mongocli iam organizations apiKeys accessLists delete <entry> [options]
 
 .. Code end marker, please don't delete this comment
 
@@ -34,7 +34,7 @@ Arguments
      - Type
      - Required
      - Description
-   * - ID
+   * - entry
      - string
      - true
      - IP or CIDR address that you want to remove from the access list. If the entry includes a subnet mask, such as 192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.

--- a/internal/cli/iam/organizations/apikeys/accesslists/create.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/create.go
@@ -51,7 +51,7 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 func (opts *CreateOpts) newAccessListAPIKeysReq() ([]*atlas.AccessListAPIKeysReq, error) {
 	req := make([]*atlas.AccessListAPIKeysReq, 0, len(opts.ips)+len(opts.cidrs))
 	if len(opts.ips) == 0 && len(opts.cidrs) == 0 {
-		return nil, fmt.Errorf("either --, --cidr must be set")
+		return nil, fmt.Errorf("either --%s, --%s must be set", flag.IP, flag.CIDR)
 	}
 	for _, v := range opts.ips {
 		entry := &atlas.AccessListAPIKeysReq{

--- a/internal/cli/iam/organizations/apikeys/accesslists/delete.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/delete.go
@@ -46,19 +46,19 @@ func (opts *DeleteOpts) Run() error {
 	return opts.Delete(opts.store.DeleteOrganizationAPIKeyAccessList, opts.ConfigOrgID(), opts.apiKey)
 }
 
-// mongocli iam organizations|orgs apiKey(s)|apikey(s) accesslist delete <IP> [--orgId orgId] [--apiKey apiKey] --force.
+// DeleteBuilder mongocli iam organizations|orgs apiKey(s)|apikey(s) accesslist delete <IP> [--orgId orgId] [--apiKey apiKey] --force.
 func DeleteBuilder() *cobra.Command {
 	opts := &DeleteOpts{
 		DeleteOpts: cli.NewDeleteOpts("Access list entry '%s' deleted\n", "Access list entry not deleted"),
 	}
 
 	cmd := &cobra.Command{
-		Use:     "delete <ID>",
+		Use:     "delete <entry>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified IP access list entry from your API Key.",
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
-			"IDDesc": "IP or CIDR address that you want to remove from the access list. If the entry includes a subnet mask, such as 192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.",
+			"entryDesc": "IP or CIDR address that you want to remove from the access list. If the entry includes a subnet mask, such as 192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.",
 		},
 		Example: fmt.Sprintf(`  # Remove the IP address 192.0.2.0 from the access list for the API key with the ID 5f24084d8dbffa3ad3f21234 in the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys accessLists delete 192.0.2.0 --apiKey 5f24084d8dbffa3ad3f21234 --orgId 5a1b39eec902201990f12345`, cli.ExampleAtlasEntryPoint()),

--- a/internal/store/ip_info.go
+++ b/internal/store/ip_info.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package store
 
 import (

--- a/test/e2e/iam/org_api_key_access_list_test.go
+++ b/test/e2e/iam/org_api_key_access_list_test.go
@@ -92,7 +92,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 	})
 
 	t.Run("Create Current IP", func(t *testing.T) {
-		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address 44.213.71.46 from access list")
+		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address from access list")
 		cmd := exec.Command(cliPath, iamEntity,
 			orgEntity,
 			apiKeysEntity,
@@ -115,7 +115,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address 44.213.71.46 from access list")
+		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address from access list")
 		deleteAccessListEntry(t, cliPath, entry, apiKeyID)
 	})
 }

--- a/test/e2e/iam/org_api_key_access_list_test.go
+++ b/test/e2e/iam/org_api_key_access_list_test.go
@@ -92,6 +92,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 	})
 
 	t.Run("Create Current IP", func(t *testing.T) {
+		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address 44.213.71.46 from access list")
 		cmd := exec.Command(cliPath, iamEntity,
 			orgEntity,
 			apiKeysEntity,
@@ -114,6 +115,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
+		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address 44.213.71.46 from access list")
 		deleteAccessListEntry(t, cliPath, entry, apiKeyID)
 	})
 }

--- a/test/e2e/iam/org_api_key_access_list_test.go
+++ b/test/e2e/iam/org_api_key_access_list_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build e2e || iam
 
 package iam_test
@@ -24,25 +25,20 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
 func TestOrgAPIKeyAccessList(t *testing.T) {
 	cliPath, er := e2e.Bin()
-	if er != nil {
-		t.Fatalf("unexpected error: %v", er)
-	}
+	require.NoError(t, er)
 
 	apiKeyID, e := createOrgAPIKey()
-	if e != nil {
-		t.Fatalf("unexpected error: %v", e)
-	}
+	require.NoError(t, e)
 
-	defer func() {
-		if e := deleteOrgAPIKey(apiKeyID); e != nil {
-			t.Errorf("error deleting test apikey: %v", e)
-		}
-	}()
+	t.Cleanup(func() {
+		require.NoError(t, deleteOrgAPIKey(apiKeyID))
+	})
 
 	n, err := e2e.RandInt(255)
 	if err != nil {
@@ -92,21 +88,52 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
-			iamEntity,
+		deleteAccessListEntry(t, cliPath, entry, apiKeyID)
+	})
+
+	t.Run("Create Current IP", func(t *testing.T) {
+		cmd := exec.Command(cliPath, iamEntity,
 			orgEntity,
 			apiKeysEntity,
 			apiKeyAccessListEntity,
-			"rm",
-			entry,
+			"create",
 			"--apiKey",
 			apiKeyID,
-			"--force")
+			"--currentIp",
+			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		if assert.NoError(t, err, string(resp)) {
-			expected := fmt.Sprintf("Access list entry '%s' deleted\n", entry)
-			assert.Equal(t, string(resp), expected)
+		a := assert.New(t)
+		if a.NoError(err, string(resp)) {
+			var key mongodbatlas.AccessListAPIKeys
+			if err := json.Unmarshal(resp, &key); a.NoError(err) {
+				a.NotEmpty(key.Results)
+				entry = key.Results[0].IPAddress
+			}
 		}
 	})
+
+	t.Run("Delete", func(t *testing.T) {
+		deleteAccessListEntry(t, cliPath, entry, apiKeyID)
+	})
+}
+
+func deleteAccessListEntry(t *testing.T, cliPath, entry, apiKeyID string) {
+	t.Helper()
+	cmd := exec.Command(cliPath,
+		iamEntity,
+		orgEntity,
+		apiKeysEntity,
+		apiKeyAccessListEntity,
+		"rm",
+		entry,
+		"--apiKey",
+		apiKeyID,
+		"--force")
+	cmd.Env = os.Environ()
+	resp, err := cmd.CombinedOutput()
+	if assert.NoError(t, err, string(resp)) {
+		expected := fmt.Sprintf("Access list entry '%s' deleted\n", entry)
+		assert.Equal(t, string(resp), expected)
+	}
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-161161


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

Manually tested, adding e2e has a limitation as the backend won't let you remove the callers IP address 
