### PR TITLE
CLOUDP-164770 Add e2e tests for "serverless backups" commands

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -133,6 +133,7 @@ functions:
           - AZURE_CLIENT_ID
           - AZURE_CLIENT_SECRET
           - E2E_TIMEOUT
+          - E2E_SERVERLESS_INSTANCE_NAME
           - revision
         env:
           <<: *go_env
@@ -1244,6 +1245,7 @@ tasks:
           E2E_TAGS: atlas,backup
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
+          E2E_SERVERLESS_INSTANCE_NAME: ${e2e_serverless_instance_name}
           E2E_TIMEOUT: 3h
   - name: atlas_cleanup_e2e
     tags: [ "e2e","cleanup", "foliage_infrequent_task" ]

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -563,7 +563,7 @@ tasks:
           MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,serverless
+          E2E_TAGS: atlas,serverless,instance
   - name: atlas_gov_clusters_flags_e2e
     tags: ["e2e","clusters","atlasgov"]
     must_have_test_results: true

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1224,9 +1224,71 @@ tasks:
           AZURE_CLIENT_ID: ${logs_decrypt_azure_client_id}
           AZURE_CLIENT_SECRET: ${logs_decrypt_azure_client_secret}
           E2E_TAGS: atlas,decrypt
-  # export buckets require cloud provider role authentication and a s3 bucket created
-  - name: atlas_backups_e2e
-    tags: [ "e2e","backup","atlas" ]
+  - name: atlas_backups_snapshots_e2e
+    tags: [ "e2e","backup","atlas","snapshot" ]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "install gotestsum"
+      - func: "e2e test"
+        vars:
+          MCLI_ORG_ID: ${atlas_org_id}
+          MCLI_PROJECT_ID: ${atlas_project_id}
+          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MCLI_SERVICE: cloud
+          E2E_TAGS: atlas,backup
+          E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
+          E2E_TEST_BUCKET: ${e2e_test_bucket}
+          E2E_TIMEOUT: 3h
+  - name: atlas_backups_exports_buckets_e2e
+    tags: [ "e2e","backup","atlas","exports","buckets" ]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "install gotestsum"
+      - func: "e2e test"
+        vars:
+          MCLI_ORG_ID: ${atlas_org_id}
+          MCLI_PROJECT_ID: ${atlas_project_id}
+          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MCLI_SERVICE: cloud
+          E2E_TAGS: atlas,backup
+          E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
+          E2E_TEST_BUCKET: ${e2e_test_bucket}
+          E2E_TIMEOUT: 3h
+  - name: atlas_backups_exports_jobs_e2e
+    tags: [ "e2e","backup","atlas","exports","jobs" ]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "install gotestsum"
+      - func: "e2e test"
+        vars:
+          MCLI_ORG_ID: ${atlas_org_id}
+          MCLI_PROJECT_ID: ${atlas_project_id}
+          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MCLI_SERVICE: cloud
+          E2E_TAGS: atlas,backup
+          E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
+          E2E_TEST_BUCKET: ${e2e_test_bucket}
+          E2E_TIMEOUT: 3h
+  - name: atlas_backups_serverless_e2e
+    tags: [ "e2e","backup","atlas","serverless" ]
     must_have_test_results: true
     depends_on:
       - name: compile

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1241,7 +1241,7 @@ tasks:
           MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,backup
+          E2E_TAGS: atlas,backup,snapshot
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_TIMEOUT: 3h
@@ -1262,7 +1262,7 @@ tasks:
           MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,backup
+          E2E_TAGS: atlas,backup,exports,buckets
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_TIMEOUT: 3h
@@ -1283,7 +1283,7 @@ tasks:
           MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,backup
+          E2E_TAGS: atlas,backup,exports,jobs
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_TIMEOUT: 3h
@@ -1304,7 +1304,7 @@ tasks:
           MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,backup
+          E2E_TAGS: atlas,backup,serverless
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_SERVERLESS_INSTANCE_NAME: ${e2e_serverless_instance_name}

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1225,7 +1225,7 @@ tasks:
           AZURE_CLIENT_SECRET: ${logs_decrypt_azure_client_secret}
           E2E_TAGS: atlas,decrypt
   - name: atlas_backups_snapshots_e2e
-    tags: [ "e2e","backup","atlas","snapshot" ]
+    tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
     depends_on:
       - name: compile
@@ -1246,7 +1246,7 @@ tasks:
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_TIMEOUT: 3h
   - name: atlas_backups_exports_buckets_e2e
-    tags: [ "e2e","backup","atlas","exports","buckets" ]
+    tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
     depends_on:
       - name: compile
@@ -1267,7 +1267,7 @@ tasks:
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_TIMEOUT: 3h
   - name: atlas_backups_exports_jobs_e2e
-    tags: [ "e2e","backup","atlas","exports","jobs" ]
+    tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
     depends_on:
       - name: compile
@@ -1288,7 +1288,7 @@ tasks:
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_TIMEOUT: 3h
   - name: atlas_backups_serverless_e2e
-    tags: [ "e2e","backup","atlas","serverless" ]
+    tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
     depends_on:
       - name: compile

--- a/test/README.md
+++ b/test/README.md
@@ -57,6 +57,9 @@
 | `backup restores describe`                  | N         |           |           | Y         |       |       |
 | `backup restores start`                     | N         |           |           | Y         |       |       |
 | `backup restores watch`                     | N         |           |           | Y         |       |       |
+| `backup schedule describe`                  | Y         |           |           | Y         |       |       |
+| `backup schedule delete`                    | Y         |           |           | Y         |       |       |
+| `backup schedule update`                    | Y         |           |           | Y         |       |       |
 | `cloudProvider aws accessRoles authorize`   | N         |           |           | Y         |       |       |
 | `cloudProvider aws accessRoles deauthorize` | N         |           |           | Y         |       |       |
 | `cloudProvider aws accessRoles create`      | Y         |           |           | Y         |       |       |
@@ -277,17 +280,6 @@
 | `automation status`                         |           | N         | N         |           | Y     | Y     |
 | `automation update`                         |           | N         | N         |           | Y     | Y     |
 | `automation watch`                          |           | N         | N         |           | Y     | Y     |
-| `backup config describe`                    |           | N         | N         |           | Y     | Y     |
-| `backup config list`                        |           | N         | N         |           | Y     | Y     |
-| `backup config update`                      |           | N         | N         |           | Y     | Y     |
-| `backup snapshots schedule describe`        |           | N         | N         |           | Y     | Y     |
-| `backup snapshots schedule update`          |           | N         | N         |           | Y     | Y     |
-| `backup snapshots list`                     |           | N         | N         |           | Y     | Y     |
-| `backup checkpoint list`                    |           | N         | N         |           | Y     | Y     |
-| `backup restore start`                      | N         | N         | N         | Y         | Y     | Y     |
-| `backup restore list`                       | N         | N         | N         | Y         | Y     | Y     |
-| `backup  enable`                            |           | N         | N         |           | Y     | Y     |
-| `backup  disable`                           |           | N         | Y         |           | Y     | Y     |
 | `cluster  apply`                            |           | Y         | Y         |           | Y     | Y     |
 | `cluster  create`                           |           | Y         | Y         |           | Y     | Y     |
 | `cluster  delete`                           |           | Y         | Y         |           | Y     | Y     |
@@ -349,6 +341,9 @@
 | `serverless describe`                       | Y         |           |           | Y         |       |       |
 | `serverless list`                           | Y         |           |           | Y         |       |       |
 | `serverless watch`                          | Y         |           |           | Y         |       |       |
+| `serverless backup snapshots list`          | Y         |           |           | Y         |       |       |
+| `serverless backup snapshots describe`      | Y         |           |           | Y         |       |       |
+| `serverless backup snapshots watch`         | Y         |           |           | Y         |       |       |
 | `livemigrations link create`                | Y         |           |           | Y         | N     | N     |
 | `livemigrations link delete`                | Y         |           |           | Y         | Y     | Y     |
 | `livemigrations validation create`          |           |           |           | Y         |       |       |

--- a/test/e2e/atlas/backup_export_buckets_test.go
+++ b/test/e2e/atlas/backup_export_buckets_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (atlas && backup)
+//go:build e2e || (atlas && backup && exports && buckets)
 
 package atlas_test
 

--- a/test/e2e/atlas/backup_export_jobs_test.go
+++ b/test/e2e/atlas/backup_export_jobs_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (atlas && backup)
+//go:build e2e || (atlas && backup && exports && jobs)
 
 package atlas_test
 

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -38,7 +38,8 @@ func TestServerlessBackup(t *testing.T) {
 	var snapshotID, restoreJobID string
 
 	g := newAtlasE2ETestGenerator(t)
-	g.generateProjectAndCluster("serverlessBackup")
+	g.generateProject("serverlessBackup")
+	g.generateServerlessCluster()
 
 	t.Run("Snapshot List", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
@@ -98,7 +99,7 @@ func TestServerlessBackup(t *testing.T) {
 			"--snapshotId",
 			snapshotID,
 			"--targetClusterName",
-			g.clusterName,
+			g.serverlessName,
 			"--targetProjectId",
 			g.projectID,
 			"-o=json")

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -37,6 +37,9 @@ func TestServerlessBackup(t *testing.T) {
 
 	var snapshotID, restoreJobID string
 
+	g := newAtlasE2ETestGenerator(t)
+	g.generateProjectAndCluster("serverlessBackup")
+
 	t.Run("Snapshot List", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			serverlessEntity,
@@ -89,11 +92,15 @@ func TestServerlessBackup(t *testing.T) {
 			restoresEntity,
 			"create",
 			"--deliveryType",
-			"download",
+			"automated",
 			"--clusterName",
 			clusterName,
 			"--snapshotId",
 			snapshotID,
+			"--targetClusterName",
+			g.clusterName,
+			"--targetProjectId",
+			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (atlas && backup)
+//go:build e2e || (atlas && backup && serverless)
 
 package atlas_test
 
@@ -61,6 +61,7 @@ func TestServerlessBackup(t *testing.T) {
 
 	t.Run("Snapshot Describe", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
+			serverlessEntity,
 			backupsEntity,
 			snapshotsEntity,
 			"describe",

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -65,6 +65,7 @@ func TestServerlessBackup(t *testing.T) {
 			backupsEntity,
 			snapshotsEntity,
 			"describe",
+			"--snapshotId",
 			snapshotID,
 			"--clusterName",
 			clusterName,

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -1,0 +1,82 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build e2e || (atlas && backup)
+
+package atlas_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	atlas "go.mongodb.org/atlas/mongodbatlas"
+)
+
+func TestServerlessBackup(t *testing.T) {
+	cliPath, err := e2e.AtlasCLIBin()
+	r := require.New(t)
+	r.NoError(err)
+
+	clusterName := os.Getenv("E2E_SERVERLESS_INSTANCE_NAME")
+	r.NotEmpty(clusterName)
+
+	var snapshotID string
+
+	t.Run("Snapshot List", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			serverlessEntity,
+			backupsEntity,
+			snapshotsEntity,
+			"list",
+			clusterName,
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+
+		r.NoError(err, string(resp))
+
+		var r atlas.CloudProviderSnapshots
+		a := assert.New(t)
+		if err = json.Unmarshal(resp, &r); a.NoError(err) {
+			a.NotEmpty(r)
+
+			snapshotID = r.Results[0].ID
+		}
+	})
+
+	t.Run("Snapshot Describe", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			snapshotsEntity,
+			"describe",
+			snapshotID,
+			"--clusterName",
+			clusterName,
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+
+		r.NoError(err, string(resp))
+
+		a := assert.New(t)
+		var result atlas.CloudProviderSnapshot
+		if err = json.Unmarshal(resp, &result); a.NoError(err) {
+			a.Equal(snapshotID, result.ID)
+		}
+	})
+}

--- a/test/e2e/atlas/backup_snapshot_test.go
+++ b/test/e2e/atlas/backup_snapshot_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (atlas && backup)
+//go:build e2e || (atlas && backup && snapshot)
 
 package atlas_test
 

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -81,6 +81,7 @@ const (
 	bucketsEntity                = "buckets"
 	jobsEntity                   = "jobs"
 	snapshotsEntity              = "snapshots"
+	restoresEntity               = "restores"
 	teamsEntity                  = "teams"
 )
 

--- a/test/e2e/atlas/serverless_test.go
+++ b/test/e2e/atlas/serverless_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (atlas && serverless)
+//go:build e2e || (atlas && serverless && instance)
 
 package atlas_test
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Add e2e tests for "serverless backups" commands

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-164770

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.

Closes #[issue number]
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
- Adding tests
- Added validation for delivery type on `atlas serverless backup restore create`
- Made backup tests run in parallel
