### PR TITLE
CLOUDP-164969: Migrate Atlas CLI Organizations Client to v2 SDK Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tangzero/inflector v1.0.0
 	github.com/withfig/autocomplete-tools/packages/cobra v1.2.0
-	go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d
+	go.mongodb.org/atlas v0.22.1-0.20230314121621-ed00e911c2ba
 	go.mongodb.org/mongo-driver v1.11.2
 	go.mongodb.org/ops-manager v0.46.0
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d h1:bLtjZ7vIBcTizQAUAqCj3SbunEJ6/rd75LlC6XeYDRw=
-go.mongodb.org/atlas v0.22.1-0.20230309165504-94fba899767d/go.mod h1:wEY7WlN8ch+KideMvGcGpNoN4/raY4CfT8lax0FzXCU=
+go.mongodb.org/atlas v0.22.1-0.20230314121621-ed00e911c2ba h1:fDgln/CsDKYA3B55tZZ2Zuln7LhraP3Xr+mS28j5KXE=
+go.mongodb.org/atlas v0.22.1-0.20230314121621-ed00e911c2ba/go.mod h1:wEY7WlN8ch+KideMvGcGpNoN4/raY4CfT8lax0FzXCU=
 go.mongodb.org/mongo-driver v1.11.2 h1:+1v2rDQUWNcGW7/7E0Jvdz51V38XXxJfhzbV17aNHCw=
 go.mongodb.org/mongo-driver v1.11.2/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.mongodb.org/ops-manager v0.46.0 h1:tNTPY/rDkUv2skhQKHHIuMQoovoDj9EcFsmQu2eTKpk=

--- a/internal/cli/iam/organizations/describe.go
+++ b/internal/cli/iam/organizations/describe.go
@@ -32,7 +32,7 @@ const (
 {{.Id}}	{{.Name}}
 `
 	describeTemplateOnPrem = `ID	NAME
-{{.Id}}	{{.Name}}
+{{.ID}}	{{.Name}}
 `
 )
 
@@ -63,7 +63,6 @@ func (opts *DescribeOpts) Run() error {
 // mongocli iam organizations(s) describe <ID>.
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
-	// opts.Template = describeTemplate
 	cmd := &cobra.Command{
 		Use:     "describe <ID>",
 		Aliases: []string{"show"},

--- a/internal/cli/iam/organizations/describe.go
+++ b/internal/cli/iam/organizations/describe.go
@@ -27,11 +27,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const describeTemplate = `ID	NAME
-{{.ID}}	{{.Name}}
+const (
+	describeTemplateCloud = `ID	NAME
+{{.Id}}	{{.Name}}
 `
+	describeTemplateOnPrem = `ID	NAME
+{{.Id}}	{{.Name}}
+`
+)
 
 type DescribeOpts struct {
+	cli.GlobalOpts
 	cli.OutputOpts
 	id    string
 	store store.OrganizationDescriber
@@ -57,7 +63,7 @@ func (opts *DescribeOpts) Run() error {
 // mongocli iam organizations(s) describe <ID>.
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
-	opts.Template = describeTemplate
+	// opts.Template = describeTemplate
 	cmd := &cobra.Command{
 		Use:     "describe <ID>",
 		Aliases: []string{"show"},
@@ -69,8 +75,10 @@ func DescribeBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the organization with the ID 5e2211c17a3e5a48f5497de3:
   %s organizations describe 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			opts.OutWriter = cmd.OutOrStdout()
-			return opts.initStore(cmd.Context())()
+			return opts.PreRunE(
+				opts.initStore(cmd.Context()),
+				opts.InitConditionalOutput(cmd.OutOrStdout(), describeTemplateCloud, describeTemplateOnPrem),
+			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.id = args[0]

--- a/internal/cli/iam/organizations/describe_test.go
+++ b/internal/cli/iam/organizations/describe_test.go
@@ -50,7 +50,7 @@ func TestDescribe_Run(t *testing.T) {
 		store: mockStore,
 		id:    "5a0a1e7e0f2912c554080adc",
 		OutputOpts: cli.OutputOpts{
-			Template:  describeTemplateOnPrem,
+			Template:  describeTemplateCloud,
 			OutWriter: buf,
 		},
 	}

--- a/internal/cli/iam/organizations/describe_test.go
+++ b/internal/cli/iam/organizations/describe_test.go
@@ -18,29 +18,48 @@
 package organizations
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas/api/v1alpha"
+	"github.com/stretchr/testify/assert"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationDescriber(ctrl)
 	defer ctrl.Finish()
+	stringVal := "test"
+	expected := &atlasv2.Organization{
+		Links: nil,
+		Id:    &stringVal,
+		Name:  stringVal,
+	}
+	buf := new(bytes.Buffer)
 
 	mockStore.
 		EXPECT().
 		Organization(gomock.Eq("5a0a1e7e0f2912c554080adc")).
-		Return(&atlasv2.Organization{}, nil).
+		Return(expected, nil).
 		Times(1)
 
 	opts := &DescribeOpts{
 		store: mockStore,
 		id:    "5a0a1e7e0f2912c554080adc",
+		OutputOpts: cli.OutputOpts{
+			Template:  describeTemplateOnPrem,
+			OutWriter: buf,
+		},
 	}
+
 	if err := opts.Run(); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
+	assert.Equal(t, `ID     NAME
+test   test
+`, buf.String())
+	t.Log(buf.String())
 }

--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -55,15 +55,12 @@ func (opts *OutputOpts) InitOutput(w io.Writer, t string) func() error {
 
 // InitOutput allow to init the OutputOpts in a functional way.
 func (opts *OutputOpts) InitConditionalOutput(w io.Writer, cloudTemplate string, onPremTemplate string) func() error {
-	if config.IsCloud() {
-		return func() error {
-			opts.Template = cloudTemplate
-			opts.OutWriter = w
-			return nil
-		}
-	}
 	return func() error {
-		opts.Template = onPremTemplate
+		if config.IsCloud() {
+			opts.Template = cloudTemplate
+		} else {
+			opts.Template = onPremTemplate
+		}
 		opts.OutWriter = w
 		return nil
 	}

--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -53,6 +53,22 @@ func (opts *OutputOpts) InitOutput(w io.Writer, t string) func() error {
 	}
 }
 
+// InitOutput allow to init the OutputOpts in a functional way.
+func (opts *OutputOpts) InitConditionalOutput(w io.Writer, cloudTemplate string, onPremTemplate string) func() error {
+	if config.IsCloud() {
+		return func() error {
+			opts.Template = cloudTemplate
+			opts.OutWriter = w
+			return nil
+		}
+	}
+	return func() error {
+		opts.Template = onPremTemplate
+		opts.OutWriter = w
+		return nil
+	}
+}
+
 // ConfigOutput returns the output format.
 // If the format is empty, it caches it after querying config.
 func (opts *OutputOpts) ConfigOutput() string {

--- a/internal/store/organizations.go
+++ b/internal/store/organizations.go
@@ -44,7 +44,7 @@ type OrganizationDeleter interface {
 func (s *Store) Organizations(opts *atlas.OrganizationsListOptions) (*atlas.Organizations, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		//TODO: Migrate once OrganizationsListOptions.IncludeDeletedOrgs property is generated CLOUDP-166105
+		//TODO: Migrate after CLOUDP-167160 (List property TotalCount always set to 0)
 		result, _, err := s.client.(*atlas.Client).Organizations.List(s.ctx, opts)
 		return result, err
 	case config.CloudManagerService, config.OpsManagerService:

--- a/internal/store/organizations.go
+++ b/internal/store/organizations.go
@@ -44,6 +44,7 @@ type OrganizationDeleter interface {
 func (s *Store) Organizations(opts *atlas.OrganizationsListOptions) (*atlas.Organizations, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
+		//TODO: Migrate once OrganizationsListOptions.IncludeDeletedOrgs property is generated CLOUDP-166105
 		result, _, err := s.client.(*atlas.Client).Organizations.List(s.ctx, opts)
 		return result, err
 	case config.CloudManagerService, config.OpsManagerService:
@@ -84,6 +85,8 @@ func (s *Store) CreateOrganization(name string) (*atlas.Organization, error) {
 func (s *Store) DeleteOrganization(id string) error {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
+		// TODO: migrate once 406 response is fixed CLOUDP-166120
+		// _, err := s.clientv2.OrganizationsApi.DeleteOrganization(s.ctx, id).Execute()
 		_, err := s.client.(*atlas.Client).Organizations.Delete(s.ctx, id)
 		return err
 	case config.CloudManagerService, config.OpsManagerService:

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,9 +31,9 @@ import (
 	"github.com/mongodb-forks/digest"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/log"
-	atlasv2 "go.mongodb.org/atlas/api/v1alpha"
 	atlasauth "go.mongodb.org/atlas/auth"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->


Updating the migration of Atlas CLI Organizations commands to the auto-generated v2 atlas SDK

Added conditional template generation

Other options we considered were 
- Creating a new store for each v2 endpoint
- Creating a new implementation of a store interface for each v2 endpoint

We opted to go with the `interface` + conditional template generation as an approach for ease of integration.
We have many commands to migrate and test, and in many cases, very few changes will be required for this approach.

If/when we end up separating mongoCLI and atlasCLI at a later stage, the removal of the on-prem template and the `store isAtlas false` cases should be straightforward 

_Jira ticket:_ CLOUDP-164969

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code


<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
