### PR TITLE
Adds a required role and preps other existing long text

### DIFF
--- a/docs/atlascli/command/atlas-accessLists-create.txt
+++ b/docs/atlascli/command/atlas-accessLists-create.txt
@@ -18,6 +18,8 @@ The access list can contain trusted IP addresses, AWS security group IDs, and en
 		
 The command doesn't overwrite existing entries in the access list. Instead, it adds the new entries to the list of entries.
 
+To use this command, you must authenticate with a user account or an API key that has the Read Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-events-organizations-list.txt
+++ b/docs/atlascli/command/atlas-events-organizations-list.txt
@@ -14,8 +14,6 @@ atlas events organizations list
 
 Return all events for the specified organization.
 
-Your API Key must have the Org Member role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-events-projects-list.txt
+++ b/docs/atlascli/command/atlas-events-projects-list.txt
@@ -14,8 +14,6 @@ atlas events projects list
 
 Return all events for the specified project.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-kubernetes-config-generate.txt
+++ b/docs/atlascli/command/atlas-kubernetes-config-generate.txt
@@ -14,9 +14,7 @@ atlas kubernetes config generate
 
 Generate Kubernetes configuration resources.
 
-This command provides your Kubernetes configuration access to Atlas.
-		
-		You can generate Atlas Operator resources for Atlas objects, including Projects, Deployments, and Users.
+This command provides your Kubernetes configuration access to Atlas. You can generate Atlas Operator resources for Atlas objects, including Projects, Deployments, and Users.
 
 Syntax
 ------

--- a/docs/atlascli/command/atlas-kubernetes-config-generate.txt
+++ b/docs/atlascli/command/atlas-kubernetes-config-generate.txt
@@ -14,7 +14,9 @@ atlas kubernetes config generate
 
 Generate Kubernetes configuration resources.
 
-This command provides your Kubernetes configuration access to Atlas. You can generate Atlas Operator resources for Atlas objects, including Projects, Deployments, and Users.
+This command provides your Kubernetes configuration access to Atlas.
+		
+		You can generate Atlas Operator resources for Atlas objects, including Projects, Deployments, and Users.
 
 Syntax
 ------

--- a/docs/atlascli/command/atlas-liveMigrations-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-create.txt
@@ -15,8 +15,6 @@ atlas liveMigrations create
 Create a new push live migration.
 
 To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax
 ------

--- a/docs/atlascli/command/atlas-liveMigrations-cutover.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-cutover.txt
@@ -15,8 +15,6 @@ atlas liveMigrations cutover
 Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
 
 To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax
 ------

--- a/docs/atlascli/command/atlas-liveMigrations-describe.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-describe.txt
@@ -14,8 +14,6 @@ atlas liveMigrations describe
 
 Return a push live migration job.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-liveMigrations-link-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-link-create.txt
@@ -15,8 +15,6 @@ atlas liveMigrations link create
 Create a new link-token for a push live migration.
 
 To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax
 ------

--- a/docs/atlascli/command/atlas-liveMigrations-link-delete.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-link-delete.txt
@@ -14,8 +14,6 @@ atlas liveMigrations link delete
 
 Delete one link-token.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
@@ -15,8 +15,6 @@ atlas liveMigrations validation create
 Create a new validation request for a push live migration.
 
 To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax
 ------

--- a/docs/atlascli/command/atlas-liveMigrations-validation-describe.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation-describe.txt
@@ -14,8 +14,6 @@ atlas liveMigrations validation describe
 
 Return one validation job.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-create.txt
+++ b/docs/atlascli/command/atlas-serverless-create.txt
@@ -14,8 +14,6 @@ atlas serverless create
 
 Creates one serverless instance in the specified project.
 
-Your API Key must have the Organization Owner or Project Owner role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-delete.txt
+++ b/docs/atlascli/command/atlas-serverless-delete.txt
@@ -14,8 +14,6 @@ atlas serverless delete
 
 Remove a serverless instance from your project.
 
-Your API Key must have the Organization Owner or Project Owner role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-describe.txt
+++ b/docs/atlascli/command/atlas-serverless-describe.txt
@@ -14,8 +14,6 @@ atlas serverless describe
 
 Return one serverless instance in the specified project.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-list.txt
+++ b/docs/atlascli/command/atlas-serverless-list.txt
@@ -14,8 +14,6 @@ atlas serverless list
 
 Return all serverless instances in the specified project.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-watch.txt
+++ b/docs/atlascli/command/atlas-serverless-watch.txt
@@ -14,7 +14,6 @@ atlas serverless watch
 
 Monitor the status of serverless instance.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
 This command checks the serverless instance's state periodically until the instance reaches an IDLE state. 
 Once the instance reaches the expected state, the command prints "Instance available."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes idle.

--- a/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-create.txt
@@ -18,6 +18,8 @@ The access list can contain trusted IP addresses, AWS security group IDs, and en
 		
 The command doesn't overwrite existing entries in the access list. Instead, it adds the new entries to the list of entries.
 
+To use this command, you must authenticate with a user account or an API key that has the Read Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-events-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-events-organizations-list.txt
@@ -14,8 +14,6 @@ mongocli atlas events organizations list
 
 Return all events for the specified organization.
 
-Your API Key must have the Org Member role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-events-projects-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-events-projects-list.txt
@@ -14,8 +14,6 @@ mongocli atlas events projects list
 
 Return all events for the specified project.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
@@ -15,8 +15,6 @@ mongocli atlas liveMigrations create
 Create a new push live migration.
 
 To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax
 ------

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-cutover.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-cutover.txt
@@ -15,8 +15,6 @@ mongocli atlas liveMigrations cutover
 Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.
 
 To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax
 ------

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-describe.txt
@@ -14,8 +14,6 @@ mongocli atlas liveMigrations describe
 
 Return a push live migration job.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-link-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-link-create.txt
@@ -15,8 +15,6 @@ mongocli atlas liveMigrations link create
 Create a new link-token for a push live migration.
 
 To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax
 ------

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-link-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-link-delete.txt
@@ -14,8 +14,6 @@ mongocli atlas liveMigrations link delete
 
 Delete one link-token.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
@@ -15,8 +15,6 @@ mongocli atlas liveMigrations validation create
 Create a new validation request for a push live migration.
 
 To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.
 
 Syntax
 ------

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-describe.txt
@@ -14,8 +14,6 @@ mongocli atlas liveMigrations validation describe
 
 Return one validation job.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-create.txt
@@ -14,8 +14,6 @@ mongocli atlas serverless create
 
 Creates one serverless instance in the specified project.
 
-Your API Key must have the Organization Owner or Project Owner role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-delete.txt
@@ -14,8 +14,6 @@ mongocli atlas serverless delete
 
 Remove a serverless instance from your project.
 
-Your API Key must have the Organization Owner or Project Owner role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-describe.txt
@@ -14,8 +14,6 @@ mongocli atlas serverless describe
 
 Return one serverless instance in the specified project.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-list.txt
@@ -14,8 +14,6 @@ mongocli atlas serverless list
 
 Return all serverless instances in the specified project.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
@@ -14,7 +14,6 @@ mongocli atlas serverless watch
 
 Monitor the status of serverless instance.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
 This command checks the serverless instance's state periodically until the instance reaches an IDLE state. 
 Once the instance reaches the expected state, the command prints "Instance available."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes idle.

--- a/docs/mongocli/command/mongocli-cloud-manager-events-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-events-organizations-list.txt
@@ -14,8 +14,6 @@ mongocli cloud-manager events organizations list
 
 Return all events for the specified organization.
 
-Your API Key must have the Org Member role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-events-projects-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-events-projects-list.txt
@@ -14,8 +14,6 @@ mongocli cloud-manager events projects list
 
 Return all events for the specified project.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-liveMigrations-link-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-liveMigrations-link-create.txt
@@ -14,8 +14,6 @@ mongocli cloud-manager liveMigrations link create
 
 Create one new organization link.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-liveMigrations-link-delete.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-liveMigrations-link-delete.txt
@@ -14,8 +14,6 @@ mongocli cloud-manager liveMigrations link delete
 
 Delete one link-token.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-liveMigrations-link-describe.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-liveMigrations-link-describe.txt
@@ -14,8 +14,6 @@ mongocli cloud-manager liveMigrations link describe
 
 Return the status of the connection between the specified source organization and the target MongoDB Atlas organization.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-events-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-events-organizations-list.txt
@@ -14,8 +14,6 @@ mongocli ops-manager events organizations list
 
 Return all events for the specified organization.
 
-Your API Key must have the Org Member role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-events-projects-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-events-projects-list.txt
@@ -14,8 +14,6 @@ mongocli ops-manager events projects list
 
 Return all events for the specified project.
 
-Your API Key must have the Project Read Only role to successfully call this resource.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-liveMigrations-link-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-liveMigrations-link-create.txt
@@ -14,8 +14,6 @@ mongocli ops-manager liveMigrations link create
 
 Create one new organization link.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-liveMigrations-link-delete.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-liveMigrations-link-delete.txt
@@ -14,8 +14,6 @@ mongocli ops-manager liveMigrations link delete
 
 Delete one link-token.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-liveMigrations-link-describe.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-liveMigrations-link-describe.txt
@@ -14,8 +14,6 @@ mongocli ops-manager liveMigrations link describe
 
 Return the status of the connection between the specified source organization and the target MongoDB Atlas organization.
 
-Your API Key must have the Organization Owner role to successfully run this command.
-
 Syntax
 ------
 

--- a/internal/cli/atlas/accesslists/create.go
+++ b/internal/cli/atlas/accesslists/create.go
@@ -136,7 +136,9 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create an IP access list entry for your project.",
 		Long: `The access list can contain trusted IP addresses, AWS security group IDs, and entries in Classless Inter-Domain Routing (CIDR) notation. You can add only one access list entry at a time. You can create one access list per project. 
 		
-The command doesn't overwrite existing entries in the access list. Instead, it adds the new entries to the list of entries.`,
+The command doesn't overwrite existing entries in the access list. Instead, it adds the new entries to the list of entries.
+
+` + fmt.Sprintf(usage.RequiredRole, "Read Write"),
 		Args: require.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"entryDesc": "IP address, CIDR address, or AWS security group ID that you want to add to the access list.",

--- a/internal/cli/atlas/accesslists/delete.go
+++ b/internal/cli/atlas/accesslists/delete.go
@@ -54,7 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <entry>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified IP access list entry from your project.",
-		Long:    "The command prompts you to confirm the operation when you run the command without the force option.",
+		Long:    `The command prompts you to confirm the operation when you run the command without the force option.`,
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"entryDesc": "The IP address, CIDR address, or AWS security group ID that you want to remove from the access list.",

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -140,7 +140,7 @@ func StartBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:       fmt.Sprintf("start <%s|%s|%s>", automatedRestore, downloadRestore, pointInTimeRestore),
 		Short:     "Start a restore job for your project and cluster.",
-		Long:      "If you create an automated or pointInTime restore job, Atlas removes all existing data on the target cluster prior to the restore.",
+		Long:      `If you create an automated or pointInTime restore job, Atlas removes all existing data on the target cluster prior to the restore.`,
 		Args:      require.ExactValidArgs(1),
 		ValidArgs: []string{automatedRestore, downloadRestore, pointInTimeRestore},
 		Annotations: map[string]string{

--- a/internal/cli/atlas/backup/schedule/update.go
+++ b/internal/cli/atlas/backup/schedule/update.go
@@ -349,7 +349,7 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update",
 		Aliases: []string{"updates"},
 		Short:   "Modify the backup schedule for the specified cluster for your project.",
-		Long:    "The backup schedule defines when MongoDB takes scheduled snapshots and how long it stores those snapshots.",
+		Long:    `The backup schedule defines when MongoDB takes scheduled snapshots and how long it stores those snapshots.`,
 		Example: fmt.Sprintf(`  # Update a snapshot backup policy for a cluster named Cluster0 to back up snapshots every 6 hours and, retain for 7 days, and update retention of previously-taken snapshots:
   %[1]s backup schedule update --clusterName Cluster0 --updateSnapshots --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7
   

--- a/internal/cli/atlas/backup/snapshots/create.go
+++ b/internal/cli/atlas/backup/snapshots/create.go
@@ -74,7 +74,7 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create <clusterName>",
 		Aliases: []string{"take"},
 		Short:   "Create a backup snapshot for your project and cluster.",
-		Long:    "You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.",
+		Long:    `You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.`,
 		Args:    require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Create a backup snapshot for the cluster named myDemo that Atlas retains for 30 days:
   %s backups snapshots create myDemo --desc "test" --retention 30`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/clusters/clusters.go
+++ b/internal/cli/atlas/clusters/clusters.go
@@ -41,7 +41,7 @@ func MongoCLIBuilder() *cobra.Command {
 		Aliases:    cli.GenerateAliases(use),
 		SuggestFor: []string{"replicasets"},
 		Short:      "Manage clusters for your project.",
-		Long:       "The clusters command provides access to your cluster configurations. You can create, edit, and delete clusters.",
+		Long:       `The clusters command provides access to your cluster configurations. You can create, edit, and delete clusters.`,
 	}
 	cmd.AddCommand(
 		ListBuilder(),
@@ -69,7 +69,7 @@ func Builder() *cobra.Command {
 		Aliases:    cli.GenerateAliases(use),
 		SuggestFor: []string{"replicasets"},
 		Short:      "Manage clusters for your project.",
-		Long:       "The clusters command provides access to your cluster configurations. You can create, edit, and delete clusters.",
+		Long:       `The clusters command provides access to your cluster configurations. You can create, edit, and delete clusters.`,
 	}
 	cmd.AddCommand(
 		ListBuilder(),

--- a/internal/cli/atlas/clusters/upgrade.go
+++ b/internal/cli/atlas/clusters/upgrade.go
@@ -116,7 +116,7 @@ func UpgradeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade [clusterName]",
 		Short: "Upgrade a shared cluster's tier, disk size, and/or MongoDB version.",
-		Long:  "This command is unavailable for dedicated clusters.",
+		Long:  `This command is unavailable for dedicated clusters.`,
 		Example: fmt.Sprintf(`  # Upgrade the tier, disk size, and MongoDB version for the shared cluster named myCluster in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s cluster upgrade myCluster --projectId 5e2211c17a3e5a48f5497de3 --tier M50 --diskSizeGB 20 --mdbVersion 4.2`,
 			cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/datalake/create.go
+++ b/internal/cli/atlas/datalake/create.go
@@ -76,7 +76,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a new federated database instance for your project.",
-		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
+		Long:  `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to create.",

--- a/internal/cli/atlas/datalake/data_lake.go
+++ b/internal/cli/atlas/datalake/data_lake.go
@@ -25,7 +25,7 @@ func Builder() *cobra.Command {
 		Use:     use,
 		Aliases: cli.GenerateAliases(use),
 		Short:   "Manage Atlas Data Lakes for your project.",
-		Long:    "The datalakes command provides access to your project data lakes. You can create, edit, and delete data lakes.",
+		Long:    `The datalakes command provides access to your project data lakes. You can create, edit, and delete data lakes.`,
 	}
 
 	cmd.AddCommand(

--- a/internal/cli/atlas/datalake/delete.go
+++ b/internal/cli/atlas/datalake/delete.go
@@ -54,7 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <name>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a federated database instance from your project.",
-		Long:    "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
+		Long:    `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to delete.",

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -61,7 +61,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <name>",
 		Short: "Return the details for the specified federated database instance.",
-		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
+		Long:  `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to retrieve.",

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -61,7 +61,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all federated database instances for your project.",
-		Long:    "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
+		Long:    `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all federated database instances in the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/atlas/datalake/update.go
+++ b/internal/cli/atlas/datalake/update.go
@@ -90,7 +90,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <name>",
 		Short: "Modify the specified federated database instance for your project.",
-		Long:  "To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.",
+		Long:  `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to update.",

--- a/internal/cli/atlas/integrations/create/ops_genie.go
+++ b/internal/cli/atlas/integrations/create/ops_genie.go
@@ -71,7 +71,7 @@ func OpsGenieBuilder() *cobra.Command {
 		Use:     opsGenieType,
 		Aliases: []string{"ops_genie", "opsGenie"},
 		Short:   "Create or update an Opsgenie integration for your project.",
-		Long:    "The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Opsgenie.",
+		Long:    `The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Opsgenie.`,
 		Example: fmt.Sprintf(`  # Integrate Opsgenie with Atlas for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create OPS_GENIE --apiKey a1a23bcdef45ghijk6789 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/integrations/create/pager_duty.go
+++ b/internal/cli/atlas/integrations/create/pager_duty.go
@@ -69,7 +69,7 @@ func PagerDutyBuilder() *cobra.Command {
 		Use:     pagerDutyIntegrationType,
 		Aliases: []string{"pager_duty", "pagerDuty"},
 		Short:   "Create or update a PagerDuty integration for your project.",
-		Long:    "The requesting API key must have the Organization Owner or Project Owner role to configure an integration with PagerDuty.",
+		Long:    `The requesting API key must have the Organization Owner or Project Owner role to configure an integration with PagerDuty.`,
 		Example: fmt.Sprintf(`  # Integrate PagerDuty with Atlas for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create PAGER_DUTY --serviceKey a1a23bcdef45ghijk6789 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/integrations/create/webhook.go
+++ b/internal/cli/atlas/integrations/create/webhook.go
@@ -71,7 +71,7 @@ func WebhookBuilder() *cobra.Command {
 		Use:     webhookIntegrationType,
 		Aliases: []string{"webhook"},
 		Short:   "Create or update a webhook integration for your project.",
-		Long:    "The requesting API key must have the Organization Owner or Project Owner role to configure a webhook integration.",
+		Long:    `The requesting API key must have the Organization Owner or Project Owner role to configure a webhook integration.`,
 		Example: fmt.Sprintf(`  # Integrate a webhook with Atlas that uses the secret mySecret for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create WEBHOOK --url http://9b4ac7aa.abc.io/payload --secret mySecret --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/integrations/delete.go
+++ b/internal/cli/atlas/integrations/delete.go
@@ -54,7 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <integrationType>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified third-party integration from your project.",
-		Long:    "Deleting an integration from a project removes that integration configuration only for that project. This does not affect any other project or organization's configured integrations.",
+		Long:    `Deleting an integration from a project removes that integration configuration only for that project. This does not affect any other project or organization's configured integrations.`,
 		Args:    require.ExactValidArgs(1),
 		Example: fmt.Sprintf(`  # Remove the Datadog integration for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations delete DATADOG --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/kubernetes/config/config.go
+++ b/internal/cli/atlas/kubernetes/config/config.go
@@ -23,7 +23,7 @@ func Builder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   use,
 		Short: "Manage Kubernetes configuration resources.",
-		Long:  "This command provides your Kubernetes configuration access to Atlas.",
+		Long:  `This command provides your Kubernetes configuration access to Atlas.`,
 	}
 
 	cmd.AddCommand(GenerateBuilder())

--- a/internal/cli/atlas/kubernetes/config/generate.go
+++ b/internal/cli/atlas/kubernetes/config/generate.go
@@ -107,9 +107,7 @@ func GenerateBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Aliases: cli.GenerateAliases(use),
 		Short:   "Generate Kubernetes configuration resources.",
-		Long: `This command provides your Kubernetes configuration access to Atlas.
-		
-		You can generate Atlas Operator resources for Atlas objects, including Projects, Deployments, and Users.`,
+		Long:    `This command provides your Kubernetes configuration access to Atlas. You can generate Atlas Operator resources for Atlas objects, including Projects, Deployments, and Users.`,
 		Example: `# Export Project, DatabaseUsers resources for a specific project without connection and integration secrets:
   atlas kubernetes config generate --projectId=<projectId>
 

--- a/internal/cli/atlas/kubernetes/config/generate.go
+++ b/internal/cli/atlas/kubernetes/config/generate.go
@@ -107,8 +107,9 @@ func GenerateBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Aliases: cli.GenerateAliases(use),
 		Short:   "Generate Kubernetes configuration resources.",
-		Long: "This command provides your Kubernetes configuration access to Atlas. " +
-			"You can generate Atlas Operator resources for Atlas objects, including Projects, Deployments, and Users.",
+		Long: `This command provides your Kubernetes configuration access to Atlas.
+		
+		You can generate Atlas Operator resources for Atlas objects, including Projects, Deployments, and Users.`,
 		Example: `# Export Project, DatabaseUsers resources for a specific project without connection and integration secrets:
   atlas kubernetes config generate --projectId=<projectId>
 

--- a/internal/cli/atlas/kubernetes/kubernetes.go
+++ b/internal/cli/atlas/kubernetes/kubernetes.go
@@ -24,7 +24,7 @@ func Builder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   use,
 		Short: "Manage kubernetes resources.",
-		Long:  "The kubernetes command provides access to kubernetes features of the atlas.",
+		Long:  `The kubernetes command provides access to kubernetes features of the atlas.`,
 	}
 
 	cmd.AddCommand(config.Builder())

--- a/internal/cli/atlas/livemigrations/create.go
+++ b/internal/cli/atlas/livemigrations/create.go
@@ -60,9 +60,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new push live migration.",
-		Long: `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.`,
+		Long:  `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),

--- a/internal/cli/atlas/livemigrations/cutover.go
+++ b/internal/cli/atlas/livemigrations/cutover.go
@@ -57,9 +57,7 @@ func CutoverBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cutover",
 		Short: "Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.",
-		Long: `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.`,
+		Long:  `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/livemigrations/describe.go
+++ b/internal/cli/atlas/livemigrations/describe.go
@@ -59,7 +59,6 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return a push live migration job.",
-		Long:    "Your API Key must have the Organization Owner role to successfully run this command.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),

--- a/internal/cli/atlas/livemigrations/link/create.go
+++ b/internal/cli/atlas/livemigrations/link/create.go
@@ -66,9 +66,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new link-token for a push live migration.",
-		Long: `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.`,
+		Long:  `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/atlas/livemigrations/link/delete.go
+++ b/internal/cli/atlas/livemigrations/link/delete.go
@@ -52,7 +52,6 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete",
 		Aliases: []string{"rm"},
 		Short:   "Delete one link-token.",
-		Long:    "Your API Key must have the Organization Owner role to successfully run this command.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/atlas/livemigrations/validation/create.go
+++ b/internal/cli/atlas/livemigrations/validation/create.go
@@ -60,9 +60,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new validation request for a push live migration.",
-		Long: `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.
-		
-Your API Key must have the Organization Owner role to successfully run this command.`,
+		Long:  `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),

--- a/internal/cli/atlas/livemigrations/validation/describe.go
+++ b/internal/cli/atlas/livemigrations/validation/describe.go
@@ -61,7 +61,6 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return one validation job.",
-		Long:    "Your API Key must have the Organization Owner role to successfully run this command.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/privateendpoints/aws/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/create.go
@@ -70,7 +70,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new AWS private endpoint for your project.",
-		Long:  "To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.",
+		Long:  `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.`,
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Create a private endpoint connection for AWS in the us-east-1 region for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws create --region us-east-1 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
@@ -68,7 +68,7 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create <endpointServiceId>",
 		Aliases: []string{"add"},
 		Short:   "Create a new interface for the specified AWS private endpoint.",
-		Long:    "To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.",
+		Long:    `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.`,
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"endpointServiceIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",

--- a/internal/cli/atlas/privateendpoints/azure/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/create.go
@@ -70,7 +70,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new Azure private endpoint for your project.",
-		Long:  "To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.",
+		Long:  `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.`,
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Create a private endpoint connection for Azure in the eastus region for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure create --region eastus --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
@@ -70,7 +70,7 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create <endpointServiceId>",
 		Aliases: []string{"add"},
 		Short:   "Create a new interface for the specified Azure private endpoint.",
-		Long:    "To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.",
+		Long:    `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.`,
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"endpointServiceIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
@@ -61,7 +61,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return the regionalized private endpoint setting for your project.",
-		Long:    "Use this command to check whether you can create multiple private resources per region.",
+		Long:    `Use this command to check whether you can create multiple private resources per region.`,
 		Example: fmt.Sprintf(`  # Return the regionalized private endpoint setting for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
@@ -56,7 +56,7 @@ func DisableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable the regionalized private endpoint setting for your project.",
-		Long:  "This disables the ability to create multiple private resources per region in all cloud service providers for this project.",
+		Long:  `This disables the ability to create multiple private resources per region in all cloud service providers for this project.`,
 		Example: fmt.Sprintf(`  # Disable the regionalied private endpoint setting in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes disable --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
@@ -56,7 +56,7 @@ func EnableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Enable the regionalized private endpoint setting for your project.",
-		Long:  "This enables the ability to create multiple private resources per region in all cloud service providers for this project.",
+		Long:  `This enables the ability to create multiple private resources per region in all cloud service providers for this project.`,
 		Example: fmt.Sprintf(`  # Enable the regionalied private endpoint setting in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes enable --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -534,7 +534,7 @@ func Builder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "quickstart",
 		Short: "Create, configure, and connect to an Atlas cluster for your project.",
-		Long:  "This command creates a new cluster, adds your public IP to the Atlas access list, creates a database user to access your new MongoDB instance, loads sample data, and connects to the new cluster using Mongosh.",
+		Long:  `This command creates a new cluster, adds your public IP to the Atlas access list, creates a database user to access your new MongoDB instance, loads sample data, and connects to the new cluster using Mongosh.`,
 		Example: fmt.Sprintf(`  # Create a Google Cloud cluster named Test with a database user named dbuserTest, add your current IP address to the access list, load sample data, and connect using Mongosh:
   %[1]s quickstart --clusterName Test --provider GCP --username dbuserTest --currentIp
 		

--- a/internal/cli/atlas/security/customercerts/create.go
+++ b/internal/cli/atlas/security/customercerts/create.go
@@ -70,7 +70,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Saves a customer-managed X.509 configuration for your project.",
-		Long:  "Saving a customer-managed X.509 configuration triggers a rolling restart.",
+		Long:  `Saving a customer-managed X.509 configuration triggers a rolling restart.`,
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Save the file named ca.pem stored in the files directory to the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts create --casFile files/ca.pem --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/security/customercerts/disable.go
+++ b/internal/cli/atlas/security/customercerts/disable.go
@@ -72,7 +72,7 @@ func DisableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Clear customer-managed X.509 settings on a project, including the uploaded Certificate Authority, and disable self-managed X.509.",
-		Long:  "Disabling customer-managed X.509 triggers a rolling restart.",
+		Long:  `Disabling customer-managed X.509 triggers a rolling restart.`,
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Disable the customer-managed X.509 configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts disable --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/serverless/create.go
+++ b/internal/cli/atlas/serverless/create.go
@@ -77,7 +77,6 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <instanceName>",
 		Short: "Creates one serverless instance in the specified project.",
-		Long:  "Your API Key must have the Organization Owner or Project Owner role to successfully call this resource.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Human-readable label that identifies your serverless instance.",

--- a/internal/cli/atlas/serverless/delete.go
+++ b/internal/cli/atlas/serverless/delete.go
@@ -53,7 +53,6 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <instanceName>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a serverless instance from your project.",
-		Long:    "Your API Key must have the Organization Owner or Project Owner role to successfully call this resource.",
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Name of the instance to delete.",

--- a/internal/cli/atlas/serverless/describe.go
+++ b/internal/cli/atlas/serverless/describe.go
@@ -59,7 +59,6 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <instanceName>",
 		Short: "Return one serverless instance in the specified project.",
-		Long:  "Your API Key must have the Project Read Only role to successfully call this resource.",
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Human-readable label that identifies your serverless instance.",

--- a/internal/cli/atlas/serverless/list.go
+++ b/internal/cli/atlas/serverless/list.go
@@ -61,7 +61,6 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all serverless instances in the specified project.",
-		Long:    "Your API Key must have the Project Read Only role to successfully call this resource.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/serverless/serverless.go
+++ b/internal/cli/atlas/serverless/serverless.go
@@ -24,7 +24,7 @@ func Builder() *cobra.Command {
 		Use:     use,
 		Aliases: []string{"sl"},
 		Short:   "Manage serverless instances for your project.",
-		Long:    "The serverless command provides access to your serverless instance configurations. You can create, edit, and delete serverless instances.",
+		Long:    `The serverless command provides access to your serverless instance configurations. You can create, edit, and delete serverless instances.`,
 	}
 	cmd.AddCommand(
 		ListBuilder(),

--- a/internal/cli/atlas/serverless/watch.go
+++ b/internal/cli/atlas/serverless/watch.go
@@ -64,8 +64,7 @@ func WatchBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "watch <instanceName>",
 		Short: "Monitor the status of serverless instance.",
-		Long: `Your API Key must have the Project Read Only role to successfully call this resource.
-This command checks the serverless instance's state periodically until the instance reaches an IDLE state. 
+		Long: `This command checks the serverless instance's state periodically until the instance reaches an IDLE state. 
 Once the instance reaches the expected state, the command prints "Instance available."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes idle.
 You can interrupt the command's polling at any time with CTRL-C.`,

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -134,7 +134,7 @@ func Builder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup",
 		Short: "Register, authenticate, create, and access an Atlas cluster.",
-		Long:  "This command takes you through registration, login, default profile creation, creating your first free tier cluster and connecting to it using MongoDB Shell.",
+		Long:  `This command takes you through registration, login, default profile creation, creating your first free tier cluster and connecting to it using MongoDB Shell.`,
 		Example: `  # Override default cluster settings like name, provider, or database username by using the command options
   atlas setup --clusterName Test --provider GCP --username dbuserTest`,
 		Hidden: false,

--- a/internal/cli/config/list.go
+++ b/internal/cli/config/list.go
@@ -43,7 +43,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return a list of available profiles by name.",
-		Long:    "If you did not specify a name for your profile, it displays as the default profile.",
+		Long:    `If you did not specify a name for your profile, it displays as the default profile.`,
 		Example: fmt.Sprintf("  %s config ls", config.BinName()),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			o.OutWriter = cmd.OutOrStdout()

--- a/internal/cli/events/orgs_list.go
+++ b/internal/cli/events/orgs_list.go
@@ -70,7 +70,6 @@ func OrgListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all events for the specified organization.",
-		Long:    "Your API Key must have the Org Member role to successfully call this resource.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of events for the organization with the ID 5dd5a6b6f10fab1d71a58495:

--- a/internal/cli/events/projects_list.go
+++ b/internal/cli/events/projects_list.go
@@ -70,7 +70,6 @@ func ProjectListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all events for the specified project.",
-		Long:    "Your API Key must have the Project Read Only role to successfully call this resource.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of events for the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/iam/organizations/apikeys/create.go
+++ b/internal/cli/iam/organizations/apikeys/create.go
@@ -72,7 +72,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an API Key for your organization.",
-		Long:  "MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.",
+		Long:  `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.`,
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Create an organization API key with organization owner access in the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys create --role ORG_OWNER --desc "My API Key" --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/organizations/delete.go
+++ b/internal/cli/iam/organizations/delete.go
@@ -53,7 +53,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified organization.",
-		Long:    "Organizations with active projects can't be removed.",
+		Long:    `Organizations with active projects can't be removed.`,
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the organization.",

--- a/internal/cli/iam/organizations/invitations/update.go
+++ b/internal/cli/iam/organizations/invitations/update.go
@@ -78,7 +78,7 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update [invitationId]",
 		Aliases: []string{"updates"},
 		Short:   "Modifies the details of the specified pending invitation to your organization.",
-		Long:    "You can use either the invitation ID or the user's email address to specify the invitation.",
+		Long:    `You can use either the invitation ID or the user's email address to specify the invitation.`,
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",
 		},

--- a/internal/cli/iam/projects/apikeys/create.go
+++ b/internal/cli/iam/projects/apikeys/create.go
@@ -69,7 +69,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an organization API key and assign it to your project.",
-		Long:  "MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.",
+		Long:  `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.`,
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Create an organization API key with the ORG_OWNER role and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role ORG_OWNER --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/projects/create.go
+++ b/internal/cli/iam/projects/create.go
@@ -145,7 +145,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <projectName>",
 		Short: "Create a project in your organization.",
-		Long:  "Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings.",
+		Long:  `Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings.`,
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"projectNameDesc": "Label that identifies the project.",

--- a/internal/cli/iam/projects/invitations/update.go
+++ b/internal/cli/iam/projects/invitations/update.go
@@ -78,7 +78,7 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update [invitationId]",
 		Aliases: []string{"updates"},
 		Short:   "Modifies the details of the specified pending invitation to your project.",
-		Long:    "You can use either the invitation ID or the user's email address to specify the invitation.",
+		Long:    `You can use either the invitation ID or the user's email address to specify the invitation.`,
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",
 		},

--- a/internal/cli/iam/projects/teams/add.go
+++ b/internal/cli/iam/projects/teams/add.go
@@ -71,7 +71,7 @@ func AddBuilder() *cobra.Command {
 		Use:   "add <teamId>",
 		Args:  require.ExactArgs(1),
 		Short: "Add the specified team to your project.",
-		Long:  "All members of the team share the same project access.",
+		Long:  `All members of the team share the same project access.`,
 		Annotations: map[string]string{
 			"teamIdDesc": "Unique 24-digit string that identifies the team.",
 		},

--- a/internal/cli/iam/projects/teams/delete.go
+++ b/internal/cli/iam/projects/teams/delete.go
@@ -54,7 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <teamId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified team from your project.",
-		Long:    "After you remove a team from your project, the team still exists in the organization in which it was created.",
+		Long:    `After you remove a team from your project, the team still exists in the organization in which it was created.`,
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"teamIdDesc": "Unique 24-digit string that identifies the team.",

--- a/internal/cli/iam/projects/users/delete.go
+++ b/internal/cli/iam/projects/users/delete.go
@@ -54,7 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified user from your project.",
-		Long:    "After you remove a user from your project, the user still exists in the organization in which it was created.",
+		Long:    `After you remove a user from your project, the user still exists in the organization in which it was created.`,
 		Args:    require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Remove the user with the ID 5dd58c647a3e5a6c5bce46c7 from the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects users delete 5dd58c647a3e5a6c5bce46c7 --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -91,7 +91,7 @@ func DescribeBuilder() *cobra.Command {
   # Return the JSON-formatted details for the the team with the name myTeam in the organization with ID 5e2211c17a3e5a48f5497de3:
   %[1]s teams describe --name myTeam --projectId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Short: "Return the details for the specified team for your organization.",
-		Long:  "You can return the details for a team using the team's ID or the team's name. You must specify either the id option or the name option.",
+		Long:  `You can return the details for a team using the team's ID or the team's name. You must specify either the id option or the name option.`,
 		Args:  require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/iam/teams/users/add.go
+++ b/internal/cli/iam/teams/users/add.go
@@ -61,7 +61,7 @@ func AddBuilder() *cobra.Command {
 		Use:   "add <userId>...",
 		Args:  require.MinimumNObjectIDArgs(1),
 		Short: "Add the specified MongoDB user to a team for your organization.",
-		Long:  "Users must be current members of your organization before you can add them to a team.",
+		Long:  `Users must be current members of your organization before you can add them to a team.`,
 		Annotations: map[string]string{
 			"userIdDesc": "Unique 24-digit string that identifies the user. You can add more than one user at a time by specifying multiple user IDs separated by a space.",
 		},

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -91,7 +91,7 @@ func DescribeBuilder() *cobra.Command {
   # Return the JSON-formatted details for the MongoDB user with the username myUser:
   %[1]s users describe --username myUser --output json`, cli.ExampleAtlasEntryPoint()),
 		Short: "Return the details for the specified MongoDB user.",
-		Long:  "You can specify either the unique 24-digit ID that identifies the MongoDB user or the username for the MongoDB user.",
+		Long:  `You can specify either the unique 24-digit ID that identifies the MongoDB user or the username for the MongoDB user.`,
 		Args:  require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prerun.ExecuteE(

--- a/internal/cli/opsmanager/clusters/reclaim_free_space.go
+++ b/internal/cli/opsmanager/clusters/reclaim_free_space.go
@@ -91,7 +91,7 @@ func ReclaimFreeSpaceBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "reclaimFreeSpace <clusterName>",
 		Short:   "Reclaim unused space for a cluster using compact.",
-		Long:    "During certain operations, MongoDB might move or delete data but it doesn't free the currently unused space. Ops Manager reclaims the disk space in a rolling fashion across members of the replica set or shards.",
+		Long:    `During certain operations, MongoDB might move or delete data but it doesn't free the currently unused space. Ops Manager reclaims the disk space in a rolling fashion across members of the replica set or shards.`,
 		Aliases: []string{"rfs"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/opsmanager/clusters/unmanage.go
+++ b/internal/cli/opsmanager/clusters/unmanage.go
@@ -76,7 +76,7 @@ func UnmanageBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unmanage <name>",
 		Short: "Stop managing a cluster via automation.",
-		Long:  "This commands only removes entries from the automation config but does not actually remove a cluster.",
+		Long:  `This commands only removes entries from the automation config but does not actually remove a cluster.`,
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the cluster for which you want to un-manage.",

--- a/internal/cli/opsmanager/featurepolicies/update.go
+++ b/internal/cli/opsmanager/featurepolicies/update.go
@@ -96,7 +96,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update feature control policies for your project.",
-		Long:  "Feature Control Policies allow you to enable or disable certain MongoDB features based on your site-specific needs.",
+		Long:  `Feature Control Policies allow you to enable or disable certain MongoDB features based on your site-specific needs.`,
 		Example: `  # Disable user management for a project:
   mongocli ops-manager featurePolicies update --projectId <projectId> --name Operator --policy DISABLE_USER_MANAGEMENT
 

--- a/internal/cli/opsmanager/livemigrations/link/create.go
+++ b/internal/cli/opsmanager/livemigrations/link/create.go
@@ -66,7 +66,6 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create one new organization link.",
-		Long:  "Your API Key must have the Organization Owner role to successfully run this command.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/opsmanager/livemigrations/link/delete.go
+++ b/internal/cli/opsmanager/livemigrations/link/delete.go
@@ -53,7 +53,6 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete",
 		Aliases: []string{"rm"},
 		Short:   "Delete one link-token.",
-		Long:    "Your API Key must have the Organization Owner role to successfully run this command.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/opsmanager/livemigrations/link/describe.go
+++ b/internal/cli/opsmanager/livemigrations/link/describe.go
@@ -58,7 +58,6 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return the status of the connection between the specified source organization and the target MongoDB Atlas organization.",
-		Long:    "Your API Key must have the Organization Owner role to successfully run this command.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/performanceadvisor/slowoperationthreshold/disable.go
+++ b/internal/cli/performanceadvisor/slowoperationthreshold/disable.go
@@ -57,7 +57,7 @@ func DisableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable the application-managed slow operation threshold for your project.",
-		Long:  "The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.",
+		Long:  `The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.`,
 		Args:  require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/performanceadvisor/slowoperationthreshold/enable.go
+++ b/internal/cli/performanceadvisor/slowoperationthreshold/enable.go
@@ -57,7 +57,7 @@ func EnableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "enable",
 		Short:   "Enable the application-managed slow operation threshold for your project.",
-		Long:    "The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).",
+		Long:    `The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).`,
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/performanceadvisor/suggestedindexes/list.go
@@ -83,7 +83,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return the suggested indexes for collections experiencing slow queries.",
-		Long:    "The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.",
+		Long:    `The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.`,
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of suggested indexes for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:


### PR DESCRIPTION
## Proposed changes

This PR:

- Adds the required role for the accessLists create command. This provides the template for how to add required roles for all commands with existing Long text going forward.
- Replaces Long text entry double quotes with a backtick quote to make it easier to add required roles for commands with existing Long text in bulk.
- Removes Long text that references required roles since this will soon be replaced by the template text.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
