### PR TITLE
CLOUDP-164354: Fix json-path parsing to output json

### DIFF
--- a/internal/jsonpathwriter/jsonpathwriter.go
+++ b/internal/jsonpathwriter/jsonpathwriter.go
@@ -17,10 +17,10 @@ package jsonpathwriter
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/PaesslerAG/jsonpath"
+	"github.com/mongodb/mongodb-atlas-cli/internal/jsonwriter"
 )
 
 var ErrEmptyPath = errors.New("empty jsonpath")
@@ -44,7 +44,5 @@ func Print(w io.Writer, path string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	_, err = fmt.Fprintln(w, v)
-	return err
+	return jsonwriter.Print(w, v)
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-164354

Pass the result of jsonpath to our json printer so it prints pretty json instead of go structs 

Before 
```bash
atlas projects ls  -o json-path="$.results[0]"
map[created:2020-02-20T10:02:42Z id:<redacted> links:[map[href:https://cloud.mongodb.com/api/atlas/v1.0/groups/<redacted> rel:self]] name:CLI ANDREA orgId:<redacted>]
```

```bash
./bin/atlas projects ls -o json-path="$.results[0]"
{
  "created": "2020-02-20T10:02:42Z",
  "id": "<redacted>",
  "links": [
    {
      "href": "https://cloud-dev.mongodb.com/api/atlas/v1.0/groups/<redacted>",
      "rel": "self"
    }
  ],
  "name": "CLI ANDREA",
  "orgId": "<redacted>"
}
```
