### PR TITLE
CLOUDP-136038: Add a main docs link to $ atlas -help command

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -36,6 +36,10 @@ import (
 func Execute() {
 	ctx := telemetry.NewContext()
 	rootCmd := atlas.Builder()
+	// append here to avoid a recursive link on generated docs
+	rootCmd.Long += `
+
+For more information, refer to the docs: https://www.mongodb.com/docs/atlas/cli/stable/`
 	if cmd, err := rootCmd.ExecuteContextC(ctx); err != nil {
 		if !telemetry.StartedTrackingCommand() {
 			telemetry.StartTrackingCommand(cmd, os.Args[1:])

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -39,7 +39,7 @@ func Execute() {
 	// append here to avoid a recursive link on generated docs
 	rootCmd.Long += `
 
-For more information, refer to the docs: https://www.mongodb.com/docs/atlas/cli/stable/`
+To learn more, see our documentation: https://www.mongodb.com/docs/atlas/cli/stable/`
 	if cmd, err := rootCmd.ExecuteContextC(ctx); err != nil {
 		if !telemetry.StartedTrackingCommand() {
 			telemetry.StartTrackingCommand(cmd, os.Args[1:])

--- a/cmd/mongocli/mongocli.go
+++ b/cmd/mongocli/mongocli.go
@@ -38,6 +38,10 @@ var (
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(ctx context.Context) {
 	rootCmd := mongocli.Builder(&profile, os.Args[1:])
+	// append here to avoid a recursive link on generated docs
+	rootCmd.Long += `
+
+For more information, refer to the docs: https://www.mongodb.com/docs/mongocli/stable/`
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/mongocli/mongocli.go
+++ b/cmd/mongocli/mongocli.go
@@ -41,7 +41,7 @@ func Execute(ctx context.Context) {
 	// append here to avoid a recursive link on generated docs
 	rootCmd.Long += `
 
-For more information, refer to the docs: https://www.mongodb.com/docs/mongocli/stable/`
+To learn more, see our documentation: https://www.mongodb.com/docs/mongocli/stable/`
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-136038

## Further comments
```bash
./bin/atlas --help
Use atlas command help for information on a specific command

For more information, refer to the docs: https://www.mongodb.com/docs/atlas/cli/stable/
```

```bash
./bin/mongocli --help
Use mongocli command help for information on a specific command

For more information, refer to the docs: https://www.mongodb.com/docs/mongocli/stable/
```
