### PR TITLE
task: remove legacy usages of +build tags

### DIFF
--- a/internal/cli/alerts/acknowledge_test.go
+++ b/internal/cli/alerts/acknowledge_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package alerts
 

--- a/internal/cli/alerts/alerts_test.go
+++ b/internal/cli/alerts/alerts_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package alerts
 

--- a/internal/cli/alerts/describe_test.go
+++ b/internal/cli/alerts/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package alerts
 

--- a/internal/cli/alerts/global_list_test.go
+++ b/internal/cli/alerts/global_list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package alerts
 

--- a/internal/cli/alerts/settings/create_test.go
+++ b/internal/cli/alerts/settings/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/alerts/settings/delete_test.go
+++ b/internal/cli/alerts/settings/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/alerts/settings/disable_test.go
+++ b/internal/cli/alerts/settings/disable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/alerts/settings/enable_test.go
+++ b/internal/cli/alerts/settings/enable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/alerts/settings/fields_type_test.go
+++ b/internal/cli/alerts/settings/fields_type_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/alerts/settings/list_test.go
+++ b/internal/cli/alerts/settings/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/alerts/settings/settings_test.go
+++ b/internal/cli/alerts/settings/settings_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/alerts/settings/update_test.go
+++ b/internal/cli/alerts/settings/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/alerts/unacknowledge_test.go
+++ b/internal/cli/alerts/unacknowledge_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package alerts
 

--- a/internal/cli/atlas/accesslists/access_lists_test.go
+++ b/internal/cli/atlas/accesslists/access_lists_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accesslists
 

--- a/internal/cli/atlas/accesslists/create_test.go
+++ b/internal/cli/atlas/accesslists/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accesslists
 

--- a/internal/cli/atlas/accesslists/delete_test.go
+++ b/internal/cli/atlas/accesslists/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accesslists
 

--- a/internal/cli/atlas/accesslists/describe_test.go
+++ b/internal/cli/atlas/accesslists/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accesslists
 

--- a/internal/cli/atlas/accesslists/list_test.go
+++ b/internal/cli/atlas/accesslists/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accesslists
 

--- a/internal/cli/atlas/accesslogs/access_logs_test.go
+++ b/internal/cli/atlas/accesslogs/access_logs_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accesslogs
 

--- a/internal/cli/atlas/accesslogs/list_test.go
+++ b/internal/cli/atlas/accesslogs/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accesslogs
 

--- a/internal/cli/atlas/atlas_darwin.go
+++ b/internal/cli/atlas/atlas_darwin.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build darwin
-// +build darwin
 
 package atlas
 

--- a/internal/cli/atlas/atlas_linux.go
+++ b/internal/cli/atlas/atlas_linux.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package atlas
 

--- a/internal/cli/atlas/atlas_test.go
+++ b/internal/cli/atlas/atlas_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package atlas
 

--- a/internal/cli/atlas/atlas_windows.go
+++ b/internal/cli/atlas/atlas_windows.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build windows
-// +build windows
 
 package atlas
 

--- a/internal/cli/atlas/backup/exports/buckets/describe_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package buckets
 

--- a/internal/cli/atlas/backup/schedule/update_test.go
+++ b/internal/cli/atlas/backup/schedule/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package schedule
 

--- a/internal/cli/atlas/backup/snapshots/describe_test.go
+++ b/internal/cli/atlas/backup/snapshots/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package snapshots
 

--- a/internal/cli/atlas/cloudproviders/accessroles/access_roles_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/access_roles_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accessroles
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/authorize_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/authorize_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/aws_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/aws_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/create_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/cloudproviders/accessroles/list_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package accessroles
 

--- a/internal/cli/atlas/cloudproviders/cloud_providers_test.go
+++ b/internal/cli/atlas/cloudproviders/cloud_providers_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package cloudproviders
 

--- a/internal/cli/atlas/clusters/advancedsettings/advanced_settings_test.go
+++ b/internal/cli/atlas/clusters/advancedsettings/advanced_settings_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package advancedsettings
 

--- a/internal/cli/atlas/clusters/advancedsettings/describe_test.go
+++ b/internal/cli/atlas/clusters/advancedsettings/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package advancedsettings
 

--- a/internal/cli/atlas/clusters/advancedsettings/update_test.go
+++ b/internal/cli/atlas/clusters/advancedsettings/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package advancedsettings
 

--- a/internal/cli/atlas/clusters/availableregions/available_regions_test.go
+++ b/internal/cli/atlas/clusters/availableregions/available_regions_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package availableregions
 

--- a/internal/cli/atlas/clusters/availableregions/list_test.go
+++ b/internal/cli/atlas/clusters/availableregions/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package availableregions
 

--- a/internal/cli/atlas/clusters/connectionstring/connection_string_test.go
+++ b/internal/cli/atlas/clusters/connectionstring/connection_string_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package connectionstring
 

--- a/internal/cli/atlas/clusters/connectionstring/describe_test.go
+++ b/internal/cli/atlas/clusters/connectionstring/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package connectionstring
 

--- a/internal/cli/atlas/clusters/create_test.go
+++ b/internal/cli/atlas/clusters/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/clusters/describe_test.go
+++ b/internal/cli/atlas/clusters/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/clusters/indexes/create_test.go
+++ b/internal/cli/atlas/clusters/indexes/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package indexes
 

--- a/internal/cli/atlas/clusters/indexes/indexes_test.go
+++ b/internal/cli/atlas/clusters/indexes/indexes_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package indexes
 

--- a/internal/cli/atlas/clusters/list_test.go
+++ b/internal/cli/atlas/clusters/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/clusters/loadSampleData_test.go
+++ b/internal/cli/atlas/clusters/loadSampleData_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/clusters/onlinearchive/create_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/onlinearchive/delete_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/onlinearchive/describe_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/onlinearchive/list_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/onlinearchive/online_archive_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/online_archive_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/onlinearchive/pause_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/pause_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/onlinearchive/start_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/start_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/onlinearchive/update_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/onlinearchive/watch_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/clusters/pause_test.go
+++ b/internal/cli/atlas/clusters/pause_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/clusters/start_test.go
+++ b/internal/cli/atlas/clusters/start_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/clusters/update_test.go
+++ b/internal/cli/atlas/clusters/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/clusters/upgrade_test.go
+++ b/internal/cli/atlas/clusters/upgrade_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/clusters/watch_test.go
+++ b/internal/cli/atlas/clusters/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/atlas/commonerrors/errors_test.go
+++ b/internal/cli/atlas/commonerrors/errors_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package commonerrors
 

--- a/internal/cli/atlas/config/config_test.go
+++ b/internal/cli/atlas/config/config_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package config
 

--- a/internal/cli/atlas/config/init_test.go
+++ b/internal/cli/atlas/config/init_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package config
 

--- a/internal/cli/atlas/customdbroles/create_test.go
+++ b/internal/cli/atlas/customdbroles/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customdbroles
 

--- a/internal/cli/atlas/customdbroles/custom_db_roles_test.go
+++ b/internal/cli/atlas/customdbroles/custom_db_roles_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customdbroles
 

--- a/internal/cli/atlas/customdbroles/delete_test.go
+++ b/internal/cli/atlas/customdbroles/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customdbroles
 

--- a/internal/cli/atlas/customdbroles/describe_test.go
+++ b/internal/cli/atlas/customdbroles/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customdbroles
 

--- a/internal/cli/atlas/customdbroles/list_test.go
+++ b/internal/cli/atlas/customdbroles/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customdbroles
 

--- a/internal/cli/atlas/customdbroles/update_test.go
+++ b/internal/cli/atlas/customdbroles/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customdbroles
 

--- a/internal/cli/atlas/customdns/aws/aws_test.go
+++ b/internal/cli/atlas/customdns/aws/aws_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/customdns/aws/describe_test.go
+++ b/internal/cli/atlas/customdns/aws/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/customdns/aws/disable_test.go
+++ b/internal/cli/atlas/customdns/aws/disable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/customdns/aws/enable_test.go
+++ b/internal/cli/atlas/customdns/aws/enable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/customdns/custom_dns_test.go
+++ b/internal/cli/atlas/customdns/custom_dns_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package customdns
 

--- a/internal/cli/atlas/datalake/create_test.go
+++ b/internal/cli/atlas/datalake/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package datalake
 

--- a/internal/cli/atlas/datalake/delete_test.go
+++ b/internal/cli/atlas/datalake/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package datalake
 

--- a/internal/cli/atlas/datalake/describe_test.go
+++ b/internal/cli/atlas/datalake/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package datalake
 

--- a/internal/cli/atlas/datalake/list_test.go
+++ b/internal/cli/atlas/datalake/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package datalake
 

--- a/internal/cli/atlas/datalake/update_test.go
+++ b/internal/cli/atlas/datalake/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package datalake
 

--- a/internal/cli/atlas/dbusers/certs/create_test.go
+++ b/internal/cli/atlas/dbusers/certs/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package certs
 

--- a/internal/cli/atlas/dbusers/certs/list_test.go
+++ b/internal/cli/atlas/dbusers/certs/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package certs
 

--- a/internal/cli/atlas/dbusers/create_test.go
+++ b/internal/cli/atlas/dbusers/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/atlas/dbusers/dbusers_test.go
+++ b/internal/cli/atlas/dbusers/dbusers_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/atlas/dbusers/delete_test.go
+++ b/internal/cli/atlas/dbusers/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/atlas/dbusers/describe_test.go
+++ b/internal/cli/atlas/dbusers/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/atlas/dbusers/list_test.go
+++ b/internal/cli/atlas/dbusers/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/atlas/dbusers/update_test.go
+++ b/internal/cli/atlas/dbusers/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/atlas/integrations/create/create_test.go
+++ b/internal/cli/atlas/integrations/create/create_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/integrations/create/datadog_test.go
+++ b/internal/cli/atlas/integrations/create/datadog_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/integrations/create/new_relic_test.go
+++ b/internal/cli/atlas/integrations/create/new_relic_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/integrations/create/ops_genie_test.go
+++ b/internal/cli/atlas/integrations/create/ops_genie_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/integrations/create/pager_duty_test.go
+++ b/internal/cli/atlas/integrations/create/pager_duty_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/integrations/create/victor_ops_test.go
+++ b/internal/cli/atlas/integrations/create/victor_ops_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/integrations/create/webhook_test.go
+++ b/internal/cli/atlas/integrations/create/webhook_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/integrations/delete_test.go
+++ b/internal/cli/atlas/integrations/delete_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package integrations
 

--- a/internal/cli/atlas/integrations/describe_test.go
+++ b/internal/cli/atlas/integrations/describe_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package integrations
 

--- a/internal/cli/atlas/integrations/integrations_test.go
+++ b/internal/cli/atlas/integrations/integrations_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package integrations
 

--- a/internal/cli/atlas/integrations/list_test.go
+++ b/internal/cli/atlas/integrations/list_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package integrations
 

--- a/internal/cli/atlas/livemigrations/create_test.go
+++ b/internal/cli/atlas/livemigrations/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package livemigrations
 

--- a/internal/cli/atlas/livemigrations/describe_test.go
+++ b/internal/cli/atlas/livemigrations/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package livemigrations
 

--- a/internal/cli/atlas/livemigrations/link/delete_test.go
+++ b/internal/cli/atlas/livemigrations/link/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package link
 

--- a/internal/cli/atlas/livemigrations/link/link_test.go
+++ b/internal/cli/atlas/livemigrations/link/link_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package link
 

--- a/internal/cli/atlas/livemigrations/live_migrations_test.go
+++ b/internal/cli/atlas/livemigrations/live_migrations_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package livemigrations
 

--- a/internal/cli/atlas/livemigrations/validation/validation_test.go
+++ b/internal/cli/atlas/livemigrations/validation/validation_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package validation
 

--- a/internal/cli/atlas/logs/decrypt_test.go
+++ b/internal/cli/atlas/logs/decrypt_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/atlas/logs/download_test.go
+++ b/internal/cli/atlas/logs/download_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/atlas/logs/logs_test.go
+++ b/internal/cli/atlas/logs/logs_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/atlas/maintenance/clear_test.go
+++ b/internal/cli/atlas/maintenance/clear_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/atlas/maintenance/defer_test.go
+++ b/internal/cli/atlas/maintenance/defer_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/atlas/maintenance/describe_test.go
+++ b/internal/cli/atlas/maintenance/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/atlas/maintenance/maintenance_test.go
+++ b/internal/cli/atlas/maintenance/maintenance_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/atlas/maintenance/update_test.go
+++ b/internal/cli/atlas/maintenance/update_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/atlas/metrics/databases/databases_test.go
+++ b/internal/cli/atlas/metrics/databases/databases_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package databases
 

--- a/internal/cli/atlas/metrics/databases/describe_test.go
+++ b/internal/cli/atlas/metrics/databases/describe_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package databases
 

--- a/internal/cli/atlas/metrics/databases/list_test.go
+++ b/internal/cli/atlas/metrics/databases/list_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package databases
 

--- a/internal/cli/atlas/metrics/disks/describe_test.go
+++ b/internal/cli/atlas/metrics/disks/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package disks
 

--- a/internal/cli/atlas/metrics/disks/disks_test.go
+++ b/internal/cli/atlas/metrics/disks/disks_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package disks
 

--- a/internal/cli/atlas/metrics/disks/list_test.go
+++ b/internal/cli/atlas/metrics/disks/list_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package disks
 

--- a/internal/cli/atlas/metrics/metrics_test.go
+++ b/internal/cli/atlas/metrics/metrics_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package metrics
 

--- a/internal/cli/atlas/metrics/processes/processes_test.go
+++ b/internal/cli/atlas/metrics/processes/processes_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package processes
 

--- a/internal/cli/atlas/networking/containers/delete_test.go
+++ b/internal/cli/atlas/networking/containers/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package containers
 

--- a/internal/cli/atlas/networking/containers/list_test.go
+++ b/internal/cli/atlas/networking/containers/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package containers
 

--- a/internal/cli/atlas/networking/peering/create/aws_test.go
+++ b/internal/cli/atlas/networking/peering/create/aws_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/networking/peering/create/azure_test.go
+++ b/internal/cli/atlas/networking/peering/create/azure_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/networking/peering/create/gcp_test.go
+++ b/internal/cli/atlas/networking/peering/create/gcp_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package create
 

--- a/internal/cli/atlas/networking/peering/delete_test.go
+++ b/internal/cli/atlas/networking/peering/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package peering
 

--- a/internal/cli/atlas/networking/peering/list_test.go
+++ b/internal/cli/atlas/networking/peering/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package peering
 

--- a/internal/cli/atlas/networking/peering/watch_test.go
+++ b/internal/cli/atlas/networking/peering/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package peering
 

--- a/internal/cli/atlas/privateendpoints/aws/aws_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/aws_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/aws/create_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/aws/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/aws/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/interfaces_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/interfaces_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/aws/list_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/aws/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/azure/azure_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/azure_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package azure
 

--- a/internal/cli/atlas/privateendpoints/azure/create_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package azure
 

--- a/internal/cli/atlas/privateendpoints/azure/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package azure
 

--- a/internal/cli/atlas/privateendpoints/azure/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package azure
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/interfaces_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/interfaces_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/azure/list_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package azure
 

--- a/internal/cli/atlas/privateendpoints/azure/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package azure
 

--- a/internal/cli/atlas/privateendpoints/create_test.go
+++ b/internal/cli/atlas/privateendpoints/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package privateendpoints
 

--- a/internal/cli/atlas/privateendpoints/datalake/aws/aws_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/aws_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/datalake/aws/create_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/datalake/aws/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/datalake/aws/list_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package aws
 

--- a/internal/cli/atlas/privateendpoints/datalake/data_lake_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/data_lake_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package datalake
 

--- a/internal/cli/atlas/privateendpoints/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package privateendpoints
 

--- a/internal/cli/atlas/privateendpoints/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package privateendpoints
 

--- a/internal/cli/atlas/privateendpoints/gcp/create_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package gcp
 

--- a/internal/cli/atlas/privateendpoints/gcp/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package gcp
 

--- a/internal/cli/atlas/privateendpoints/gcp/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package gcp
 

--- a/internal/cli/atlas/privateendpoints/gcp/gcp_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/gcp_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package gcp
 

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/interfaces_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/interfaces_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/gcp/list_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package gcp
 

--- a/internal/cli/atlas/privateendpoints/gcp/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package gcp
 

--- a/internal/cli/atlas/privateendpoints/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package interfaces
 

--- a/internal/cli/atlas/privateendpoints/list_test.go
+++ b/internal/cli/atlas/privateendpoints/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package privateendpoints
 

--- a/internal/cli/atlas/privateendpoints/onlinearchive/online_archive_test.go
+++ b/internal/cli/atlas/privateendpoints/onlinearchive/online_archive_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package onlinearchive
 

--- a/internal/cli/atlas/privateendpoints/private_endpoint_test.go
+++ b/internal/cli/atlas/privateendpoints/private_endpoint_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package privateendpoints
 

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package regionalmodes
 

--- a/internal/cli/atlas/privateendpoints/regionalmodes/disable_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/disable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package regionalmodes
 

--- a/internal/cli/atlas/privateendpoints/regionalmodes/enable_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/enable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package regionalmodes
 

--- a/internal/cli/atlas/privateendpoints/regionalmodes/regional_mode_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/regional_mode_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package regionalmodes
 

--- a/internal/cli/atlas/privateendpoints/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package privateendpoints
 

--- a/internal/cli/atlas/processes/processes_test.go
+++ b/internal/cli/atlas/processes/processes_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package processes
 

--- a/internal/cli/atlas/quickstart/quick_start_test.go
+++ b/internal/cli/atlas/quickstart/quick_start_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package quickstart
 

--- a/internal/cli/atlas/search/create_test.go
+++ b/internal/cli/atlas/search/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package search
 

--- a/internal/cli/atlas/search/delete_test.go
+++ b/internal/cli/atlas/search/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package search
 

--- a/internal/cli/atlas/search/describe_test.go
+++ b/internal/cli/atlas/search/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package search
 

--- a/internal/cli/atlas/search/list_test.go
+++ b/internal/cli/atlas/search/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package search
 

--- a/internal/cli/atlas/search/update_test.go
+++ b/internal/cli/atlas/search/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package search
 

--- a/internal/cli/atlas/security/customercerts/create_test.go
+++ b/internal/cli/atlas/security/customercerts/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customercerts
 

--- a/internal/cli/atlas/security/customercerts/describe_test.go
+++ b/internal/cli/atlas/security/customercerts/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customercerts
 

--- a/internal/cli/atlas/security/customercerts/disable_test.go
+++ b/internal/cli/atlas/security/customercerts/disable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package customercerts
 

--- a/internal/cli/atlas/security/ldap/delete_test.go
+++ b/internal/cli/atlas/security/ldap/delete_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package ldap
 

--- a/internal/cli/atlas/security/ldap/get_test.go
+++ b/internal/cli/atlas/security/ldap/get_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package ldap
 

--- a/internal/cli/atlas/security/ldap/ldap_test.go
+++ b/internal/cli/atlas/security/ldap/ldap_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package ldap
 

--- a/internal/cli/atlas/security/ldap/save_test.go
+++ b/internal/cli/atlas/security/ldap/save_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package ldap
 

--- a/internal/cli/atlas/security/ldap/status_test.go
+++ b/internal/cli/atlas/security/ldap/status_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package ldap
 

--- a/internal/cli/atlas/security/ldap/verify_test.go
+++ b/internal/cli/atlas/security/ldap/verify_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package ldap
 

--- a/internal/cli/atlas/security/ldap/watch_test.go
+++ b/internal/cli/atlas/security/ldap/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package ldap
 

--- a/internal/cli/atlas/security/security_test.go
+++ b/internal/cli/atlas/security/security_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package security
 

--- a/internal/cli/atlas/serverless/backup/snapshots/describe_test.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package snapshots
 

--- a/internal/cli/atlas/serverless/create_test.go
+++ b/internal/cli/atlas/serverless/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package serverless
 

--- a/internal/cli/atlas/serverless/delete_test.go
+++ b/internal/cli/atlas/serverless/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package serverless
 

--- a/internal/cli/atlas/serverless/describe_test.go
+++ b/internal/cli/atlas/serverless/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package serverless
 

--- a/internal/cli/atlas/serverless/list_test.go
+++ b/internal/cli/atlas/serverless/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package serverless
 

--- a/internal/cli/atlas/serverless/serverless_test.go
+++ b/internal/cli/atlas/serverless/serverless_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package serverless
 

--- a/internal/cli/atlas/serverless/watch_test.go
+++ b/internal/cli/atlas/serverless/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package serverless
 

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package auth
 

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package auth
 

--- a/internal/cli/auth/whoami_test.go
+++ b/internal/cli/auth/whoami_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package auth
 

--- a/internal/cli/cloudmanager/cloud_manager_test.go
+++ b/internal/cli/cloudmanager/cloud_manager_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package cloudmanager
 

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package config
 

--- a/internal/cli/config/default_editor.go
+++ b/internal/cli/config/default_editor.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package config
 

--- a/internal/cli/config/set_test.go
+++ b/internal/cli/config/set_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package config
 

--- a/internal/cli/decryption/key_providers_test.go
+++ b/internal/cli/decryption/key_providers_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package decryption
 

--- a/internal/cli/decryption/list_key_provider_test.go
+++ b/internal/cli/decryption/list_key_provider_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package decryption
 

--- a/internal/cli/events/list_test.go
+++ b/internal/cli/events/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package events
 

--- a/internal/cli/events/orgs_list.go
+++ b/internal/cli/events/orgs_list.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package events
 
 import (
@@ -48,7 +49,6 @@ func (opts *orgListOpts) Run() error {
 	var r *atlas.EventResponse
 	var err error
 	r, err = opts.store.OrganizationEvents(opts.ConfigOrgID(), listOpts)
-
 	if err != nil {
 		return err
 	}

--- a/internal/cli/figautocomplete/fig_autocomplete_test.go
+++ b/internal/cli/figautocomplete/fig_autocomplete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package figautocomplete
 

--- a/internal/cli/iam/globalaccesslists/create_test.go
+++ b/internal/cli/iam/globalaccesslists/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalaccesslists
 

--- a/internal/cli/iam/globalaccesslists/delete_test.go
+++ b/internal/cli/iam/globalaccesslists/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalaccesslists
 

--- a/internal/cli/iam/globalaccesslists/describe_test.go
+++ b/internal/cli/iam/globalaccesslists/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalaccesslists
 

--- a/internal/cli/iam/globalaccesslists/global_access_lists_test.go
+++ b/internal/cli/iam/globalaccesslists/global_access_lists_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalaccesslists
 

--- a/internal/cli/iam/globalaccesslists/list_test.go
+++ b/internal/cli/iam/globalaccesslists/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalaccesslists
 

--- a/internal/cli/iam/globalapikeys/create_test.go
+++ b/internal/cli/iam/globalapikeys/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalapikeys
 

--- a/internal/cli/iam/globalapikeys/delete_test.go
+++ b/internal/cli/iam/globalapikeys/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalapikeys
 

--- a/internal/cli/iam/globalapikeys/describe_test.go
+++ b/internal/cli/iam/globalapikeys/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalapikeys
 

--- a/internal/cli/iam/globalapikeys/list_test.go
+++ b/internal/cli/iam/globalapikeys/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalapikeys
 

--- a/internal/cli/iam/globalapikeys/update_test.go
+++ b/internal/cli/iam/globalapikeys/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package globalapikeys
 

--- a/internal/cli/iam/iam_test.go
+++ b/internal/cli/iam/iam_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package iam
 

--- a/internal/cli/iam/organizations/apikeys/create_test.go
+++ b/internal/cli/iam/organizations/apikeys/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/iam/organizations/apikeys/delete_test.go
+++ b/internal/cli/iam/organizations/apikeys/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/iam/organizations/apikeys/describe_test.go
+++ b/internal/cli/iam/organizations/apikeys/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/iam/organizations/apikeys/list_test.go
+++ b/internal/cli/iam/organizations/apikeys/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/iam/organizations/apikeys/update_test.go
+++ b/internal/cli/iam/organizations/apikeys/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/iam/organizations/invitations/delete_test.go
+++ b/internal/cli/iam/organizations/invitations/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/organizations/invitations/describe_test.go
+++ b/internal/cli/iam/organizations/invitations/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/organizations/invitations/invitations_test.go
+++ b/internal/cli/iam/organizations/invitations/invitations_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/organizations/invitations/invite_test.go
+++ b/internal/cli/iam/organizations/invitations/invite_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/organizations/invitations/list_test.go
+++ b/internal/cli/iam/organizations/invitations/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/organizations/invitations/update_test.go
+++ b/internal/cli/iam/organizations/invitations/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/organizations/list_test.go
+++ b/internal/cli/iam/organizations/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package organizations
 

--- a/internal/cli/iam/projects/apikeys/delete_test.go
+++ b/internal/cli/iam/projects/apikeys/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/iam/projects/create_test.go
+++ b/internal/cli/iam/projects/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package projects
 

--- a/internal/cli/iam/projects/delete_test.go
+++ b/internal/cli/iam/projects/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package projects
 

--- a/internal/cli/iam/projects/describe_test.go
+++ b/internal/cli/iam/projects/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package projects
 

--- a/internal/cli/iam/projects/invitations/delete_test.go
+++ b/internal/cli/iam/projects/invitations/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/projects/invitations/describe_test.go
+++ b/internal/cli/iam/projects/invitations/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/projects/invitations/invitations_test.go
+++ b/internal/cli/iam/projects/invitations/invitations_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/projects/invitations/invite_test.go
+++ b/internal/cli/iam/projects/invitations/invite_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/projects/invitations/list_test.go
+++ b/internal/cli/iam/projects/invitations/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/projects/invitations/update_test.go
+++ b/internal/cli/iam/projects/invitations/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package invitations
 

--- a/internal/cli/iam/projects/projects_test.go
+++ b/internal/cli/iam/projects/projects_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package projects
 

--- a/internal/cli/iam/projects/settings/describe_test.go
+++ b/internal/cli/iam/projects/settings/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/iam/projects/settings/settings_test.go
+++ b/internal/cli/iam/projects/settings/settings_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/iam/projects/settings/update_test.go
+++ b/internal/cli/iam/projects/settings/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package settings
 

--- a/internal/cli/iam/projects/teams/add_test.go
+++ b/internal/cli/iam/projects/teams/add_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package teams
 

--- a/internal/cli/iam/projects/teams/delete_test.go
+++ b/internal/cli/iam/projects/teams/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package teams
 

--- a/internal/cli/iam/projects/teams/list_test.go
+++ b/internal/cli/iam/projects/teams/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package teams
 

--- a/internal/cli/iam/projects/teams/update_test.go
+++ b/internal/cli/iam/projects/teams/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package teams
 

--- a/internal/cli/iam/projects/users/delete_test.go
+++ b/internal/cli/iam/projects/users/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package users
 

--- a/internal/cli/iam/projects/users/list_test.go
+++ b/internal/cli/iam/projects/users/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package users
 

--- a/internal/cli/iam/teams/create_test.go
+++ b/internal/cli/iam/teams/create_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package teams
 

--- a/internal/cli/iam/teams/delete_test.go
+++ b/internal/cli/iam/teams/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package teams
 

--- a/internal/cli/iam/teams/describe_test.go
+++ b/internal/cli/iam/teams/describe_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package teams
 

--- a/internal/cli/iam/teams/list_test.go
+++ b/internal/cli/iam/teams/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package teams
 

--- a/internal/cli/iam/teams/users/add_test.go
+++ b/internal/cli/iam/teams/users/add_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package users
 

--- a/internal/cli/iam/teams/users/delete_test.go
+++ b/internal/cli/iam/teams/users/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package users
 

--- a/internal/cli/iam/teams/users/list_test.go
+++ b/internal/cli/iam/teams/users/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package users
 

--- a/internal/cli/iam/users/delete_test.go
+++ b/internal/cli/iam/users/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package users
 

--- a/internal/cli/iam/users/describe_test.go
+++ b/internal/cli/iam/users/describe_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package users
 

--- a/internal/cli/iam/users/invite_test.go
+++ b/internal/cli/iam/users/invite_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package users
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/blockstore_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/blockstore_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package blockstore
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/create_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package blockstore
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package blockstore
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package blockstore
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package blockstore
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/update_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package blockstore
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/create_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package filesystem
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package filesystem
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package filesystem
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/file_system_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/file_system_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package filesystem
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package filesystem
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/update_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package filesystem
 

--- a/internal/cli/opsmanager/admin/backup/oplog/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/create_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package oplog
 

--- a/internal/cli/opsmanager/admin/backup/oplog/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package oplog
 

--- a/internal/cli/opsmanager/admin/backup/oplog/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package oplog
 

--- a/internal/cli/opsmanager/admin/backup/oplog/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package oplog
 

--- a/internal/cli/opsmanager/admin/backup/oplog/oplog_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/oplog_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package oplog
 

--- a/internal/cli/opsmanager/admin/backup/oplog/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/update_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package oplog
 

--- a/internal/cli/opsmanager/admin/backup/s3/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/create_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package s3
 

--- a/internal/cli/opsmanager/admin/backup/s3/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package s3
 

--- a/internal/cli/opsmanager/admin/backup/s3/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package s3
 

--- a/internal/cli/opsmanager/admin/backup/s3/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package s3
 

--- a/internal/cli/opsmanager/admin/backup/s3/s3_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/s3_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package s3
 

--- a/internal/cli/opsmanager/admin/backup/s3/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/update_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package s3
 

--- a/internal/cli/opsmanager/admin/backup/sync/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package sync
 

--- a/internal/cli/opsmanager/admin/backup/sync/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package sync
 

--- a/internal/cli/opsmanager/admin/backup/sync/sync_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/sync_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package sync
 

--- a/internal/cli/opsmanager/admin/backup/sync/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/update_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package sync
 

--- a/internal/cli/opsmanager/agents/agent_test.go
+++ b/internal/cli/opsmanager/agents/agent_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package agents
 

--- a/internal/cli/opsmanager/agents/apikeys/create_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/opsmanager/agents/apikeys/delete_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/opsmanager/agents/apikeys/list_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package apikeys
 

--- a/internal/cli/opsmanager/agents/list_test.go
+++ b/internal/cli/opsmanager/agents/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package agents
 

--- a/internal/cli/opsmanager/agents/upgrade_test.go
+++ b/internal/cli/opsmanager/agents/upgrade_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package agents
 

--- a/internal/cli/opsmanager/agents/versions/list_test.go
+++ b/internal/cli/opsmanager/agents/versions/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package versions
 

--- a/internal/cli/opsmanager/agents/versions/versions_test.go
+++ b/internal/cli/opsmanager/agents/versions/versions_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package versions
 

--- a/internal/cli/opsmanager/automation/describe_test.go
+++ b/internal/cli/opsmanager/automation/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package automation
 

--- a/internal/cli/opsmanager/automation/status_test.go
+++ b/internal/cli/opsmanager/automation/status_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package automation
 

--- a/internal/cli/opsmanager/automation/update_test.go
+++ b/internal/cli/opsmanager/automation/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package automation
 

--- a/internal/cli/opsmanager/automation/watch_test.go
+++ b/internal/cli/opsmanager/automation/watch_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package automation
 

--- a/internal/cli/opsmanager/backup/backup_test.go
+++ b/internal/cli/opsmanager/backup/backup_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package backup
 

--- a/internal/cli/opsmanager/backup/checkpoints_list_test.go
+++ b/internal/cli/opsmanager/backup/checkpoints_list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package backup
 

--- a/internal/cli/opsmanager/backup/config/config_test.go
+++ b/internal/cli/opsmanager/backup/config/config_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package config
 

--- a/internal/cli/opsmanager/backup/config/describe_test.go
+++ b/internal/cli/opsmanager/backup/config/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package config
 

--- a/internal/cli/opsmanager/backup/config/list_test.go
+++ b/internal/cli/opsmanager/backup/config/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package config
 

--- a/internal/cli/opsmanager/backup/config/update_test.go
+++ b/internal/cli/opsmanager/backup/config/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package config
 

--- a/internal/cli/opsmanager/backup/disable_test.go
+++ b/internal/cli/opsmanager/backup/disable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package backup
 

--- a/internal/cli/opsmanager/backup/enable_test.go
+++ b/internal/cli/opsmanager/backup/enable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package backup
 

--- a/internal/cli/opsmanager/backup/restores_list_test.go
+++ b/internal/cli/opsmanager/backup/restores_list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package backup
 

--- a/internal/cli/opsmanager/backup/restores_start_test.go
+++ b/internal/cli/opsmanager/backup/restores_start_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package backup
 

--- a/internal/cli/opsmanager/backup/snapshots/list_test.go
+++ b/internal/cli/opsmanager/backup/snapshots/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package snapshots
 

--- a/internal/cli/opsmanager/backup/snapshots/snapshots_test.go
+++ b/internal/cli/opsmanager/backup/snapshots/snapshots_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package snapshots
 

--- a/internal/cli/opsmanager/clusters/apply_test.go
+++ b/internal/cli/opsmanager/clusters/apply_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/clusters_test.go
+++ b/internal/cli/opsmanager/clusters/clusters_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/create_test.go
+++ b/internal/cli/opsmanager/clusters/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/delete_test.go
+++ b/internal/cli/opsmanager/clusters/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/describe_test.go
+++ b/internal/cli/opsmanager/clusters/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/indexes_create_test.go
+++ b/internal/cli/opsmanager/clusters/indexes_create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/list_test.go
+++ b/internal/cli/opsmanager/clusters/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/reclaim_free_space_test.go
+++ b/internal/cli/opsmanager/clusters/reclaim_free_space_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/restart_test.go
+++ b/internal/cli/opsmanager/clusters/restart_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/shutdown_test.go
+++ b/internal/cli/opsmanager/clusters/shutdown_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/startup_test.go
+++ b/internal/cli/opsmanager/clusters/startup_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/unmanage_test.go
+++ b/internal/cli/opsmanager/clusters/unmanage_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/clusters/update_test.go
+++ b/internal/cli/opsmanager/clusters/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package clusters
 

--- a/internal/cli/opsmanager/dbusers/create_test.go
+++ b/internal/cli/opsmanager/dbusers/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/opsmanager/dbusers/dbusers_test.go
+++ b/internal/cli/opsmanager/dbusers/dbusers_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/opsmanager/dbusers/delete_test.go
+++ b/internal/cli/opsmanager/dbusers/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/opsmanager/dbusers/list_test.go
+++ b/internal/cli/opsmanager/dbusers/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package dbusers
 

--- a/internal/cli/opsmanager/diagnosearchive/diagnose_archive_download_test.go
+++ b/internal/cli/opsmanager/diagnosearchive/diagnose_archive_download_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package diagnosearchive
 

--- a/internal/cli/opsmanager/diagnosearchive/diagnose_archive_test.go
+++ b/internal/cli/opsmanager/diagnosearchive/diagnose_archive_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package diagnosearchive
 

--- a/internal/cli/opsmanager/featurepolicies/feature_policies_test.go
+++ b/internal/cli/opsmanager/featurepolicies/feature_policies_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package featurepolicies
 

--- a/internal/cli/opsmanager/featurepolicies/list_test.go
+++ b/internal/cli/opsmanager/featurepolicies/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package featurepolicies
 

--- a/internal/cli/opsmanager/featurepolicies/update_test.go
+++ b/internal/cli/opsmanager/featurepolicies/update_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package featurepolicies
 

--- a/internal/cli/opsmanager/livemigrations/link/create_test.go
+++ b/internal/cli/opsmanager/livemigrations/link/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package link
 

--- a/internal/cli/opsmanager/livemigrations/link/delete_test.go
+++ b/internal/cli/opsmanager/livemigrations/link/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package link
 

--- a/internal/cli/opsmanager/livemigrations/link/describe_test.go
+++ b/internal/cli/opsmanager/livemigrations/link/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package link
 

--- a/internal/cli/opsmanager/livemigrations/link/link_test.go
+++ b/internal/cli/opsmanager/livemigrations/link/link_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package link
 

--- a/internal/cli/opsmanager/livemigrations/live_migrations_test.go
+++ b/internal/cli/opsmanager/livemigrations/live_migrations_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package livemigrations
 

--- a/internal/cli/opsmanager/logs/decrypt_test.go
+++ b/internal/cli/opsmanager/logs/decrypt_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/opsmanager/logs/jobs_collect_test.go
+++ b/internal/cli/opsmanager/logs/jobs_collect_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/opsmanager/logs/jobs_delete_test.go
+++ b/internal/cli/opsmanager/logs/jobs_delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/opsmanager/logs/jobs_download_test.go
+++ b/internal/cli/opsmanager/logs/jobs_download_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/opsmanager/logs/jobs_list_test.go
+++ b/internal/cli/opsmanager/logs/jobs_list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/opsmanager/logs/jobs_test.go
+++ b/internal/cli/opsmanager/logs/jobs_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/opsmanager/logs/logs_test.go
+++ b/internal/cli/opsmanager/logs/logs_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package logs
 

--- a/internal/cli/opsmanager/maintenance/create_test.go
+++ b/internal/cli/opsmanager/maintenance/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/opsmanager/maintenance/delete_test.go
+++ b/internal/cli/opsmanager/maintenance/delete_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/opsmanager/maintenance/describe_test.go
+++ b/internal/cli/opsmanager/maintenance/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/opsmanager/maintenance/list_test.go
+++ b/internal/cli/opsmanager/maintenance/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/opsmanager/maintenance/maintenance_test.go
+++ b/internal/cli/opsmanager/maintenance/maintenance_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/opsmanager/maintenance/update_test.go
+++ b/internal/cli/opsmanager/maintenance/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package maintenance
 

--- a/internal/cli/opsmanager/metrics/databases_describe_test.go
+++ b/internal/cli/opsmanager/metrics/databases_describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package metrics
 

--- a/internal/cli/opsmanager/metrics/databases_list_test.go
+++ b/internal/cli/opsmanager/metrics/databases_list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package metrics
 

--- a/internal/cli/opsmanager/metrics/disks_describe_test.go
+++ b/internal/cli/opsmanager/metrics/disks_describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package metrics
 

--- a/internal/cli/opsmanager/metrics/disks_list_test.go
+++ b/internal/cli/opsmanager/metrics/disks_list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package metrics
 

--- a/internal/cli/opsmanager/metrics/metrics_test.go
+++ b/internal/cli/opsmanager/metrics/metrics_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package metrics
 

--- a/internal/cli/opsmanager/metrics/process_test.go
+++ b/internal/cli/opsmanager/metrics/process_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package metrics
 

--- a/internal/cli/opsmanager/monitoring/disable_test.go
+++ b/internal/cli/opsmanager/monitoring/disable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package monitoring
 

--- a/internal/cli/opsmanager/monitoring/enable_test.go
+++ b/internal/cli/opsmanager/monitoring/enable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package monitoring
 

--- a/internal/cli/opsmanager/monitoring/stop_test.go
+++ b/internal/cli/opsmanager/monitoring/stop_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package monitoring
 

--- a/internal/cli/opsmanager/ops_manager_test.go
+++ b/internal/cli/opsmanager/ops_manager_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package opsmanager
 

--- a/internal/cli/opsmanager/owner/create_test.go
+++ b/internal/cli/opsmanager/owner/create_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package owner
 

--- a/internal/cli/opsmanager/owner/owner_test.go
+++ b/internal/cli/opsmanager/owner/owner_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package owner
 

--- a/internal/cli/opsmanager/processes/describe_test.go
+++ b/internal/cli/opsmanager/processes/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package processes
 

--- a/internal/cli/opsmanager/processes/list_test.go
+++ b/internal/cli/opsmanager/processes/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package processes
 

--- a/internal/cli/opsmanager/processes/processes_test.go
+++ b/internal/cli/opsmanager/processes/processes_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package processes
 

--- a/internal/cli/opsmanager/security/enable_test.go
+++ b/internal/cli/opsmanager/security/enable_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package security
 

--- a/internal/cli/opsmanager/security/security_test.go
+++ b/internal/cli/opsmanager/security/security_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package security
 

--- a/internal/cli/opsmanager/servers/list_test.go
+++ b/internal/cli/opsmanager/servers/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package servers
 

--- a/internal/cli/opsmanager/servers/servers_test.go
+++ b/internal/cli/opsmanager/servers/servers_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package servers
 

--- a/internal/cli/opsmanager/serverusage/capture_test.go
+++ b/internal/cli/opsmanager/serverusage/capture_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package serverusage
 

--- a/internal/cli/opsmanager/serverusage/download_test.go
+++ b/internal/cli/opsmanager/serverusage/download_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package serverusage
 

--- a/internal/cli/opsmanager/serverusage/organizations/hosts/hosts_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/hosts/hosts_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package hosts
 

--- a/internal/cli/opsmanager/serverusage/organizations/hosts/list_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/hosts/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package hosts
 

--- a/internal/cli/opsmanager/serverusage/organizations/organizations_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/organizations_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package organizations
 

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/describe_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package servertype
 

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/server_type_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/server_type_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package servertype
 

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/set_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/set_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package servertype
 

--- a/internal/cli/opsmanager/serverusage/projects/hosts/hosts_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/hosts/hosts_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //go:build unit
-// +build unit
 
 package hosts
 

--- a/internal/cli/opsmanager/serverusage/projects/hosts/list_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/hosts/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package hosts
 

--- a/internal/cli/opsmanager/serverusage/projects/projects_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/projects_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package projects
 

--- a/internal/cli/opsmanager/serverusage/projects/servertype/describe_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/describe_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package servertype
 

--- a/internal/cli/opsmanager/serverusage/projects/servertype/server_type_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/server_type_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package servertype
 

--- a/internal/cli/opsmanager/serverusage/projects/servertype/set_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/set_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package servertype
 

--- a/internal/cli/opsmanager/serverusage/server_usage_test.go
+++ b/internal/cli/opsmanager/serverusage/server_usage_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package serverusage
 

--- a/internal/cli/opsmanager/softwarecomponents/list_test.go
+++ b/internal/cli/opsmanager/softwarecomponents/list_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package softwarecompotents
 

--- a/internal/cli/opsmanager/softwarecomponents/software_components_test.go
+++ b/internal/cli/opsmanager/softwarecomponents/software_components_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package softwarecompotents
 

--- a/internal/cli/opsmanager/versionmanifest/update_test.go
+++ b/internal/cli/opsmanager/versionmanifest/update_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package versionmanifest
 

--- a/internal/cli/opsmanager/versionmanifest/version_manifest_test.go
+++ b/internal/cli/opsmanager/versionmanifest/version_manifest_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package versionmanifest
 

--- a/internal/cli/performanceadvisor/suggestedindexes/list_test.go
+++ b/internal/cli/performanceadvisor/suggestedindexes/list_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package suggestedindexes
 

--- a/internal/cli/performanceadvisor/suggestedindexes/suggestedindexes_test.go
+++ b/internal/cli/performanceadvisor/suggestedindexes/suggestedindexes_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package suggestedindexes
 

--- a/internal/decryption/pem/pem_test.go
+++ b/internal/decryption/pem/pem_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package pem
 
@@ -25,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const DummyCA = `-----BEGIN CERTIFICATE-----
+const dummyCA = `-----BEGIN CERTIFICATE-----
 MIIDVDCCAjwCCQDYPsYgBDwJyDANBgkqhkiG9w0BAQsFADBsMQswCQYDVQQGEwJJ
 RTEKMAgGA1UECAwBRDEPMA0GA1UEBwwGRHVibGluMRUwEwYDVQQKDAxETyBOT1Qg
 VFJVU1QxFTATBgNVBAsMDERPIE5PVCBUUlVTVDESMBAGA1UEAwwJbG9jYWxob3N0
@@ -129,8 +128,8 @@ U7dWGIYfntsGNMmigGYyUY8+RtrhyaUURJJ9OlJ68w1wEh/BRdCFFSQ=
 `
 
 /* #nosec */
-const DummyPwd = "njs5Ndl1HllX1I2"
-const DummyEncryptedCert = `-----BEGIN CERTIFICATE-----
+const dummyPwd = "njs5Ndl1HllX1I2"
+const dummyEncryptedCert = `-----BEGIN CERTIFICATE-----
 MIIFNTCCBB2gAwIBAgIJAPWNjXbYMr7kMA0GCSqGSIb3DQEBCwUAMGwxCzAJBgNV
 BAYTAklFMQowCAYDVQQIDAFEMQ8wDQYDVQQHDAZEdWJsaW4xFTATBgNVBAoMDERP
 IE5PVCBUUlVTVDEVMBMGA1UECwwMRE8gTk9UIFRSVVNUMRIwEAYDVQQDDAlsb2Nh
@@ -219,7 +218,7 @@ IXbLbUL9NcvLyZnehDa7vPWIoQ==
 func TestValidateBlocks(t *testing.T) {
 	t.Run("CA with private key and cert blocks is valid", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		_ = afero.WriteFile(fs, "pemfile", []byte(DummyCA), 0600)
+		_ = afero.WriteFile(fs, "pemfile", []byte(dummyCA), 0600)
 		pem := &pemDecoderValidator{fs: fs}
 
 		isEncrypted, err := pem.ValidateBlocks("pemfile")
@@ -241,7 +240,7 @@ func TestValidateBlocks(t *testing.T) {
 
 	t.Run("client cert with encrypted private key and cert blocks is valid", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		_ = afero.WriteFile(fs, "pemfile", []byte(DummyEncryptedCert), 0600)
+		_ = afero.WriteFile(fs, "pemfile", []byte(dummyEncryptedCert), 0600)
 		pem := &pemDecoderValidator{fs: fs}
 
 		isEncrypted, err := pem.ValidateBlocks("pemfile")
@@ -278,7 +277,7 @@ func TestValidateBlocks(t *testing.T) {
 func TestDecode(t *testing.T) {
 	t.Run("decode CA", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		_ = afero.WriteFile(fs, "pemfile", []byte(DummyCA), 0600)
+		_ = afero.WriteFile(fs, "pemfile", []byte(dummyCA), 0600)
 		pem := &pemDecoderValidator{fs: fs}
 
 		cert, privateKey, err := pem.Decode("pemfile", "")
@@ -290,7 +289,7 @@ func TestDecode(t *testing.T) {
 
 	t.Run("decode client cert with encrypted private key using wrong password returns error", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		_ = afero.WriteFile(fs, "pemfile", []byte(DummyEncryptedCert), 0600)
+		_ = afero.WriteFile(fs, "pemfile", []byte(dummyEncryptedCert), 0600)
 		pem := &pemDecoderValidator{fs: fs}
 
 		cert, privateKey, err := pem.Decode("pemfile", "wrong pwd")
@@ -302,10 +301,10 @@ func TestDecode(t *testing.T) {
 
 	t.Run("decode client cert with encrypted private key using correct password is successful", func(t *testing.T) {
 		fs := afero.NewMemMapFs()
-		_ = afero.WriteFile(fs, "pemfile", []byte(DummyEncryptedCert), 0600)
+		_ = afero.WriteFile(fs, "pemfile", []byte(dummyEncryptedCert), 0600)
 		pem := &pemDecoderValidator{fs: fs}
 
-		cert, privateKey, err := pem.Decode("pemfile", DummyPwd)
+		cert, privateKey, err := pem.Decode("pemfile", dummyPwd)
 
 		assert.NoError(t, err)
 		assert.Contains(t, string(cert), CertificateBlock)

--- a/internal/latestrelease/finder_test.go
+++ b/internal/latestrelease/finder_test.go
@@ -11,8 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build unit
-// +build unit
 
 package latestrelease
 

--- a/internal/search/example_search_test.go
+++ b/internal/search/example_search_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package search
 

--- a/tools/release/main_test.go
+++ b/tools/release/main_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unit
-// +build unit
 
 package main
 


### PR DESCRIPTION
`+ build` has been replaced by `//build` since go 1.18, intellij now flags when using both to remove the legacy annotation, this is a basic find and replace to make intellij visual linter nicer 