### PR TITLE
(DOCSP-28202) Changes values accepted for atlas metrics processes command

### DIFF
--- a/docs/atlascli/command/atlas-metrics-processes.txt
+++ b/docs/atlascli/command/atlas-metrics-processes.txt
@@ -94,7 +94,7 @@ Options
    * - --type
      - strings
      - false
-     - Measurements to return. If this is not specified, all measurements are returned. Valid values are DATABASE_AVERAGE_OBJECT_SIZE, DATABASE_COLLECTION_COUNT, DATABASE_DATA_SIZE, DATABASE_STORAGE_SIZE, DATABASE_INDEX_SIZE, DATABASE_INDEX_COUNT, DATABASE_EXTENT_COUNT, DATABASE_OBJECT_COUNT, and DATABASE_VIEW_COUNT
+     - Measurements to return. If this is not specified, all measurements are returned. To learn which values the CLI accepts, see the Items Enum for m in the Atlas API spec: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Monitoring-and-Logs/operation/getHostMeasurements/.
 
 Inherited Options
 -----------------

--- a/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
@@ -94,7 +94,7 @@ Options
    * - --type
      - strings
      - false
-     - Measurements to return. If this is not specified, all measurements are returned. Valid values are DATABASE_AVERAGE_OBJECT_SIZE, DATABASE_COLLECTION_COUNT, DATABASE_DATA_SIZE, DATABASE_STORAGE_SIZE, DATABASE_INDEX_SIZE, DATABASE_INDEX_COUNT, DATABASE_EXTENT_COUNT, DATABASE_OBJECT_COUNT, and DATABASE_VIEW_COUNT
+     - Measurements to return. If this is not specified, all measurements are returned. To learn which values the CLI accepts, see the Items Enum for m in the Atlas API spec: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Monitoring-and-Logs/operation/getHostMeasurements/.
 
 Inherited Options
 -----------------

--- a/internal/cli/atlas/metrics/processes/processes.go
+++ b/internal/cli/atlas/metrics/processes/processes.go
@@ -101,7 +101,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Period, flag.Period, "", usage.Period)
 	cmd.Flags().StringVar(&opts.Start, flag.Start, "", usage.MeasurementStart)
 	cmd.Flags().StringVar(&opts.End, flag.End, "", usage.MeasurementEnd)
-	cmd.Flags().StringSliceVar(&opts.MeasurementType, flag.TypeFlag, nil, usage.MeasurementType)
+	cmd.Flags().StringSliceVar(&opts.MeasurementType, flag.TypeFlag, nil, usage.MetricsMeasurementType)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -106,6 +106,7 @@ dbName and collection are required only for built-in roles.`
 	MeasurementStart                          = "ISO 8601-formatted date and time that specifies when to start retrieving measurements. You can't set this parameter and period in the same request."
 	MeasurementEnd                            = "ISO 8601-formatted date and time that specifies when to stop retrieving measurements. You can't set this parameter and period in the same request."
 	MeasurementType                           = "Measurements to return. If this is not specified, all measurements are returned. Valid values are DATABASE_AVERAGE_OBJECT_SIZE, DATABASE_COLLECTION_COUNT, DATABASE_DATA_SIZE, DATABASE_STORAGE_SIZE, DATABASE_INDEX_SIZE, DATABASE_INDEX_COUNT, DATABASE_EXTENT_COUNT, DATABASE_OBJECT_COUNT, and DATABASE_VIEW_COUNT"
+	MetricsMeasurementType                    = "Measurements to return. If this is not specified, all measurements are returned. To learn which values the CLI accepts, see the Items Enum for m in the Atlas API spec: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Monitoring-and-Logs/operation/getHostMeasurements/."
 	FirstName                                 = "First or given name for the user."
 	LastName                                  = "Last name, family name, or surname for the user."
 	OrgRole                                   = "User's roles for the associated organization. Valid values include ORG_OWNER, ORG_MEMBER, ORG_GROUP_CREATOR, ORG_BILLING_ADMIN, and ORG_READ_ONLY."


### PR DESCRIPTION
## Proposed changes

As part of the CLI backfill, we added the wrong values accepted for the atlas metrics processes command. This PR fixes that error and points them to the OpenAPI spec.


_Jira ticket:_ 

https://jira.mongodb.org/browse/DOCSP-28202

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
