### PR TITLE
CLOUDP-167792: Migrate Access Tracking CLI stores to v2 sdk

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -399,8 +399,6 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.mongodb.org/atlas v0.23.2-0.20230323083450-19965fe766ed h1:mSlSzrMKpDV4ozQqkb0kWUYj73VboV2h45KrstgSg1U=
-go.mongodb.org/atlas v0.23.2-0.20230323083450-19965fe766ed/go.mod h1:r5HHjwxout7CJwjkAcJt+c2yA43rrB6LXidPk3pyeuo=
 go.mongodb.org/atlas v0.23.2-0.20230323121922-76f1516f3ff9 h1:5/GxsRQFvAW9UZD/GAcjQMQAfEWTjvdv1INYjqoL53w=
 go.mongodb.org/atlas v0.23.2-0.20230323121922-76f1516f3ff9/go.mod h1:r5HHjwxout7CJwjkAcJt+c2yA43rrB6LXidPk3pyeuo=
 go.mongodb.org/mongo-driver v1.11.2 h1:+1v2rDQUWNcGW7/7E0Jvdz51V38XXxJfhzbV17aNHCw=

--- a/internal/cli/atlas/accesslogs/list.go
+++ b/internal/cli/atlas/accesslogs/list.go
@@ -32,8 +32,8 @@ import (
 const (
 	success      = "success"
 	fail         = "fail"
-	listTemplate = `HOSTNAME	CLUSTER NAME	AUTH RESULT	LOG LINE {{range .AccessLogs}}
-{{if .Hostname}}{{.Hostname}} {{else}}N/A{{end}}{{.Hostname}}	{{if .ClusterName}}{{.ClusterName}} {{else}}N/A{{end}}	{{.AuthResult}}	{{.LogLine}}{{end}}
+	listTemplate = `HOSTNAME	AUTH RESULT	LOG LINE {{range .AccessLogs}}
+{{if .Hostname}}{{.Hostname}} {{else}}N/A{{end}}{{.Hostname}}	{{.AuthResult}}	{{.LogLine}}{{end}}
 `
 	missingClusterNameHostnameErrorMessage = "one between --%s and --%s must be set"
 	invalidValueAuthResultErrorMessage     = `--%s must be set to "%s" or "%s"`

--- a/internal/cli/atlas/accesslogs/list_test.go
+++ b/internal/cli/atlas/accesslogs/list_test.go
@@ -27,26 +27,25 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestAccessLogListClusterName_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAccessLogsLister(ctrl)
 
-	expected := &mongodbatlas.AccessLogSettings{
-		AccessLogs: []*mongodbatlas.AccessLogs{
+	expected := &atlasv2.MongoDBAccessLogsList{
+		AccessLogs: []atlasv2.MongoDBAccessLogs{
 			{
-				GroupID:       "test",
-				Hostname:      "test",
-				ClusterName:   "test",
-				IPAddress:     "test",
+				GroupId:       pointer.Get("test"),
+				Hostname:      pointer.Get("test"),
+				IpAddress:     pointer.Get("test"),
 				AuthResult:    pointer.Get(true),
-				LogLine:       "test",
-				Timestamp:     "test",
-				Username:      "test",
-				FailureReason: "test",
-				AuthSource:    "test",
+				LogLine:       pointer.Get("test"),
+				Timestamp:     pointer.Get("test"),
+				Username:      pointer.Get("test"),
+				FailureReason: pointer.Get("test"),
+				AuthSource:    pointer.Get("test"),
 			},
 		},
 	}
@@ -71,8 +70,8 @@ func TestAccessLogListClusterName_Run(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	assert.Equal(t, `HOSTNAME    CLUSTER NAME   AUTH RESULT   LOG LINE 
-test test   test           true          test
+	assert.Equal(t, `HOSTNAME    AUTH RESULT   LOG LINE 
+test test   true          test
 `, buf.String())
 	t.Log(buf.String())
 }
@@ -81,7 +80,7 @@ func TestAccessLogListHostname_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAccessLogsLister(ctrl)
 
-	expected := &mongodbatlas.AccessLogSettings{}
+	expected := &atlasv2.MongoDBAccessLogsList{}
 
 	describeOpts := &ListOpts{
 		store:    mockStore,

--- a/internal/mocks/mock_access_logs.go
+++ b/internal/mocks/mock_access_logs.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
+	mongodbatlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 // MockAccessLogsListerByClusterName is a mock of AccessLogsListerByClusterName interface.
@@ -111,10 +112,10 @@ func (m *MockAccessLogsLister) EXPECT() *MockAccessLogsListerMockRecorder {
 }
 
 // AccessLogsByClusterName mocks base method.
-func (m *MockAccessLogsLister) AccessLogsByClusterName(arg0, arg1 string, arg2 *mongodbatlas.AccessLogOptions) (*mongodbatlas.AccessLogSettings, error) {
+func (m *MockAccessLogsLister) AccessLogsByClusterName(arg0, arg1 string, arg2 *mongodbatlas.AccessLogOptions) (*mongodbatlasv2.MongoDBAccessLogsList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AccessLogsByClusterName", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*mongodbatlas.AccessLogSettings)
+	ret0, _ := ret[0].(*mongodbatlasv2.MongoDBAccessLogsList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -126,10 +127,10 @@ func (mr *MockAccessLogsListerMockRecorder) AccessLogsByClusterName(arg0, arg1, 
 }
 
 // AccessLogsByHostname mocks base method.
-func (m *MockAccessLogsLister) AccessLogsByHostname(arg0, arg1 string, arg2 *mongodbatlas.AccessLogOptions) (*mongodbatlas.AccessLogSettings, error) {
+func (m *MockAccessLogsLister) AccessLogsByHostname(arg0, arg1 string, arg2 *mongodbatlas.AccessLogOptions) (*mongodbatlasv2.MongoDBAccessLogsList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AccessLogsByHostname", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*mongodbatlas.AccessLogSettings)
+	ret0, _ := ret[0].(*mongodbatlasv2.MongoDBAccessLogsList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/store/access_logs.go
+++ b/internal/store/access_logs.go
@@ -16,9 +16,11 @@ package store
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 //go:generate mockgen -destination=../mocks/mock_access_logs.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store AccessLogsListerByClusterName,AccessLogsListerByHostname,AccessLogsLister
@@ -32,27 +34,76 @@ type AccessLogsListerByHostname interface {
 }
 
 type AccessLogsLister interface {
-	AccessLogsByHostname(string, string, *atlas.AccessLogOptions) (*atlas.AccessLogSettings, error)
-	AccessLogsByClusterName(string, string, *atlas.AccessLogOptions) (*atlas.AccessLogSettings, error)
+	AccessLogsByHostname(string, string, *atlas.AccessLogOptions) (*atlasv2.MongoDBAccessLogsList, error)
+	AccessLogsByClusterName(string, string, *atlas.AccessLogOptions) (*atlasv2.MongoDBAccessLogsList, error)
 }
 
 // AccessLogsByHostname encapsulates the logic to manage different cloud providers.
-func (s *Store) AccessLogsByHostname(groupID, hostname string, opts *atlas.AccessLogOptions) (*atlas.AccessLogSettings, error) {
+func (s *Store) AccessLogsByHostname(groupID, hostname string, opts *atlas.AccessLogOptions) (*atlasv2.MongoDBAccessLogsList, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		result, _, err := s.client.(*atlas.Client).AccessTracking.ListByHostname(s.ctx, groupID, hostname, opts)
-		return result, err
+		result := s.clientv2.AccessTrackingApi.ListAccessLogsByHostname(s.ctx, groupID, hostname)
+
+		if opts != nil {
+			if opts.Start != "" {
+				startTime, _ := time.Parse(time.RFC3339, opts.Start)
+				result = result.Start(startTime)
+			}
+			if opts.End != "" {
+				endTime, _ := time.Parse(time.RFC3339, opts.End)
+				result = result.End(endTime)
+			}
+
+			if opts.NLogs > 0 {
+				result = result.NLogs(int32(opts.NLogs))
+			}
+
+			if opts.IPAddress != "" {
+				result = result.IpAddress(opts.IPAddress)
+			}
+
+			if opts.AuthResult != nil {
+				result = result.AuthResult(*opts.AuthResult)
+			}
+		}
+
+		res, _, err := result.Execute()
+		return res, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
 	}
 }
 
 // AccessLogsByClusterName encapsulates the logic to manage different cloud providers.
-func (s *Store) AccessLogsByClusterName(groupID, clusterName string, opts *atlas.AccessLogOptions) (*atlas.AccessLogSettings, error) {
+func (s *Store) AccessLogsByClusterName(groupID, clusterName string, opts *atlas.AccessLogOptions) (*atlasv2.MongoDBAccessLogsList, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		result, _, err := s.client.(*atlas.Client).AccessTracking.ListByCluster(s.ctx, groupID, clusterName, opts)
-		return result, err
+		result := s.clientv2.AccessTrackingApi.ListAccessLogsByClusterName(s.ctx, groupID, clusterName)
+
+		if opts != nil {
+			if opts.Start != "" {
+				startTime, _ := time.Parse(time.RFC3339, opts.Start)
+				result = result.Start(startTime)
+			}
+			if opts.End != "" {
+				result = result.End(opts.End)
+			}
+
+			if opts.NLogs > 0 {
+				result = result.NLogs(int64(opts.NLogs))
+			}
+
+			if opts.IPAddress != "" {
+				result = result.IpAddress(opts.IPAddress)
+			}
+
+			if opts.AuthResult != nil {
+				result = result.AuthResult(*opts.AuthResult)
+			}
+		}
+		res, _, err := result.Execute()
+
+		return res, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
 	}

--- a/test/e2e/atlas/access_logs_test.go
+++ b/test/e2e/atlas/access_logs_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestAccessLogs(t *testing.T) {
@@ -48,7 +48,7 @@ func TestAccessLogs(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.NoError(err)
-		var entries *mongodbatlas.AccessLogSettings
+		var entries *atlasv2.MongoDBAccessLogsList
 		err = json.Unmarshal(resp, &entries)
 		req.NoError(err)
 	})
@@ -63,7 +63,7 @@ func TestAccessLogs(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.NoError(err)
-		var entries *mongodbatlas.AccessLogSettings
+		var entries *atlasv2.MongoDBAccessLogsList
 		err = json.Unmarshal(resp, &entries)
 		req.NoError(err)
 	})


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-# [CLOUDP-167792](https://jira.mongodb.org/browse/CLOUDP-167792)

EVG patch: https://spruce.mongodb.com/version/641c690157e85a39ccabc584/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
