### PR TITLE
(DOCSP-28110)(DOCSP-28113) Adds required roles for accessLists, accessLogs, alerts, dbusers, events, and integrations commands

### DIFF
--- a/docs/atlascli/command/atlas-accessLists-delete.txt
+++ b/docs/atlascli/command/atlas-accessLists-delete.txt
@@ -16,6 +16,8 @@ Remove the specified IP access list entry from your project.
 
 The command prompts you to confirm the operation when you run the command without the force option.
 
+To use this command, you must authenticate with a user account or an API key that has the Read Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-accessLists-describe.txt
+++ b/docs/atlascli/command/atlas-accessLists-describe.txt
@@ -14,6 +14,8 @@ atlas accessLists describe
 
 Return the details for the specified IP access list entry.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-accessLists-list.txt
+++ b/docs/atlascli/command/atlas-accessLists-list.txt
@@ -14,6 +14,8 @@ atlas accessLists list
 
 Return all IP access list entries for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-accessLogs-list.txt
+++ b/docs/atlascli/command/atlas-accessLogs-list.txt
@@ -14,6 +14,8 @@ atlas accessLogs list
 
 Retrieve the access logs of a cluster identified by the cluster's name or hostname.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Monitoring Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-acknowledge.txt
+++ b/docs/atlascli/command/atlas-alerts-acknowledge.txt
@@ -14,6 +14,8 @@ atlas alerts acknowledge
 
 Acknowledges the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-describe.txt
+++ b/docs/atlascli/command/atlas-alerts-describe.txt
@@ -14,6 +14,8 @@ atlas alerts describe
 
 Return the details for the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-list.txt
+++ b/docs/atlascli/command/atlas-alerts-list.txt
@@ -14,6 +14,8 @@ atlas alerts list
 
 Return all alerts for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-settings-create.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-create.txt
@@ -14,6 +14,8 @@ atlas alerts settings create
 
 Create an alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-settings-delete.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-delete.txt
@@ -14,6 +14,8 @@ atlas alerts settings delete
 
 Remove the specified alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-settings-fields-type.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-fields-type.txt
@@ -14,6 +14,8 @@ atlas alerts settings fields type
 
 Return all available field types that the matcherFieldName option accepts when you create or update an alert configuration.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-settings-list.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-list.txt
@@ -14,6 +14,8 @@ atlas alerts settings list
 
 Returns all alert configurations for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-settings-update.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-update.txt
@@ -14,6 +14,8 @@ atlas alerts settings update
 
 Modify the details of the specified alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-alerts-unacknowledge.txt
+++ b/docs/atlascli/command/atlas-alerts-unacknowledge.txt
@@ -14,6 +14,8 @@ atlas alerts unacknowledge
 
 Unacknowledge the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dbusers-create.txt
+++ b/docs/atlascli/command/atlas-dbusers-create.txt
@@ -16,6 +16,8 @@ Create a database user for your project.
 
 If you set --ldapType, --x509Type, and --awsIAMType to NONE, Atlas authenticates this user through SCRAM-SHA. To learn more, see https://www.mongodb.com/docs/manual/core/security-scram/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dbusers-delete.txt
+++ b/docs/atlascli/command/atlas-dbusers-delete.txt
@@ -14,6 +14,8 @@ atlas dbusers delete
 
 Remove the specified database user from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dbusers-describe.txt
+++ b/docs/atlascli/command/atlas-dbusers-describe.txt
@@ -14,6 +14,8 @@ atlas dbusers describe
 
 Return the details for the specified database user for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dbusers-list.txt
+++ b/docs/atlascli/command/atlas-dbusers-list.txt
@@ -14,6 +14,8 @@ atlas dbusers list
 
 Return all database users for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dbusers-update.txt
+++ b/docs/atlascli/command/atlas-dbusers-update.txt
@@ -14,6 +14,8 @@ atlas dbusers update
 
 Modify the details for a database user for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-integrations-create-DATADOG.txt
+++ b/docs/atlascli/command/atlas-integrations-create-DATADOG.txt
@@ -20,6 +20,8 @@ After you integrate with Datadog, you can send metric data about your project to
 		
 Datadog integration is available only for M10+ clusters.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-integrations-create-OPS_GENIE.txt
+++ b/docs/atlascli/command/atlas-integrations-create-OPS_GENIE.txt
@@ -16,6 +16,8 @@ Create or update an Opsgenie integration for your project.
 
 The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Opsgenie.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-integrations-create-PAGER_DUTY.txt
+++ b/docs/atlascli/command/atlas-integrations-create-PAGER_DUTY.txt
@@ -16,6 +16,8 @@ Create or update a PagerDuty integration for your project.
 
 The requesting API key must have the Organization Owner or Project Owner role to configure an integration with PagerDuty.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-integrations-create-VICTOR_OPS.txt
+++ b/docs/atlascli/command/atlas-integrations-create-VICTOR_OPS.txt
@@ -18,6 +18,8 @@ VictorOps is now Splunk On-Call.
 		
 The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Splunk On-Call.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-integrations-create-WEBHOOK.txt
+++ b/docs/atlascli/command/atlas-integrations-create-WEBHOOK.txt
@@ -16,6 +16,8 @@ Create or update a webhook integration for your project.
 
 The requesting API key must have the Organization Owner or Project Owner role to configure a webhook integration.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-integrations-delete.txt
+++ b/docs/atlascli/command/atlas-integrations-delete.txt
@@ -16,6 +16,8 @@ Remove the specified third-party integration from your project.
 
 Deleting an integration from a project removes that integration configuration only for that project. This does not affect any other project or organization's configured integrations.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-integrations-describe.txt
+++ b/docs/atlascli/command/atlas-integrations-describe.txt
@@ -14,6 +14,8 @@ atlas integrations describe
 
 Return the details for the specified third-party integration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-integrations-list.txt
+++ b/docs/atlascli/command/atlas-integrations-list.txt
@@ -14,6 +14,8 @@ atlas integrations list
 
 Return all active third-party integrations for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-accessLists-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-delete.txt
@@ -16,6 +16,8 @@ Remove the specified IP access list entry from your project.
 
 The command prompts you to confirm the operation when you run the command without the force option.
 
+To use this command, you must authenticate with a user account or an API key that has the Read Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-accessLists-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas accessLists describe
 
 Return the details for the specified IP access list entry.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-accessLists-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-list.txt
@@ -14,6 +14,8 @@ mongocli atlas accessLists list
 
 Return all IP access list entries for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-accessLogs-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLogs-list.txt
@@ -14,6 +14,8 @@ mongocli atlas accessLogs list
 
 Retrieve the access logs of a cluster identified by the cluster's name or hostname.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Monitoring Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-acknowledge.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-acknowledge.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts acknowledge
 
 Acknowledges the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts describe
 
 Return the details for the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-list.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts list
 
 Return all alerts for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-create.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts settings create
 
 Create an alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts settings delete
 
 Remove the specified alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-fields-type.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-fields-type.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts settings fields type
 
 Return all available field types that the matcherFieldName option accepts when you create or update an alert configuration.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts settings list
 
 Returns all alert configurations for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-update.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts settings update
 
 Modify the details of the specified alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-unacknowledge.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-unacknowledge.txt
@@ -14,6 +14,8 @@ mongocli atlas alerts unacknowledge
 
 Unacknowledge the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-create.txt
@@ -16,6 +16,8 @@ Create a database user for your project.
 
 If you set --ldapType, --x509Type, and --awsIAMType to NONE, Atlas authenticates this user through SCRAM-SHA. To learn more, see https://www.mongodb.com/docs/manual/core/security-scram/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas dbusers delete
 
 Remove the specified database user from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas dbusers describe
 
 Return the details for the specified database user for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-list.txt
@@ -14,6 +14,8 @@ mongocli atlas dbusers list
 
 Return all database users for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-update.txt
@@ -14,6 +14,8 @@ mongocli atlas dbusers update
 
 Modify the details for a database user for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-integrations-create-DATADOG.txt
+++ b/docs/mongocli/command/mongocli-atlas-integrations-create-DATADOG.txt
@@ -20,6 +20,8 @@ After you integrate with Datadog, you can send metric data about your project to
 		
 Datadog integration is available only for M10+ clusters.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-integrations-create-OPS_GENIE.txt
+++ b/docs/mongocli/command/mongocli-atlas-integrations-create-OPS_GENIE.txt
@@ -16,6 +16,8 @@ Create or update an Opsgenie integration for your project.
 
 The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Opsgenie.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-integrations-create-PAGER_DUTY.txt
+++ b/docs/mongocli/command/mongocli-atlas-integrations-create-PAGER_DUTY.txt
@@ -16,6 +16,8 @@ Create or update a PagerDuty integration for your project.
 
 The requesting API key must have the Organization Owner or Project Owner role to configure an integration with PagerDuty.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-integrations-create-VICTOR_OPS.txt
+++ b/docs/mongocli/command/mongocli-atlas-integrations-create-VICTOR_OPS.txt
@@ -18,6 +18,8 @@ VictorOps is now Splunk On-Call.
 		
 The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Splunk On-Call.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-integrations-create-WEBHOOK.txt
+++ b/docs/mongocli/command/mongocli-atlas-integrations-create-WEBHOOK.txt
@@ -16,6 +16,8 @@ Create or update a webhook integration for your project.
 
 The requesting API key must have the Organization Owner or Project Owner role to configure a webhook integration.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-integrations-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-integrations-delete.txt
@@ -16,6 +16,8 @@ Remove the specified third-party integration from your project.
 
 Deleting an integration from a project removes that integration configuration only for that project. This does not affect any other project or organization's configured integrations.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-integrations-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-integrations-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas integrations describe
 
 Return the details for the specified third-party integration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-integrations-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-integrations-list.txt
@@ -14,6 +14,8 @@ mongocli atlas integrations list
 
 Return all active third-party integrations for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-acknowledge.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-acknowledge.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts acknowledge
 
 Acknowledges the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-describe.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-describe.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts describe
 
 Return the details for the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts list
 
 Return all alerts for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-create.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts settings create
 
 Create an alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-delete.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-delete.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts settings delete
 
 Remove the specified alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-fields-type.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-fields-type.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts settings fields type
 
 Return all available field types that the matcherFieldName option accepts when you create or update an alert configuration.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts settings list
 
 Returns all alert configurations for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-update.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-update.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts settings update
 
 Modify the details of the specified alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-unacknowledge.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-unacknowledge.txt
@@ -14,6 +14,8 @@ mongocli cloud-manager alerts unacknowledge
 
 Unacknowledge the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-acknowledge.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-acknowledge.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts acknowledge
 
 Acknowledges the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-describe.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-describe.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts describe
 
 Return the details for the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts list
 
 Return all alerts for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-create.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-create.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts settings create
 
 Create an alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-delete.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-delete.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts settings delete
 
 Remove the specified alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-fields-type.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-fields-type.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts settings fields type
 
 Return all available field types that the matcherFieldName option accepts when you create or update an alert configuration.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts settings list
 
 Returns all alert configurations for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-update.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-update.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts settings update
 
 Modify the details of the specified alert configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-unacknowledge.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-unacknowledge.txt
@@ -14,6 +14,8 @@ mongocli ops-manager alerts unacknowledge
 
 Unacknowledge the specified alert for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/internal/cli/alerts/acknowledge.go
+++ b/internal/cli/alerts/acknowledge.go
@@ -79,6 +79,7 @@ func AcknowledgeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "acknowledge <alertId>",
 		Short:   "Acknowledges the specified alert for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"ack"},
 		Args:    require.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/alerts/describe.go
+++ b/internal/cli/alerts/describe.go
@@ -63,6 +63,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <alertId>",
 		Aliases: []string{"get"},
 		Short:   "Return the details for the specified alert for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"alertIdDesc": "Unique identifier of the alert you want to describe.",

--- a/internal/cli/alerts/list.go
+++ b/internal/cli/alerts/list.go
@@ -74,6 +74,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Return all alerts for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all alerts for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s alerts list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Aliases: []string{"ls"},

--- a/internal/cli/alerts/settings/create.go
+++ b/internal/cli/alerts/settings/create.go
@@ -67,6 +67,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an alert configuration for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Create an alert configuration that notifies a user when they join a group for the project with the ID 5df90590f10fab5e33de2305:
   %s alerts settings create --event JOINED_GROUP --enabled \
   --notificationType USER --notificationEmailEnabled \

--- a/internal/cli/alerts/settings/delete.go
+++ b/internal/cli/alerts/settings/delete.go
@@ -55,6 +55,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <alertConfigId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified alert configuration for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"alertConfigIdDesc": "Unique identifier of the alert configuration to delete.",

--- a/internal/cli/alerts/settings/fields_type.go
+++ b/internal/cli/alerts/settings/fields_type.go
@@ -58,6 +58,7 @@ func FieldsTypeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "type",
 		Short:   "Return all available field types that the matcherFieldName option accepts when you create or update an alert configuration.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"types"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of accepted field types for the matchersFieldName option:

--- a/internal/cli/alerts/settings/list.go
+++ b/internal/cli/alerts/settings/list.go
@@ -62,6 +62,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Returns all alert configurations for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all alert configurations for the project with the ID 5df90590f10fab5e33de2305:
   %s alerts settings list --projectId 5df90590f10fab5e33de2305 --output json`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{},

--- a/internal/cli/alerts/settings/update.go
+++ b/internal/cli/alerts/settings/update.go
@@ -65,6 +65,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <alertConfigId>",
 		Short: "Modify the details of the specified alert configuration for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"alertConfigIdDesc": "Unique identifier of the alert configuration you want to update.",

--- a/internal/cli/alerts/unacknowledge.go
+++ b/internal/cli/alerts/unacknowledge.go
@@ -69,6 +69,7 @@ func UnacknowledgeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "unacknowledge <alertId>",
 		Short:   "Unacknowledge the specified alert for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"unack"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/atlas/accesslists/delete.go
+++ b/internal/cli/atlas/accesslists/delete.go
@@ -54,8 +54,10 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <entry>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified IP access list entry from your project.",
-		Long:    `The command prompts you to confirm the operation when you run the command without the force option.`,
-		Args:    require.ExactArgs(1),
+		Long: `The command prompts you to confirm the operation when you run the command without the force option.
+
+` + fmt.Sprintf(usage.RequiredRole, "Read Write"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"entryDesc": "The IP address, CIDR address, or AWS security group ID that you want to remove from the access list.",
 		},

--- a/internal/cli/atlas/accesslists/describe.go
+++ b/internal/cli/atlas/accesslists/describe.go
@@ -62,6 +62,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <entry>",
 		Aliases: []string{"get"},
 		Short:   "Return the details for the specified IP access list entry.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"entryDesc": "The IP address, CIDR address, or AWS security group ID of the access list entry to return.",

--- a/internal/cli/atlas/accesslists/list.go
+++ b/internal/cli/atlas/accesslists/list.go
@@ -16,6 +16,7 @@ package accesslists
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -62,6 +63,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all IP access list entries for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: `  # Return a JSON-formatted list of all access list entries for the project with ID 5e1234c17a3e5a48f5497de3:		

--- a/internal/cli/atlas/accesslogs/list.go
+++ b/internal/cli/atlas/accesslogs/list.go
@@ -117,6 +117,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Retrieve the access logs of a cluster identified by the cluster's name or hostname.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Monitoring Admin"),
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -173,7 +173,9 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create [builtInRole]...",
 		Short: "Create a database user for your project.",
-		Long:  `If you set --ldapType, --x509Type, and --awsIAMType to NONE, Atlas authenticates this user through SCRAM-SHA. To learn more, see https://www.mongodb.com/docs/manual/core/security-scram/.`,
+		Long: `If you set --ldapType, --x509Type, and --awsIAMType to NONE, Atlas authenticates this user through SCRAM-SHA. To learn more, see https://www.mongodb.com/docs/manual/core/security-scram/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Create an Atlas database admin user named myAdmin for the project with ID 5e2211c17a3e5a48f5497de3:
   %[1]s dbusers create atlasAdmin --username myAdmin  --projectId 5e2211c17a3e5a48f5497de3
 

--- a/internal/cli/atlas/dbusers/delete.go
+++ b/internal/cli/atlas/dbusers/delete.go
@@ -56,6 +56,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <username>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified database user from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"usernameDesc": "Username to delete from the MongoDB database. The format of the username depends on the user's method of authentication.",

--- a/internal/cli/atlas/dbusers/describe.go
+++ b/internal/cli/atlas/dbusers/describe.go
@@ -63,6 +63,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe <username>",
 		Short:   "Return the details for the specified database user for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.ExactArgs(1),
 		Aliases: []string{"get"},
 		Annotations: map[string]string{

--- a/internal/cli/atlas/dbusers/list.go
+++ b/internal/cli/atlas/dbusers/list.go
@@ -62,6 +62,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all database users for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all database users for the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/atlas/dbusers/update.go
+++ b/internal/cli/atlas/dbusers/update.go
@@ -79,6 +79,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <username>",
 		Short: "Modify the details for a database user for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Update roles for a database user named myUser for the project with the ID 5e2211c17a3e5a48f5497de3:
   %[1]s dbuser update myUser --role readWriteAnyDatabase --projectId 5e2211c17a3e5a48f5497de3
 

--- a/internal/cli/atlas/integrations/create/datadog.go
+++ b/internal/cli/atlas/integrations/create/datadog.go
@@ -75,7 +75,9 @@ func DatadogBuilder() *cobra.Command {
 
 After you integrate with Datadog, you can send metric data about your project to your Datadog dashboard. To learn more about the metrics available to Datadog, see https://www.mongodb.com/docs/atlas/tutorial/datadog-integration/.
 		
-Datadog integration is available only for M10+ clusters.`,
+Datadog integration is available only for M10+ clusters.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Integrate Datadog with Atlas for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create DATADOG --apiKey a1a23bcdef45ghijk6789 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/integrations/create/new_relic.go
+++ b/internal/cli/atlas/integrations/create/new_relic.go
@@ -16,6 +16,7 @@ package create
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -74,6 +75,7 @@ func NewRelicBuilder() *cobra.Command {
 		Use:     "NEW_RELIC",
 		Aliases: []string{"new_relic", "newRelic"},
 		Short:   "Create or update the New Relic integration.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/integrations/create/ops_genie.go
+++ b/internal/cli/atlas/integrations/create/ops_genie.go
@@ -71,7 +71,9 @@ func OpsGenieBuilder() *cobra.Command {
 		Use:     opsGenieType,
 		Aliases: []string{"ops_genie", "opsGenie"},
 		Short:   "Create or update an Opsgenie integration for your project.",
-		Long:    `The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Opsgenie.`,
+		Long: `The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Opsgenie.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Integrate Opsgenie with Atlas for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create OPS_GENIE --apiKey a1a23bcdef45ghijk6789 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/integrations/create/pager_duty.go
+++ b/internal/cli/atlas/integrations/create/pager_duty.go
@@ -69,7 +69,9 @@ func PagerDutyBuilder() *cobra.Command {
 		Use:     pagerDutyIntegrationType,
 		Aliases: []string{"pager_duty", "pagerDuty"},
 		Short:   "Create or update a PagerDuty integration for your project.",
-		Long:    `The requesting API key must have the Organization Owner or Project Owner role to configure an integration with PagerDuty.`,
+		Long: `The requesting API key must have the Organization Owner or Project Owner role to configure an integration with PagerDuty.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Integrate PagerDuty with Atlas for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create PAGER_DUTY --serviceKey a1a23bcdef45ghijk6789 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/integrations/create/victor_ops.go
+++ b/internal/cli/atlas/integrations/create/victor_ops.go
@@ -73,7 +73,9 @@ func VictorOpsBuilder() *cobra.Command {
 		Short:   "Create or update a Splunk On-Call integration for your project.",
 		Long: `VictorOps is now Splunk On-Call.
 		
-The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Splunk On-Call.`,
+The requesting API key must have the Organization Owner or Project Owner role to configure an integration with Splunk On-Call.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Integrate Splunk On-Call with Atlas using the routing key operations for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create VICTOR_OPS --apiKey a1a23bcdef45ghijk6789 --routingKey operations --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/integrations/create/webhook.go
+++ b/internal/cli/atlas/integrations/create/webhook.go
@@ -71,7 +71,9 @@ func WebhookBuilder() *cobra.Command {
 		Use:     webhookIntegrationType,
 		Aliases: []string{"webhook"},
 		Short:   "Create or update a webhook integration for your project.",
-		Long:    `The requesting API key must have the Organization Owner or Project Owner role to configure a webhook integration.`,
+		Long: `The requesting API key must have the Organization Owner or Project Owner role to configure a webhook integration.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Integrate a webhook with Atlas that uses the secret mySecret for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create WEBHOOK --url http://9b4ac7aa.abc.io/payload --secret mySecret --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/integrations/delete.go
+++ b/internal/cli/atlas/integrations/delete.go
@@ -54,8 +54,10 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <integrationType>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified third-party integration from your project.",
-		Long:    `Deleting an integration from a project removes that integration configuration only for that project. This does not affect any other project or organization's configured integrations.`,
-		Args:    require.ExactValidArgs(1),
+		Long: `Deleting an integration from a project removes that integration configuration only for that project. This does not affect any other project or organization's configured integrations.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.ExactValidArgs(1),
 		Example: fmt.Sprintf(`  # Remove the Datadog integration for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations delete DATADOG --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		ValidArgs: []string{"PAGER_DUTY", "MICROSOFT_TEAMS", "SLACK", "DATADOG", "NEW_RELIC", "OPS_GENIE", "VICTOR_OPS", "WEBHOOK", "PROMETHEUS"},

--- a/internal/cli/atlas/integrations/describe.go
+++ b/internal/cli/atlas/integrations/describe.go
@@ -101,6 +101,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <integrationType>",
 		Short: "Return the details for the specified third-party integration for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.ExactValidArgs(1),
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the Datadog integration for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations describe DATADOG --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/integrations/list.go
+++ b/internal/cli/atlas/integrations/list.go
@@ -60,6 +60,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all active third-party integrations for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of active third-party integrations for the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/events/list.go
+++ b/internal/cli/events/list.go
@@ -100,6 +100,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Return all events for an organization or project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Deprecated: `  
   To return project events prefer
   mongocli atlas|ops-manager|cloud-manager events projects list [--projectId <projectId>]


### PR DESCRIPTION
## Proposed changes

Adds required roles for accessLists, accessLogs, alerts, dbusers, events, and integrations commands

All role info is taken from the OpenAPI spec.

Sorry for the long tedious reviews

_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-28110
https://jira.mongodb.org/browse/DOCSP-28113

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
