### PR TITLE
CLOUDP-163723: fix login with isGov flag

### DIFF
--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -184,7 +184,7 @@ func (opts *Opts) quickstartPreRun(ctx context.Context, outWriter io.Writer) err
 		)
 	}
 
-	if err := opts.LoginPreRun(ctx, config.Default())(); err != nil {
+	if err := opts.LoginPreRun(ctx)(); err != nil {
 		return err
 	}
 
@@ -217,9 +217,11 @@ func (opts *Opts) PreRun(ctx context.Context, outWriter io.Writer) error {
 	opts.shouldRunLogin = false
 	opts.setTier()
 
+	defaultProfile := config.Default()
 	return opts.PreRunE(
 		opts.initStore(ctx),
-		opts.InitFlow(config.Default()),
+		opts.SyncWithOAuthAccessProfile(defaultProfile),
+		opts.InitFlow(defaultProfile),
 		opts.InitOutput(outWriter, ""),
 	)
 }

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -276,10 +276,10 @@ func (opts *LoginOpts) LoginPreRun(ctx context.Context) func() error {
 	return func() error {
 		// ignore expired tokens since logging in
 		if err := opts.RefreshAccessToken(ctx); err != nil && !errors.Is(err, cli.ErrInvalidRefreshToken) {
+			// clean up any expired or invalid tokens
+			opts.config.Set(config.AccessTokenField, "")
 			return err
 		}
-		// clean up any expired tokens
-		opts.config.Set(config.AccessTokenField, "")
 		return nil
 	}
 }

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -275,11 +275,15 @@ func newRegenerationPrompt() survey.Prompt {
 func (opts *LoginOpts) LoginPreRun(ctx context.Context) func() error {
 	return func() error {
 		// ignore expired tokens since logging in
-		if err := opts.RefreshAccessToken(ctx); err != nil && !errors.Is(err, cli.ErrInvalidRefreshToken) {
+		if err := opts.RefreshAccessToken(ctx); err != nil {
 			// clean up any expired or invalid tokens
 			opts.config.Set(config.AccessTokenField, "")
-			return err
+
+			if !errors.Is(err, cli.ErrInvalidRefreshToken) {
+				return err
+			}
 		}
+
 		return nil
 	}
 }

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -63,28 +63,39 @@ type LoginFlow interface {
 	LoginPreRun() error
 }
 
-func (opts *LoginOpts) SetUpOAuthAccess() {
-	switch {
-	case opts.IsGov:
-		opts.Service = config.CloudGovService
-	case opts.isCloudManager:
-		opts.Service = config.CloudManagerService
-	default:
-		opts.Service = config.CloudService
-	}
-	opts.config.Set("service", opts.Service)
+// SyncWithOAuthAccessProfile returns a function that is synchronizing the oauth settings
+// from a login config profile with the provided command opts.
+func (opts *LoginOpts) SyncWithOAuthAccessProfile(c LoginConfig) func() error {
+	return func() error {
+		opts.config = c
 
-	if opts.AccessToken != "" {
-		opts.config.Set(config.AccessTokenField, opts.AccessToken)
-	}
-	if opts.RefreshToken != "" {
-		opts.config.Set(config.RefreshTokenField, opts.RefreshToken)
-	}
-	if opts.OpsManagerURL != "" {
-		opts.config.Set(config.OpsManagerURLField, opts.OpsManagerURL)
-	}
-	if config.ClientID() != "" {
-		opts.config.Set(config.ClientIDField, config.ClientID())
+		switch {
+		case opts.IsGov:
+			opts.Service = config.CloudGovService
+		case opts.isCloudManager:
+			opts.Service = config.CloudManagerService
+		default:
+			opts.Service = config.CloudService
+		}
+		opts.config.Set("service", opts.Service)
+
+		if opts.AccessToken != "" {
+			opts.config.Set(config.AccessTokenField, opts.AccessToken)
+		}
+		if opts.RefreshToken != "" {
+			opts.config.Set(config.RefreshTokenField, opts.RefreshToken)
+		}
+
+		// sync OpsManagerURL from command opts (higher priority)
+		// and OpsManagerURL from default profile
+		if opts.OpsManagerURL != "" {
+			opts.config.Set(config.OpsManagerURLField, opts.OpsManagerURL)
+		}
+		if config.OpsManagerURL() != "" {
+			opts.OpsManagerURL = config.OpsManagerURL()
+		}
+
+		return nil
 	}
 }
 
@@ -92,7 +103,12 @@ func (opts *LoginOpts) LoginRun(ctx context.Context) error {
 	if err := opts.oauthFlow(ctx); err != nil {
 		return err
 	}
-	opts.SetUpOAuthAccess()
+	// oauth config might have changed,
+	// re-sync config profile with login opts
+	if err := opts.SyncWithOAuthAccessProfile(opts.config)(); err != nil {
+		return err
+	}
+
 	s, err := opts.config.AccessTokenSubject()
 	if err != nil {
 		return err
@@ -256,12 +272,8 @@ func newRegenerationPrompt() survey.Prompt {
 	}
 }
 
-func (opts *LoginOpts) LoginPreRun(ctx context.Context, c LoginConfig) func() error {
+func (opts *LoginOpts) LoginPreRun(ctx context.Context) func() error {
 	return func() error {
-		opts.config = c
-		if config.OpsManagerURL() != "" {
-			opts.OpsManagerURL = config.OpsManagerURL()
-		}
 		// ignore expired tokens since logging in
 		if err := opts.RefreshAccessToken(ctx); err != nil && !errors.Is(err, cli.ErrInvalidRefreshToken) {
 			return err
@@ -290,9 +302,11 @@ func LoginBuilder() *cobra.Command {
 `, tool(), config.BinName()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
+			defaultProfile := config.Default()
 			return prerun.ExecuteE(
-				opts.InitFlow(config.Default()),
-				opts.LoginPreRun(cmd.Context(), config.Default()),
+				opts.SyncWithOAuthAccessProfile(defaultProfile),
+				opts.InitFlow(defaultProfile),
+				opts.LoginPreRun(cmd.Context()),
 				validate.NoAPIKeys,
 				validate.NoAccessToken,
 			)

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -69,41 +69,43 @@ func TestLoginBuilder(t *testing.T) {
 	)
 }
 
-func Test_loginOpts_SyncWithOAuthAccessProfile_DefaultService(t *testing.T) {
+func Test_loginOpts_SyncWithOAuthAccessProfile(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockConfig := mocks.NewMockLoginConfig(ctrl)
 
-	opts := &LoginOpts{
-		NoBrowser:    true,
-		AccessToken:  "at",
-		RefreshToken: "rt",
-	}
-	opts.OutWriter = new(bytes.Buffer)
+	t.Run("cloud service run", func(t *testing.T) {
+		mockConfig := mocks.NewMockLoginConfig(ctrl)
+		opts := &LoginOpts{
+			NoBrowser:    true,
+			AccessToken:  "at",
+			RefreshToken: "rt",
+		}
+		opts.OutWriter = new(bytes.Buffer)
 
-	mockConfig.EXPECT().Set("service", "cloud").Times(1)
-	mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
-	mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
-	mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
-	require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
-}
+		mockConfig.EXPECT().Set("service", "cloud").Times(1)
+		mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
+		mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
+		mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
 
-func Test_loginOpts_SyncWithOAuthAccessProfile_GovService(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockConfig := mocks.NewMockLoginConfig(ctrl)
+		require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
+	})
 
-	opts := &LoginOpts{
-		NoBrowser:    true,
-		AccessToken:  "at",
-		RefreshToken: "rt",
-		IsGov:        true,
-	}
-	opts.OutWriter = new(bytes.Buffer)
+	t.Run("cloudgov service run", func(t *testing.T) {
+		mockConfig := mocks.NewMockLoginConfig(ctrl)
+		opts := &LoginOpts{
+			NoBrowser:    true,
+			AccessToken:  "at",
+			RefreshToken: "rt",
+			IsGov:        true,
+		}
+		opts.OutWriter = new(bytes.Buffer)
 
-	mockConfig.EXPECT().Set("service", "cloudgov").Times(1)
-	mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
-	mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
-	mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
-	require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
+		mockConfig.EXPECT().Set("service", "cloudgov").Times(1)
+		mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
+		mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
+		mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
+
+		require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
+	})
 }
 
 func Test_loginOpts_Run(t *testing.T) {

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -69,6 +69,43 @@ func TestLoginBuilder(t *testing.T) {
 	)
 }
 
+func Test_loginOpts_SyncWithOAuthAccessProfile_DefaultService(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockConfig := mocks.NewMockLoginConfig(ctrl)
+
+	opts := &LoginOpts{
+		NoBrowser:    true,
+		AccessToken:  "at",
+		RefreshToken: "rt",
+	}
+	opts.OutWriter = new(bytes.Buffer)
+
+	mockConfig.EXPECT().Set("service", "cloud").Times(1)
+	mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
+	mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
+	mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
+	require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
+}
+
+func Test_loginOpts_SyncWithOAuthAccessProfile_GovService(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockConfig := mocks.NewMockLoginConfig(ctrl)
+
+	opts := &LoginOpts{
+		NoBrowser:    true,
+		AccessToken:  "at",
+		RefreshToken: "rt",
+		IsGov:        true,
+	}
+	opts.OutWriter = new(bytes.Buffer)
+
+	mockConfig.EXPECT().Set("service", "cloudgov").Times(1)
+	mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
+	mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
+	mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
+	require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
+}
+
 func Test_loginOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockFlow := mocks.NewMockRefresher(ctrl)

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -72,40 +72,34 @@ func TestLoginBuilder(t *testing.T) {
 func Test_loginOpts_SyncWithOAuthAccessProfile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	t.Run("cloud service run", func(t *testing.T) {
-		mockConfig := mocks.NewMockLoginConfig(ctrl)
-		opts := &LoginOpts{
-			NoBrowser:    true,
-			AccessToken:  "at",
-			RefreshToken: "rt",
-		}
-		opts.OutWriter = new(bytes.Buffer)
+	tests := []struct {
+		name            string
+		isGov           bool
+		expectedService string
+	}{
+		{name: "cloud service run", isGov: false, expectedService: "cloud"},
+		{name: "cloudgov service run", isGov: true, expectedService: "cloudgov"},
+	}
 
-		mockConfig.EXPECT().Set("service", "cloud").Times(1)
-		mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
-		mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
-		mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := mocks.NewMockLoginConfig(ctrl)
+			opts := &LoginOpts{
+				NoBrowser:    true,
+				AccessToken:  "at",
+				RefreshToken: "rt",
+				IsGov:        tt.isGov,
+			}
+			opts.OutWriter = new(bytes.Buffer)
 
-		require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
-	})
+			mockConfig.EXPECT().Set("service", tt.expectedService).Times(1)
+			mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
+			mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
+			mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
 
-	t.Run("cloudgov service run", func(t *testing.T) {
-		mockConfig := mocks.NewMockLoginConfig(ctrl)
-		opts := &LoginOpts{
-			NoBrowser:    true,
-			AccessToken:  "at",
-			RefreshToken: "rt",
-			IsGov:        true,
-		}
-		opts.OutWriter = new(bytes.Buffer)
-
-		mockConfig.EXPECT().Set("service", "cloudgov").Times(1)
-		mockConfig.EXPECT().Set("access_token", opts.AccessToken).Times(1)
-		mockConfig.EXPECT().Set("refresh_token", opts.RefreshToken).Times(1)
-		mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
-
-		require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
-	})
+			require.NoError(t, opts.SyncWithOAuthAccessProfile(mockConfig)())
+		})
+	}
 }
 
 func Test_loginOpts_Run(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Login/Register/Quickstart/Setup flows: fixed an issue where oauth flow was initialized before the command opts and the oauth access profile were synchronized. One of the side-effects was that some command opts were ignored (e.g. isGov)

_Jira ticket:_ CLOUDP-163723


## Checklist
- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Manual testing checklist (IN PROGRESS)
- [x] Log in
    * configured access tokens, org and proj
- [x] Log in with --isGov (only start the flow)
    * redirected to https://account.mongodbgov.com/account/login?fromURI=https://account.mongodbgov.com/account/connect
- [x] Log in when already logged in
    * got error `Error: already authenticated with an account (xxx@mongodb.com)\nTo log out, run: atlas auth logout`
- [x] Log in with --isGov, when already logged in
    * got error `Error: already authenticated with an account (xxx@mongodb.com)\nTo log out, run: atlas auth logout`
- [x] Log in when already logged in (expired credentials)
    * token was refreshed, then got error `Error: already authenticated with an account (xxx@mongodb.com)\nTo log out, run: atlas auth logout`
- [x] Log in with API keys in profile 
    * `Error: already authenticated with an API key (jopnzhhr) To authenticate using your Atlas username and password on a new profile, run: atlas auth login --profile <profile_name>`
- [x] Log in with API keys in profile and --gov
    * `Error: already authenticated with an API key (jopnzhhr) To authenticate using your Atlas username and password on a new profile, run: atlas auth login --profile <profile_name>`
- [❓] Log in let code expire and get confirmation to regenerate 
    * access_token was refreshed and then got `Error: already authenticated with an account (xxx@mongodb.com)\nTo log out, run: atlas auth logout`
- [x] Register
    * `To continue, go to https://account-dev.mongodb.com/account/register/cli`
    * `Successfully logged in as ciprian.tibulca+20230323-1@mongodb.com.`
- [x] Register with --isGov (only start the flow)
    * `Error: unknown flag: --gov`
- [x] Register when already logged in
    * `Error: already authenticated with an account (ciprian.tibulca+20230323-1@mongodb.com)`
    * `To log out, run: atlas auth logout`
- [x] Register with --isGov when already logged in (only start the flow)
    * `Error: unknown flag: --gov`
- [❓] Quickstart
    * `To continue, go to https://account-dev.mongodb.com/account/connect`
    * `Successfully logged in as ciprian.tibulca+20230323-2@mongodb.com.`
    * `? Do you want to enter the Project ID manually? No`
    * `? Do you want to set up your first free database in Atlas with default settings (it's free forever)? Yes`
    * **`Error: groupID is invalid because must be set`**
    * 2nd attempt (without resetting the profile):
    * `Error: required flag(s) "projectId" not set`
    * 3rd attempt (new profile): same behavior with atlascli 1.5.1
    * 4rd attempt (new profile): before continuing the flow, go to cloud-dev (this will create the default org and proj):
    * `? Do you want to set up your first free database in Atlas with default settings (it's free forever)? Yes Error: POST https://account-dev.mongodb.com/api/atlas/v1.0/groups/641c828a5455a05ef5648708/databaseUsers: 401 (request "") You are not authorized for this resource.`
    * 5th attempt (without resetting the profile): success
- [x] Quickstart with --isGov (only start the flow)
    * `Error: unknown flag: --gov`
- [x] Quickstart logged in
    * `Do you want to set up your first free database in Atlas with default settings (it's free forever)? Yes`
    * `We are deploying Cluster88344...`
- [x] Quickstart logged in with --isGov (only start the flow)
    * `Error: unknown flag: --gov`
- [x] Set up (new profile)
    * `This command will help you ... To verify your account, copy your one-time ... ? Do you want to set up your first free database in Atlas with default settings (it's free forever)? Yes
We are deploying Cluster90846... Please store your database authentication access details in a secure location: Database User Username: ...Creating your cluster... [It's safe to 'Ctrl + C']`
- [x] Set up with --isGov (only start the flow)
    * `To continue, go to https://account.mongodbgov.com/account/register/cli`
- [x] Set up logged in
    * `You are already authenticated with an account (ciprian.tibulca+20230323-4@mongodb.com). Run "atlas auth setup --profile <profile_name>" to create a new Atlas account on a new Atlas CLI profile.` but the setup was not interrupted and completed successfully 
- [x] Set up with --isGov logged in (only start the flow)
    * `You are already authenticated with an account (ciprian.tibulca+20230323-1@mongodb.com). Run "atlas auth setup --profile <profile_name>" to create a new Atlas account on a new Atlas CLI profile.`

