### PR TITLE
basic plugin engine support for atlas-cli

### DIFF
--- a/internal/cli/plugin/plugin.go
+++ b/internal/cli/plugin/plugin.go
@@ -1,0 +1,41 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func Builder() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "plugin",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdPath := os.Args[2:]
+			err := HandleCommand(NewExecHandler(), cmdPath)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		Short: "Atlas CLI plugins",
+		Long:  "Atlas CLI plugins",
+		Annotations: map[string]string{
+			"toc": "false",
+		},
+	}
+	return cmd
+}

--- a/internal/cli/plugin/plugin_engine.go
+++ b/internal/cli/plugin/plugin_engine.go
@@ -1,0 +1,104 @@
+package plugin
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+// NewExecHandler creates and returns a new ExecHandler configured with
+// the prefix.
+func NewExecHandler() *ExecHandler {
+	return &ExecHandler{
+		Exec: syscall.Exec,
+	}
+}
+
+// HandleCommand receives a PluginHandler and command-line arguments and attempts to find
+// a plugin executable on the PATH that satisfies the given arguments.
+func HandleCommand(handler PluginHandler, args []string) error {
+	foundBinary, remaining := findBinary(handler, args)
+	if foundBinary == "" {
+		return nil
+	}
+
+	if err := handler.Execute(foundBinary, args[len(remaining):], os.Environ()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// PluginHandler provides functionality for finding and executing external
+// plugins.
+type PluginHandler interface {
+	// Lookup should return the full path to an executable for the provided
+	// command, or "" if no matching command can be found.
+	Lookup(command string) string
+
+	// Execute should execute the provided path, passing in the args and env.
+	Execute(filename string, args, env []string) error
+}
+
+type execFunc func(string, []string, []string) (err error)
+
+// ExecHandler implements PluginHandler using the "os/exec" package.
+type ExecHandler struct {
+	Exec execFunc
+}
+
+var _ PluginHandler = (*ExecHandler)(nil)
+
+// Lookup implements PluginHandler, using
+// https://golang.org/pkg/os/exec/#LookPath to search for the command.
+func (h *ExecHandler) Lookup(command string) string {
+	if runtime.GOOS == "windows" {
+		command = command + ".exe"
+	}
+	path, err := exec.LookPath(command)
+	if err == nil && len(path) != 0 {
+		return path
+	}
+	return ""
+}
+
+// Execute implements PluginHandler.Execute
+func (h *ExecHandler) Execute(filename string, args, env []string) error {
+	// Windows does not support exec syscall.
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command(filename, args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		cmd.Env = env
+		err := cmd.Run()
+		if err == nil {
+			os.Exit(0)
+		}
+		return err
+	}
+	return h.Exec(filename, append([]string{filename}, args...), env)
+}
+
+func findBinary(handler PluginHandler, args []string) (string, []string) {
+	found := ""
+	remaining := []string{}
+	for idx := range args {
+		if strings.HasPrefix(args[idx], "-") {
+			break
+		}
+		remaining = append(remaining, strings.Replace(args[idx], "-", "_", -1))
+	}
+	for len(remaining) > 0 {
+		path := handler.Lookup(strings.Join(remaining, "-"))
+		if path == "" {
+			remaining = remaining[:len(remaining)-1]
+			continue
+		}
+
+		found = path
+		break
+	}
+	return found, remaining
+}

--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -57,6 +57,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/iam/teams"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/iam/users"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/performanceadvisor"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli/plugin"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/homebrew"
@@ -219,6 +220,7 @@ func Builder() *cobra.Command {
 		registerCmd,
 		figautocomplete.Builder(),
 		kubernetes.Builder(),
+		plugin.Builder(),
 	)
 
 	rootCmd.PersistentFlags().StringVarP(&profile, flag.Profile, flag.ProfileShort, "", usage.Profile)


### PR DESCRIPTION
This is just random idea done in free time. I was curious if there can be some registry of plugins.
Something like https://krew.sigs.k8s.io/.

This is very lightweight implementation  without plugin management but it has basic support for execution.
Just random idea that i need to support generated clis.