### PR TITLE
(DOCSP-28115) Adds required roles for remaining commands

### DIFF
--- a/docs/atlascli/command/atlas-clusters-loadSampleData.txt
+++ b/docs/atlascli/command/atlas-clusters-loadSampleData.txt
@@ -14,6 +14,8 @@ atlas clusters loadSampleData
 
 Load sample data into the specified cluster for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dataLakes-create.txt
+++ b/docs/atlascli/command/atlas-dataLakes-create.txt
@@ -16,8 +16,6 @@ Create a new federated database instance for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
-To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dataLakes-delete.txt
+++ b/docs/atlascli/command/atlas-dataLakes-delete.txt
@@ -16,8 +16,6 @@ Remove a federated database instance from your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
-To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dataLakes-describe.txt
+++ b/docs/atlascli/command/atlas-dataLakes-describe.txt
@@ -16,8 +16,6 @@ Return the details for the specified federated database instance.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
-To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-dataLakes-list.txt
+++ b/docs/atlascli/command/atlas-dataLakes-list.txt
@@ -16,8 +16,6 @@ Return all federated database instances for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
-To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
-
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-networking-containers-delete.txt
+++ b/docs/atlascli/command/atlas-networking-containers-delete.txt
@@ -14,6 +14,8 @@ atlas networking containers delete
 
 Remove the specified network peering container from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-networking-containers-list.txt
+++ b/docs/atlascli/command/atlas-networking-containers-list.txt
@@ -14,6 +14,8 @@ atlas networking containers list
 
 Return all network peering containers for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-networking-peering-create-aws.txt
+++ b/docs/atlascli/command/atlas-networking-peering-create-aws.txt
@@ -18,6 +18,8 @@ The network peering create command checks if a VPC exists in the region you spec
 		
 To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-networking-peering-create-azure.txt
+++ b/docs/atlascli/command/atlas-networking-peering-create-azure.txt
@@ -20,6 +20,8 @@ The network peering create command checks if a VNet exists in the region you spe
 		
 To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-networking-peering-create-gcp.txt
+++ b/docs/atlascli/command/atlas-networking-peering-create-gcp.txt
@@ -18,6 +18,8 @@ The network peering create command checks if a VPC exists in the region you spec
 		
 To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-networking-peering-delete.txt
+++ b/docs/atlascli/command/atlas-networking-peering-delete.txt
@@ -14,6 +14,8 @@ atlas networking peering delete
 
 Remove the specified peering connection from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-networking-peering-list.txt
+++ b/docs/atlascli/command/atlas-networking-peering-list.txt
@@ -14,6 +14,8 @@ atlas networking peering list
 
 Return the details for all network peering connections for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-networking-peering-watch.txt
+++ b/docs/atlascli/command/atlas-networking-peering-watch.txt
@@ -19,6 +19,8 @@ Once it reaches the expected state, the command prints "Network peering changes 
 If you run the command in the terminal, it blocks the terminal session until the resource is available.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-create.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-create.txt
@@ -16,6 +16,8 @@ Create an IP access list entry for your API Key.
 
 To view possible values for the apiKey option, run atlas organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Read Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-delete.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-delete.txt
@@ -14,6 +14,8 @@ atlas organizations apiKeys accessLists delete
 
 Remove the specified IP access list entry from your API Key.
 
+To use this command, you must authenticate with a user account or an API key that has the Read Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-list.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-list.txt
@@ -16,6 +16,8 @@ Return all IP access list entries for your API Key.
 
 To view possible values for the apiKeyID argument, run atlas organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-assign.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-assign.txt
@@ -18,6 +18,8 @@ When you modify the roles for an organization API key with this command, the val
 		
 To view possible values for the apiKeyId argument, run atlas organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-create.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-create.txt
@@ -16,6 +16,8 @@ Create an API Key for your organization.
 
 MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-delete.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-delete.txt
@@ -16,6 +16,8 @@ Remove the specified API key for your organization.
 
 To view possible values for the ID argument, run atlas organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-describe.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-describe.txt
@@ -16,6 +16,8 @@ Return the details for the specified API key for your organization.
 
 To view possible values for the ID argument, run atlas organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-list.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-list.txt
@@ -14,6 +14,8 @@ atlas organizations apiKeys list
 
 Return all API keys for your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-delete.txt
+++ b/docs/atlascli/command/atlas-organizations-delete.txt
@@ -16,6 +16,8 @@ Remove the specified organization.
 
 Organizations with active projects can't be removed.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-describe.txt
+++ b/docs/atlascli/command/atlas-organizations-describe.txt
@@ -14,6 +14,8 @@ atlas organizations describe
 
 Return the details for the specified organizations.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-invitations-delete.txt
+++ b/docs/atlascli/command/atlas-organizations-invitations-delete.txt
@@ -14,6 +14,8 @@ atlas organizations invitations delete
 
 Remove the specified pending invitation to your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-invitations-describe.txt
+++ b/docs/atlascli/command/atlas-organizations-invitations-describe.txt
@@ -14,6 +14,8 @@ atlas organizations invitations describe
 
 Return the details for the specified pending invitation to your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-invitations-invite.txt
+++ b/docs/atlascli/command/atlas-organizations-invitations-invite.txt
@@ -14,6 +14,8 @@ atlas organizations invitations invite
 
 Invite the specified MongoDB user to your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-invitations-list.txt
+++ b/docs/atlascli/command/atlas-organizations-invitations-list.txt
@@ -14,6 +14,8 @@ atlas organizations invitations list
 
 Return all pending invitations to your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-invitations-update.txt
+++ b/docs/atlascli/command/atlas-organizations-invitations-update.txt
@@ -16,6 +16,8 @@ Modifies the details of the specified pending invitation to your organization.
 
 You can use either the invitation ID or the user's email address to specify the invitation.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-list.txt
+++ b/docs/atlascli/command/atlas-organizations-list.txt
@@ -14,6 +14,8 @@ atlas organizations list
 
 Return all organizations.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-organizations-users-list.txt
+++ b/docs/atlascli/command/atlas-organizations-users-list.txt
@@ -14,6 +14,8 @@ atlas organizations users list
 
 Return all users for an organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-performanceAdvisor-namespaces-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-namespaces-list.txt
@@ -18,6 +18,8 @@ Namespaces appear in the following format: {database}.{collection}.
 		
 If you don't set the duration option or the since option, this command returns data from the last 24 hours.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-performanceAdvisor-slowOperationThreshold-disable.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-slowOperationThreshold-disable.txt
@@ -16,6 +16,8 @@ Disable the application-managed slow operation threshold for your project.
 
 The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-performanceAdvisor-slowOperationThreshold-enable.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-slowOperationThreshold-enable.txt
@@ -16,6 +16,8 @@ Enable the application-managed slow operation threshold for your project.
 
 The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
@@ -18,6 +18,8 @@ The Performance Advisor monitors queries that MongoDB considers slow and suggest
 		
 If you don't set the duration option or the since option, this command returns data from the last 24 hours.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-performanceAdvisor-suggestedIndexes-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-suggestedIndexes-list.txt
@@ -16,6 +16,8 @@ Return the suggested indexes for collections experiencing slow queries.
 
 The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-create.txt
@@ -16,6 +16,8 @@ Create a new AWS private endpoint for your project.
 
 To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-delete.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints aws delete
 
 Remove the specified AWS private endpoint from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints aws describe
 
 Return the details for the specified AWS private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-create.txt
@@ -16,6 +16,8 @@ Create a new interface for the specified AWS private endpoint.
 
 To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-delete.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints aws interfaces delete
 
 Remove the specified AWS private endpoint interface and related service from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints aws interfaces describe
 
 Return the details for the specified AWS private endpoint interface for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-list.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints aws list
 
 Return all AWS private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
@@ -19,6 +19,8 @@ Once the endpoint reaches the expected state, the command prints "Private endpoi
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-create.txt
@@ -16,6 +16,8 @@ Create a new Azure private endpoint for your project.
 
 To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-delete.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints azure delete
 
 Remove the specified Azure private endpoint from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-describe.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints azure describe
 
 Return the details for the specified Azure private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-interfaces-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-interfaces-create.txt
@@ -16,6 +16,8 @@ Create a new interface for the specified Azure private endpoint.
 
 To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-interfaces-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-interfaces-delete.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints azure interfaces delete
 
 Remove the specified Azure private endpoint interface and related service from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-interfaces-describe.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints azure interfaces describe
 
 Return the details for the specified Azure private endpoint interface for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-list.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints azure list
 
 Return all Azure private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
@@ -19,6 +19,8 @@ Once the endpoint reaches the expected state, the command prints "Private endpoi
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-create.txt
@@ -20,6 +20,8 @@ When you run this command:
 - If the endpoint ID doesn't exist, Atlas Data Lake appends the new endpoint to the list of endpoints in the endpoint ID list.
 Your API key must have the GROUP_ATLAS_ADMIN (Project Owner) role to create a private endpoint.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-delete.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints dataLakes aws delete
 
 Delete a specific Data Lake private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints dataLakes aws describe
 
 Return a specific Data Lake private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-list.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints dataLakes aws list
 
 List Data Lake private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-create.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints gcp create
 
 Create a new GCP private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-delete.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints gcp delete
 
 Delete a GCP private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-describe.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints gcp describe
 
 Return a specific GCP private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-create.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints gcp interfaces create
 
 Create a GCP private endpoint interface.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-delete.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints gcp interfaces delete
 
 Delete a specific GCP private endpoint interface for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints gcp interfaces describe
 
 Return a specific GCP private endpoint interface for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-list.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints gcp list
 
 List GCP private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
@@ -19,6 +19,8 @@ Once the endpoint reaches the expected state, the command prints "GCP Private en
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-create.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-create.txt
@@ -20,6 +20,8 @@ When you run this command:
 - If the endpoint ID doesn't exist, Atlas Data Lake appends the new endpoint to the list of endpoints in the endpoint ID list.
 Your API key must have the GROUP_ATLAS_ADMIN (Project Owner) role to create a private endpoint.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-delete.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-delete.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints onlineArchive aws delete
 
 Delete a specific Data Lake private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints onlineArchive aws describe
 
 Return a specific Data Lake private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-list.txt
@@ -14,6 +14,8 @@ atlas privateEndpoints onlineArchive aws list
 
 List Data Lake private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-regionalModes-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-regionalModes-describe.txt
@@ -16,6 +16,8 @@ Return the regionalized private endpoint setting for your project.
 
 Use this command to check whether you can create multiple private resources per region.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-regionalModes-disable.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-regionalModes-disable.txt
@@ -16,6 +16,8 @@ Disable the regionalized private endpoint setting for your project.
 
 This disables the ability to create multiple private resources per region in all cloud service providers for this project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-regionalModes-enable.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-regionalModes-enable.txt
@@ -16,6 +16,8 @@ Enable the regionalized private endpoint setting for your project.
 
 This enables the ability to create multiple private resources per region in all cloud service providers for this project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-loadSampleData.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-loadSampleData.txt
@@ -14,6 +14,8 @@ mongocli atlas clusters loadSampleData
 
 Load sample data into the specified cluster for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-create.txt
@@ -16,8 +16,6 @@ Create a new federated database instance for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
-To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-delete.txt
@@ -16,8 +16,6 @@ Remove a federated database instance from your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
-To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
@@ -16,8 +16,6 @@ Return the details for the specified federated database instance.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
-To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-list.txt
@@ -16,8 +16,6 @@ Return all federated database instances for your project.
 
 To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
 
-To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
-
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-containers-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-containers-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas networking containers delete
 
 Remove the specified network peering container from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-containers-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-containers-list.txt
@@ -14,6 +14,8 @@ mongocli atlas networking containers list
 
 Return all network peering containers for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-create-aws.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-create-aws.txt
@@ -18,6 +18,8 @@ The network peering create command checks if a VPC exists in the region you spec
 		
 To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-create-azure.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-create-azure.txt
@@ -20,6 +20,8 @@ The network peering create command checks if a VNet exists in the region you spe
 		
 To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-create-gcp.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-create-gcp.txt
@@ -18,6 +18,8 @@ The network peering create command checks if a VPC exists in the region you spec
 		
 To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas networking peering delete
 
 Remove the specified peering connection from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-list.txt
@@ -14,6 +14,8 @@ mongocli atlas networking peering list
 
 Return the details for all network peering connections for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
@@ -19,6 +19,8 @@ Once it reaches the expected state, the command prints "Network peering changes 
 If you run the command in the terminal, it blocks the terminal session until the resource is available.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-performanceAdvisor-namespaces-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-performanceAdvisor-namespaces-list.txt
@@ -18,6 +18,8 @@ Namespaces appear in the following format: {database}.{collection}.
 		
 If you don't set the duration option or the since option, this command returns data from the last 24 hours.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-performanceAdvisor-slowOperationThreshold-disable.txt
+++ b/docs/mongocli/command/mongocli-atlas-performanceAdvisor-slowOperationThreshold-disable.txt
@@ -16,6 +16,8 @@ Disable the application-managed slow operation threshold for your project.
 
 The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-performanceAdvisor-slowOperationThreshold-enable.txt
+++ b/docs/mongocli/command/mongocli-atlas-performanceAdvisor-slowOperationThreshold-enable.txt
@@ -16,6 +16,8 @@ Enable the application-managed slow operation threshold for your project.
 
 The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-performanceAdvisor-slowQueryLogs-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-performanceAdvisor-slowQueryLogs-list.txt
@@ -18,6 +18,8 @@ The Performance Advisor monitors queries that MongoDB considers slow and suggest
 		
 If you don't set the duration option or the since option, this command returns data from the last 24 hours.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-performanceAdvisor-suggestedIndexes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-performanceAdvisor-suggestedIndexes-list.txt
@@ -16,6 +16,8 @@ Return the suggested indexes for collections experiencing slow queries.
 
 The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-create.txt
@@ -16,6 +16,8 @@ Create a new AWS private endpoint for your project.
 
 To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints aws delete
 
 Remove the specified AWS private endpoint from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints aws describe
 
 Return the details for the specified AWS private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-create.txt
@@ -16,6 +16,8 @@ Create a new interface for the specified AWS private endpoint.
 
 To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints aws interfaces delete
 
 Remove the specified AWS private endpoint interface and related service from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints aws interfaces describe
 
 Return the details for the specified AWS private endpoint interface for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-list.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints aws list
 
 Return all AWS private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
@@ -19,6 +19,8 @@ Once the endpoint reaches the expected state, the command prints "Private endpoi
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-create.txt
@@ -16,6 +16,8 @@ Create a new Azure private endpoint for your project.
 
 To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints azure delete
 
 Remove the specified Azure private endpoint from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints azure describe
 
 Return the details for the specified Azure private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-interfaces-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-interfaces-create.txt
@@ -16,6 +16,8 @@ Create a new interface for the specified Azure private endpoint.
 
 To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-interfaces-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-interfaces-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints azure interfaces delete
 
 Remove the specified Azure private endpoint interface and related service from your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-interfaces-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints azure interfaces describe
 
 Return the details for the specified Azure private endpoint interface for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-list.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints azure list
 
 Return all Azure private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
@@ -19,6 +19,8 @@ Once the endpoint reaches the expected state, the command prints "Private endpoi
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-create.txt
@@ -20,6 +20,8 @@ When you run this command:
 - If the endpoint ID doesn't exist, Atlas Data Lake appends the new endpoint to the list of endpoints in the endpoint ID list.
 Your API key must have the GROUP_ATLAS_ADMIN (Project Owner) role to create a private endpoint.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints dataLakes aws delete
 
 Delete a specific Data Lake private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints dataLakes aws describe
 
 Return a specific Data Lake private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-list.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints dataLakes aws list
 
 List Data Lake private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-create.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints gcp create
 
 Create a new GCP private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints gcp delete
 
 Delete a GCP private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints gcp describe
 
 Return a specific GCP private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-create.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints gcp interfaces create
 
 Create a GCP private endpoint interface.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints gcp interfaces delete
 
 Delete a specific GCP private endpoint interface for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints gcp interfaces describe
 
 Return a specific GCP private endpoint interface for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-list.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints gcp list
 
 List GCP private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
@@ -19,6 +19,8 @@ Once the endpoint reaches the expected state, the command prints "GCP Private en
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-create.txt
@@ -20,6 +20,8 @@ When you run this command:
 - If the endpoint ID doesn't exist, Atlas Data Lake appends the new endpoint to the list of endpoints in the endpoint ID list.
 Your API key must have the GROUP_ATLAS_ADMIN (Project Owner) role to create a private endpoint.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-delete.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-delete.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints onlineArchive aws delete
 
 Delete a specific Data Lake private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints onlineArchive aws describe
 
 Return a specific Data Lake private endpoint for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-list.txt
@@ -14,6 +14,8 @@ mongocli atlas privateEndpoints onlineArchive aws list
 
 List Data Lake private endpoints for your project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-describe.txt
@@ -16,6 +16,8 @@ Return the regionalized private endpoint setting for your project.
 
 Use this command to check whether you can create multiple private resources per region.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-disable.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-disable.txt
@@ -16,6 +16,8 @@ Disable the regionalized private endpoint setting for your project.
 
 This disables the ability to create multiple private resources per region in all cloud service providers for this project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-enable.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-enable.txt
@@ -16,6 +16,8 @@ Enable the regionalized private endpoint setting for your project.
 
 This enables the ability to create multiple private resources per region in all cloud service providers for this project.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-namespaces-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-namespaces-list.txt
@@ -18,6 +18,8 @@ Namespaces appear in the following format: {database}.{collection}.
 		
 If you don't set the duration option or the since option, this command returns data from the last 24 hours.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-slowOperationThreshold-disable.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-slowOperationThreshold-disable.txt
@@ -16,6 +16,8 @@ Disable the application-managed slow operation threshold for your project.
 
 The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-slowOperationThreshold-enable.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-slowOperationThreshold-enable.txt
@@ -16,6 +16,8 @@ Enable the application-managed slow operation threshold for your project.
 
 The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-slowQueryLogs-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-slowQueryLogs-list.txt
@@ -18,6 +18,8 @@ The Performance Advisor monitors queries that MongoDB considers slow and suggest
 		
 If you don't set the duration option or the since option, this command returns data from the last 24 hours.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-suggestedIndexes-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-performanceAdvisor-suggestedIndexes-list.txt
@@ -16,6 +16,8 @@ Return the suggested indexes for collections experiencing slow queries.
 
 The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-create.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-create.txt
@@ -16,6 +16,8 @@ Create an IP access list entry for your API Key.
 
 To view possible values for the apiKey option, run mongocli organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Read Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-delete.txt
@@ -14,6 +14,8 @@ mongocli iam organizations apiKeys accessLists delete
 
 Remove the specified IP access list entry from your API Key.
 
+To use this command, you must authenticate with a user account or an API key that has the Read Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-list.txt
@@ -16,6 +16,8 @@ Return all IP access list entries for your API Key.
 
 To view possible values for the apiKeyID argument, run mongocli organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-assign.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-assign.txt
@@ -18,6 +18,8 @@ When you modify the roles for an organization API key with this command, the val
 		
 To view possible values for the apiKeyId argument, run mongocli organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-create.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-create.txt
@@ -16,6 +16,8 @@ Create an API Key for your organization.
 
 MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-delete.txt
@@ -16,6 +16,8 @@ Remove the specified API key for your organization.
 
 To view possible values for the ID argument, run mongocli organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-describe.txt
@@ -16,6 +16,8 @@ Return the details for the specified API key for your organization.
 
 To view possible values for the ID argument, run mongocli organizations apiKeys list.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-list.txt
@@ -14,6 +14,8 @@ mongocli iam organizations apiKeys list
 
 Return all API keys for your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-delete.txt
@@ -16,6 +16,8 @@ Remove the specified organization.
 
 Organizations with active projects can't be removed.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-describe.txt
@@ -14,6 +14,8 @@ mongocli iam organizations describe
 
 Return the details for the specified organizations.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-invitations-delete.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-invitations-delete.txt
@@ -14,6 +14,8 @@ mongocli iam organizations invitations delete
 
 Remove the specified pending invitation to your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-invitations-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-invitations-describe.txt
@@ -14,6 +14,8 @@ mongocli iam organizations invitations describe
 
 Return the details for the specified pending invitation to your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-invitations-invite.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-invitations-invite.txt
@@ -14,6 +14,8 @@ mongocli iam organizations invitations invite
 
 Invite the specified MongoDB user to your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-invitations-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-invitations-list.txt
@@ -14,6 +14,8 @@ mongocli iam organizations invitations list
 
 Return all pending invitations to your organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization User Admin role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-invitations-update.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-invitations-update.txt
@@ -16,6 +16,8 @@ Modifies the details of the specified pending invitation to your organization.
 
 You can use either the invitation ID or the user's email address to specify the invitation.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-list.txt
@@ -14,6 +14,8 @@ mongocli iam organizations list
 
 Return all organizations.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-users-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-users-list.txt
@@ -14,6 +14,8 @@ mongocli iam organizations users list
 
 Return all users for an organization.
 
+To use this command, you must authenticate with a user account or an API key that has the Organization Member role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-namespaces-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-namespaces-list.txt
@@ -18,6 +18,8 @@ Namespaces appear in the following format: {database}.{collection}.
 		
 If you don't set the duration option or the since option, this command returns data from the last 24 hours.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-slowOperationThreshold-disable.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-slowOperationThreshold-disable.txt
@@ -16,6 +16,8 @@ Disable the application-managed slow operation threshold for your project.
 
 The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-slowOperationThreshold-enable.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-slowOperationThreshold-enable.txt
@@ -16,6 +16,8 @@ Enable the application-managed slow operation threshold for your project.
 
 The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).
 
+To use this command, you must authenticate with a user account or an API key that has the Project Owner role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-slowQueryLogs-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-slowQueryLogs-list.txt
@@ -18,6 +18,8 @@ The Performance Advisor monitors queries that MongoDB considers slow and suggest
 		
 If you don't set the duration option or the since option, this command returns data from the last 24 hours.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Data Access Read/Write role.
+
 Syntax
 ------
 

--- a/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-suggestedIndexes-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-performanceAdvisor-suggestedIndexes-list.txt
@@ -16,6 +16,8 @@ Return the suggested indexes for collections experiencing slow queries.
 
 The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.
 
+To use this command, you must authenticate with a user account or an API key that has the Project Read Only role.
+
 Syntax
 ------
 

--- a/internal/cli/atlas/clusters/loadSampleData.go
+++ b/internal/cli/atlas/clusters/loadSampleData.go
@@ -16,6 +16,7 @@ package clusters
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -58,6 +59,7 @@ func LoadSampleDataBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "loadSampleData <clusterName>",
 		Short: "Load sample data into the specified cluster for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster for which you want to load sample data.",

--- a/internal/cli/atlas/datalake/create.go
+++ b/internal/cli/atlas/datalake/create.go
@@ -76,10 +76,8 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <name>",
 		Short: "Create a new federated database instance for your project.",
-		Long: `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
-		Args: require.ExactArgs(1),
+		Long:  `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
+		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to create.",
 		},

--- a/internal/cli/atlas/datalake/delete.go
+++ b/internal/cli/atlas/datalake/delete.go
@@ -54,10 +54,8 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <name>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a federated database instance from your project.",
-		Long: `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
-		Args: require.ExactArgs(1),
+		Long:    `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
+		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to delete.",
 		},

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -61,10 +61,8 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "describe <name>",
 		Short: "Return the details for the specified federated database instance.",
-		Long: `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
-		Args: require.ExactArgs(1),
+		Long:  `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
+		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to retrieve.",
 		},

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -59,11 +59,9 @@ func (opts *ListOpts) Run() error {
 func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "Return all federated database instances for your project.",
-		Long: `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
+		Use:     "list",
+		Short:   "Return all federated database instances for your project.",
+		Long:    `To learn more about Atlas Data Federation (previously named Atlas Data Lake), see https://www.mongodb.com/docs/atlas/data-federation/overview/.`,
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all federated database instances in the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/atlas/networking/containers/delete.go
+++ b/internal/cli/atlas/networking/containers/delete.go
@@ -54,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <containerId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified network peering container from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"containerIdDesc": "Unique 24-hexadecimal digit string that identifies the network container that you want to remove.",

--- a/internal/cli/atlas/networking/containers/list.go
+++ b/internal/cli/atlas/networking/containers/list.go
@@ -77,6 +77,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return all network peering containers for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of network peering containers in the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/atlas/networking/peering/create/aws.go
+++ b/internal/cli/atlas/networking/peering/create/aws.go
@@ -126,7 +126,9 @@ func AwsBuilder() *cobra.Command {
 		Short: "Create a network peering connection between the Atlas VPC and your AWS VPC.",
 		Long: `The network peering create command checks if a VPC exists in the region you specify for your Atlas project. If one exists, this command creates the peering connection between that VPC and your VPC. If an Atlas VPC doesn't exist, this command creates one and creates a connection between it and your VPC.
 		
-To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.`,
+To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create a network peering connection between the Atlas VPC in CIDR block 192.168.0.0/24 and your AWS VPC in CIDR block 10.0.0.0/24 for AWS account number 854333054055:
   %s networking peering create aws --accountId 854333054055 --atlasCidrBlock 192.168.0.0/24 --region us-east-1 --routeTableCidrBlock 10.0.0.0/24 --vpcId vpc-078ac381aa90e1e63`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/networking/peering/create/azure.go
+++ b/internal/cli/atlas/networking/peering/create/azure.go
@@ -128,7 +128,9 @@ func AzureBuilder() *cobra.Command {
 		
 The network peering create command checks if a VNet exists in the region you specify for your Atlas project. If one exists, this command creates the peering connection between that VNet and your VPC. If an Atlas VPC does not exist, this command creates one and creates a connection between it and your VNet.
 		
-To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.`,
+To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Create a network peering connection between the Atlas VPC in CIDR block 192.168.0.0/24 and your Azure VNet named atlascli-test in in US_EAST_2:
   %s networking peering create azure --atlasCidrBlock 192.168.0.0/24 --directoryId 56657fdb-ca45-40dc-fr56-77fd8b6d2b37 --subscriptionId 345654f3-77cf-4084-9e06-8943a079ed75 --resourceGroup atlascli-test --region US_EAST_2 --vnet atlascli-test`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/networking/peering/create/gcp.go
+++ b/internal/cli/atlas/networking/peering/create/gcp.go
@@ -112,7 +112,9 @@ func GCPBuilder() *cobra.Command {
 		Short: "Create a network peering connection between the Atlas VPC and your Google Cloud VPC.",
 		Long: `The network peering create command checks if a VPC exists in the region you specify for your Atlas project. If one exists, this command creates the peering connection between that VPC and your VPC. If an Atlas VPC doesn't exist, this command creates one and creates a connection between it and your VPC.
 		
-To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.`,
+To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Create a network peering connection between the Atlas VPC in CIDR block 192.168.0.0/24 and your GCP VPC with the GCP project ID grandiose-branch-256701 in the network named cli-test:
   %s networking peering create gcp --atlasCidrBlock 192.168.0.0/24 --gcpProjectId grandiose-branch-256701 --network cli-test --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/atlas/networking/peering/delete.go
+++ b/internal/cli/atlas/networking/peering/delete.go
@@ -54,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <peerId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified peering connection from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Remove the network peering connection with the ID 5f60c5bd0948295c093565ba in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s networking peering delete 5f60c5bd0948295c093565ba --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/networking/peering/list.go
+++ b/internal/cli/atlas/networking/peering/list.go
@@ -71,6 +71,7 @@ func ListBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "Return the details for all network peering connections for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for all network peering connections in the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -77,7 +77,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the peering connection's status periodically until it becomes available. 
 Once it reaches the expected state, the command prints "Network peering changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource is available.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  Watch for the network peering connection with the ID 5f621dc701240c5b7c3a888e to become available in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s networking peering watch 5f621dc701240c5b7c3a888e --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),

--- a/internal/cli/atlas/privateendpoints/aws/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/create.go
@@ -70,8 +70,10 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new AWS private endpoint for your project.",
-		Long:  `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.`,
-		Args:  require.NoArgs,
+		Long: `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create a private endpoint connection for AWS in the us-east-1 region for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws create --region us-east-1 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/delete.go
@@ -54,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <privateEndpointId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified AWS private endpoint from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",

--- a/internal/cli/atlas/privateendpoints/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe.go
@@ -69,6 +69,7 @@ func DescribeBuilder() *cobra.Command {
 			return validate.ObjectID(args[0])
 		}),
 		Short: "Return the details for the specified AWS private endpoints for your project.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
 		},

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
@@ -68,8 +68,10 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create <endpointServiceId>",
 		Aliases: []string{"add"},
 		Short:   "Create a new interface for the specified AWS private endpoint.",
-		Long:    `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.`,
-		Args:    require.ExactArgs(1),
+		Long: `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"endpointServiceIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
 		},

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
@@ -55,6 +55,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <interfaceEndpointId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified AWS private endpoint interface and related service from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"interfaceEndpointIdDesc": "Unique string that identifies the AWS private endpoint interface in AWS.",

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -65,6 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return the details for the specified AWS private endpoint interface for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"interfaceEndpointIdDesc": "Unique string that identifies the AWS private endpoint interface in AWS.",
 		},

--- a/internal/cli/atlas/privateendpoints/aws/list.go
+++ b/internal/cli/atlas/privateendpoints/aws/list.go
@@ -63,6 +63,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all AWS private endpoints for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all AWS private endpoints for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/aws/watch.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch.go
@@ -67,7 +67,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the endpoint's state periodically until the endpoint reaches an AVAILABLE or FAILED state. 
 Once the endpoint reaches the expected state, the command prints "Private endpoint changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  # Watch for the AWS private endpoint with the ID 5f4fc14da2b47835a58c63a2 to become available in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws watch 5f4fc14da2b47835a58c63a2 --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),

--- a/internal/cli/atlas/privateendpoints/azure/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/create.go
@@ -70,8 +70,10 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new Azure private endpoint for your project.",
-		Long:  `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.`,
-		Args:  require.NoArgs,
+		Long: `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create a private endpoint connection for Azure in the eastus region for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure create --region eastus --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/azure/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/delete.go
@@ -54,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <privateEndpointId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified Azure private endpoint from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",

--- a/internal/cli/atlas/privateendpoints/azure/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/describe.go
@@ -64,6 +64,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return the details for the specified Azure private endpoint for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
 		},

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
@@ -70,8 +70,10 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create <endpointServiceId>",
 		Aliases: []string{"add"},
 		Short:   "Create a new interface for the specified Azure private endpoint.",
-		Long:    `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.`,
-		Args:    require.ExactArgs(1),
+		Long: `To learn more about how to set up private endpoints with the Atlas CLI, see the tutorial on the Atlas CLI tab here: https://www.mongodb.com/docs/atlas/security-cluster-private-endpoint/.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"endpointServiceIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
 		},

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
@@ -55,6 +55,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <privateEndpointResourceId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified Azure private endpoint interface and related service from your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointResourceIdDesc": "Unique string that identifies the Azure private endpoint interface in Azure.",

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
@@ -65,6 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return the details for the specified Azure private endpoint interface for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointResourceIdDesc": "Unique string that identifies the Azure private endpoint interface in Azure.",
 		},

--- a/internal/cli/atlas/privateendpoints/azure/list.go
+++ b/internal/cli/atlas/privateendpoints/azure/list.go
@@ -63,6 +63,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all Azure private endpoints for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all Azure private endpoints for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/azure/watch.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch.go
@@ -67,7 +67,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the endpoint's state periodically until the endpoint reaches an AVAILABLE or FAILED state. 
 Once the endpoint reaches the expected state, the command prints "Private endpoint changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  # Watch for the Azure private endpoint with the ID 5f4fc14da2b47835a58c63a2 to become available in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure watch 5f4fc14da2b47835a58c63a2 --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),

--- a/internal/cli/atlas/privateendpoints/datalake/aws/create.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/create.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -74,7 +75,9 @@ func CreateBuilder() *cobra.Command {
 - If the endpoint ID already exists and there is no change to the associated comment, Atlas Data Lake makes no change to the endpoint ID list.
 - If the endpoint ID already exists and there is a change to the associated comment, Atlas Data Lake updates the comment value only in the endpoint ID list.
 - If the endpoint ID doesn't exist, Atlas Data Lake appends the new endpoint to the list of endpoints in the endpoint ID list.
-Your API key must have the GROUP_ATLAS_ADMIN (Project Owner) role to create a private endpoint.`,
+Your API key must have the GROUP_ATLAS_ADMIN (Project Owner) role to create a private endpoint.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/datalake/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/delete.go
@@ -54,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <privateEndpointId>",
 		Aliases: []string{"rm"},
 		Short:   "Delete a specific Data Lake private endpoint for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
@@ -62,6 +62,7 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe <privateEndpointId>",
 		Aliases: []string{"get"},
 		Short:   "Return a specific Data Lake private endpoint for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},

--- a/internal/cli/atlas/privateendpoints/datalake/aws/list.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/list.go
@@ -16,6 +16,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -61,6 +62,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List Data Lake private endpoints for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/gcp/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create.go
@@ -70,6 +70,7 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a new GCP private endpoint for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  %s privateEndpoints gcp create --region CENTRAL_US`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/gcp/delete.go
+++ b/internal/cli/atlas/privateendpoints/gcp/delete.go
@@ -57,6 +57,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <privateEndpointId>",
 		Aliases: []string{"rm"},
 		Short:   "Delete a GCP private endpoint for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},

--- a/internal/cli/atlas/privateendpoints/gcp/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe.go
@@ -65,6 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return a specific GCP private endpoint for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
@@ -95,6 +95,7 @@ func CreateBuilder() *cobra.Command {
 		Use:     "create <endpointGroupId>",
 		Aliases: []string{"add"},
 		Short:   "Create a GCP private endpoint interface.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"endpointGroupIdDesc": "Unique identifier for the endpoint group.",

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/delete.go
@@ -56,6 +56,7 @@ func DeleteBuilder() *cobra.Command {
 		Aliases: []string{"rm"},
 		Args:    require.ExactArgs(1),
 		Short:   "Delete a specific GCP private endpoint interface for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"idDesc": "Unique identifier for the endpoint group.",
 		},

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
@@ -65,6 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return a specific GCP private endpoint interface for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"idDesc": "Unique identifier of the private endpoint you want to retrieve.",
 		},

--- a/internal/cli/atlas/privateendpoints/gcp/list.go
+++ b/internal/cli/atlas/privateendpoints/gcp/list.go
@@ -63,6 +63,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List GCP private endpoints for your project.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  %s privateEndpoint gcp ls`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/gcp/watch.go
+++ b/internal/cli/atlas/privateendpoints/gcp/watch.go
@@ -67,7 +67,9 @@ func WatchBuilder() *cobra.Command {
 		Long: `This command checks the endpoint's state periodically until the endpoint reaches an AVAILABLE or FAILED state. 
 Once the endpoint reaches the expected state, the command prints "GCP Private endpoint changes completed."
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
-You can interrupt the command's polling at any time with CTRL-C.`,
+You can interrupt the command's polling at any time with CTRL-C.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
 		},

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
@@ -61,7 +61,9 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return the regionalized private endpoint setting for your project.",
-		Long:    `Use this command to check whether you can create multiple private resources per region.`,
+		Long: `Use this command to check whether you can create multiple private resources per region.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  # Return the regionalized private endpoint setting for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
@@ -56,7 +56,9 @@ func DisableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable the regionalized private endpoint setting for your project.",
-		Long:  `This disables the ability to create multiple private resources per region in all cloud service providers for this project.`,
+		Long: `This disables the ability to create multiple private resources per region in all cloud service providers for this project.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Disable the regionalied private endpoint setting in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes disable --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
@@ -56,7 +56,9 @@ func EnableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Enable the regionalized private endpoint setting for your project.",
-		Long:  `This enables the ability to create multiple private resources per region in all cloud service providers for this project.`,
+		Long: `This enables the ability to create multiple private resources per region in all cloud service providers for this project.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: fmt.Sprintf(`  # Enable the regionalied private endpoint setting in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes enable --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/iam/organizations/apikeys/accesslists/create.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/create.go
@@ -91,7 +91,9 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an IP access list entry for your API Key.",
-		Long:  fmt.Sprintf(`To view possible values for the apiKey option, run %s organizations apiKeys list.`, cli.ExampleAtlasEntryPoint()),
+		Long: fmt.Sprintf(`To view possible values for the apiKey option, run %s organizations apiKeys list.
+
+`+fmt.Sprintf(usage.RequiredRole, "Read Write"), cli.ExampleAtlasEntryPoint()),
 		Example: fmt.Sprintf(`  # Create access list entries for two IP addresses for the API key with the ID 5f24084d8dbffa3ad3f21234 in the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys accessLists create --apiKey 5f24084d8dbffa3ad3f21234 --cidr 192.0.2.0/24,198.51.100.0/24 --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/iam/organizations/apikeys/accesslists/delete.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/delete.go
@@ -56,6 +56,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <entry>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified IP access list entry from your API Key.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Read Write"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"entryDesc": "IP or CIDR address that you want to remove from the access list. If the entry includes a subnet mask, such as 192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.",

--- a/internal/cli/iam/organizations/apikeys/accesslists/list.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/list.go
@@ -63,7 +63,9 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return all IP access list entries for your API Key.",
-		Long:    fmt.Sprintf(`To view possible values for the apiKeyID argument, run %s organizations apiKeys list.`, cli.ExampleAtlasEntryPoint()),
+		Long: fmt.Sprintf(`To view possible values for the apiKeyID argument, run %s organizations apiKeys list.
+
+`+fmt.Sprintf(usage.RequiredRole, "Organization Member"), cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"apiKeyIDDesc": "Unique 24-digit string that identifies your API key.",
 		},

--- a/internal/cli/iam/organizations/apikeys/create.go
+++ b/internal/cli/iam/organizations/apikeys/create.go
@@ -72,8 +72,10 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an API Key for your organization.",
-		Long:  `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.`,
-		Args:  require.NoArgs,
+		Long: `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
+
+` + fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
+		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create an organization API key with organization owner access in the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys create --role ORG_OWNER --desc "My API Key" --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/iam/organizations/apikeys/delete.go
+++ b/internal/cli/iam/organizations/apikeys/delete.go
@@ -55,8 +55,10 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified API key for your organization.",
-		Long:    fmt.Sprintf(`To view possible values for the ID argument, run %s organizations apiKeys list.`, cli.ExampleAtlasEntryPoint()),
-		Args:    require.ExactArgs(1),
+		Long: fmt.Sprintf(`To view possible values for the ID argument, run %s organizations apiKeys list.
+
+`+fmt.Sprintf(usage.RequiredRole, "Organization User Admin"), cli.ExampleAtlasEntryPoint()),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the organization's API key.",
 		},

--- a/internal/cli/iam/organizations/apikeys/describe.go
+++ b/internal/cli/iam/organizations/apikeys/describe.go
@@ -63,7 +63,9 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"show"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return the details for the specified API key for your organization.",
-		Long:    fmt.Sprintf(`To view possible values for the ID argument, run %s organizations apiKeys list.`, cli.ExampleAtlasEntryPoint()),
+		Long: fmt.Sprintf(`To view possible values for the ID argument, run %s organizations apiKeys list.
+
+`+fmt.Sprintf(usage.RequiredRole, "Organization Member"), cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies your API key.",
 		},

--- a/internal/cli/iam/organizations/apikeys/list.go
+++ b/internal/cli/iam/organizations/apikeys/list.go
@@ -63,6 +63,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all API keys for your organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of organization API keys for the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys list --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/organizations/apikeys/update.go
+++ b/internal/cli/iam/organizations/apikeys/update.go
@@ -73,7 +73,9 @@ func UpdateBuilder() *cobra.Command {
 		Short:   "Modify the roles or description for the specified organization API key.",
 		Long: fmt.Sprintf(`When you modify the roles for an organization API key with this command, the values you specify overwrite the existing roles assigned to the API key.
 		
-To view possible values for the apiKeyId argument, run %s organizations apiKeys list.`, cli.ExampleAtlasEntryPoint()),
+To view possible values for the apiKeyId argument, run %s organizations apiKeys list.
+
+`+fmt.Sprintf(usage.RequiredRole, "Organization User Admin"), cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"apiKeyIdDesc": "Unique 24-digit string that identifies your API key.",
 		},

--- a/internal/cli/iam/organizations/delete.go
+++ b/internal/cli/iam/organizations/delete.go
@@ -53,8 +53,10 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <ID>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified organization.",
-		Long:    `Organizations with active projects can't be removed.`,
-		Args:    require.ExactArgs(1),
+		Long: `Organizations with active projects can't be removed.
+
+` + fmt.Sprintf(usage.RequiredRole, "Organization Owner"),
+		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the organization.",
 		},

--- a/internal/cli/iam/organizations/describe.go
+++ b/internal/cli/iam/organizations/describe.go
@@ -63,6 +63,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"show"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return the details for the specified organizations.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the organization.",
 		},

--- a/internal/cli/iam/organizations/invitations/delete.go
+++ b/internal/cli/iam/organizations/invitations/delete.go
@@ -54,6 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete <invitationId>",
 		Aliases: []string{"rm"},
 		Short:   "Remove the specified pending invitation to your organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",

--- a/internal/cli/iam/organizations/invitations/describe.go
+++ b/internal/cli/iam/organizations/invitations/describe.go
@@ -64,6 +64,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
 		Short:   "Return the details for the specified pending invitation to your organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",
 		},

--- a/internal/cli/iam/organizations/invitations/invite.go
+++ b/internal/cli/iam/organizations/invitations/invite.go
@@ -72,6 +72,7 @@ func InviteBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "invite <email>",
 		Short:   "Invite the specified MongoDB user to your organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Aliases: []string{"create"},
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{

--- a/internal/cli/iam/organizations/invitations/list.go
+++ b/internal/cli/iam/organizations/invitations/list.go
@@ -69,6 +69,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all pending invitations to your organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of pending invitations to the organization with the ID 5f71e5255afec75a3d0f96dc:
   %s organizations invitations list --orgId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/organizations/invitations/update.go
+++ b/internal/cli/iam/organizations/invitations/update.go
@@ -78,7 +78,9 @@ func UpdateBuilder() *cobra.Command {
 		Use:     "update [invitationId]",
 		Aliases: []string{"updates"},
 		Short:   "Modifies the details of the specified pending invitation to your organization.",
-		Long:    `You can use either the invitation ID or the user's email address to specify the invitation.`,
+		Long: `You can use either the invitation ID or the user's email address to specify the invitation.
+
+` + fmt.Sprintf(usage.RequiredRole, "Organization Owner"),
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",
 		},

--- a/internal/cli/iam/organizations/list.go
+++ b/internal/cli/iam/organizations/list.go
@@ -72,6 +72,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all organizations.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all organizations:
   %[1]s organizations list --output json

--- a/internal/cli/iam/organizations/users/list.go
+++ b/internal/cli/iam/organizations/users/list.go
@@ -65,6 +65,7 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "Return all users for an organization.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all users for the organization with the ID 5e2211c17a3e5a48f5497de3:
   %s organizations users list --orgId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
@@ -94,8 +95,9 @@ func ListBuilder() *cobra.Command {
 func Builder() *cobra.Command {
 	const use = "users"
 	cmd := &cobra.Command{
-		Use:     use,
-		Short:   fmt.Sprintf("Manage your %s users.", cli.DescriptionServiceName()),
+		Use: use,
+		Short: fmt.Sprintf("Manage your %s users.",
+			cli.DescriptionServiceName()),
 		Aliases: cli.GenerateAliases(use),
 	}
 

--- a/internal/cli/performanceadvisor/namespaces/list.go
+++ b/internal/cli/performanceadvisor/namespaces/list.go
@@ -77,7 +77,9 @@ func ListBuilder() *cobra.Command {
 		Short: "Return up to 20 namespaces for collections experiencing slow queries on the specified host.",
 		Long: `Namespaces appear in the following format: {database}.{collection}.
 		
-If you don't set the duration option or the since option, this command returns data from the last 24 hours.`,
+If you don't set the duration option or the since option, this command returns data from the last 24 hours.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of namespaces for collections with slow queries for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/performanceadvisor/slowoperationthreshold/disable.go
+++ b/internal/cli/performanceadvisor/slowoperationthreshold/disable.go
@@ -57,8 +57,10 @@ func DisableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable the application-managed slow operation threshold for your project.",
-		Long:  `The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.`,
-		Args:  require.NoArgs,
+		Long: `The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/performanceadvisor/slowoperationthreshold/enable.go
+++ b/internal/cli/performanceadvisor/slowoperationthreshold/enable.go
@@ -55,9 +55,11 @@ func (opts *EnableOpts) Run() error {
 func EnableBuilder() *cobra.Command {
 	opts := new(EnableOpts)
 	cmd := &cobra.Command{
-		Use:     "enable",
-		Short:   "Enable the application-managed slow operation threshold for your project.",
-		Long:    `The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).`,
+		Use:   "enable",
+		Short: "Enable the application-managed slow operation threshold for your project.",
+		Long: `The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/performanceadvisor/slowquerylogs/list.go
+++ b/internal/cli/performanceadvisor/slowquerylogs/list.go
@@ -84,7 +84,9 @@ func ListBuilder() *cobra.Command {
 		Short: "Return log lines for slow queries that the Performance Advisor and Query Profiler identified.",
 		Long: `The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance. The threshold for slow queries varies based on the average time of operations on your cluster to provide recommendations pertinent to your workload.
 		
-If you don't set the duration option or the since option, this command returns data from the last 24 hours.`,
+If you don't set the duration option or the since option, this command returns data from the last 24 hours.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Data Access Read/Write"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of log lines for collections with slow queries for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:

--- a/internal/cli/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/performanceadvisor/suggestedindexes/list.go
@@ -81,9 +81,11 @@ func (opts *ListOpts) newSuggestedIndexOptions() *atlas.SuggestedIndexOptions {
 func ListBuilder() *cobra.Command {
 	opts := new(ListOpts)
 	cmd := &cobra.Command{
-		Use:     "list",
-		Short:   "Return the suggested indexes for collections experiencing slow queries.",
-		Long:    `The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.`,
+		Use:   "list",
+		Short: "Return the suggested indexes for collections experiencing slow queries.",
+		Long: `The Performance Advisor monitors queries that MongoDB considers slow and suggests new indexes to improve query performance.
+
+` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of suggested indexes for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:


### PR DESCRIPTION
## Proposed changes

This adds required roles for networking, performanceAdvisor, privateEndpoints, and organizations commands. It also removes a few that were placed in error on dataLakes commands (should have been on privateEndpoints-dataLakes commands).

_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-28115

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
