### PR TITLE
fix: update client library to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tangzero/inflector v1.0.0
 	github.com/withfig/autocomplete-tools/packages/cobra v1.2.0
-	go.mongodb.org/atlas v0.22.1-0.20230221160003-711c38e02870
+	go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d
 	go.mongodb.org/mongo-driver v1.11.2
 	go.mongodb.org/ops-manager v0.46.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.mongodb.org/atlas v0.22.1-0.20230221160003-711c38e02870 h1:SvNyICLDxCmYdj1K5fGUtCey9KWSIwDWwqO/CVF7LAk=
-go.mongodb.org/atlas v0.22.1-0.20230221160003-711c38e02870/go.mod h1:wEY7WlN8ch+KideMvGcGpNoN4/raY4CfT8lax0FzXCU=
+go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d h1:bLtjZ7vIBcTizQAUAqCj3SbunEJ6/rd75LlC6XeYDRw=
+go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d/go.mod h1:wEY7WlN8ch+KideMvGcGpNoN4/raY4CfT8lax0FzXCU=
 go.mongodb.org/mongo-driver v1.11.2 h1:+1v2rDQUWNcGW7/7E0Jvdz51V38XXxJfhzbV17aNHCw=
 go.mongodb.org/mongo-driver v1.11.2/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.mongodb.org/ops-manager v0.46.0 h1:tNTPY/rDkUv2skhQKHHIuMQoovoDj9EcFsmQu2eTKpk=

--- a/internal/cli/iam/organizations/describe_test.go
+++ b/internal/cli/iam/organizations/describe_test.go
@@ -33,7 +33,7 @@ func TestDescribe_Run(t *testing.T) {
 	mockStore.
 		EXPECT().
 		Organization(gomock.Eq("5a0a1e7e0f2912c554080adc")).
-		Return(&atlasv2.ApiOrganizationView{}, nil).
+		Return(&atlasv2.Organization{}, nil).
 		Times(1)
 
 	opts := &DescribeOpts{


### PR DESCRIPTION
Updating mongodb-atlas-client v2 version to latest. 
Done checks and all renames would affect CLI in any way as we never include and list return models as they are. 
