### PR TITLE
(DOCSP-28116)(28117) Adds required roles for additional commands

### DIFF
--- a/docs/atlascli/command/atlas-processes-list.txt
+++ b/docs/atlascli/command/atlas-processes-list.txt
@@ -14,6 +14,8 @@ atlas processes list
 
 Return all MongoDB processes for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-apiKeys-create.txt
+++ b/docs/atlascli/command/atlas-projects-apiKeys-create.txt
@@ -16,6 +16,8 @@ Create an organization API key and assign it to your project.
 
 MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-apiKeys-delete.txt
+++ b/docs/atlascli/command/atlas-projects-apiKeys-delete.txt
@@ -18,6 +18,8 @@ The API key still exists at the organization level. To reassign the organization
 		
 To view possible values for the ID argument, run atlas organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-apiKeys-list.txt
+++ b/docs/atlascli/command/atlas-projects-apiKeys-list.txt
@@ -14,6 +14,8 @@ atlas projects apiKeys list
 
 Return all organization API keys assigned to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-create.txt
+++ b/docs/atlascli/command/atlas-projects-create.txt
@@ -16,6 +16,8 @@ Create a project in your organization.
 
 Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-delete.txt
+++ b/docs/atlascli/command/atlas-projects-delete.txt
@@ -14,6 +14,8 @@ atlas projects delete
 
 Remove the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-describe.txt
+++ b/docs/atlascli/command/atlas-projects-describe.txt
@@ -14,6 +14,8 @@ atlas projects describe
 
 Return the details for the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-invitations-delete.txt
+++ b/docs/atlascli/command/atlas-projects-invitations-delete.txt
@@ -14,6 +14,8 @@ atlas projects invitations delete
 
 Remove the specified pending invitation to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-invitations-describe.txt
+++ b/docs/atlascli/command/atlas-projects-invitations-describe.txt
@@ -14,6 +14,8 @@ atlas projects invitations describe
 
 Return the details for the specified pending invitation to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-invitations-invite.txt
+++ b/docs/atlascli/command/atlas-projects-invitations-invite.txt
@@ -14,6 +14,8 @@ atlas projects invitations invite
 
 Invite the specified MongoDB user to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-invitations-list.txt
+++ b/docs/atlascli/command/atlas-projects-invitations-list.txt
@@ -14,6 +14,8 @@ atlas projects invitations list
 
 Return all pending invitations to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-invitations-update.txt
+++ b/docs/atlascli/command/atlas-projects-invitations-update.txt
@@ -16,6 +16,8 @@ Modifies the details of the specified pending invitation to your project.
 
 You can use either the invitation ID or the user's email address to specify the invitation.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-list.txt
+++ b/docs/atlascli/command/atlas-projects-list.txt
@@ -14,6 +14,8 @@ atlas projects list
 
 Return all projects.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-teams-add.txt
+++ b/docs/atlascli/command/atlas-projects-teams-add.txt
@@ -16,6 +16,8 @@ Add the specified team to your project.
 
 All members of the team share the same project access.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-teams-delete.txt
+++ b/docs/atlascli/command/atlas-projects-teams-delete.txt
@@ -16,6 +16,8 @@ Remove the specified team from your project.
 
 After you remove a team from your project, the team still exists in the organization in which it was created.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-teams-list.txt
+++ b/docs/atlascli/command/atlas-projects-teams-list.txt
@@ -14,6 +14,8 @@ atlas projects teams list
 
 Return all teams for a project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-teams-update.txt
+++ b/docs/atlascli/command/atlas-projects-teams-update.txt
@@ -14,6 +14,8 @@ atlas projects teams update
 
 Modify the roles for the specified team for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-users-delete.txt
+++ b/docs/atlascli/command/atlas-projects-users-delete.txt
@@ -16,6 +16,8 @@ Remove the specified user from your project.
 
 After you remove a user from your project, the user still exists in the organization in which it was created.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-projects-users-list.txt
+++ b/docs/atlascli/command/atlas-projects-users-list.txt
@@ -14,6 +14,8 @@ atlas projects users list
 
 Return all users for a project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-customerCerts-create.txt
+++ b/docs/atlascli/command/atlas-security-customerCerts-create.txt
@@ -16,6 +16,8 @@ Saves a customer-managed X.509 configuration for your project.
 
 Saving a customer-managed X.509 configuration triggers a rolling restart.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-customerCerts-describe.txt
+++ b/docs/atlascli/command/atlas-security-customerCerts-describe.txt
@@ -14,6 +14,8 @@ atlas security customerCerts describe
 
 Return the details for the current customer-managed X.509 configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-customerCerts-disable.txt
+++ b/docs/atlascli/command/atlas-security-customerCerts-disable.txt
@@ -16,6 +16,8 @@ Clear customer-managed X.509 settings on a project, including the uploaded Certi
 
 Disabling customer-managed X.509 triggers a rolling restart.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-ldap-delete.txt
+++ b/docs/atlascli/command/atlas-security-ldap-delete.txt
@@ -14,6 +14,8 @@ atlas security ldap delete
 
 Remove the current LDAP configuration captured in the userToDNMapping document from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-ldap-get.txt
+++ b/docs/atlascli/command/atlas-security-ldap-get.txt
@@ -14,6 +14,8 @@ atlas security ldap get
 
 Return the current LDAP configuration details for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-ldap-save.txt
+++ b/docs/atlascli/command/atlas-security-ldap-save.txt
@@ -14,6 +14,8 @@ atlas security ldap save
 
 Save an LDAP configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
@@ -19,6 +19,8 @@ Once the LDAP configuration reaches the expected status, the command prints "LDA
 If you run the command in the terminal, it blocks the terminal session until the resource status succeeds or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-ldap-verify-status.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify-status.txt
@@ -14,6 +14,8 @@ atlas security ldap verify status
 
 Get the status of an LDAP configuration request.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-security-ldap-verify.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify.txt
@@ -14,6 +14,8 @@ atlas security ldap verify
 
 Request verification of an LDAP configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-create.txt
+++ b/docs/atlascli/command/atlas-serverless-create.txt
@@ -14,6 +14,8 @@ atlas serverless create
 
 Creates one serverless instance in the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-delete.txt
+++ b/docs/atlascli/command/atlas-serverless-delete.txt
@@ -14,6 +14,8 @@ atlas serverless delete
 
 Remove a serverless instance from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-describe.txt
+++ b/docs/atlascli/command/atlas-serverless-describe.txt
@@ -14,6 +14,8 @@ atlas serverless describe
 
 Return one serverless instance in the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-list.txt
+++ b/docs/atlascli/command/atlas-serverless-list.txt
@@ -14,6 +14,8 @@ atlas serverless list
 
 Return all serverless instances in the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-serverless-watch.txt
+++ b/docs/atlascli/command/atlas-serverless-watch.txt
@@ -19,6 +19,8 @@ Once the instance reaches the expected state, the command prints "Instance avail
 If you run the command in the terminal, it blocks the terminal session until the resource becomes idle.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-teams-create.txt
+++ b/docs/atlascli/command/atlas-teams-create.txt
@@ -14,6 +14,8 @@ atlas teams create
 
 Create a team for your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-teams-delete.txt
+++ b/docs/atlascli/command/atlas-teams-delete.txt
@@ -14,6 +14,8 @@ atlas teams delete
 
 Remove the specified team from your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-teams-describe.txt
+++ b/docs/atlascli/command/atlas-teams-describe.txt
@@ -16,6 +16,8 @@ Return the details for the specified team for your organization.
 
 You can return the details for a team using the team's ID or the team's name. You must specify either the id option or the name option.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-teams-list.txt
+++ b/docs/atlascli/command/atlas-teams-list.txt
@@ -14,6 +14,8 @@ atlas teams list
 
 Return all teams for your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-teams-users-add.txt
+++ b/docs/atlascli/command/atlas-teams-users-add.txt
@@ -16,6 +16,8 @@ Add the specified MongoDB user to a team for your organization.
 
 Users must be current members of your organization before you can add them to a team.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-teams-users-delete.txt
+++ b/docs/atlascli/command/atlas-teams-users-delete.txt
@@ -14,6 +14,8 @@ atlas teams users delete
 
 Remove the specified user from a team for your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-teams-users-list.txt
+++ b/docs/atlascli/command/atlas-teams-users-list.txt
@@ -14,6 +14,8 @@ atlas teams users list
 
 Return all users for a team.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-users-describe.txt
+++ b/docs/atlascli/command/atlas-users-describe.txt
@@ -15,6 +15,8 @@ atlas users describe
 Return the details for the specified MongoDB user.
 
 You can specify either the unique 24-digit ID that identifies the MongoDB user or the username for the MongoDB user.
+		
+User accounts and API keys with any role can run this command.
 
 Syntax
 ------

--- a/docs/mongocli/command/mongocli-atlas-processes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-processes-list.txt
@@ -14,6 +14,8 @@ mongocli atlas processes list
 
 Return all MongoDB processes for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-customerCerts-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-customerCerts-create.txt
@@ -16,6 +16,8 @@ Saves a customer-managed X.509 configuration for your project.
 
 Saving a customer-managed X.509 configuration triggers a rolling restart.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-customerCerts-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-customerCerts-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas security customerCerts describe
 
 Return the details for the current customer-managed X.509 configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-customerCerts-disable.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-customerCerts-disable.txt
@@ -16,6 +16,8 @@ Clear customer-managed X.509 settings on a project, including the uploaded Certi
 
 Disabling customer-managed X.509 triggers a rolling restart.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas security ldap delete
 
 Remove the current LDAP configuration captured in the userToDNMapping document from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-get.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-get.txt
@@ -14,6 +14,8 @@ mongocli atlas security ldap get
 
 Return the current LDAP configuration details for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-save.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-save.txt
@@ -14,6 +14,8 @@ mongocli atlas security ldap save
 
 Save an LDAP configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
@@ -19,6 +19,8 @@ Once the LDAP configuration reaches the expected status, the command prints "LDA
 If you run the command in the terminal, it blocks the terminal session until the resource status succeeds or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status.txt
@@ -14,6 +14,8 @@ mongocli atlas security ldap verify status
 
 Get the status of an LDAP configuration request.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify.txt
@@ -14,6 +14,8 @@ mongocli atlas security ldap verify
 
 Request verification of an LDAP configuration for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-create.txt
@@ -14,6 +14,8 @@ mongocli atlas serverless create
 
 Creates one serverless instance in the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas serverless delete
 
 Remove a serverless instance from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas serverless describe
 
 Return one serverless instance in the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-list.txt
@@ -14,6 +14,8 @@ mongocli atlas serverless list
 
 Return all serverless instances in the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-watch.txt
@@ -19,6 +19,8 @@ Once the instance reaches the expected state, the command prints "Instance avail
 If you run the command in the terminal, it blocks the terminal session until the resource becomes idle.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-apiKeys-create.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-apiKeys-create.txt
@@ -16,6 +16,8 @@ Create an organization API key and assign it to your project.
 
 MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-apiKeys-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-apiKeys-delete.txt
@@ -18,6 +18,8 @@ The API key still exists at the organization level. To reassign the organization
 		
 To view possible values for the ID argument, run mongocli organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-apiKeys-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-apiKeys-list.txt
@@ -14,6 +14,8 @@ mongocli iam projects apiKeys list
 
 Return all organization API keys assigned to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-create.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-create.txt
@@ -16,6 +16,8 @@ Create a project in your organization.
 
 Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-delete.txt
@@ -14,6 +14,8 @@ mongocli iam projects delete
 
 Remove the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-describe.txt
@@ -14,6 +14,8 @@ mongocli iam projects describe
 
 Return the details for the specified project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-invitations-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-invitations-delete.txt
@@ -14,6 +14,8 @@ mongocli iam projects invitations delete
 
 Remove the specified pending invitation to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-invitations-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-invitations-describe.txt
@@ -14,6 +14,8 @@ mongocli iam projects invitations describe
 
 Return the details for the specified pending invitation to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-invitations-invite.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-invitations-invite.txt
@@ -14,6 +14,8 @@ mongocli iam projects invitations invite
 
 Invite the specified MongoDB user to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-invitations-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-invitations-list.txt
@@ -14,6 +14,8 @@ mongocli iam projects invitations list
 
 Return all pending invitations to your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-invitations-update.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-invitations-update.txt
@@ -16,6 +16,8 @@ Modifies the details of the specified pending invitation to your project.
 
 You can use either the invitation ID or the user's email address to specify the invitation.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-list.txt
@@ -14,6 +14,8 @@ mongocli iam projects list
 
 Return all projects.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-teams-add.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-teams-add.txt
@@ -16,6 +16,8 @@ Add the specified team to your project.
 
 All members of the team share the same project access.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-teams-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-teams-delete.txt
@@ -16,6 +16,8 @@ Remove the specified team from your project.
 
 After you remove a team from your project, the team still exists in the organization in which it was created.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-teams-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-teams-list.txt
@@ -14,6 +14,8 @@ mongocli iam projects teams list
 
 Return all teams for a project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-teams-update.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-teams-update.txt
@@ -14,6 +14,8 @@ mongocli iam projects teams update
 
 Modify the roles for the specified team for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-users-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-users-delete.txt
@@ -16,6 +16,8 @@ Remove the specified user from your project.
 
 After you remove a user from your project, the user still exists in the organization in which it was created.
 
+To use this command, you must authenticate with a user account or an API key that has the Project User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-projects-users-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-users-list.txt
@@ -14,6 +14,8 @@ mongocli iam projects users list
 
 Return all users for a project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-teams-create.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-create.txt
@@ -14,6 +14,8 @@ mongocli iam teams create
 
 Create a team for your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-teams-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-delete.txt
@@ -14,6 +14,8 @@ mongocli iam teams delete
 
 Remove the specified team from your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-teams-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-describe.txt
@@ -16,6 +16,8 @@ Return the details for the specified team for your organization.
 
 You can return the details for a team using the team's ID or the team's name. You must specify either the id option or the name option.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-teams-list.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-list.txt
@@ -14,6 +14,8 @@ mongocli iam teams list
 
 Return all teams for your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-teams-users-add.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-users-add.txt
@@ -16,6 +16,8 @@ Add the specified MongoDB user to a team for your organization.
 
 Users must be current members of your organization before you can add them to a team.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-teams-users-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-users-delete.txt
@@ -14,6 +14,8 @@ mongocli iam teams users delete
 
 Remove the specified user from a team for your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-teams-users-list.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-users-list.txt
@@ -14,6 +14,8 @@ mongocli iam teams users list
 
 Return all users for a team.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-users-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-users-describe.txt
@@ -15,6 +15,8 @@ mongocli iam users describe
 Return the details for the specified MongoDB user.
 
 You can specify either the unique 24-digit ID that identifies the MongoDB user or the username for the MongoDB user.
+		
+User accounts and API keys with any role can run this command.
 
 Syntax
 ------

--- a/internal/cli/atlas/processes/list.go
+++ b/internal/cli/atlas/processes/list.go
@@ -69,6 +69,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all MongoDB processes for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all MongoDB processes in the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/atlas/security/customercerts/create.go
+++ b/internal/cli/atlas/security/customercerts/create.go
@@ -70,8 +70,10 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Saves a customer-managed X.509 configuration for your project.",
-		Long:  `Saving a customer-managed X.509 configuration triggers a rolling restart.`,
-		Args:  require.NoArgs,
+		Long: `Saving a customer-managed X.509 configuration triggers a rolling restart.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Save the file named ca.pem stored in the files directory to the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts create --casFile files/ca.pem --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/security/customercerts/describe.go
+++ b/internal/cli/atlas/security/customercerts/describe.go
@@ -59,6 +59,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe",
 		Short: "Return the details for the current customer-managed X.509 configuration for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the customer-managed X.509 configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/security/customercerts/disable.go
+++ b/internal/cli/atlas/security/customercerts/disable.go
@@ -72,8 +72,10 @@ func DisableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Clear customer-managed X.509 settings on a project, including the uploaded Certificate Authority, and disable self-managed X.509.",
-		Long:  `Disabling customer-managed X.509 triggers a rolling restart.`,
-		Args:  require.NoArgs,
+		Long: `Disabling customer-managed X.509 triggers a rolling restart.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Disable the customer-managed X.509 configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts disable --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/security/ldap/delete.go
+++ b/internal/cli/atlas/security/ldap/delete.go
@@ -53,6 +53,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete",
 		Aliases: []string{"rm"},
 		Short:   "Remove the current LDAP configuration captured in the userToDNMapping document from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Remove the current LDAP configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security ldap delete --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/security/ldap/get.go
+++ b/internal/cli/atlas/security/ldap/get.go
@@ -59,6 +59,7 @@ func GetBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: "Return the current LDAP configuration details for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the current LDAP configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security ldap get --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/security/ldap/save.go
+++ b/internal/cli/atlas/security/ldap/save.go
@@ -124,6 +124,7 @@ func SaveBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "save",
 		Short: "Save an LDAP configuration for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Save an LDAP server configuration to authenticate and authorize MongoDB users for the host atlas-ldaps-01.ldap.myteam.com: 
   %s security ldap save --authenticationEnabled --authorizationEnabled 
   --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername 

--- a/internal/cli/atlas/security/ldap/status.go
+++ b/internal/cli/atlas/security/ldap/status.go
@@ -16,6 +16,7 @@ package ldap
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -61,6 +62,7 @@ func StatusBuilder() *cobra.Command {
 		Use:   "status <requestId>",
 		Args:  require.ExactValidArgs(1),
 		Short: "Get the status of an LDAP configuration request.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"requestIdDesc": "ID of the request to verify an LDAP configuration.",
 		},

--- a/internal/cli/atlas/security/ldap/verify.go
+++ b/internal/cli/atlas/security/ldap/verify.go
@@ -106,6 +106,7 @@ func VerifyBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Request verification of an LDAP configuration for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Request the JSON-formatted verification of the LDAP configuration for the atlas-ldaps-01.ldap.myteam.com host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security ldap verify --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com" --bindPassword changeMe --projectId 5e2211c17a3e5a48f5497de3 --output json
 `, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/security/ldap/watch.go
+++ b/internal/cli/atlas/security/ldap/watch.go
@@ -68,7 +68,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the LDAP configuration's status periodically until it reaches a SUCCESS or FAILED status. 
 Once the LDAP configuration reaches the expected status, the command prints "LDAP Configuration request completed."
 If you run the command in the terminal, it blocks the terminal session until the resource status succeeds or fails.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  %s security ldap status watch requestIdSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/atlas/serverless/create.go
+++ b/internal/cli/atlas/serverless/create.go
@@ -17,6 +17,7 @@ package serverless
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -77,6 +78,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <instanceName>",
 		Short: "Creates one serverless instance in the specified project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Human-readable label that identifies your serverless instance.",

--- a/internal/cli/atlas/serverless/delete.go
+++ b/internal/cli/atlas/serverless/delete.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -53,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <instanceName>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a serverless instance from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Name of the instance to delete.",

--- a/internal/cli/atlas/serverless/describe.go
+++ b/internal/cli/atlas/serverless/describe.go
@@ -15,6 +15,7 @@ package serverless
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -59,6 +60,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <instanceName>",
 		Short: "Return one serverless instance in the specified project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Human-readable label that identifies your serverless instance.",

--- a/internal/cli/atlas/serverless/list.go
+++ b/internal/cli/atlas/serverless/list.go
@@ -16,6 +16,7 @@ package serverless
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -61,6 +62,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all serverless instances in the specified project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/serverless/watch.go
+++ b/internal/cli/atlas/serverless/watch.go
@@ -67,7 +67,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the serverless instance's state periodically until the instance reaches an IDLE state. 
 Once the instance reaches the expected state, the command prints "Instance available."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes idle.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  %s serverless watch instanceNameSample`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/iam/projects/apikeys/create.go
+++ b/internal/cli/iam/projects/apikeys/create.go
@@ -69,8 +69,10 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an organization API key and assign it to your project.",
-		Long:  `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.`,
-		Args:  require.NoArgs,
+		Long: `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
+		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create an organization API key with the ORG_OWNER role and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role ORG_OWNER --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/iam/projects/apikeys/delete.go
+++ b/internal/cli/iam/projects/apikeys/delete.go
@@ -57,7 +57,9 @@ func DeleteBuilder() *cobra.Command {
 		Short:   "Remove the specified organization API key from your project.",
 		Long: fmt.Sprintf(`The API key still exists at the organization level. To reassign the organization API key to a project, run the  %[1]s projects apiKeys assign command.
 		
-To view possible values for the ID argument, run %[1]s organizations apiKeys list.`, cli.ExampleAtlasEntryPoint()),
+To view possible values for the ID argument, run %[1]s organizations apiKeys list.
+
+`+fmt.Sprintf(usage.RequiredRole, "Project User Admin"), cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies your API key.",

--- a/internal/cli/iam/projects/apikeys/list.go
+++ b/internal/cli/iam/projects/apikeys/list.go
@@ -64,6 +64,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all organization API keys assigned to your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of organization API keys assigned to the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys list --projectId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/projects/create.go
+++ b/internal/cli/iam/projects/create.go
@@ -145,8 +145,10 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <projectName>",
 		Short: "Create a project in your organization.",
-		Long:  `Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings.`,
-		Args:  require.ExactArgs(1),
+		Long: `Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, and alert settings.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Data Access Read/Write"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"projectNameDesc": "Label that identifies the project.",
 		},

--- a/internal/cli/iam/projects/delete.go
+++ b/internal/cli/iam/projects/delete.go
@@ -53,6 +53,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the project.",

--- a/internal/cli/iam/projects/describe.go
+++ b/internal/cli/iam/projects/describe.go
@@ -63,6 +63,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"show", "get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return the details for the specified project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the project.",
 		},

--- a/internal/cli/iam/projects/invitations/delete.go
+++ b/internal/cli/iam/projects/invitations/delete.go
@@ -54,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <invitationId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified pending invitation to your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",

--- a/internal/cli/iam/projects/invitations/describe.go
+++ b/internal/cli/iam/projects/invitations/describe.go
@@ -64,6 +64,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return the details for the specified pending invitation to your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",
 		},

--- a/internal/cli/iam/projects/invitations/invite.go
+++ b/internal/cli/iam/projects/invitations/invite.go
@@ -72,6 +72,7 @@ func InviteBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "invite <email>",
 		Short:   "Invite the specified MongoDB user to your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Aliases: []string{"create"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/iam/projects/invitations/list.go
+++ b/internal/cli/iam/projects/invitations/list.go
@@ -69,6 +69,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all pending invitations to your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of pending invitations to the project with the ID 5f71e5255afec75a3d0f96dc:
   %s projects invitations list --projectId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/projects/invitations/update.go
+++ b/internal/cli/iam/projects/invitations/update.go
@@ -78,7 +78,9 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update [invitationId]",
 		Aliases: []string{"updates"},
 		Short:   "Modifies the details of the specified pending invitation to your project.",
-		Long:    `You can use either the invitation ID or the user's email address to specify the invitation.`,
+		Long: `You can use either the invitation ID or the user's email address to specify the invitation.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",
 		},

--- a/internal/cli/iam/projects/list.go
+++ b/internal/cli/iam/projects/list.go
@@ -71,6 +71,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all projects.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Data Access Read/Write"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all projects:
   %s projects list --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/projects/teams/add.go
+++ b/internal/cli/iam/projects/teams/add.go
@@ -71,7 +71,9 @@ func AddBuilder() *cobra.Command {
 		Use:   "add <teamId>",
 		Args:  require.ExactArgs(1),
 		Short: "Add the specified team to your project.",
-		Long:  `All members of the team share the same project access.`,
+		Long: `All members of the team share the same project access.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"teamIdDesc": "Unique 24-digit string that identifies the team.",
 		},

--- a/internal/cli/iam/projects/teams/delete.go
+++ b/internal/cli/iam/projects/teams/delete.go
@@ -54,8 +54,10 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <teamId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified team from your project.",
-		Long:    `After you remove a team from your project, the team still exists in the organization in which it was created.`,
-		Args:    require.ExactArgs(1),
+		Long: `After you remove a team from your project, the team still exists in the organization in which it was created.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"teamIdDesc": "Unique 24-digit string that identifies the team.",
 		},

--- a/internal/cli/iam/projects/teams/list.go
+++ b/internal/cli/iam/projects/teams/list.go
@@ -62,6 +62,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all teams for a project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all teams for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects teams list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/projects/teams/update.go
+++ b/internal/cli/iam/projects/teams/update.go
@@ -69,6 +69,7 @@ func UpdateBuilder() *cobra.Command {
 		Aliases: []string{"updates"},
 		Args:    require.ExactArgs(1),
 		Short:   "Modify the roles for the specified team for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Annotations: map[string]string{
 			"teamIdDesc": "Unique 24-digit string that identifies the team.",
 		},

--- a/internal/cli/iam/projects/users/delete.go
+++ b/internal/cli/iam/projects/users/delete.go
@@ -54,8 +54,10 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified user from your project.",
-		Long:    `After you remove a user from your project, the user still exists in the organization in which it was created.`,
-		Args:    require.ExactArgs(1),
+		Long: `After you remove a user from your project, the user still exists in the organization in which it was created.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
+		Args: require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Remove the user with the ID 5dd58c647a3e5a6c5bce46c7 from the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects users delete 5dd58c647a3e5a6c5bce46c7 --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{

--- a/internal/cli/iam/projects/users/list.go
+++ b/internal/cli/iam/projects/users/list.go
@@ -64,6 +64,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all users for a project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all users for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects users list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/teams/create.go
+++ b/internal/cli/iam/teams/create.go
@@ -67,6 +67,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a team for your organization.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Organization Owner"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Label that identifies the team.",

--- a/internal/cli/iam/teams/delete.go
+++ b/internal/cli/iam/teams/delete.go
@@ -54,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <teamId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified team from your organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"teamIdDesc": "Unique 24-digit string that identifies the team.",

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -91,8 +91,10 @@ func DescribeBuilder() *cobra.Command {
   # Return the JSON-formatted details for the the team with the name myTeam in the organization with ID 5e2211c17a3e5a48f5497de3:
   %[1]s teams describe --name myTeam --projectId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Short: "Return the details for the specified team for your organization.",
-		Long:  `You can return the details for a team using the team's ID or the team's name. You must specify either the id option or the name option.`,
-		Args:  require.NoArgs,
+		Long: `You can return the details for a team using the team's ID or the team's name. You must specify either the id option or the name option.
+
+` + fmt.Sprintf(usage.RequiredRole, "Organization Member"),
+		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,

--- a/internal/cli/iam/teams/list.go
+++ b/internal/cli/iam/teams/list.go
@@ -64,6 +64,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all teams for your organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of the teams for the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams list --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/iam/teams/users/add.go
+++ b/internal/cli/iam/teams/users/add.go
@@ -61,7 +61,9 @@ func AddBuilder() *cobra.Command {
 		Use:   "add <userId>...",
 		Args:  require.MinimumNObjectIDArgs(1),
 		Short: "Add the specified MongoDB user to a team for your organization.",
-		Long:  `Users must be current members of your organization before you can add them to a team.`,
+		Long: `Users must be current members of your organization before you can add them to a team.
+
+` + fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Annotations: map[string]string{
 			"userIdDesc": "Unique 24-digit string that identifies the user. You can add more than one user at a time by specifying multiple user IDs separated by a space.",
 		},

--- a/internal/cli/iam/teams/users/delete.go
+++ b/internal/cli/iam/teams/users/delete.go
@@ -55,6 +55,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <userId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified user from a team for your organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Args:    require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Remove the user with the ID 5dd58c647a3e5a6c5bce46c7 from the team with the ID 5f6a5c6c713184005d72fe6e for the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams users delete 5dd58c647a3e5a6c5bce46c7 --teamId 5f6a5c6c713184005d72fe6e --orgId 5e1234c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/teams/users/list.go
+++ b/internal/cli/iam/teams/users/list.go
@@ -62,6 +62,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all users for a team.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of the users for the team with the ID 5f6a5c6c713184005d72fe6e in the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams users list --teamId 5f6a5c6c713184005d72fe6e --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -91,8 +91,10 @@ func DescribeBuilder() *cobra.Command {
   # Return the JSON-formatted details for the MongoDB user with the username myUser:
   %[1]s users describe --username myUser --output json`, cli.ExampleAtlasEntryPoint()),
 		Short: "Return the details for the specified MongoDB user.",
-		Long:  `You can specify either the unique 24-digit ID that identifies the MongoDB user or the username for the MongoDB user.`,
-		Args:  require.NoArgs,
+		Long: `You can specify either the unique 24-digit ID that identifies the MongoDB user or the username for the MongoDB user.
+		
+User accounts and API keys with any role can run this command.`,
+		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prerun.ExecuteE(
 				opts.initStore(cmd.Context()),


### PR DESCRIPTION
## Proposed changes

Adds required roles for processes, projects, security, serverless, teams, and users commands.

_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-28116
https://jira.mongodb.org/browse/DOCSP-28117

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
