### PR TITLE
CLOUDP-167676: fix evergreen env for unit tests

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -73,6 +73,7 @@ functions:
       params:
         <<: *go_options
         env:
+          <<: *go_env
           TEST_CMD: gotestsum --junitfile unit-tests.xml --
         command: make unit-test
   "integration-test":


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Expand `go_env` variables in the unit-test task env so that the GOPROXY is correctly set.
Before, we were expanding `go_options` which has an `env` section (go_env) but this was overwritten by the env section unit-test task already had. 

Tested locally with `evergreen evaluate build/ci/evergreen.yml`.

_Jira ticket:_ CLOUDP-167676

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
