### PR TITLE
(DOCSP-28111) Adds required roles for backups, cloudproviders and clusters commands

### DIFF
--- a/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-create.txt
@@ -14,6 +14,8 @@ atlas backups exports buckets create
 
 Create an export destination for Atlas backups using an existing AWS S3 bucket.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-exports-buckets-delete.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-delete.txt
@@ -14,6 +14,8 @@ atlas backups exports buckets delete
 
 Delete a snapshot export bucket.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
@@ -14,6 +14,8 @@ atlas backups exports buckets list
 
 List cloud backup restore buckets for your project and cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
@@ -14,6 +14,8 @@ atlas backups exports jobs create
 
 Export one backup snapshot for an M10 or higher Atlas cluster to an existing AWS S3 bucket.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -14,6 +14,8 @@ atlas backups exports jobs describe
 
 Return one cloud backup export job for your project, cluster and job.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
@@ -14,6 +14,8 @@ atlas backups exports jobs list
 
 Return all cloud backup export jobs for your project and cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-restores-describe.txt
+++ b/docs/atlascli/command/atlas-backups-restores-describe.txt
@@ -14,6 +14,8 @@ atlas backups restores describe
 
 Describe a cloud backup restore job.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-restores-list.txt
+++ b/docs/atlascli/command/atlas-backups-restores-list.txt
@@ -14,6 +14,8 @@ atlas backups restores list
 
 Return all cloud backup restore jobs for your project and cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-restores-start.txt
+++ b/docs/atlascli/command/atlas-backups-restores-start.txt
@@ -16,6 +16,8 @@ Start a restore job for your project and cluster.
 
 If you create an automated or pointInTime restore job, Atlas removes all existing data on the target cluster prior to the restore.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-schedule-delete.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-delete.txt
@@ -14,6 +14,8 @@ atlas backups schedule delete
 
 Delete all backup schedules of a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-schedule-describe.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-describe.txt
@@ -14,6 +14,8 @@ atlas backups schedule describe
 
 Describe a cloud backup schedule for the cluster you specify.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-schedule-update.txt
+++ b/docs/atlascli/command/atlas-backups-schedule-update.txt
@@ -16,6 +16,8 @@ Modify the backup schedule for the specified cluster for your project.
 
 The backup schedule defines when MongoDB takes scheduled snapshots and how long it stores those snapshots.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-snapshots-create.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-create.txt
@@ -16,6 +16,8 @@ Create a backup snapshot for your project and cluster.
 
 You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-snapshots-delete.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-delete.txt
@@ -14,6 +14,8 @@ atlas backups snapshots delete
 
 Remove the specified backup snapshot.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-snapshots-describe.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-describe.txt
@@ -14,6 +14,8 @@ atlas backups snapshots describe
 
 Return the details for the specified snapshot for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-snapshots-list.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-list.txt
@@ -14,6 +14,8 @@ atlas backups snapshots list
 
 Return all cloud backup snapshots for your project and cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-backups-snapshots-watch.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-watch.txt
@@ -19,6 +19,8 @@ Once the snapshot reaches the expected status, the command prints "Snapshot chan
 If you run the command in the terminal, it blocks the terminal session until the resource status completes or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-cloudProviders-accessRoles-aws-create.txt
+++ b/docs/atlascli/command/atlas-cloudProviders-accessRoles-aws-create.txt
@@ -14,6 +14,8 @@ atlas cloudProviders accessRoles aws create
 
 Create an AWS IAM role.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-cloudProviders-accessRoles-aws-deauthorize.txt
+++ b/docs/atlascli/command/atlas-cloudProviders-accessRoles-aws-deauthorize.txt
@@ -14,6 +14,8 @@ atlas cloudProviders accessRoles aws deauthorize
 
 Deauthorize an AWS IAM role.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-cloudProviders-accessRoles-list.txt
+++ b/docs/atlascli/command/atlas-cloudProviders-accessRoles-list.txt
@@ -14,6 +14,8 @@ atlas cloudProviders accessRoles list
 
 List AWS IAM role access in Atlas.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-advancedSettings-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-advancedSettings-describe.txt
@@ -14,6 +14,8 @@ atlas clusters advancedSettings describe
 
 Retrieve advanced configuration settings for one cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-connectionStrings-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-connectionStrings-describe.txt
@@ -14,6 +14,8 @@ atlas clusters connectionStrings describe
 
 Return the SRV connection string for the cluster you specify.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-create.txt
+++ b/docs/atlascli/command/atlas-clusters-create.txt
@@ -17,6 +17,8 @@ Create a cluster for your project.
 To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
 For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-delete.txt
+++ b/docs/atlascli/command/atlas-clusters-delete.txt
@@ -18,6 +18,8 @@ The command prompts you to confirm the operation when you run the command withou
 		
 Deleting a cluster also deletes any backup snapshots for that cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-describe.txt
@@ -14,6 +14,8 @@ atlas clusters describe
 
 Return the details for the specified cluster for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-indexes-create.txt
+++ b/docs/atlascli/command/atlas-clusters-indexes-create.txt
@@ -14,6 +14,8 @@ atlas clusters indexes create
 
 Create a rolling index for the specified cluster for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-list.txt
+++ b/docs/atlascli/command/atlas-clusters-list.txt
@@ -14,6 +14,8 @@ atlas clusters list
 
 Return all clusters for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-create.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-create.txt
@@ -18,6 +18,8 @@ You can create an online archive for an M10 or larger cluster.
 		
 To learn more about online archives, see https://www.mongodb.com/docs/atlas/online-archive/manage-online-archive/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-delete.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-delete.txt
@@ -14,6 +14,8 @@ atlas clusters onlineArchives delete
 
 Remove the specified online archive from your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-describe.txt
@@ -14,6 +14,8 @@ atlas clusters onlineArchives describe
 
 Return the details for the specified online archive for your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-list.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-list.txt
@@ -14,6 +14,8 @@ atlas clusters onlineArchives list
 
 Return all online archives for your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-pause.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-pause.txt
@@ -14,6 +14,8 @@ atlas clusters onlineArchives pause
 
 Pause the specfied online archive for your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-start.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-start.txt
@@ -14,6 +14,8 @@ atlas clusters onlineArchives start
 
 Start a paused online archive from a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-update.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-update.txt
@@ -14,6 +14,8 @@ atlas clusters onlineArchives update
 
 Modify the archiving rule for the specified online archive for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
@@ -19,6 +19,8 @@ Once the archive reaches the expected status, the command prints "Online archive
 If you run the command in the terminal, it blocks the terminal session until the resource status changes to the expected status.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-pause.txt
+++ b/docs/atlascli/command/atlas-clusters-pause.txt
@@ -14,6 +14,8 @@ atlas clusters pause
 
 Pause the specified running MongoDB cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Cluster Manager role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-search-indexes-create.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-create.txt
@@ -14,6 +14,8 @@ atlas clusters search indexes create
 
 Create a search index for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-search-indexes-delete.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-delete.txt
@@ -14,6 +14,8 @@ atlas clusters search indexes delete
 
 Delete the specified search index from the specified cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-search-indexes-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-describe.txt
@@ -14,6 +14,8 @@ atlas clusters search indexes describe
 
 Return the details for the search index for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-list.txt
@@ -14,6 +14,8 @@ atlas clusters search indexes list
 
 List all Atlas Search indexes for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-search-indexes-update.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-update.txt
@@ -14,6 +14,8 @@ atlas clusters search indexes update
 
 Modify a search index for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-start.txt
+++ b/docs/atlascli/command/atlas-clusters-start.txt
@@ -14,6 +14,8 @@ atlas clusters start
 
 Start the specified paused MongoDB cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Cluster Manager role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-update.txt
+++ b/docs/atlascli/command/atlas-clusters-update.txt
@@ -20,6 +20,8 @@ You can modify only M10 or larger clusters that are single-region replica sets.
 		
 You can't change the name of the cluster or downgrade the MongoDB version of your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Cluster Manager role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-upgrade.txt
+++ b/docs/atlascli/command/atlas-clusters-upgrade.txt
@@ -16,6 +16,8 @@ Upgrade a shared cluster's tier, disk size, and/or MongoDB version.
 
 This command is unavailable for dedicated clusters.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Cluster Manager role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-clusters-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-watch.txt
@@ -19,6 +19,8 @@ Once the cluster reaches the expected state, the command prints "Cluster availab
 If you run the command in the terminal, it blocks the terminal session until the resource state changes to IDLE.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
@@ -14,6 +14,8 @@ mongocli atlas backups restores list
 
 Return all cloud backup restore jobs for your project and cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-start.txt
@@ -16,6 +16,8 @@ Start a restore job for your project and cluster.
 
 If you create an automated or pointInTime restore job, Atlas removes all existing data on the target cluster prior to the restore.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-create.txt
@@ -16,6 +16,8 @@ Create a backup snapshot for your project and cluster.
 
 You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas backups snapshots delete
 
 Remove the specified backup snapshot.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas backups snapshots describe
 
 Return the details for the specified snapshot for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-list.txt
@@ -14,6 +14,8 @@ mongocli atlas backups snapshots list
 
 Return all cloud backup snapshots for your project and cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-watch.txt
@@ -19,6 +19,8 @@ Once the snapshot reaches the expected status, the command prints "Snapshot chan
 If you run the command in the terminal, it blocks the terminal session until the resource status completes or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-aws-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-aws-create.txt
@@ -14,6 +14,8 @@ mongocli atlas cloudProviders accessRoles aws create
 
 Create an AWS IAM role.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-aws-deauthorize.txt
+++ b/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-aws-deauthorize.txt
@@ -14,6 +14,8 @@ mongocli atlas cloudProviders accessRoles aws deauthorize
 
 Deauthorize an AWS IAM role.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-list.txt
@@ -14,6 +14,8 @@ mongocli atlas cloudProviders accessRoles list
 
 List AWS IAM role access in Atlas.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-connectionStrings-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-connectionStrings-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters connectionStrings describe
 
 Return the SRV connection string for the cluster you specify.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-create.txt
@@ -17,6 +17,8 @@ Create a cluster for your project.
 To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
 For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-delete.txt
@@ -18,6 +18,8 @@ The command prompts you to confirm the operation when you run the command withou
 		
 Deleting a cluster also deletes any backup snapshots for that cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters describe
 
 Return the details for the specified cluster for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-indexes-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-indexes-create.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters indexes create
 
 Create a rolling index for the specified cluster for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-list.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters list
 
 Return all clusters for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-create.txt
@@ -18,6 +18,8 @@ You can create an online archive for an M10 or larger cluster.
 		
 To learn more about online archives, see https://www.mongodb.com/docs/atlas/online-archive/manage-online-archive/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters onlineArchives delete
 
 Remove the specified online archive from your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters onlineArchives describe
 
 Return the details for the specified online archive for your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-list.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters onlineArchives list
 
 Return all online archives for your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-pause.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-pause.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters onlineArchives pause
 
 Pause the specfied online archive for your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-start.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters onlineArchives start
 
 Start a paused online archive from a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-update.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters onlineArchives update
 
 Modify the archiving rule for the specified online archive for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
@@ -19,6 +19,8 @@ Once the archive reaches the expected status, the command prints "Online archive
 If you run the command in the terminal, it blocks the terminal session until the resource status changes to the expected status.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-pause.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-pause.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters pause
 
 Pause the specified running MongoDB cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Cluster Manager role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-create.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters search indexes create
 
 Create a search index for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters search indexes delete
 
 Delete the specified search index from the specified cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters search indexes describe
 
 Return the details for the search index for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-list.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters search indexes list
 
 List all Atlas Search indexes for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-update.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters search indexes update
 
 Modify a search index for a cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-start.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters start
 
 Start the specified paused MongoDB cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Cluster Manager role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-update.txt
@@ -20,6 +20,8 @@ You can modify only M10 or larger clusters that are single-region replica sets.
 		
 You can't change the name of the cluster or downgrade the MongoDB version of your cluster.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Cluster Manager role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
@@ -19,6 +19,8 @@ Once the cluster reaches the expected state, the command prints "Cluster availab
 If you run the command in the terminal, it blocks the terminal session until the resource state changes to IDLE.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/internal/cli/atlas/backup/exports/buckets/create.go
+++ b/internal/cli/atlas/backup/exports/buckets/create.go
@@ -74,6 +74,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <bucketName>",
 		Short: "Create an export destination for Atlas backups using an existing AWS S3 bucket.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # The following command creates an export destination for Atlas backups using the existing AWS S3 bucket named test-bucket:
   %s backup export buckets create test-bucket --cloudProvider AWS --iamRoleId 12345678f901a234dbdb00ca`, config.BinName()),
 		Args: require.ExactArgs(1),

--- a/internal/cli/atlas/backup/exports/buckets/delete.go
+++ b/internal/cli/atlas/backup/exports/buckets/delete.go
@@ -59,6 +59,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete",
 		Aliases: []string{"rm"},
 		Short:   "Delete a snapshot export bucket.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # The following deletes the continuous backup export bucket specified by ID:
   %s backup exports buckets delete --bucketId dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/backup/exports/buckets/list.go
+++ b/internal/cli/atlas/backup/exports/buckets/list.go
@@ -63,6 +63,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List cloud backup restore buckets for your project and cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return all continuous backup export buckets for your project:
   %s backup exports buckets list`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/backup/exports/jobs/create.go
+++ b/internal/cli/atlas/backup/exports/jobs/create.go
@@ -80,6 +80,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Export one backup snapshot for an M10 or higher Atlas cluster to an existing AWS S3 bucket.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # The following command exports one backup snapshot of the ExampleCluster cluster to an existing AWS S3 bucket:
   %s backup export jobs create --clusterName ExampleCluster --bucketId 62c569f85b7a381c093cc539 --snapshotId 62c808ceeb4e021d850dfe1b --customData name=test,info=test`, config.BinName()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/backup/exports/jobs/decribe.go
+++ b/internal/cli/atlas/backup/exports/jobs/decribe.go
@@ -63,6 +63,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return one cloud backup export job for your project, cluster and job.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup export job with the ID 5df90590f10fab5e33de2305 for the cluster named Cluster0:
   %s backup exports jobs describe --clusterName Cluster0 --exportID 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/backup/exports/jobs/list.go
+++ b/internal/cli/atlas/backup/exports/jobs/list.go
@@ -64,6 +64,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list <clusterName>",
 		Aliases: []string{"ls"},
 		Short:   "Return all cloud backup export jobs for your project and cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve restore jobs.",

--- a/internal/cli/atlas/backup/restores/describe.go
+++ b/internal/cli/atlas/backup/restores/describe.go
@@ -62,6 +62,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <restoreJobId>",
 		Short: "Describe a cloud backup restore job.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"restoreJobIdDesc": "ID of the restore job.",

--- a/internal/cli/atlas/backup/restores/list.go
+++ b/internal/cli/atlas/backup/restores/list.go
@@ -64,6 +64,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list <clusterName>",
 		Aliases: []string{"ls"},
 		Short:   "Return all cloud backup restore jobs for your project and cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve restore jobs.",

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -138,9 +138,11 @@ func markRequiredPointInTimeRestoreFlags(cmd *cobra.Command) error {
 func StartBuilder() *cobra.Command {
 	opts := new(StartOpts)
 	cmd := &cobra.Command{
-		Use:       fmt.Sprintf("start <%s|%s|%s>", automatedRestore, downloadRestore, pointInTimeRestore),
-		Short:     "Start a restore job for your project and cluster.",
-		Long:      `If you create an automated or pointInTime restore job, Atlas removes all existing data on the target cluster prior to the restore.`,
+		Use:   fmt.Sprintf("start <%s|%s|%s>", automatedRestore, downloadRestore, pointInTimeRestore),
+		Short: "Start a restore job for your project and cluster.",
+		Long: `If you create an automated or pointInTime restore job, Atlas removes all existing data on the target cluster prior to the restore.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:      require.ExactValidArgs(1),
 		ValidArgs: []string{automatedRestore, downloadRestore, pointInTimeRestore},
 		Annotations: map[string]string{

--- a/internal/cli/atlas/backup/schedule/delete.go
+++ b/internal/cli/atlas/backup/schedule/delete.go
@@ -57,6 +57,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <clusterName>",
 		Aliases: []string{"rm"},
 		Short:   "Delete all backup schedules of a cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster.",

--- a/internal/cli/atlas/backup/schedule/describe.go
+++ b/internal/cli/atlas/backup/schedule/describe.go
@@ -65,6 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <clusterName>",
 		Aliases: []string{"get"},
 		Short:   "Describe a cloud backup schedule for the cluster you specify.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Human-readable label for the cluster.",

--- a/internal/cli/atlas/backup/schedule/update.go
+++ b/internal/cli/atlas/backup/schedule/update.go
@@ -349,7 +349,9 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update",
 		Aliases: []string{"updates"},
 		Short:   "Modify the backup schedule for the specified cluster for your project.",
-		Long:    `The backup schedule defines when MongoDB takes scheduled snapshots and how long it stores those snapshots.`,
+		Long: `The backup schedule defines when MongoDB takes scheduled snapshots and how long it stores those snapshots.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Update a snapshot backup policy for a cluster named Cluster0 to back up snapshots every 6 hours and, retain for 7 days, and update retention of previously-taken snapshots:
   %[1]s backup schedule update --clusterName Cluster0 --updateSnapshots --policy 62da8faac84a2721e448d767,62da8faac84a2721e448d768,hourly,6,days,7
   

--- a/internal/cli/atlas/backup/snapshots/create.go
+++ b/internal/cli/atlas/backup/snapshots/create.go
@@ -74,8 +74,10 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create <clusterName>",
 		Aliases: []string{"take"},
 		Short:   "Create a backup snapshot for your project and cluster.",
-		Long:    `You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.`,
-		Args:    require.ExactArgs(1),
+		Long: `You can create on-demand backup snapshots for Atlas cluster tiers M10 and larger.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Create a backup snapshot for the cluster named myDemo that Atlas retains for 30 days:
   %s backups snapshots create myDemo --desc "test" --retention 30`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{

--- a/internal/cli/atlas/backup/snapshots/delete.go
+++ b/internal/cli/atlas/backup/snapshots/delete.go
@@ -56,6 +56,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <snapshotId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified backup snapshot.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Remove the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the cluster named myDemo:
   %s backups snapshots delete 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/backup/snapshots/describe.go
+++ b/internal/cli/atlas/backup/snapshots/describe.go
@@ -61,6 +61,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <snapshotId>",
 		Short: "Return the details for the specified snapshot for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:  require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Return the details for the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the cluster named myDemo:
   %s backups snapshots describe 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/backup/snapshots/list.go
+++ b/internal/cli/atlas/backup/snapshots/list.go
@@ -63,6 +63,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list <clusterName>",
 		Short:   "Return all cloud backup snapshots for your project and cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/atlas/backup/snapshots/watch.go
+++ b/internal/cli/atlas/backup/snapshots/watch.go
@@ -68,7 +68,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the snapshot's status periodically until it reaches a completed or failed status. 
 Once the snapshot reaches the expected status, the command prints "Snapshot changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource status completes or fails.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  # Watch the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 in the cluster named myDemo until it becomes available:
   %s backups snapshots watch 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/create.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/create.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -63,6 +64,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an AWS IAM role.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -77,6 +78,7 @@ func DeauthorizeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deauthorize <roleId>",
 		Short: "Deauthorize an AWS IAM role.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"roleIdDesc": "Unique ID of the role to authorize.",

--- a/internal/cli/atlas/cloudproviders/accessroles/list.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/list.go
@@ -16,6 +16,7 @@ package accessroles
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -59,6 +60,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List AWS IAM role access in Atlas.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/clusters/advancedsettings/describe.go
+++ b/internal/cli/atlas/clusters/advancedsettings/describe.go
@@ -61,6 +61,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <clusterName>",
 		Aliases: []string{"get"},
 		Short:   "Retrieve advanced configuration settings for one cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve configuration settings.",

--- a/internal/cli/atlas/clusters/connectionstring/describe.go
+++ b/internal/cli/atlas/clusters/connectionstring/describe.go
@@ -66,6 +66,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <clusterName>",
 		Aliases: []string{"get"},
 		Short:   "Return the SRV connection string for the cluster you specify.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve connection strings.",

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -189,7 +189,9 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create [name]",
 		Short: "Create a cluster for your project.",
 		Long: `To get started quickly, specify a name for your cluster, a cloud provider, and a region to deploy a three-member replica set with the latest MongoDB server version.
-For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.`,
+For full control of your deployment, or to create multi-cloud clusters, provide a JSON configuration file with the --file flag.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Deploy a free cluster named myCluster for the project with the ID 5e2211c17a3e5a48f5497de3:
   %[1]s cluster create myCluster --projectId 5e2211c17a3e5a48f5497de3 --provider AWS --region US_EAST_1 --tier M0
 

--- a/internal/cli/atlas/clusters/delete.go
+++ b/internal/cli/atlas/clusters/delete.go
@@ -58,7 +58,9 @@ func DeleteBuilder() *cobra.Command {
 		Short:   "Remove the specified cluster from your project.",
 		Long: `The command prompts you to confirm the operation when you run the command without the --force option. 
 		
-Deleting a cluster also deletes any backup snapshots for that cluster.`,
+Deleting a cluster also deletes any backup snapshots for that cluster.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Remove a cluster named myCluster after prompting for a confirmation:
   %[1]s clusters delete myCluster
   

--- a/internal/cli/atlas/clusters/describe.go
+++ b/internal/cli/atlas/clusters/describe.go
@@ -61,6 +61,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <clusterName>",
 		Aliases: []string{"get"},
 		Short:   "Return the details for the specified cluster for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to retrieve.",

--- a/internal/cli/atlas/clusters/indexes/create.go
+++ b/internal/cli/atlas/clusters/indexes/create.go
@@ -102,6 +102,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [indexName]",
 		Short: "Create a rolling index for the specified cluster for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Args:  require.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"indexNameDesc": "Name of the index.",

--- a/internal/cli/atlas/clusters/list.go
+++ b/internal/cli/atlas/clusters/list.go
@@ -62,6 +62,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all clusters for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all clusters for the project with ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/atlas/clusters/onlinearchive/create.go
+++ b/internal/cli/atlas/clusters/onlinearchive/create.go
@@ -101,7 +101,9 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create an online archive for a collection in the specified cluster.",
 		Long: `You can create an online archive for an M10 or larger cluster.
 		
-To learn more about online archives, see https://www.mongodb.com/docs/atlas/online-archive/manage-online-archive/.`,
+To learn more about online archives, see https://www.mongodb.com/docs/atlas/online-archive/manage-online-archive/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create an online archive for the sample_mflix.movies collection in a cluster named myTestCluster when the current date is greater than the value of released date plus 2 days:
   %[1]s clusters onlineArchive create --clusterName myTestCluster --db sample_mflix --collection movies --dateField released --archiveAfter 2 --output json

--- a/internal/cli/atlas/clusters/onlinearchive/delete.go
+++ b/internal/cli/atlas/clusters/onlinearchive/delete.go
@@ -56,6 +56,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <archiveId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified online archive from your cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to delete.",

--- a/internal/cli/atlas/clusters/onlinearchive/describe.go
+++ b/internal/cli/atlas/clusters/onlinearchive/describe.go
@@ -63,6 +63,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <archiveId>",
 		Short: "Return the details for the specified online archive for your cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to retrieve.",

--- a/internal/cli/atlas/clusters/onlinearchive/list.go
+++ b/internal/cli/atlas/clusters/onlinearchive/list.go
@@ -63,6 +63,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all online archives for your cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of online archives for the cluster named myCluster:

--- a/internal/cli/atlas/clusters/onlinearchive/pause.go
+++ b/internal/cli/atlas/clusters/onlinearchive/pause.go
@@ -66,6 +66,7 @@ func PauseBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pause <archiveId>",
 		Short: "Pause the specfied online archive for your cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to pause.",

--- a/internal/cli/atlas/clusters/onlinearchive/start.go
+++ b/internal/cli/atlas/clusters/onlinearchive/start.go
@@ -16,6 +16,7 @@ package onlinearchive
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -65,6 +66,7 @@ func StartBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start <archiveId>",
 		Short: "Start a paused online archive from a cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to start.",

--- a/internal/cli/atlas/clusters/onlinearchive/update.go
+++ b/internal/cli/atlas/clusters/onlinearchive/update.go
@@ -73,6 +73,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <archiveId>",
 		Short: "Modify the archiving rule for the specified online archive for a cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to update.",

--- a/internal/cli/atlas/clusters/onlinearchive/watch.go
+++ b/internal/cli/atlas/clusters/onlinearchive/watch.go
@@ -70,7 +70,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the archive's status periodically until it reaches a state different from PENDING or PAUSING. 
 Once the archive reaches the expected status, the command prints "Online archive available."
 If you run the command in the terminal, it blocks the terminal session until the resource status changes to the expected status.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  %s cluster onlineArchive watch archiveIdSample --clusterName clusterNameSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/atlas/clusters/pause.go
+++ b/internal/cli/atlas/clusters/pause.go
@@ -60,6 +60,7 @@ func PauseBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pause <clusterName>",
 		Short: "Pause the specified running MongoDB cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Cluster Manager"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to pause.",

--- a/internal/cli/atlas/clusters/start.go
+++ b/internal/cli/atlas/clusters/start.go
@@ -60,6 +60,7 @@ func StartBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "start <clusterName>",
 		Short: "Start the specified paused MongoDB cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Cluster Manager"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to start.",

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -133,7 +133,9 @@ func UpdateBuilder() *cobra.Command {
 		
 You can modify only M10 or larger clusters that are single-region replica sets.
 		
-You can't change the name of the cluster or downgrade the MongoDB version of your cluster.`,
+You can't change the name of the cluster or downgrade the MongoDB version of your cluster.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Cluster Manager"),
 		Example: fmt.Sprintf(`  # Update the tier for a cluster named myCluster for the project with ID 5e2211c17a3e5a48f5497de3:
   %[1]s cluster update myCluster --projectId 5e2211c17a3e5a48f5497de3 --tier M50
 

--- a/internal/cli/atlas/clusters/upgrade.go
+++ b/internal/cli/atlas/clusters/upgrade.go
@@ -116,7 +116,9 @@ func UpgradeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade [clusterName]",
 		Short: "Upgrade a shared cluster's tier, disk size, and/or MongoDB version.",
-		Long:  `This command is unavailable for dedicated clusters.`,
+		Long: `This command is unavailable for dedicated clusters.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Cluster Manager"),
 		Example: fmt.Sprintf(`  # Upgrade the tier, disk size, and MongoDB version for the shared cluster named myCluster in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s cluster upgrade myCluster --projectId 5e2211c17a3e5a48f5497de3 --tier M50 --diskSizeGB 20 --mdbVersion 4.2`,
 			cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -77,7 +77,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the cluster's status periodically until it reaches an IDLE state. 
 Once the cluster reaches the expected state, the command prints "Cluster available."
 If you run the command in the terminal, it blocks the terminal session until the resource state changes to IDLE.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  # Watch for the cluster named myCluster to become available for the project with ID 5e2211c17a3e5a48f5497de3:
   %s clusters watch myCluster --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),

--- a/internal/cli/atlas/search/create.go
+++ b/internal/cli/atlas/search/create.go
@@ -90,6 +90,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [indexName]",
 		Short: "Create a search index for a cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Args:  require.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"indexNameDesc": "Name of the index.",

--- a/internal/cli/atlas/search/delete.go
+++ b/internal/cli/atlas/search/delete.go
@@ -56,6 +56,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <indexId>",
 		Aliases: []string{"rm"},
 		Short:   "Delete the specified search index from the specified cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",

--- a/internal/cli/atlas/search/describe.go
+++ b/internal/cli/atlas/search/describe.go
@@ -63,6 +63,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <indexId>",
 		Short: "Return the details for the search index for a cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Read/Write"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",

--- a/internal/cli/atlas/search/list.go
+++ b/internal/cli/atlas/search/list.go
@@ -64,6 +64,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List all Atlas Search indexes for a cluster.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Data Access Read/Write"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the JSON-formatted list of Atlas search indexes on the sample_mflix.movies database in the cluster named myCluster:

--- a/internal/cli/atlas/search/update.go
+++ b/internal/cli/atlas/search/update.go
@@ -91,6 +91,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <indexId>",
 		Short: "Modify a search index for a cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Admin"),
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",
 		},


### PR DESCRIPTION
## Proposed changes

Adds the required roles for backups, cloudproviders and clusters commands.
All roles are copied from the OpenAPI spec for the command that corresponds to an endpoint

_Jira ticket:_ CLOUDP-#

https://jira.mongodb.org/browse/DOCSP-28111

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
