### PR TITLE
CLOUDP-161495: disable bodyclose rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,7 +64,6 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
     - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
     - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f()) [fast: true, auto-fix: false]
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
@@ -104,6 +103,7 @@ linters:
     - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
 
   # don't enable:
+  # - bodyclose # checks whether HTTP response body is closed successfully [fast: false, auto-fix: false]
   # - asasalint # check for pass []any as any in variadic func(...any) [fast: false, auto-fix: false]
   # - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers [fast: true, auto-fix: false]
   # - bidichk # Checks for dangerous unicode character sequences [fast: true, auto-fix: false]

--- a/internal/store/organizations.go
+++ b/internal/store/organizations.go
@@ -58,8 +58,7 @@ func (s *Store) Organizations(opts *atlas.OrganizationsListOptions) (*atlas.Orga
 func (s *Store) Organization(id string) (interface{}, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		result, res, err := s.clientv2.OrganizationsApi.GetOrganization(s.ctx, id).Execute()
-		defer res.Body.Close()
+		result, _, err := s.clientv2.OrganizationsApi.GetOrganization(s.ctx, id).Execute()
 		return result, err
 	case config.CloudManagerService, config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).Organizations.Get(s.ctx, id)


### PR DESCRIPTION
See: https://jira.mongodb.org/browse/CLOUDP-161495

TL:DR - there are so many false positives for bodyclose that this rule only works when stream is opened only within the same golang scope (same code block). Any functions, or external library response objects are reported as errors.
Considering the very poor maintenance of the rule (those issues were reported years ago) I recomend to disable rule rather than adding +400 exceptions. 


This PR is an alternative to current approach:
Supplying extra defer for all sdk calls (which would result in noop as body is closed already)