### PR TITLE
CLOUDP-127887: Remove redundant "defer ctrl.Finish()" from tests

### DIFF
--- a/internal/cli/alerts/acknowledge_test.go
+++ b/internal/cli/alerts/acknowledge_test.go
@@ -47,7 +47,6 @@ func TestAcknowledgeBuilder(t *testing.T) {
 func TestAcknowledgeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertAcknowledger(ctrl)
-	defer ctrl.Finish()
 
 	tests := []struct {
 		name    string

--- a/internal/cli/alerts/describe_test.go
+++ b/internal/cli/alerts/describe_test.go
@@ -46,7 +46,7 @@ func TestDescribeBuilder(t *testing.T) {
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertDescriber(ctrl)
-	defer ctrl.Finish()
+
 	expected := &mongodbatlas.Alert{
 		ID:            "test",
 		EventTypeName: "test",

--- a/internal/cli/alerts/global_list_test.go
+++ b/internal/cli/alerts/global_list_test.go
@@ -28,7 +28,6 @@ import (
 func TestGlobalList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAlertLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.GlobalAlerts{}
 

--- a/internal/cli/alerts/list_test.go
+++ b/internal/cli/alerts/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AlertsResponse{
 		Links: nil,

--- a/internal/cli/alerts/settings/create_test.go
+++ b/internal/cli/alerts/settings/create_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertConfigurationCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AlertConfiguration{}
 

--- a/internal/cli/alerts/settings/delete_test.go
+++ b/internal/cli/alerts/settings/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestConfigsDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertConfigurationDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store:      mockStore,

--- a/internal/cli/alerts/settings/disable_test.go
+++ b/internal/cli/alerts/settings/disable_test.go
@@ -44,7 +44,6 @@ func TestDisableBuilder(t *testing.T) {
 func TestDisableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertConfigurationDisabler(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DisableOpts{
 		alertID: "alertID",

--- a/internal/cli/alerts/settings/enable_test.go
+++ b/internal/cli/alerts/settings/enable_test.go
@@ -44,7 +44,6 @@ func TestEnableBuilder(t *testing.T) {
 func TestEnableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertConfigurationEnabler(ctrl)
-	defer ctrl.Finish()
 
 	opts := &EnableOpts{
 		alertID: "alertID",

--- a/internal/cli/alerts/settings/fields_type_test.go
+++ b/internal/cli/alerts/settings/fields_type_test.go
@@ -27,7 +27,6 @@ import (
 func TestFieldsType_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockMatcherFieldsLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []string
 

--- a/internal/cli/alerts/settings/list_test.go
+++ b/internal/cli/alerts/settings/list_test.go
@@ -32,7 +32,6 @@ import (
 func TestConfigList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertConfigurationLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := []mongodbatlas.AlertConfiguration{
 		{

--- a/internal/cli/alerts/settings/update_test.go
+++ b/internal/cli/alerts/settings/update_test.go
@@ -28,7 +28,6 @@ import (
 func TestUpdates_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertConfigurationUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AlertConfiguration{}
 

--- a/internal/cli/alerts/unacknowledge_test.go
+++ b/internal/cli/alerts/unacknowledge_test.go
@@ -28,7 +28,6 @@ import (
 func TestUnacknowledge_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertAcknowledger(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Alert{}
 

--- a/internal/cli/atlas/accesslists/create_test.go
+++ b/internal/cli/atlas/accesslists/create_test.go
@@ -30,7 +30,6 @@ import (
 func TestWhitelistCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectIPAccessListCreator(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.ProjectIPAccessLists
 
@@ -62,7 +61,6 @@ func TestCreateBuilder(t *testing.T) {
 func TestValidateCurrentIPFlag(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectIPAccessListCreator(ctrl)
-	defer ctrl.Finish()
 
 	tests := []struct {
 		name         string

--- a/internal/cli/atlas/accesslists/delete_test.go
+++ b/internal/cli/atlas/accesslists/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestWhitelistDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectIPAccessListDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/accesslists/describe_test.go
+++ b/internal/cli/atlas/accesslists/describe_test.go
@@ -33,7 +33,6 @@ import (
 func TestWhitelistDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectIPAccessListDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProjectIPAccessList{
 		AwsSecurityGroup: "test",

--- a/internal/cli/atlas/accesslists/list_test.go
+++ b/internal/cli/atlas/accesslists/list_test.go
@@ -33,7 +33,6 @@ import (
 func TestWhitelistList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectIPAccessListLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProjectIPAccessLists{
 		Links: []*mongodbatlas.Link{

--- a/internal/cli/atlas/accesslogs/list_test.go
+++ b/internal/cli/atlas/accesslogs/list_test.go
@@ -34,7 +34,6 @@ import (
 func TestAccessLogListClusterName_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAccessLogsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AccessLogSettings{
 		AccessLogs: []*mongodbatlas.AccessLogs{
@@ -82,7 +81,6 @@ test test   test           true          test
 func TestAccessLogListHostname_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAccessLogsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AccessLogSettings{}
 

--- a/internal/cli/atlas/backup/exports/buckets/create_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/create_test.go
@@ -27,7 +27,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockExportBucketsCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotExportBucket{}
 

--- a/internal/cli/atlas/backup/exports/buckets/delete_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/delete_test.go
@@ -27,7 +27,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockExportBucketsDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/backup/exports/buckets/describe_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockExportBucketsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected mongodbatlas.CloudProviderSnapshotExportBucket
 

--- a/internal/cli/atlas/backup/exports/buckets/list_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/list_test.go
@@ -27,7 +27,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockExportBucketsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotExportBuckets{}
 

--- a/internal/cli/atlas/backup/exports/jobs/create_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/create_test.go
@@ -27,7 +27,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockExportJobsCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotExportJob{}
 

--- a/internal/cli/atlas/backup/exports/jobs/describe_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/describe_test.go
@@ -27,7 +27,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockExportJobsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotExportJob{}
 

--- a/internal/cli/atlas/backup/exports/jobs/list_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/list_test.go
@@ -27,7 +27,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockExportJobsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotExportJobs{}
 

--- a/internal/cli/atlas/backup/restores/describe_test.go
+++ b/internal/cli/atlas/backup/restores/describe_test.go
@@ -29,7 +29,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockRestoreJobsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotRestoreJob{}
 

--- a/internal/cli/atlas/backup/restores/list_test.go
+++ b/internal/cli/atlas/backup/restores/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockRestoreJobsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotRestoreJobs{}
 

--- a/internal/cli/atlas/backup/restores/start_test.go
+++ b/internal/cli/atlas/backup/restores/start_test.go
@@ -29,7 +29,6 @@ import (
 func TestStart_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockRestoreJobsCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotRestoreJob{}
 

--- a/internal/cli/atlas/backup/restores/watch_test.go
+++ b/internal/cli/atlas/backup/restores/watch_test.go
@@ -43,7 +43,6 @@ func TestWatchBuilder(t *testing.T) {
 func TestWatchOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockRestoreJobsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotRestoreJob{
 		Failed: pointy.Bool(true),

--- a/internal/cli/atlas/backup/schedule/describe_test.go
+++ b/internal/cli/atlas/backup/schedule/describe_test.go
@@ -27,7 +27,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockScheduleDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshotBackupPolicy{}
 

--- a/internal/cli/atlas/backup/snapshots/create_test.go
+++ b/internal/cli/atlas/backup/snapshots/create_test.go
@@ -27,7 +27,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotsCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshot{}
 

--- a/internal/cli/atlas/backup/snapshots/delete_test.go
+++ b/internal/cli/atlas/backup/snapshots/delete_test.go
@@ -27,7 +27,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotsDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/backup/snapshots/describe_test.go
+++ b/internal/cli/atlas/backup/snapshots/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected mongodbatlas.CloudProviderSnapshot
 

--- a/internal/cli/atlas/backup/snapshots/list_test.go
+++ b/internal/cli/atlas/backup/snapshots/list_test.go
@@ -27,7 +27,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshots{}
 

--- a/internal/cli/atlas/backup/snapshots/watch_test.go
+++ b/internal/cli/atlas/backup/snapshots/watch_test.go
@@ -27,7 +27,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	watchOpts := &WatchOpts{
 		id:          "test",

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/authorize_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/authorize_test.go
@@ -30,7 +30,6 @@ import (
 func TestAuthorizeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudProviderAccessRoleAuthorizer(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AWSIAMRole{}
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/create_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/create_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudProviderAccessRoleCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AWSIAMRole{}
 

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize_test.go
@@ -30,7 +30,6 @@ import (
 func TestDeauthorizeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudProviderAccessRoleDeauthorizer(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DeauthorizeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/cloudproviders/accessroles/list_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudProviderAccessRoleLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.CloudProviderAccessRoles
 

--- a/internal/cli/atlas/clusters/advancedsettings/describe_test.go
+++ b/internal/cli/atlas/clusters/advancedsettings/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterConfigurationOptionsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessArgs{}
 

--- a/internal/cli/atlas/clusters/advancedsettings/update_test.go
+++ b/internal/cli/atlas/clusters/advancedsettings/update_test.go
@@ -31,7 +31,7 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterConfigurationOptionsUpdater(ctrl)
-	defer ctrl.Finish()
+
 	expected := &mongodbatlas.ProcessArgs{
 		DefaultReadConcern:               "",
 		DefaultWriteConcern:              "",

--- a/internal/cli/atlas/clusters/availableregions/list_test.go
+++ b/internal/cli/atlas/clusters/availableregions/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run_NoFlags(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudProviderRegionsLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.CloudProviders
 	var empty []*string
@@ -53,7 +52,6 @@ func TestList_Run_NoFlags(t *testing.T) {
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudProviderRegionsLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.CloudProviders
 

--- a/internal/cli/atlas/clusters/connectionstring/describe_test.go
+++ b/internal/cli/atlas/clusters/connectionstring/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AdvancedCluster{}
 

--- a/internal/cli/atlas/clusters/create_test.go
+++ b/internal/cli/atlas/clusters/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockClusterCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AdvancedCluster{}
 

--- a/internal/cli/atlas/clusters/describe_test.go
+++ b/internal/cli/atlas/clusters/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AdvancedCluster{}
 

--- a/internal/cli/atlas/clusters/indexes/create_test.go
+++ b/internal/cli/atlas/clusters/indexes/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIndexCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		name:        "ProjectBar",

--- a/internal/cli/atlas/clusters/list_test.go
+++ b/internal/cli/atlas/clusters/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockClusterLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected mongodbatlas.AdvancedClustersResponse
 

--- a/internal/cli/atlas/clusters/loadSampleData_test.go
+++ b/internal/cli/atlas/clusters/loadSampleData_test.go
@@ -30,7 +30,6 @@ import (
 func TestLoadSampleDataOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSampleDataAdder(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.SampleDatasetJob{}
 

--- a/internal/cli/atlas/clusters/onlinearchive/create_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/create_test.go
@@ -49,7 +49,6 @@ func TestCreateBuilder(t *testing.T) {
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOnlineArchiveCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &CreateOpts{
 		store: mockStore,

--- a/internal/cli/atlas/clusters/onlinearchive/delete_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/delete_test.go
@@ -43,7 +43,6 @@ func TestDeleteBuilder(t *testing.T) {
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOnlineArchiveDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/clusters/onlinearchive/describe_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/describe_test.go
@@ -43,7 +43,6 @@ func TestDescribeBuilder(t *testing.T) {
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOnlineArchiveDescriber(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &DescribeOpts{
 		clusterName: "test",

--- a/internal/cli/atlas/clusters/onlinearchive/list_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/list_test.go
@@ -45,7 +45,6 @@ func TestListBuilder(t *testing.T) {
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOnlineArchiveLister(ctrl)
-	defer ctrl.Finish()
 
 	listOpts := &ListOpts{
 		store: mockStore,

--- a/internal/cli/atlas/clusters/onlinearchive/pause_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/pause_test.go
@@ -43,7 +43,6 @@ func TestPauseBuilder(t *testing.T) {
 func TestPause_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOnlineArchiveUpdater(ctrl)
-	defer ctrl.Finish()
 
 	updateOpts := &PauseOpts{
 		id:    "1",

--- a/internal/cli/atlas/clusters/onlinearchive/start_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/start_test.go
@@ -43,7 +43,6 @@ func TestStartBuilder(t *testing.T) {
 func TestStart_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOnlineArchiveUpdater(ctrl)
-	defer ctrl.Finish()
 
 	updateOpts := &StartOpts{
 		id:    "1",

--- a/internal/cli/atlas/clusters/onlinearchive/update_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/update_test.go
@@ -44,7 +44,6 @@ func TestUpdateBuilder(t *testing.T) {
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOnlineArchiveUpdater(ctrl)
-	defer ctrl.Finish()
 
 	updateOpts := &UpdateOpts{
 		id:    "1",

--- a/internal/cli/atlas/clusters/onlinearchive/watch_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/watch_test.go
@@ -30,7 +30,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOnlineArchiveDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.OnlineArchive{State: "IDLE"}
 

--- a/internal/cli/atlas/clusters/pause_test.go
+++ b/internal/cli/atlas/clusters/pause_test.go
@@ -31,8 +31,6 @@ func TestPause_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockClusterPauser(ctrl)
 
-	defer ctrl.Finish()
-
 	updateOpts := &PauseOpts{
 		name:  "ProjectBar",
 		store: mockStore,

--- a/internal/cli/atlas/clusters/start_test.go
+++ b/internal/cli/atlas/clusters/start_test.go
@@ -30,7 +30,6 @@ import (
 func TestStart_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockClusterStarter(ctrl)
-	defer ctrl.Finish()
 
 	updateOpts := &StartOpts{
 		name:  "ProjectBar",

--- a/internal/cli/atlas/clusters/update_test.go
+++ b/internal/cli/atlas/clusters/update_test.go
@@ -31,7 +31,7 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterGetterUpdater(ctrl)
-	defer ctrl.Finish()
+
 	expected := &mongodbatlas.AdvancedCluster{}
 
 	t.Run("flags run", func(t *testing.T) {

--- a/internal/cli/atlas/clusters/upgrade_test.go
+++ b/internal/cli/atlas/clusters/upgrade_test.go
@@ -33,7 +33,7 @@ const atlasM10 = "M10"
 func TestUpgrade_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasSharedClusterGetterUpgrader(ctrl)
-	defer ctrl.Finish()
+
 	expected := &mongodbatlas.Cluster{}
 
 	t.Run("flags run", func(t *testing.T) {

--- a/internal/cli/atlas/clusters/watch_test.go
+++ b/internal/cli/atlas/clusters/watch_test.go
@@ -30,7 +30,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AdvancedCluster{StateName: "IDLE"}
 

--- a/internal/cli/atlas/customdbroles/create_test.go
+++ b/internal/cli/atlas/customdbroles/create_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseRoleCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CustomDBRole{}
 

--- a/internal/cli/atlas/customdbroles/delete_test.go
+++ b/internal/cli/atlas/customdbroles/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDBUsersDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseRoleDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/customdbroles/describe_test.go
+++ b/internal/cli/atlas/customdbroles/describe_test.go
@@ -34,7 +34,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseRoleDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := mongodbatlas.CustomDBRole{
 		Actions: []mongodbatlas.Action{

--- a/internal/cli/atlas/customdbroles/list_test.go
+++ b/internal/cli/atlas/customdbroles/list_test.go
@@ -34,7 +34,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseRoleLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &[]mongodbatlas.CustomDBRole{
 		{

--- a/internal/cli/atlas/customdbroles/update_test.go
+++ b/internal/cli/atlas/customdbroles/update_test.go
@@ -30,7 +30,6 @@ import (
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseRoleUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CustomDBRole{}
 

--- a/internal/cli/atlas/customdns/aws/describe_test.go
+++ b/internal/cli/atlas/customdns/aws/describe_test.go
@@ -39,7 +39,6 @@ func TestDescribeBuilder(t *testing.T) {
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCustomDNSDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &atlas.AWSCustomDNSSetting{
 		Enabled: false,

--- a/internal/cli/atlas/customdns/aws/disable_test.go
+++ b/internal/cli/atlas/customdns/aws/disable_test.go
@@ -39,7 +39,6 @@ func TestDisableBuilder(t *testing.T) {
 func TestDisableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCustomDNSDisabler(ctrl)
-	defer ctrl.Finish()
 
 	expected := &atlas.AWSCustomDNSSetting{
 		Enabled: false,

--- a/internal/cli/atlas/customdns/aws/enable_test.go
+++ b/internal/cli/atlas/customdns/aws/enable_test.go
@@ -39,7 +39,6 @@ func TestEnableBuilder(t *testing.T) {
 func TestEnableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCustomDNSEnabler(ctrl)
-	defer ctrl.Finish()
 
 	expected := &atlas.AWSCustomDNSSetting{
 		Enabled: true,

--- a/internal/cli/atlas/datalake/create_test.go
+++ b/internal/cli/atlas/datalake/create_test.go
@@ -28,7 +28,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakeCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store: mockStore,

--- a/internal/cli/atlas/datalake/delete_test.go
+++ b/internal/cli/atlas/datalake/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakeDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/datalake/describe_test.go
+++ b/internal/cli/atlas/datalake/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakeDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := mongodbatlas.DataLake{}
 

--- a/internal/cli/atlas/datalake/list_test.go
+++ b/internal/cli/atlas/datalake/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakeLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.DataLake
 	listOpts := &ListOpts{

--- a/internal/cli/atlas/datalake/update_test.go
+++ b/internal/cli/atlas/datalake/update_test.go
@@ -28,7 +28,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakeUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := mongodbatlas.DataLake{}
 

--- a/internal/cli/atlas/dbusers/certs/create_test.go
+++ b/internal/cli/atlas/dbusers/certs/create_test.go
@@ -29,8 +29,6 @@ func TestCreateBuilder(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDBUserCertificateCreator(ctrl)
 
-	defer ctrl.Finish()
-
 	var expected = &mongodbatlas.UserCertificate{}
 
 	username := "to_create"

--- a/internal/cli/atlas/dbusers/certs/list_test.go
+++ b/internal/cli/atlas/dbusers/certs/list_test.go
@@ -29,8 +29,6 @@ func TestListBuilder(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDBUserCertificateLister(ctrl)
 
-	defer ctrl.Finish()
-
 	var expected []mongodbatlas.UserCertificate
 
 	username := "user"

--- a/internal/cli/atlas/dbusers/create_test.go
+++ b/internal/cli/atlas/dbusers/create_test.go
@@ -28,7 +28,6 @@ import (
 func TestDBUserCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseUserCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.DatabaseUser{}
 

--- a/internal/cli/atlas/dbusers/delete_test.go
+++ b/internal/cli/atlas/dbusers/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDBUsersDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseUserDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/dbusers/describe_test.go
+++ b/internal/cli/atlas/dbusers/describe_test.go
@@ -29,7 +29,6 @@ import (
 func TestDBUserDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseUserDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected mongodbatlas.DatabaseUser
 

--- a/internal/cli/atlas/dbusers/list_test.go
+++ b/internal/cli/atlas/dbusers/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestDBUserList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseUserLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.DatabaseUser
 

--- a/internal/cli/atlas/dbusers/update_test.go
+++ b/internal/cli/atlas/dbusers/update_test.go
@@ -28,7 +28,6 @@ import (
 func TestDBUserUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDatabaseUserUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &atlas.DatabaseUser{}
 

--- a/internal/cli/atlas/integrations/create/datadog_test.go
+++ b/internal/cli/atlas/integrations/create/datadog_test.go
@@ -29,7 +29,6 @@ import (
 func TestDatadogOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DatadogOpts{
 		store: mockStore,

--- a/internal/cli/atlas/integrations/create/new_relic_test.go
+++ b/internal/cli/atlas/integrations/create/new_relic_test.go
@@ -29,7 +29,6 @@ import (
 func TestNewRelicOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &NewRelicOpts{
 		store: mockStore,

--- a/internal/cli/atlas/integrations/create/ops_genie_test.go
+++ b/internal/cli/atlas/integrations/create/ops_genie_test.go
@@ -29,7 +29,6 @@ import (
 func TestOpsGenieOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &OpsGenieOpts{
 		store: mockStore,

--- a/internal/cli/atlas/integrations/create/pager_duty_test.go
+++ b/internal/cli/atlas/integrations/create/pager_duty_test.go
@@ -29,7 +29,6 @@ import (
 func TestPagerDutyOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &PagerDutyOpts{
 		store: mockStore,

--- a/internal/cli/atlas/integrations/create/victor_ops_test.go
+++ b/internal/cli/atlas/integrations/create/victor_ops_test.go
@@ -29,7 +29,6 @@ import (
 func TestVictorOpsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &VictorOpsOpts{
 		store: mockStore,

--- a/internal/cli/atlas/integrations/create/webhook_test.go
+++ b/internal/cli/atlas/integrations/create/webhook_test.go
@@ -29,7 +29,6 @@ import (
 func TestWebhookOpsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &WebhookOpts{
 		store: mockStore,

--- a/internal/cli/atlas/integrations/delete_test.go
+++ b/internal/cli/atlas/integrations/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationDeleter(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/atlas/integrations/describe_test.go
+++ b/internal/cli/atlas/integrations/describe_test.go
@@ -29,7 +29,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationDescriber(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &DescribeOpts{
 		store:           mockStore,

--- a/internal/cli/atlas/integrations/list_test.go
+++ b/internal/cli/atlas/integrations/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestDBUserList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockIntegrationLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.ThirdPartyIntegrations
 

--- a/internal/cli/atlas/livemigrations/create_test.go
+++ b/internal/cli/atlas/livemigrations/create_test.go
@@ -32,7 +32,6 @@ import (
 func TestLiveMigrationCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := mongodbatlas.LiveMigration{}
 

--- a/internal/cli/atlas/livemigrations/cutover_test.go
+++ b/internal/cli/atlas/livemigrations/cutover_test.go
@@ -28,7 +28,6 @@ import (
 func TestCutoverOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationCutoverCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Validation{}
 

--- a/internal/cli/atlas/livemigrations/describe_test.go
+++ b/internal/cli/atlas/livemigrations/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestLiveMigrationDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		liveMigrationID: "1",

--- a/internal/cli/atlas/livemigrations/link/create_test.go
+++ b/internal/cli/atlas/livemigrations/link/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestLinkTokenCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLinkTokenCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.LinkToken{}
 

--- a/internal/cli/atlas/livemigrations/link/delete_test.go
+++ b/internal/cli/atlas/livemigrations/link/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestLinkTokenDeleteOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLinkTokenDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		GlobalOpts: cli.GlobalOpts{OrgID: "1"},

--- a/internal/cli/atlas/livemigrations/validation/create_test.go
+++ b/internal/cli/atlas/livemigrations/validation/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestLiveMigrationValidationCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationValidationsCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := mongodbatlas.Validation{}
 

--- a/internal/cli/atlas/livemigrations/validation/describe_test.go
+++ b/internal/cli/atlas/livemigrations/validation/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestValidationDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationValidationsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := mongodbatlas.Validation{}
 

--- a/internal/cli/atlas/logs/download_test.go
+++ b/internal/cli/atlas/logs/download_test.go
@@ -31,7 +31,6 @@ import (
 func TestLogsDownloadOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLogsDownloader(ctrl)
-	defer ctrl.Finish()
 
 	validLogsToDownload := []string{
 		"mongodb.gz",

--- a/internal/cli/atlas/maintenance/clear_test.go
+++ b/internal/cli/atlas/maintenance/clear_test.go
@@ -29,7 +29,6 @@ import (
 func TestClearOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockMaintenanceWindowClearer(ctrl)
-	defer ctrl.Finish()
 
 	updateOpts := &ClearOpts{
 		store: mockStore,

--- a/internal/cli/atlas/maintenance/defer_test.go
+++ b/internal/cli/atlas/maintenance/defer_test.go
@@ -28,7 +28,6 @@ import (
 func TestDeferOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockMaintenanceWindowDeferrer(ctrl)
-	defer ctrl.Finish()
 
 	updateOpts := &DeferOpts{
 		store: mockStore,

--- a/internal/cli/atlas/maintenance/describe_test.go
+++ b/internal/cli/atlas/maintenance/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockMaintenanceWindowDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/maintenance/update_test.go
+++ b/internal/cli/atlas/maintenance/update_test.go
@@ -28,7 +28,6 @@ import (
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockMaintenanceWindowUpdater(ctrl)
-	defer ctrl.Finish()
 
 	updateOpts := &UpdateOpts{
 		store:     mockStore,

--- a/internal/cli/atlas/metrics/databases/describe_test.go
+++ b/internal/cli/atlas/metrics/databases/describe_test.go
@@ -29,7 +29,6 @@ import (
 func TestDatabasesDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProcessDatabaseMeasurementsLister(ctrl)
-	defer ctrl.Finish()
 
 	listOpts := &DescribeOpts{
 		host:  "hard-00-00.mongodb.net",

--- a/internal/cli/atlas/metrics/databases/list_test.go
+++ b/internal/cli/atlas/metrics/databases/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestDatabasesListsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProcessDatabaseLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessDatabasesResponse{}
 

--- a/internal/cli/atlas/metrics/disks/describe_test.go
+++ b/internal/cli/atlas/metrics/disks/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDisksDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProcessDiskMeasurementsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessDiskMeasurements{}
 

--- a/internal/cli/atlas/metrics/disks/list_test.go
+++ b/internal/cli/atlas/metrics/disks/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestDisksListsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProcessDisksLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessDisksResponse{}
 

--- a/internal/cli/atlas/metrics/processes/processes_test.go
+++ b/internal/cli/atlas/metrics/processes/processes_test.go
@@ -32,7 +32,6 @@ const oneMinute = "PT1M"
 func TestProcess_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProcessMeasurementLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessMeasurements{}
 

--- a/internal/cli/atlas/networking/containers/delete_test.go
+++ b/internal/cli/atlas/networking/containers/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockContainersDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/networking/containers/list_test.go
+++ b/internal/cli/atlas/networking/containers/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockContainersLister(ctrl)
-	defer ctrl.Finish()
 
 	t.Run("no provider", func(t *testing.T) {
 		listOpts := &ListOpts{

--- a/internal/cli/atlas/networking/peering/create/aws_test.go
+++ b/internal/cli/atlas/networking/peering/create/aws_test.go
@@ -30,7 +30,6 @@ import (
 func TestAwsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAWSPeeringConnectionCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &AWSOpts{
 		store:  mockStore,

--- a/internal/cli/atlas/networking/peering/create/azure_test.go
+++ b/internal/cli/atlas/networking/peering/create/azure_test.go
@@ -30,7 +30,6 @@ import (
 func TestAzureOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAzurePeeringConnectionCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &AzureOpts{
 		store:  mockStore,

--- a/internal/cli/atlas/networking/peering/create/gcp_test.go
+++ b/internal/cli/atlas/networking/peering/create/gcp_test.go
@@ -30,7 +30,6 @@ import (
 func TestGCPOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGCPPeeringConnectionCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &GCPOpts{
 		store:   mockStore,

--- a/internal/cli/atlas/networking/peering/delete_test.go
+++ b/internal/cli/atlas/networking/peering/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPeeringConnectionDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/networking/peering/list_test.go
+++ b/internal/cli/atlas/networking/peering/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPeeringConnectionLister(ctrl)
-	defer ctrl.Finish()
 
 	t.Run("no provider", func(t *testing.T) {
 		listOpts := &ListOpts{

--- a/internal/cli/atlas/networking/peering/watch_test.go
+++ b/internal/cli/atlas/networking/peering/watch_test.go
@@ -56,7 +56,7 @@ func TestWatchOpts_Run(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			mockStore := mocks.NewMockPeeringConnectionDescriber(ctrl)
-			defer ctrl.Finish()
+
 			describeOpts := &WatchOpts{
 				id:    "test",
 				store: mockStore,

--- a/internal/cli/atlas/privateendpoints/aws/create_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:  mockStore,

--- a/internal/cli/atlas/privateendpoints/aws/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/aws/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:               mockStore,

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store:                    mockStore,

--- a/internal/cli/atlas/privateendpoints/aws/list_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/list_test.go
@@ -31,7 +31,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.PrivateEndpointConnection
 

--- a/internal/cli/atlas/privateendpoints/aws/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch_test.go
@@ -30,7 +30,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &WatchOpts{
 		id:    "test",

--- a/internal/cli/atlas/privateendpoints/azure/create_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:  mockStore,

--- a/internal/cli/atlas/privateendpoints/azure/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/azure/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:               mockStore,

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store:                    mockStore,

--- a/internal/cli/atlas/privateendpoints/azure/list_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/list_test.go
@@ -31,7 +31,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.PrivateEndpointConnection
 

--- a/internal/cli/atlas/privateendpoints/azure/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch_test.go
@@ -30,7 +30,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &WatchOpts{
 		id:    "test",

--- a/internal/cli/atlas/privateendpoints/create_test.go
+++ b/internal/cli/atlas/privateendpoints/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointCreatorDeprecated(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:    mockStore,

--- a/internal/cli/atlas/privateendpoints/datalake/aws/create_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakePrivateEndpointCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store: mockStore,

--- a/internal/cli/atlas/privateendpoints/datalake/aws/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakePrivateEndpointDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakePrivateEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.PrivateLinkEndpointDataLake{}
 

--- a/internal/cli/atlas/privateendpoints/datalake/aws/list_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/list_test.go
@@ -31,7 +31,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDataLakePrivateEndpointLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.PrivateLinkEndpointDataLakeResponse
 

--- a/internal/cli/atlas/privateendpoints/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDeleterDeprecated(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDescriberDeprecated(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/privateendpoints/gcp/create_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:  mockStore,

--- a/internal/cli/atlas/privateendpoints/gcp/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/gcp/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:                    mockStore,

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store:                    mockStore,

--- a/internal/cli/atlas/privateendpoints/gcp/list_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/list_test.go
@@ -31,7 +31,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.PrivateEndpointConnection
 

--- a/internal/cli/atlas/privateendpoints/gcp/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/watch_test.go
@@ -30,7 +30,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDescriber(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &WatchOpts{
 		id:    "test",

--- a/internal/cli/atlas/privateendpoints/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/create_test.go
@@ -31,7 +31,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointCreatorDeprecated(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:               mockStore,

--- a/internal/cli/atlas/privateendpoints/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/delete_test.go
@@ -31,7 +31,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointDeleterDeprecated(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/privateendpoints/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockInterfaceEndpointDescriberDeprecated(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store:             mockStore,

--- a/internal/cli/atlas/privateendpoints/list_test.go
+++ b/internal/cli/atlas/privateendpoints/list_test.go
@@ -31,7 +31,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointListerDeprecated(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.PrivateEndpointConnectionDeprecated
 

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockRegionalizedPrivateEndpointSettingDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/privateendpoints/regionalmodes/disable_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/disable_test.go
@@ -30,7 +30,6 @@ import (
 func TestDisableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockRegionalizedPrivateEndpointSettingUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &atlas.RegionalizedPrivateEndpointSetting{
 		Enabled: true,

--- a/internal/cli/atlas/privateendpoints/regionalmodes/enable_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/enable_test.go
@@ -30,7 +30,6 @@ import (
 func TestEnableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockRegionalizedPrivateEndpointSettingUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &atlas.RegionalizedPrivateEndpointSetting{
 		Enabled: true,

--- a/internal/cli/atlas/privateendpoints/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/watch_test.go
@@ -30,7 +30,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPrivateEndpointDescriberDeprecated(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &WatchOpts{
 		id:    "test",

--- a/internal/cli/atlas/processes/describe_test.go
+++ b/internal/cli/atlas/processes/describe_test.go
@@ -38,7 +38,6 @@ func TestDescribeBuilder(t *testing.T) {
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProcessDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.Process
 

--- a/internal/cli/atlas/processes/list_test.go
+++ b/internal/cli/atlas/processes/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProcessLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []*mongodbatlas.Process
 

--- a/internal/cli/atlas/quickstart/quick_start_test.go
+++ b/internal/cli/atlas/quickstart/quick_start_test.go
@@ -59,7 +59,6 @@ func TestQuickstartOpts_Run(t *testing.T) {
 	t.Cleanup(test.CleanupConfig)
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterQuickStarter(ctrl)
-	defer ctrl.Finish()
 
 	expectedCluster := &mongodbatlas.AdvancedCluster{
 		StateName: "IDLE",
@@ -116,7 +115,7 @@ func TestQuickstartOpts_Run_NotLoggedIn(t *testing.T) {
 	t.Cleanup(test.CleanupConfig)
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterQuickStarter(ctrl)
-	defer ctrl.Finish()
+
 	buf := new(bytes.Buffer)
 	ctx := context.TODO()
 	opts := &Opts{
@@ -140,7 +139,6 @@ func TestQuickstartOpts_Run_NeedLogin_ForceAfterLogin(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterQuickStarter(ctrl)
 	mockLoginFlow := mocks.NewMockLoginFlow(ctrl)
-	defer ctrl.Finish()
 
 	ctx := context.TODO()
 	buf := new(bytes.Buffer)
@@ -220,7 +218,6 @@ func TestQuickstartOpts_Run_CheckFlagsSet(t *testing.T) {
 	t.Cleanup(test.CleanupConfig)
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterQuickStarter(ctrl)
-	defer ctrl.Finish()
 
 	expectedCluster := &mongodbatlas.AdvancedCluster{
 		StateName: "IDLE",

--- a/internal/cli/atlas/search/create_test.go
+++ b/internal/cli/atlas/search/create_test.go
@@ -32,7 +32,6 @@ const testJSON = `{"name":"default"}`
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSearchIndexCreator(ctrl)
-	defer ctrl.Finish()
 
 	t.Run("flags run", func(t *testing.T) {
 		opts := &CreateOpts{

--- a/internal/cli/atlas/search/delete_test.go
+++ b/internal/cli/atlas/search/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSearchIndexDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/search/describe_test.go
+++ b/internal/cli/atlas/search/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSearchIndexDescriber(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &DescribeOpts{
 		clusterName: "test",

--- a/internal/cli/atlas/search/list_test.go
+++ b/internal/cli/atlas/search/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSearchIndexLister(ctrl)
-	defer ctrl.Finish()
 
 	listOpts := &ListOpts{
 		store: mockStore,

--- a/internal/cli/atlas/search/update_test.go
+++ b/internal/cli/atlas/search/update_test.go
@@ -31,8 +31,6 @@ func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSearchIndexUpdater(ctrl)
 
-	defer ctrl.Finish()
-
 	t.Run("flags run", func(t *testing.T) {
 		updateOpts := &UpdateOpts{
 			store: mockStore,

--- a/internal/cli/atlas/security/customercerts/create_test.go
+++ b/internal/cli/atlas/security/customercerts/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockX509CertificateConfSaver(ctrl)
-	defer ctrl.Finish()
 
 	fs := afero.NewMemMapFs()
 	fileName := "/path/to/cert.pem"

--- a/internal/cli/atlas/security/customercerts/describe_test.go
+++ b/internal/cli/atlas/security/customercerts/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockX509CertificateConfDescriber(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/security/customercerts/disable_test.go
+++ b/internal/cli/atlas/security/customercerts/disable_test.go
@@ -27,7 +27,6 @@ import (
 func TestDisableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockX509CertificateConfDisabler(ctrl)
-	defer ctrl.Finish()
 
 	saveOpts := &DisableOpts{
 		store:   mockStore,

--- a/internal/cli/atlas/security/ldap/delete_test.go
+++ b/internal/cli/atlas/security/ldap/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLDAPConfigurationDeleter(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/atlas/security/ldap/get_test.go
+++ b/internal/cli/atlas/security/ldap/get_test.go
@@ -30,7 +30,6 @@ import (
 func TestGet_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLDAPConfigurationGetter(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.LDAPConfiguration{}
 

--- a/internal/cli/atlas/security/ldap/save_test.go
+++ b/internal/cli/atlas/security/ldap/save_test.go
@@ -30,7 +30,6 @@ import (
 func TestSave_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLDAPConfigurationSaver(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.LDAPConfiguration
 

--- a/internal/cli/atlas/security/ldap/status_test.go
+++ b/internal/cli/atlas/security/ldap/status_test.go
@@ -30,7 +30,6 @@ import (
 func TestVerifyStatus_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLDAPConfigurationDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.LDAPConfiguration
 

--- a/internal/cli/atlas/security/ldap/verify_test.go
+++ b/internal/cli/atlas/security/ldap/verify_test.go
@@ -30,7 +30,6 @@ import (
 func TestVerify_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLDAPConfigurationVerifier(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.LDAPConfiguration
 

--- a/internal/cli/atlas/security/ldap/watch_test.go
+++ b/internal/cli/atlas/security/ldap/watch_test.go
@@ -30,7 +30,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLDAPConfigurationDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.LDAPConfiguration{Status: "SUCCESS"}
 

--- a/internal/cli/atlas/serverless/backup/snapshots/describe_test.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessSnapshotsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected mongodbatlas.CloudProviderSnapshot
 

--- a/internal/cli/atlas/serverless/backup/snapshots/list_test.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/list_test.go
@@ -27,7 +27,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessSnapshotsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.CloudProviderSnapshots{}
 

--- a/internal/cli/atlas/serverless/create_test.go
+++ b/internal/cli/atlas/serverless/create_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessInstanceCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := &CreateOpts{
 		store: mockStore,

--- a/internal/cli/atlas/serverless/delete_test.go
+++ b/internal/cli/atlas/serverless/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessInstanceDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/atlas/serverless/describe_test.go
+++ b/internal/cli/atlas/serverless/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessInstanceDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected mongodbatlas.Cluster
 

--- a/internal/cli/atlas/serverless/list_test.go
+++ b/internal/cli/atlas/serverless/list_test.go
@@ -39,7 +39,6 @@ func TestListBuilder(t *testing.T) {
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessInstanceLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.ClustersResponse
 

--- a/internal/cli/atlas/serverless/watch_test.go
+++ b/internal/cli/atlas/serverless/watch_test.go
@@ -30,7 +30,6 @@ import (
 func TestWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessInstanceDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Cluster{StateName: "IDLE"}
 

--- a/internal/cli/atlas/setup/setup_cmd_test.go
+++ b/internal/cli/atlas/setup/setup_cmd_test.go
@@ -53,7 +53,7 @@ func Test_setupOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockRegFlow := mocks.NewMockRegisterFlow(ctrl)
 	mockQuickstartFlow := mocks.NewMockFlow(ctrl)
-	defer ctrl.Finish()
+
 	ctx := context.TODO()
 	buf := new(bytes.Buffer)
 
@@ -92,7 +92,7 @@ func Test_setupOpts_RunWithAPIKeys(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockRegFlow := mocks.NewMockRegisterFlow(ctrl)
 	mockQuickstartFlow := mocks.NewMockFlow(ctrl)
-	defer ctrl.Finish()
+
 	ctx := context.TODO()
 	buf := new(bytes.Buffer)
 
@@ -134,7 +134,7 @@ func Test_setupOpts_RunSkipRegister(t *testing.T) {
 	mockRegFlow := mocks.NewMockRegisterFlow(ctrl)
 	mockQuickstartFlow := mocks.NewMockFlow(ctrl)
 	mockLoginFlow := mocks.NewMockLoginFlow(ctrl)
-	defer ctrl.Finish()
+
 	ctx := context.TODO()
 
 	buf := new(bytes.Buffer)

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -87,7 +87,7 @@ func Test_loginOpts_Run(t *testing.T) {
 	mockFlow := mocks.NewMockAuthenticator(ctrl)
 	mockConfig := mocks.NewMockLoginConfig(ctrl)
 	mockStore := mocks.NewMockProjectOrgsLister(ctrl)
-	defer ctrl.Finish()
+
 	buf := new(bytes.Buffer)
 
 	opts := &LoginOpts{
@@ -170,7 +170,7 @@ func Test_loginOpts_oauthFlow(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockFlow := mocks.NewMockAuthenticator(ctrl)
 		mockConfig := mocks.NewMockLoginConfig(ctrl)
-		defer ctrl.Finish()
+
 		buf := new(bytes.Buffer)
 		ctx := context.TODO()
 
@@ -228,7 +228,7 @@ To continue, go to http://localhost
 		ctrl := gomock.NewController(t)
 		mockFlow := mocks.NewMockAuthenticator(ctrl)
 		mockConfig := mocks.NewMockLoginConfig(ctrl)
-		defer ctrl.Finish()
+
 		buf := new(bytes.Buffer)
 		ctx := context.TODO()
 		regenerateCodePromptMock := &confirmPromptMock{

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -43,7 +43,7 @@ func Test_logoutOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockFlow := mocks.NewMockRevoker(ctrl)
 	mockConfig := mocks.NewMockConfigDeleter(ctrl)
-	defer ctrl.Finish()
+
 	buf := new(bytes.Buffer)
 
 	opts := logoutOpts{
@@ -72,7 +72,7 @@ func Test_logoutOpts_Run_Keep(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockFlow := mocks.NewMockRevoker(ctrl)
 	mockConfig := mocks.NewMockConfigDeleter(ctrl)
-	defer ctrl.Finish()
+
 	buf := new(bytes.Buffer)
 
 	opts := logoutOpts{

--- a/internal/cli/auth/register_test.go
+++ b/internal/cli/auth/register_test.go
@@ -53,7 +53,7 @@ func Test_registerOpts_Run(t *testing.T) {
 	}
 	mockConfig := mocks.NewMockLoginConfig(ctrl)
 	mockStore := mocks.NewMockProjectOrgsLister(ctrl)
-	defer ctrl.Finish()
+
 	buf := new(bytes.Buffer)
 	ctx := context.TODO()
 	loginOpts := &LoginOpts{

--- a/internal/cli/config/set_test.go
+++ b/internal/cli/config/set_test.go
@@ -27,7 +27,6 @@ import (
 func TestSet_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSetSaver(ctrl)
-	defer ctrl.Finish()
 
 	t.Run("valid prop", func(t *testing.T) {
 		setOpts := &SetOpts{

--- a/internal/cli/default_setter_opts_test.go
+++ b/internal/cli/default_setter_opts_test.go
@@ -77,7 +77,7 @@ func TestDefaultOpts_DefaultQuestions(t *testing.T) {
 func TestDefaultOpts_Projects(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectOrgsLister(ctrl)
-	defer ctrl.Finish()
+
 	opts := &DefaultSetterOpts{
 		Service: "cloud",
 		Store:   mockStore,
@@ -109,7 +109,7 @@ func TestDefaultOpts_Projects(t *testing.T) {
 func TestDefaultOpts_Orgs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectOrgsLister(ctrl)
-	defer ctrl.Finish()
+
 	opts := &DefaultSetterOpts{
 		Service: "cloud",
 		Store:   mockStore,

--- a/internal/cli/events/list_test.go
+++ b/internal/cli/events/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockEventLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.EventResponse{}
 

--- a/internal/cli/events/orgs_list_test.go
+++ b/internal/cli/events/orgs_list_test.go
@@ -27,7 +27,6 @@ import (
 func Test_orgListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationEventLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.EventResponse{}
 	listOpts := &orgListOpts{

--- a/internal/cli/events/projects_list_test.go
+++ b/internal/cli/events/projects_list_test.go
@@ -27,7 +27,6 @@ import (
 func Test_projectListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectEventLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.EventResponse{}
 	listOpts := &projectListOpts{

--- a/internal/cli/iam/globalaccesslists/create_test.go
+++ b/internal/cli/iam/globalaccesslists/create_test.go
@@ -28,7 +28,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyWhitelistCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:       mockStore,

--- a/internal/cli/iam/globalaccesslists/delete_test.go
+++ b/internal/cli/iam/globalaccesslists/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyWhitelistDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/globalaccesslists/describe_test.go
+++ b/internal/cli/iam/globalaccesslists/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyWhitelistDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/iam/globalaccesslists/list_test.go
+++ b/internal/cli/iam/globalaccesslists/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyWhitelistLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected = &opsmngr.GlobalWhitelistAPIKeys{
 		Results: []*opsmngr.GlobalWhitelistAPIKey{},

--- a/internal/cli/iam/globalapikeys/create_test.go
+++ b/internal/cli/iam/globalapikeys/create_test.go
@@ -28,7 +28,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.APIKey{
 		ID: "1",

--- a/internal/cli/iam/globalapikeys/delete_test.go
+++ b/internal/cli/iam/globalapikeys/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/globalapikeys/describe_test.go
+++ b/internal/cli/iam/globalapikeys/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/iam/globalapikeys/list_test.go
+++ b/internal/cli/iam/globalapikeys/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.APIKey
 

--- a/internal/cli/iam/globalapikeys/update_test.go
+++ b/internal/cli/iam/globalapikeys/update_test.go
@@ -28,7 +28,6 @@ import (
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.APIKey{
 		ID: "1",

--- a/internal/cli/iam/organizations/apikeys/accesslists/create_test.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyAccessListCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:  mockStore,

--- a/internal/cli/iam/organizations/apikeys/accesslists/delete_test.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyAccessListDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/organizations/apikeys/accesslists/list_test.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyAccessListLister(ctrl)
-	defer ctrl.Finish()
 
 	opts := &ListOpts{
 		store: mockStore,

--- a/internal/cli/iam/organizations/apikeys/create_test.go
+++ b/internal/cli/iam/organizations/apikeys/create_test.go
@@ -28,7 +28,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.APIKey{
 		ID: "1",

--- a/internal/cli/iam/organizations/apikeys/delete_test.go
+++ b/internal/cli/iam/organizations/apikeys/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/organizations/apikeys/describe_test.go
+++ b/internal/cli/iam/organizations/apikeys/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/iam/organizations/apikeys/list_test.go
+++ b/internal/cli/iam/organizations/apikeys/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.APIKey
 

--- a/internal/cli/iam/organizations/apikeys/update_test.go
+++ b/internal/cli/iam/organizations/apikeys/update_test.go
@@ -28,7 +28,6 @@ import (
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.APIKey{
 		ID: "1",

--- a/internal/cli/iam/organizations/delete_test.go
+++ b/internal/cli/iam/organizations/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/iam/organizations/describe_test.go
+++ b/internal/cli/iam/organizations/describe_test.go
@@ -27,7 +27,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationDescriber(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/iam/organizations/invitations/delete_test.go
+++ b/internal/cli/iam/organizations/invitations/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationInvitationDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/organizations/invitations/describe_test.go
+++ b/internal/cli/iam/organizations/invitations/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationInvitationDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/iam/organizations/invitations/invite_test.go
+++ b/internal/cli/iam/organizations/invitations/invite_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationInviter(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Invitation{}
 	opts := &InviteOpts{

--- a/internal/cli/iam/organizations/invitations/list_test.go
+++ b/internal/cli/iam/organizations/invitations/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationInvitationLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []*mongodbatlas.Invitation
 

--- a/internal/cli/iam/organizations/invitations/update_test.go
+++ b/internal/cli/iam/organizations/invitations/update_test.go
@@ -31,7 +31,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationInvitationUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &atlas.Invitation{}
 

--- a/internal/cli/iam/organizations/list_test.go
+++ b/internal/cli/iam/organizations/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Organizations{}
 

--- a/internal/cli/iam/organizations/users/list_test.go
+++ b/internal/cli/iam/organizations/users/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockUserLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AtlasUsersResponse{}
 

--- a/internal/cli/iam/projects/apikeys/assign_test.go
+++ b/internal/cli/iam/projects/apikeys/assign_test.go
@@ -26,7 +26,6 @@ import (
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectAPIKeyAssigner(ctrl)
-	defer ctrl.Finish()
 
 	opts := &AssignOpts{
 		store: mockStore,

--- a/internal/cli/iam/projects/apikeys/create_test.go
+++ b/internal/cli/iam/projects/apikeys/create_test.go
@@ -27,7 +27,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectAPIKeyCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store:       mockStore,

--- a/internal/cli/iam/projects/apikeys/delete_test.go
+++ b/internal/cli/iam/projects/apikeys/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectAPIKeyDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/projects/apikeys/list_test.go
+++ b/internal/cli/iam/projects/apikeys/list_test.go
@@ -27,7 +27,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectAPIKeyLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.APIKey
 

--- a/internal/cli/iam/projects/create_test.go
+++ b/internal/cli/iam/projects/create_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectCreator(ctrl)
-	defer ctrl.Finish()
 
 	opts := CreateOpts{}
 	expected := &mongodbatlas.Project{}

--- a/internal/cli/iam/projects/delete_test.go
+++ b/internal/cli/iam/projects/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/iam/projects/describe_test.go
+++ b/internal/cli/iam/projects/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectDescriber(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/iam/projects/invitations/delete_test.go
+++ b/internal/cli/iam/projects/invitations/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectInvitationDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/projects/invitations/describe_test.go
+++ b/internal/cli/iam/projects/invitations/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectInvitationDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/iam/projects/invitations/invite_test.go
+++ b/internal/cli/iam/projects/invitations/invite_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectInviter(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Invitation{}
 	opts := &InviteOpts{

--- a/internal/cli/iam/projects/invitations/list_test.go
+++ b/internal/cli/iam/projects/invitations/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectInvitationLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []*mongodbatlas.Invitation
 

--- a/internal/cli/iam/projects/invitations/update_test.go
+++ b/internal/cli/iam/projects/invitations/update_test.go
@@ -31,7 +31,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectInvitationUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &atlas.Invitation{}
 

--- a/internal/cli/iam/projects/list_test.go
+++ b/internal/cli/iam/projects/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Projects{}
 

--- a/internal/cli/iam/projects/settings/describe_test.go
+++ b/internal/cli/iam/projects/settings/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectSettingsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/iam/projects/settings/update_test.go
+++ b/internal/cli/iam/projects/settings/update_test.go
@@ -33,7 +33,6 @@ import (
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectSettingsUpdater(ctrl)
-	defer ctrl.Finish()
 
 	opts := &UpdateOpts{
 		store:                                    mockStore,

--- a/internal/cli/iam/projects/teams/add_test.go
+++ b/internal/cli/iam/projects/teams/add_test.go
@@ -28,7 +28,6 @@ import (
 func TestAdd_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectTeamAdder(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.TeamsAssigned
 

--- a/internal/cli/iam/projects/teams/delete_test.go
+++ b/internal/cli/iam/projects/teams/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectTeamDeleter(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/projects/teams/list_test.go
+++ b/internal/cli/iam/projects/teams/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectTeamLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.Team
 

--- a/internal/cli/iam/projects/teams/update_test.go
+++ b/internal/cli/iam/projects/teams/update_test.go
@@ -28,7 +28,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockTeamRolesUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := []atlas.TeamRoles{}
 

--- a/internal/cli/iam/projects/users/delete_test.go
+++ b/internal/cli/iam/projects/users/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectUserDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/iam/projects/users/list_test.go
+++ b/internal/cli/iam/projects/users/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectUsersLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.AtlasUser
 

--- a/internal/cli/iam/teams/create_test.go
+++ b/internal/cli/iam/teams/create_test.go
@@ -27,7 +27,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockTeamCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Team{}
 

--- a/internal/cli/iam/teams/delete_test.go
+++ b/internal/cli/iam/teams/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockTeamDeleter(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/teams/describe_test.go
+++ b/internal/cli/iam/teams/describe_test.go
@@ -27,7 +27,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockTeamDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.Team
 

--- a/internal/cli/iam/teams/list_test.go
+++ b/internal/cli/iam/teams/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockTeamLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.Team
 

--- a/internal/cli/iam/teams/users/add_test.go
+++ b/internal/cli/iam/teams/users/add_test.go
@@ -28,7 +28,6 @@ import (
 func TestAdd_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockTeamAdder(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.Team
 

--- a/internal/cli/iam/teams/users/delete_test.go
+++ b/internal/cli/iam/teams/users/delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockTeamUserRemover(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/iam/teams/users/list_test.go
+++ b/internal/cli/iam/teams/users/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockTeamUserLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected []mongodbatlas.Team
 

--- a/internal/cli/iam/users/delete_test.go
+++ b/internal/cli/iam/users/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockUserDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/iam/users/describe_test.go
+++ b/internal/cli/iam/users/describe_test.go
@@ -27,7 +27,6 @@ import (
 func TestDescribe_Run_ByID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockUserDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected mongodbatlas.AtlasUser
 
@@ -50,7 +49,6 @@ func TestDescribe_Run_ByID(t *testing.T) {
 func TestDescribe_Run_ByName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockUserDescriber(ctrl)
-	defer ctrl.Finish()
 
 	var expected mongodbatlas.AtlasUser
 

--- a/internal/cli/iam/users/invite_test.go
+++ b/internal/cli/iam/users/invite_test.go
@@ -33,7 +33,6 @@ import (
 func TestInvite_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockUserCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.AtlasUser{
 		Username: "testUser",

--- a/internal/cli/opsmanager/admin/backup/blockstore/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockBlockstoresCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockBlockstoresDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/opsmanager/admin/backup/blockstore/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockBlockstoresDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockBlockstoresLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStores{}
 

--- a/internal/cli/opsmanager/admin/backup/blockstore/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/update_test.go
@@ -29,7 +29,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockBlockstoresUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockFileSystemsCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.FileSystemStoreConfiguration{}
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockFileSystemsDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/opsmanager/admin/backup/filesystem/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockFileSystemsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.FileSystemStoreConfiguration{}
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockFileSystemsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.FileSystemStoreConfigurations{}
 

--- a/internal/cli/opsmanager/admin/backup/filesystem/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/update_test.go
@@ -29,7 +29,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockFileSystemsUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.FileSystemStoreConfiguration{}
 

--- a/internal/cli/opsmanager/admin/backup/oplog/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOplogsCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/admin/backup/oplog/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOplogsDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/opsmanager/admin/backup/oplog/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOplogsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/admin/backup/oplog/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOplogsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStores{}
 

--- a/internal/cli/opsmanager/admin/backup/oplog/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/update_test.go
@@ -29,7 +29,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOplogsUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/admin/backup/s3/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockS3BlockstoresCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.S3Blockstore{}
 

--- a/internal/cli/opsmanager/admin/backup/s3/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockS3BlockstoresDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/opsmanager/admin/backup/s3/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockS3BlockstoresDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.S3Blockstore{}
 

--- a/internal/cli/opsmanager/admin/backup/s3/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockS3BlockstoresLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.S3Blockstores{}
 

--- a/internal/cli/opsmanager/admin/backup/s3/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/s3/update_test.go
@@ -29,7 +29,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockS3BlockstoresUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.S3Blockstore{}
 

--- a/internal/cli/opsmanager/admin/backup/sync/create_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSyncsCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/admin/backup/sync/delete_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSyncsDeleter(ctrl)
-	defer ctrl.Finish()
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/opsmanager/admin/backup/sync/describe_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSyncsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/admin/backup/sync/list_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSyncsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStores{}
 

--- a/internal/cli/opsmanager/admin/backup/sync/update_test.go
+++ b/internal/cli/opsmanager/admin/backup/sync/update_test.go
@@ -29,7 +29,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSyncsUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupStore{}
 

--- a/internal/cli/opsmanager/agents/apikeys/create_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAgentAPIKeyCreator(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/agents/apikeys/delete_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAgentAPIKeyDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/agents/apikeys/list_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestAgentsList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAgentAPIKeyLister(ctrl)
-	defer ctrl.Finish()
 
 	listOpts := ListOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/agents/list_test.go
+++ b/internal/cli/opsmanager/agents/list_test.go
@@ -32,7 +32,6 @@ import (
 func TestAgentsList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAgentLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.Agents{}
 

--- a/internal/cli/opsmanager/agents/upgrade_test.go
+++ b/internal/cli/opsmanager/agents/upgrade_test.go
@@ -28,7 +28,6 @@ import (
 func TestAgentsUpgradeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAgentUpgrader(ctrl)
-	defer ctrl.Finish()
 
 	expected := new(opsmngr.AutomationConfigAgent)
 

--- a/internal/cli/opsmanager/agents/versions/list_test.go
+++ b/internal/cli/opsmanager/agents/versions/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAgentProjectVersionsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.AgentVersions{}
 

--- a/internal/cli/opsmanager/automation/describe_test.go
+++ b/internal/cli/opsmanager/automation/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestAutomationShowOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationGetter(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/automation/status_test.go
+++ b/internal/cli/opsmanager/automation/status_test.go
@@ -28,7 +28,6 @@ import (
 func TestAutomationStatus_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationStatusGetter(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationStatus()
 

--- a/internal/cli/opsmanager/automation/update_test.go
+++ b/internal/cli/opsmanager/automation/update_test.go
@@ -29,7 +29,6 @@ import (
 func TestAutomationUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.AutomationConfig{
 		Version: 1,

--- a/internal/cli/opsmanager/automation/watch_test.go
+++ b/internal/cli/opsmanager/automation/watch_test.go
@@ -28,7 +28,6 @@ import (
 func TestAutomationWatch_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationStatusGetter(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationStatus()
 

--- a/internal/cli/opsmanager/backup/checkpoints_list_test.go
+++ b/internal/cli/opsmanager/backup/checkpoints_list_test.go
@@ -28,7 +28,6 @@ import (
 func TestCheckpointsList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCheckpointsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.Checkpoints{}
 	clusterID := "5ec2ac941271767f21cbaefd"

--- a/internal/cli/opsmanager/backup/config/describe_test.go
+++ b/internal/cli/opsmanager/backup/config/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockBackupConfigGetter(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupConfig{}
 

--- a/internal/cli/opsmanager/backup/config/list_test.go
+++ b/internal/cli/opsmanager/backup/config/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockBackupConfigLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupConfigs{}
 

--- a/internal/cli/opsmanager/backup/config/update_test.go
+++ b/internal/cli/opsmanager/backup/config/update_test.go
@@ -30,7 +30,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockBackupConfigUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.BackupConfig{}
 

--- a/internal/cli/opsmanager/backup/disable_test.go
+++ b/internal/cli/opsmanager/backup/disable_test.go
@@ -39,7 +39,6 @@ func TestDisableBuilder(t *testing.T) {
 func TestDisableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfigWithBackup()
 

--- a/internal/cli/opsmanager/backup/enable_test.go
+++ b/internal/cli/opsmanager/backup/enable_test.go
@@ -39,7 +39,6 @@ func TestEnableBuilder(t *testing.T) {
 func TestEnableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/backup/restores_list_test.go
+++ b/internal/cli/opsmanager/backup/restores_list_test.go
@@ -28,7 +28,6 @@ import (
 func TestRestoresListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockContinuousJobLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ContinuousJobs{}
 	clusterID := "5ec2ac941271767f21cbaeff"

--- a/internal/cli/opsmanager/backup/restores_start_test.go
+++ b/internal/cli/opsmanager/backup/restores_start_test.go
@@ -28,7 +28,6 @@ import (
 func TestRestoresStart_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockContinuousJobCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ContinuousJobs{}
 

--- a/internal/cli/opsmanager/backup/snapshots/list_test.go
+++ b/internal/cli/opsmanager/backup/snapshots/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockContinuousSnapshotsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ContinuousSnapshots{}
 	clusterID := "5ec2ac941271767f21cbaefe"

--- a/internal/cli/opsmanager/backup/snapshots/schedule/describe_test.go
+++ b/internal/cli/opsmanager/backup/snapshots/schedule/describe_test.go
@@ -29,7 +29,6 @@ import (
 func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotScheduleDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.SnapshotSchedule{}
 

--- a/internal/cli/opsmanager/backup/snapshots/schedule/update_test.go
+++ b/internal/cli/opsmanager/backup/snapshots/schedule/update_test.go
@@ -29,7 +29,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotScheduleUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.SnapshotSchedule{}
 

--- a/internal/cli/opsmanager/clusters/apply_test.go
+++ b/internal/cli/opsmanager/clusters/apply_test.go
@@ -29,7 +29,6 @@ import (
 func TestApply_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 	appFS := afero.NewMemMapFs()

--- a/internal/cli/opsmanager/clusters/create_test.go
+++ b/internal/cli/opsmanager/clusters/create_test.go
@@ -29,7 +29,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 	appFS := afero.NewMemMapFs()

--- a/internal/cli/opsmanager/clusters/delete_test.go
+++ b/internal/cli/opsmanager/clusters/delete_test.go
@@ -33,8 +33,6 @@ func TestDeleteReplicaSet_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudManagerClustersDeleter(ctrl)
 
-	defer ctrl.Finish()
-
 	expected := fixture.AutomationConfig()
 	watchExpected := fixture.AutomationStatus()
 	host0 := &opsmngr.Host{
@@ -109,8 +107,6 @@ func TestDeleteReplicaSet_Run(t *testing.T) {
 func TestDeleteShardedCluster_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudManagerClustersDeleter(ctrl)
-
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfigWithOneShardedCluster("MyCluster", false)
 	watchExpected := fixture.AutomationStatus()

--- a/internal/cli/opsmanager/clusters/describe_test.go
+++ b/internal/cli/opsmanager/clusters/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudManagerClustersDescriber(ctrl)
-	defer ctrl.Finish()
 
 	t.Run("describe cluster simplified", func(t *testing.T) {
 		descOpts := &DescribeOpts{

--- a/internal/cli/opsmanager/clusters/indexes_create_test.go
+++ b/internal/cli/opsmanager/clusters/indexes_create_test.go
@@ -29,7 +29,6 @@ import (
 func TestIndexesCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/clusters/list_test.go
+++ b/internal/cli/opsmanager/clusters/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCloudManagerClustersLister(ctrl)
-	defer ctrl.Finish()
 
 	t.Run("clusters for project simple view", func(t *testing.T) {
 		expected := &opsmngr.Clusters{}

--- a/internal/cli/opsmanager/clusters/reclaim_free_space_test.go
+++ b/internal/cli/opsmanager/clusters/reclaim_free_space_test.go
@@ -30,7 +30,6 @@ import (
 func TestReclaimFreeSpace_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/clusters/restart_test.go
+++ b/internal/cli/opsmanager/clusters/restart_test.go
@@ -30,7 +30,6 @@ import (
 func TestRestart_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/clusters/shutdown_test.go
+++ b/internal/cli/opsmanager/clusters/shutdown_test.go
@@ -30,7 +30,6 @@ import (
 func TestShutdown_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/clusters/startup_test.go
+++ b/internal/cli/opsmanager/clusters/startup_test.go
@@ -30,7 +30,6 @@ import (
 func TestStartup_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/clusters/unmanage_test.go
+++ b/internal/cli/opsmanager/clusters/unmanage_test.go
@@ -29,7 +29,6 @@ import (
 func TestUnmanage_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/clusters/update_test.go
+++ b/internal/cli/opsmanager/clusters/update_test.go
@@ -29,7 +29,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 	appFS := afero.NewMemMapFs()

--- a/internal/cli/opsmanager/dbusers/create_test.go
+++ b/internal/cli/opsmanager/dbusers/create_test.go
@@ -28,7 +28,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/dbusers/delete_test.go
+++ b/internal/cli/opsmanager/dbusers/delete_test.go
@@ -29,7 +29,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfigWithMongoDBUsers()
 

--- a/internal/cli/opsmanager/dbusers/list_test.go
+++ b/internal/cli/opsmanager/dbusers/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/diagnosearchive/diagnose_archive_download_test.go
+++ b/internal/cli/opsmanager/diagnosearchive/diagnose_archive_download_test.go
@@ -28,7 +28,6 @@ import (
 func TestDiagnoseArchiveDownloadOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockArchivesDownloader(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DownloadOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/featurepolicies/list_test.go
+++ b/internal/cli/opsmanager/featurepolicies/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockFeatureControlPoliciesLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.FeaturePolicy{}
 

--- a/internal/cli/opsmanager/featurepolicies/update_test.go
+++ b/internal/cli/opsmanager/featurepolicies/update_test.go
@@ -30,7 +30,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockFeatureControlPoliciesUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.FeaturePolicy{}
 

--- a/internal/cli/opsmanager/livemigrations/link/create_test.go
+++ b/internal/cli/opsmanager/livemigrations/link/create_test.go
@@ -32,7 +32,6 @@ import (
 func TestLinkCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationsConnector(ctrl)
-	defer ctrl.Finish()
 
 	createOpts := &CreateOpts{
 		GlobalOpts: cli.GlobalOpts{OrgID: "1"},

--- a/internal/cli/opsmanager/livemigrations/link/delete_test.go
+++ b/internal/cli/opsmanager/livemigrations/link/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestLinkTokenDeleteOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLinkTokenDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		GlobalOpts: cli.GlobalOpts{OrgID: "1"},

--- a/internal/cli/opsmanager/livemigrations/link/describe_test.go
+++ b/internal/cli/opsmanager/livemigrations/link/describe_test.go
@@ -31,7 +31,6 @@ import (
 func TestLinkDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationsDescriber(ctrl)
-	defer ctrl.Finish()
 
 	describeOpts := &DescribeOpts{
 		GlobalOpts: cli.GlobalOpts{OrgID: "1"},

--- a/internal/cli/opsmanager/logs/jobs_collect_test.go
+++ b/internal/cli/opsmanager/logs/jobs_collect_test.go
@@ -28,7 +28,6 @@ import (
 func TestLogsCollectOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLogCollector(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.LogCollectionJob{ID: "1"}
 

--- a/internal/cli/opsmanager/logs/jobs_delete_test.go
+++ b/internal/cli/opsmanager/logs/jobs_delete_test.go
@@ -28,7 +28,6 @@ import (
 func TestJobsDeleteOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLogJobDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &JobsDeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/opsmanager/logs/jobs_download_test.go
+++ b/internal/cli/opsmanager/logs/jobs_download_test.go
@@ -30,7 +30,6 @@ import (
 func TestDownloadOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLogJobsDownloader(ctrl)
-	defer ctrl.Finish()
 
 	opts := &JobsDownloadOpts{
 		id:    "1",

--- a/internal/cli/opsmanager/logs/jobs_list_test.go
+++ b/internal/cli/opsmanager/logs/jobs_list_test.go
@@ -28,7 +28,6 @@ import (
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLogJobLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.LogCollectionJobs{}
 

--- a/internal/cli/opsmanager/maintenance/create_test.go
+++ b/internal/cli/opsmanager/maintenance/create_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOpsManagerMaintenanceWindowCreator(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.MaintenanceWindow{}
 

--- a/internal/cli/opsmanager/maintenance/delete_test.go
+++ b/internal/cli/opsmanager/maintenance/delete_test.go
@@ -30,7 +30,6 @@ import (
 func TestDelete_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOpsManagerMaintenanceWindowDeleter(ctrl)
-	defer ctrl.Finish()
 
 	deleteOpts := &DeleteOpts{
 		DeleteOpts: &cli.DeleteOpts{

--- a/internal/cli/opsmanager/maintenance/describe_test.go
+++ b/internal/cli/opsmanager/maintenance/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOpsManagerMaintenanceWindowDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.MaintenanceWindow{}
 

--- a/internal/cli/opsmanager/maintenance/list_test.go
+++ b/internal/cli/opsmanager/maintenance/list_test.go
@@ -31,7 +31,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOpsManagerMaintenanceWindowLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.MaintenanceWindows{}
 

--- a/internal/cli/opsmanager/maintenance/update_test.go
+++ b/internal/cli/opsmanager/maintenance/update_test.go
@@ -30,7 +30,6 @@ import (
 func TestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOpsManagerMaintenanceWindowUpdater(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.MaintenanceWindow{}
 

--- a/internal/cli/opsmanager/metrics/databases_describe_test.go
+++ b/internal/cli/opsmanager/metrics/databases_describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDatabasesDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostDatabaseMeasurementsLister(ctrl)
-	defer ctrl.Finish()
 
 	listOpts := &DatabasesDescribeOpts{
 		hostID: "1",

--- a/internal/cli/opsmanager/metrics/databases_list_test.go
+++ b/internal/cli/opsmanager/metrics/databases_list_test.go
@@ -28,7 +28,6 @@ import (
 func TestDatabasesListsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostDatabaseLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessDatabasesResponse{}
 

--- a/internal/cli/opsmanager/metrics/disks_describe_test.go
+++ b/internal/cli/opsmanager/metrics/disks_describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDisksDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostDiskMeasurementsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessDiskMeasurements{
 		ProcessMeasurements: &mongodbatlas.ProcessMeasurements{

--- a/internal/cli/opsmanager/metrics/disks_list_test.go
+++ b/internal/cli/opsmanager/metrics/disks_list_test.go
@@ -28,7 +28,6 @@ import (
 func TestDisksListsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostDisksLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessDisksResponse{}
 

--- a/internal/cli/opsmanager/metrics/process_test.go
+++ b/internal/cli/opsmanager/metrics/process_test.go
@@ -30,7 +30,6 @@ const oneMinute = "PT1M"
 func TestProcess_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostMeasurementLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &mongodbatlas.ProcessMeasurements{}
 

--- a/internal/cli/opsmanager/monitoring/disable_test.go
+++ b/internal/cli/opsmanager/monitoring/disable_test.go
@@ -39,7 +39,6 @@ func TestDisableBuilder(t *testing.T) {
 func TestDisableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfigWithMonitoring()
 

--- a/internal/cli/opsmanager/monitoring/enable_test.go
+++ b/internal/cli/opsmanager/monitoring/enable_test.go
@@ -48,7 +48,6 @@ func TestEnableBuilder(t *testing.T) {
 func TestEnableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/monitoring/stop_test.go
+++ b/internal/cli/opsmanager/monitoring/stop_test.go
@@ -39,7 +39,6 @@ func TestStopBuilder(t *testing.T) {
 func TestStopOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockMonitoringStopper(ctrl)
-	defer ctrl.Finish()
 
 	opts := &StopOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/owner/create_test.go
+++ b/internal/cli/opsmanager/owner/create_test.go
@@ -30,7 +30,6 @@ import (
 func TestManagerOwnerCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOwnerCreator(ctrl)
-	defer ctrl.Finish()
 
 	email := "test@test.com"
 	password := "Passw0rd!"

--- a/internal/cli/opsmanager/processes/describe_test.go
+++ b/internal/cli/opsmanager/processes/describe_test.go
@@ -28,7 +28,6 @@ import (
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostDescriber(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.Host{}
 

--- a/internal/cli/opsmanager/processes/list_test.go
+++ b/internal/cli/opsmanager/processes/list_test.go
@@ -28,7 +28,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.Hosts{}
 

--- a/internal/cli/opsmanager/security/enable_test.go
+++ b/internal/cli/opsmanager/security/enable_test.go
@@ -28,7 +28,6 @@ import (
 func TestSecurityEnableOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAutomationPatcher(ctrl)
-	defer ctrl.Finish()
 
 	expected := fixture.AutomationConfig()
 

--- a/internal/cli/opsmanager/servers/list_test.go
+++ b/internal/cli/opsmanager/servers/list_test.go
@@ -31,7 +31,6 @@ import (
 func TestAgentsList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAgentLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.Agents{}
 

--- a/internal/cli/opsmanager/serverusage/capture_test.go
+++ b/internal/cli/opsmanager/serverusage/capture_test.go
@@ -28,7 +28,6 @@ import (
 func TestCapture_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotGenerator(ctrl)
-	defer ctrl.Finish()
 
 	opts := CaptureOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/serverusage/download_test.go
+++ b/internal/cli/opsmanager/serverusage/download_test.go
@@ -30,7 +30,6 @@ import (
 func TestLogsDownloadOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerUsageReportDownloader(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DownloadOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/serverusage/organizations/hosts/list_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/hosts/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationHostAssignmentLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.HostAssignments{}
 

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/describe_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestGetOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationServerTypeGetter(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.ServerType{}
 

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/set_test.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/set_test.go
@@ -29,7 +29,6 @@ import (
 func TestSetOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationServerTypeUpdater(ctrl)
-	defer ctrl.Finish()
 
 	opts := &SetOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/serverusage/projects/hosts/list_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/hosts/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectHostAssignmentLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.HostAssignments{}
 

--- a/internal/cli/opsmanager/serverusage/projects/servertype/describe_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/describe_test.go
@@ -30,7 +30,6 @@ import (
 func TestGetOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectServerTypeGetter(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.ServerType{}
 

--- a/internal/cli/opsmanager/serverusage/projects/servertype/set_test.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/set_test.go
@@ -29,7 +29,6 @@ import (
 func TestSetOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectServerTypeUpdater(ctrl)
-	defer ctrl.Finish()
 
 	opts := &SetOpts{
 		store: mockStore,

--- a/internal/cli/opsmanager/softwarecomponents/list_test.go
+++ b/internal/cli/opsmanager/softwarecomponents/list_test.go
@@ -30,7 +30,6 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAgentGlobalVersionsLister(ctrl)
-	defer ctrl.Finish()
 
 	expected := &opsmngr.SoftwareVersions{}
 

--- a/internal/cli/opsmanager/versionmanifest/update_test.go
+++ b/internal/cli/opsmanager/versionmanifest/update_test.go
@@ -31,7 +31,6 @@ func TestVersionManifestUpdate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockVersionManifestUpdaterServiceVersionDescriber(ctrl)
 	mockStoreStaticPath := mocks.NewMockVersionManifestGetter(ctrl)
-	defer ctrl.Finish()
 
 	tests := []struct {
 		name            string

--- a/internal/cli/performanceadvisor/namespaces/list_test.go
+++ b/internal/cli/performanceadvisor/namespaces/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestNamespacesList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPerformanceAdvisorNamespacesLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.Namespaces
 

--- a/internal/cli/performanceadvisor/slowoperationthreshold/disable_test.go
+++ b/internal/cli/performanceadvisor/slowoperationthreshold/disable_test.go
@@ -28,7 +28,6 @@ import (
 func TestDisable_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPerformanceAdvisorSlowOperationThresholdDisabler(ctrl)
-	defer ctrl.Finish()
 
 	opts := &DisableOpts{
 		store: mockStore,

--- a/internal/cli/performanceadvisor/slowoperationthreshold/enable_test.go
+++ b/internal/cli/performanceadvisor/slowoperationthreshold/enable_test.go
@@ -28,7 +28,6 @@ import (
 func TestEnable_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPerformanceAdvisorSlowOperationThresholdEnabler(ctrl)
-	defer ctrl.Finish()
 
 	opts := &EnableOpts{
 		store: mockStore,

--- a/internal/cli/performanceadvisor/slowquerylogs/list_test.go
+++ b/internal/cli/performanceadvisor/slowquerylogs/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestSlowQueryLogsList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPerformanceAdvisorSlowQueriesLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.SlowQueries
 

--- a/internal/cli/performanceadvisor/suggestedindexes/list_test.go
+++ b/internal/cli/performanceadvisor/suggestedindexes/list_test.go
@@ -29,7 +29,6 @@ import (
 func TestNamespacesList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockPerformanceAdvisorIndexesLister(ctrl)
-	defer ctrl.Finish()
 
 	var expected *mongodbatlas.SuggestedIndexes
 

--- a/internal/cli/root/atlas/builder_test.go
+++ b/internal/cli/root/atlas/builder_test.go
@@ -53,7 +53,6 @@ func TestOutputOpts_notifyIfApplicable(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			mockDescriber := mocks.NewMockReleaseVersionDescriber(ctrl)
-			defer ctrl.Finish()
 
 			mockDescriber.
 				EXPECT().

--- a/internal/cli/root/mongocli/builder_test.go
+++ b/internal/cli/root/mongocli/builder_test.go
@@ -143,7 +143,6 @@ func TestOutputOpts_notifyIfApplicable(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			mockDescriber := mocks.NewMockReleaseVersionDescriber(ctrl)
-			defer ctrl.Finish()
 
 			mockDescriber.
 				EXPECT().

--- a/internal/latestrelease/finder_test.go
+++ b/internal/latestrelease/finder_test.go
@@ -125,7 +125,6 @@ func TestOutputOpts_Find_NoCache(t *testing.T) {
 		t.Run(fmt.Sprintf("%v / %v", tt.currentVersion, tt.release.GetTagName()), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockDescriber := mocks.NewMockReleaseVersionDescriber(ctrl)
-			defer ctrl.Finish()
 
 			mockDescriber.
 				EXPECT().

--- a/internal/telemetry/tracker_test.go
+++ b/internal/telemetry/tracker_test.go
@@ -34,7 +34,6 @@ import (
 func TestTrackCommand(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockEventsSender(ctrl)
-	defer ctrl.Finish()
 
 	config.ToolName = config.AtlasCLI
 
@@ -68,7 +67,6 @@ func TestTrackCommand(t *testing.T) {
 func TestTrackCommandWithError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockEventsSender(ctrl)
-	defer ctrl.Finish()
 
 	config.ToolName = config.AtlasCLI
 
@@ -109,7 +107,6 @@ func TestTrackCommandWithError(t *testing.T) {
 func TestTrackCommandWithSendError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockEventsSender(ctrl)
-	defer ctrl.Finish()
 
 	config.ToolName = config.AtlasCLI
 


### PR DESCRIPTION
## Proposed changes


_Jira ticket:_ CLOUDP-127887


## Further comments

Find and replace any usage 