### PR TITLE
CLOUDP-164969: Migrate Atlas CLI Organizations Client to v2 SDK Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tangzero/inflector v1.0.0
 	github.com/withfig/autocomplete-tools/packages/cobra v1.2.0
-	go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d
+	go.mongodb.org/atlas v0.22.1-0.20230314121621-ed00e911c2ba
 	go.mongodb.org/mongo-driver v1.11.2
 	go.mongodb.org/ops-manager v0.46.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d h1:bLtjZ7vIBcTizQAUAqCj3SbunEJ6/rd75LlC6XeYDRw=
-go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d/go.mod h1:wEY7WlN8ch+KideMvGcGpNoN4/raY4CfT8lax0FzXCU=
+go.mongodb.org/atlas v0.22.1-0.20230314121621-ed00e911c2ba h1:fDgln/CsDKYA3B55tZZ2Zuln7LhraP3Xr+mS28j5KXE=
+go.mongodb.org/atlas v0.22.1-0.20230314121621-ed00e911c2ba/go.mod h1:wEY7WlN8ch+KideMvGcGpNoN4/raY4CfT8lax0FzXCU=
 go.mongodb.org/mongo-driver v1.11.2 h1:+1v2rDQUWNcGW7/7E0Jvdz51V38XXxJfhzbV17aNHCw=
 go.mongodb.org/mongo-driver v1.11.2/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.mongodb.org/ops-manager v0.46.0 h1:tNTPY/rDkUv2skhQKHHIuMQoovoDj9EcFsmQu2eTKpk=

--- a/internal/cli/default_setter_opts.go
+++ b/internal/cli/default_setter_opts.go
@@ -36,7 +36,7 @@ import (
 type ProjectOrgsLister interface {
 	Project(id string) (interface{}, error)
 	Projects(*atlas.ListOptions) (interface{}, error)
-	Organization(id string) (interface{}, error)
+	Organization(id string) (*atlas.Organization, error)
 	Organizations(*atlas.OrganizationsListOptions) (*atlas.Organizations, error)
 	GetOrgProjects(string, *atlas.ProjectsListOptions) (interface{}, error)
 }

--- a/internal/mocks/mock_default_opts.go
+++ b/internal/mocks/mock_default_opts.go
@@ -50,10 +50,10 @@ func (mr *MockProjectOrgsListerMockRecorder) GetOrgProjects(arg0, arg1 interface
 }
 
 // Organization mocks base method.
-func (m *MockProjectOrgsLister) Organization(arg0 string) (interface{}, error) {
+func (m *MockProjectOrgsLister) Organization(arg0 string) (*mongodbatlas.Organization, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Organization", arg0)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(*mongodbatlas.Organization)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mocks/mock_organizations.go
+++ b/internal/mocks/mock_organizations.go
@@ -148,10 +148,10 @@ func (m *MockOrganizationDescriber) EXPECT() *MockOrganizationDescriberMockRecor
 }
 
 // Organization mocks base method.
-func (m *MockOrganizationDescriber) Organization(arg0 string) (interface{}, error) {
+func (m *MockOrganizationDescriber) Organization(arg0 string) (*mongodbatlas.Organization, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Organization", arg0)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(*mongodbatlas.Organization)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/store/organizations.go
+++ b/internal/store/organizations.go
@@ -46,7 +46,7 @@ type OrganizationDeleter interface {
 func (s *Store) Organizations(opts *atlas.OrganizationsListOptions) (*atlas.Organizations, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		//TODO: Migrate once OrganizationsListOptions.IncludeDeletedOrgs property is generated
+		//TODO: Migrate once OrganizationsListOptions.IncludeDeletedOrgs property is generated CLOUDP-166105
 		result, _, err := s.client.(*atlas.Client).Organizations.List(s.ctx, opts)
 		return result, err
 	case config.CloudManagerService, config.OpsManagerService:
@@ -88,7 +88,7 @@ func (s *Store) CreateOrganization(name string) (*atlas.Organization, error) {
 func (s *Store) DeleteOrganization(id string) error {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		// TODO: migrate once 406 response is fixed
+		// TODO: migrate once 406 response is fixed CLOUDP-166120
 		// _, err := s.clientv2.OrganizationsApi.DeleteOrganization(s.ctx, id).Execute()
 		_, err := s.client.(*atlas.Client).Organizations.Delete(s.ctx, id)
 		return err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,9 +31,9 @@ import (
 	"github.com/mongodb-forks/digest"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/log"
-	atlasv2 "go.mongodb.org/atlas/api/v1alpha"
 	atlasauth "go.mongodb.org/atlas/auth"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Updating the migration of Atlas CLI Organizations commands to the auto-generated v2 atlas SDK

Proposing an alternative approach to the store re-architecture, mapping new v2 client struct properties to the existing structs that are returned. 

This should:
- address backwards compatibility concerns
- mean changes to incorporate the new client version are effectively all done in one place
- allow us to validate with the existing e2e tests
  - in returning `interface{}`, we will need some rearchitecture of e2e tests or breaking template change

_Jira ticket:_ CLOUDP-164969

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
