### PR TITLE
(DOCSP-28112) Adds required roles for customDNS, customDB, and dataLakes commands in OpenAPI

### DIFF
--- a/docs/atlascli/command/atlas-customDbRoles-create.txt
+++ b/docs/atlascli/command/atlas-customDbRoles-create.txt
@@ -14,6 +14,8 @@ atlas customDbRoles create
 
 Create a custom database role for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-customDbRoles-delete.txt
+++ b/docs/atlascli/command/atlas-customDbRoles-delete.txt
@@ -14,6 +14,8 @@ atlas customDbRoles delete
 
 Remove the specified custom database role from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-customDbRoles-describe.txt
+++ b/docs/atlascli/command/atlas-customDbRoles-describe.txt
@@ -14,6 +14,8 @@ atlas customDbRoles describe
 
 Return a single custom database role for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-customDbRoles-list.txt
+++ b/docs/atlascli/command/atlas-customDbRoles-list.txt
@@ -14,6 +14,8 @@ atlas customDbRoles list
 
 List custom database roles for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-customDbRoles-update.txt
+++ b/docs/atlascli/command/atlas-customDbRoles-update.txt
@@ -14,6 +14,8 @@ atlas customDbRoles update
 
 Update a custom database role for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-customDns-aws-describe.txt
+++ b/docs/atlascli/command/atlas-customDns-aws-describe.txt
@@ -14,6 +14,8 @@ atlas customDns aws describe
 
 Describe the custom DNS configuration of an Atlas project’s cluster deployed to AWS.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-customDns-aws-disable.txt
+++ b/docs/atlascli/command/atlas-customDns-aws-disable.txt
@@ -14,6 +14,8 @@ atlas customDns aws disable
 
 Disable the custom DNS configuration of an Atlas project’s cluster deployed to AWS.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-customDns-aws-enable.txt
+++ b/docs/atlascli/command/atlas-customDns-aws-enable.txt
@@ -14,6 +14,8 @@ atlas customDns aws enable
 
 Enable the custom DNS configuration of an Atlas project’s cluster deployed to AWS.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dataLakes-create.txt
+++ b/docs/atlascli/command/atlas-dataLakes-create.txt
@@ -16,6 +16,8 @@ Create a new federated database instance for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dataLakes-delete.txt
+++ b/docs/atlascli/command/atlas-dataLakes-delete.txt
@@ -16,6 +16,8 @@ Remove a federated database instance from your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dataLakes-describe.txt
+++ b/docs/atlascli/command/atlas-dataLakes-describe.txt
@@ -16,6 +16,8 @@ Return the details for the specified federated database instance.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dataLakes-list.txt
+++ b/docs/atlascli/command/atlas-dataLakes-list.txt
@@ -16,6 +16,8 @@ Return all federated database instances for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-customDbRoles-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDbRoles-create.txt
@@ -14,6 +14,8 @@ mongocli atlas customDbRoles create
 
 Create a custom database role for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-customDbRoles-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDbRoles-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas customDbRoles delete
 
 Remove the specified custom database role from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-customDbRoles-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDbRoles-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas customDbRoles describe
 
 Return a single custom database role for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-customDbRoles-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDbRoles-list.txt
@@ -14,6 +14,8 @@ mongocli atlas customDbRoles list
 
 List custom database roles for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-customDbRoles-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDbRoles-update.txt
@@ -14,6 +14,8 @@ mongocli atlas customDbRoles update
 
 Update a custom database role for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-customDns-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDns-aws-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas customDns aws describe
 
 Describe the custom DNS configuration of an Atlas project’s cluster deployed to AWS.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-customDns-aws-disable.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDns-aws-disable.txt
@@ -14,6 +14,8 @@ mongocli atlas customDns aws disable
 
 Disable the custom DNS configuration of an Atlas project’s cluster deployed to AWS.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-customDns-aws-enable.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDns-aws-enable.txt
@@ -14,6 +14,8 @@ mongocli atlas customDns aws enable
 
 Enable the custom DNS configuration of an Atlas project’s cluster deployed to AWS.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-create.txt
@@ -16,6 +16,8 @@ Create a new federated database instance for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-delete.txt
@@ -16,6 +16,8 @@ Remove a federated database instance from your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
@@ -16,6 +16,8 @@ Return the details for the specified federated database instance.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-list.txt
@@ -16,6 +16,8 @@ Return all federated database instances for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/internal/cli/atlas/customdbroles/create.go
+++ b/internal/cli/atlas/customdbroles/create.go
@@ -82,6 +82,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create <roleName>",
 		Short:   "Create a custom database role for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  %s customDbRoles create customRole --privilege FIND@database,UPDATE@database`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/atlas/customdbroles/delete.go
+++ b/internal/cli/atlas/customdbroles/delete.go
@@ -16,6 +16,7 @@ package customdbroles
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -53,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <roleName>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified custom database role from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"roleNameDesc": "Name of the custom role to delete.",

--- a/internal/cli/atlas/customdbroles/describe.go
+++ b/internal/cli/atlas/customdbroles/describe.go
@@ -15,6 +15,7 @@ package customdbroles
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -60,6 +61,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <roleName>",
 		Short: "Return a single custom database role for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"roleNameDesc": "Name of the custom role to retrieve.",

--- a/internal/cli/atlas/customdbroles/list.go
+++ b/internal/cli/atlas/customdbroles/list.go
@@ -16,6 +16,7 @@ package customdbroles
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -63,6 +64,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List custom database roles for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/customdbroles/update.go
+++ b/internal/cli/atlas/customdbroles/update.go
@@ -17,6 +17,7 @@ package customdbroles
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -94,6 +95,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <roleName>",
 		Short: "Update a custom database role for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"roleNameDesc": "Name of the custom role to update.",
 		},

--- a/internal/cli/atlas/customdns/aws/describe.go
+++ b/internal/cli/atlas/customdns/aws/describe.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
@@ -57,6 +58,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe",
 		Short:   "Describe the custom DNS configuration of an Atlas project’s cluster deployed to AWS.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"get"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/customdns/aws/disable.go
+++ b/internal/cli/atlas/customdns/aws/disable.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
@@ -55,6 +56,7 @@ func DisableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable the custom DNS configuration of an Atlas project’s cluster deployed to AWS.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/customdns/aws/enable.go
+++ b/internal/cli/atlas/customdns/aws/enable.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
@@ -55,6 +56,7 @@ func EnableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Enable the custom DNS configuration of an Atlas project’s cluster deployed to AWS.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/datalake/create.go
+++ b/internal/cli/atlas/datalake/create.go
@@ -76,8 +76,10 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a new federated database instance for your project.",
-		Long:  `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
-		Args:  require.ExactArgs(1),
+		Long: `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to create.",
 		},

--- a/internal/cli/atlas/datalake/delete.go
+++ b/internal/cli/atlas/datalake/delete.go
@@ -54,8 +54,10 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <name>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a federated database instance from your project.",
-		Long:    `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
-		Args:    require.ExactArgs(1),
+		Long: `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to delete.",
 		},

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -61,8 +61,10 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <name>",
 		Short: "Return the details for the specified federated database instance.",
-		Long:  `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
-		Args:  require.ExactArgs(1),
+		Long: `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to retrieve.",
 		},

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -59,9 +59,11 @@ func (opts *ListOpts) Run() error {
 func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{
-		Use:     "list",
-		Short:   "Return all federated database instances for your project.",
-		Long:    `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
+		Use:   "list",
+		Short: "Return all federated database instances for your project.",
+		Long: `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all federated database instances in the project with the ID 5e2211c17a3e5a48f5497de3:


### PR DESCRIPTION
## Proposed changes

Adds required roles for customDNS, customDB, and dataLakes commands. All role info comes from the OpenAPI spec.

_Jira ticket:_ 

https://jira.mongodb.org/browse/DOCSP-28112

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
