### PR TITLE
CLOUDP-150028: atlas setup command should detect existence of cluster

### DIFF
--- a/internal/cli/atlas/clusters/list.go
+++ b/internal/cli/atlas/clusters/list.go
@@ -48,12 +48,12 @@ var listTemplate = `ID	NAME	MDB VER	STATE{{range .Results}}
 
 func (opts *ListOpts) Run() error {
 	listOpts := opts.NewListOptions()
-	r, err := opts.store.ProjectClusters(opts.ConfigProjectID(), listOpts)
+	r1, r2, err := opts.store.ProjectClusters(opts.ConfigProjectID(), listOpts)
 	if err != nil {
 		return err
 	}
 
-	return opts.Print(r)
+	return opts.PrintFirst(r1, r2)
 }
 
 // mongocli atlas cluster(s) list --projectId projectId [--page N] [--limit N].

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -244,6 +244,15 @@ func (opts *Opts) Run() error {
 		return dErr
 	}
 
+	r1, r2, err := opts.store.ProjectClusters(opts.ConfigProjectID(), &atlas.ListOptions{
+		PageNum: 1, ItemsPerPage: 1, IncludeCount: true})
+	if err != nil {
+		return err
+	}
+	if (r1 != nil && r1.TotalCount > 0) || (r2 != nil && r2.TotalCount > 0) {
+		fmt.Print("TODO: warn users about account having multiple clusters ")
+	}
+
 	if err := opts.askConfirmDefaultQuestion(values); err != nil || !opts.Confirm {
 		fmt.Print(quickstartTemplateIntro)
 

--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -106,6 +106,16 @@ func (opts *OutputOpts) Print(o interface{}) error {
 	return err
 }
 
+// Print first non nil object from objectsToPrint array.
+func (opts *OutputOpts) PrintFirst(objectsToPrint ...interface{}) error {
+	for _, printerObj := range objectsToPrint {
+		if printerObj != nil {
+			return opts.Print(printerObj)
+		}
+	}
+	return nil
+}
+
 // outputTypeAndValue returns the output type and the associated value
 // Current available output types are:
 // "go-template=Template string",

--- a/internal/mocks/mock_atlas_operator_cluster_store.go
+++ b/internal/mocks/mock_atlas_operator_cluster_store.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
+	opsmngr "go.mongodb.org/ops-manager/opsmngr"
 )
 
 // MockAtlasOperatorClusterStore is a mock of AtlasOperatorClusterStore interface.
@@ -95,12 +96,13 @@ func (mr *MockAtlasOperatorClusterStoreMockRecorder) GlobalCluster(arg0, arg1 in
 }
 
 // ProjectClusters mocks base method.
-func (m *MockAtlasOperatorClusterStore) ProjectClusters(arg0 string, arg1 *mongodbatlas.ListOptions) (interface{}, error) {
+func (m *MockAtlasOperatorClusterStore) ProjectClusters(arg0 string, arg1 *mongodbatlas.ListOptions) (*mongodbatlas.AdvancedClustersResponse, *opsmngr.Clusters, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProjectClusters", arg0, arg1)
-	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*mongodbatlas.AdvancedClustersResponse)
+	ret1, _ := ret[1].(*opsmngr.Clusters)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ProjectClusters indicates an expected call of ProjectClusters.

--- a/internal/mocks/mock_automation.go
+++ b/internal/mocks/mock_automation.go
@@ -231,12 +231,13 @@ func (mr *MockCloudManagerClustersListerMockRecorder) ListAllProjectClusters() *
 }
 
 // ProjectClusters mocks base method.
-func (m *MockCloudManagerClustersLister) ProjectClusters(arg0 string, arg1 *mongodbatlas.ListOptions) (interface{}, error) {
+func (m *MockCloudManagerClustersLister) ProjectClusters(arg0 string, arg1 *mongodbatlas.ListOptions) (*mongodbatlas.AdvancedClustersResponse, *opsmngr.Clusters, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProjectClusters", arg0, arg1)
-	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*mongodbatlas.AdvancedClustersResponse)
+	ret1, _ := ret[1].(*opsmngr.Clusters)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ProjectClusters indicates an expected call of ProjectClusters.

--- a/internal/mocks/mock_clusters.go
+++ b/internal/mocks/mock_clusters.go
@@ -36,12 +36,13 @@ func (m *MockClusterLister) EXPECT() *MockClusterListerMockRecorder {
 }
 
 // ProjectClusters mocks base method.
-func (m *MockClusterLister) ProjectClusters(arg0 string, arg1 *mongodbatlas.ListOptions) (interface{}, error) {
+func (m *MockClusterLister) ProjectClusters(arg0 string, arg1 *mongodbatlas.ListOptions) (*mongodbatlas.AdvancedClustersResponse, *opsmngr.Clusters, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProjectClusters", arg0, arg1)
-	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*mongodbatlas.AdvancedClustersResponse)
+	ret1, _ := ret[1].(*opsmngr.Clusters)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ProjectClusters indicates an expected call of ProjectClusters.
@@ -497,12 +498,13 @@ func (mr *MockAtlasClusterQuickStarterMockRecorder) DatabaseUser(arg0, arg1, arg
 }
 
 // ProjectClusters mocks base method.
-func (m *MockAtlasClusterQuickStarter) ProjectClusters(arg0 string, arg1 *mongodbatlas.ListOptions) (interface{}, error) {
+func (m *MockAtlasClusterQuickStarter) ProjectClusters(arg0 string, arg1 *mongodbatlas.ListOptions) (*mongodbatlas.AdvancedClustersResponse, *opsmngr.Clusters, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProjectClusters", arg0, arg1)
-	ret0, _ := ret[0].(interface{})
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(*mongodbatlas.AdvancedClustersResponse)
+	ret1, _ := ret[1].(*opsmngr.Clusters)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // ProjectClusters indicates an expected call of ProjectClusters.


### PR DESCRIPTION
WIP for early feedback about architecture changes.

# Description

When running `atlas setup` users should be notified about having existing clusters in the atlas.
Some of the clusters might be limited (M0 on Atlas etc.) so we need to notify about issues

## API 

As for now, API doesn't give us the ability to search for clusters based on `tier`. 
That is why I have decided to settle with a warning for users having existing clusters (any existing ones) and asking them if they would like to continue. Alternatively, we could read the total values and traverse thru all pages for lookout for specific cluster type.  However this approach will be bundling an dynamic business logic (one m0 cluster possible) into CLI which is not great from update point of view.
