### PR TITLE
CLOUDP-167793:Migrate Atlas Search CLI stores to v2 sdk

### DIFF
--- a/docs/atlascli/command/atlas-clusters-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-list.txt
@@ -52,18 +52,10 @@ Options
      - 
      - false
      - help for list
-   * - --limit
-     - int
-     - false
-     - Number of items per results page. This value defaults to 100.
    * - -o, --output
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file.
-   * - --page
-     - int
-     - false
-     - Page number that specifies a page of results. This value defaults to 1.
    * - --projectId
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-list.txt
@@ -52,18 +52,10 @@ Options
      - 
      - false
      - help for list
-   * - --limit
-     - int
-     - false
-     - Number of items per results page. This value defaults to 100.
    * - -o, --output
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file.
-   * - --page
-     - int
-     - false
-     - Page number that specifies a page of results. This value defaults to 1.
    * - --projectId
      - string
      - false

--- a/internal/cli/atlas/search/create_test.go
+++ b/internal/cli/atlas/search/create_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/spf13/afero"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 const testName = "default"
@@ -42,7 +42,7 @@ func TestCreateOpts_Run(t *testing.T) {
 		if err != nil {
 			t.Fatalf("newSearchIndex() unexpected error: %v", err)
 		}
-		expected := &mongodbatlas.SearchIndex{}
+		expected := &atasv2.FTSIndex{}
 		mockStore.
 			EXPECT().
 			CreateSearchIndexes(opts.ProjectID, opts.clusterName, request).
@@ -66,7 +66,7 @@ func TestCreateOpts_Run(t *testing.T) {
 		opts.filename = fileName
 		opts.fs = appFS
 
-		expected := &mongodbatlas.SearchIndex{}
+		expected := &atasv2.FTSIndex{}
 		request, err := opts.newSearchIndex()
 		if err != nil {
 			t.Fatalf("newSearchIndex() unexpected error: %v", err)

--- a/internal/cli/atlas/search/create_test.go
+++ b/internal/cli/atlas/search/create_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/spf13/afero"
-	atasv2 "go.mongodb.org/atlas/mongodbatlasv2"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 const testName = "default"
@@ -42,7 +42,7 @@ func TestCreateOpts_Run(t *testing.T) {
 		if err != nil {
 			t.Fatalf("newSearchIndex() unexpected error: %v", err)
 		}
-		expected := &atasv2.FTSIndex{}
+		expected := &atlasv2.FTSIndex{}
 		mockStore.
 			EXPECT().
 			CreateSearchIndexes(opts.ProjectID, opts.clusterName, request).
@@ -66,7 +66,7 @@ func TestCreateOpts_Run(t *testing.T) {
 		opts.filename = fileName
 		opts.fs = appFS
 
-		expected := &atasv2.FTSIndex{}
+		expected := &atlasv2.FTSIndex{}
 		request, err := opts.newSearchIndex()
 		if err != nil {
 			t.Fatalf("newSearchIndex() unexpected error: %v", err)

--- a/internal/cli/atlas/search/describe_test.go
+++ b/internal/cli/atlas/search/describe_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestDescribe_Run(t *testing.T) {
@@ -34,7 +34,7 @@ func TestDescribe_Run(t *testing.T) {
 		store:       mockStore,
 	}
 
-	expected := &mongodbatlas.SearchIndex{}
+	expected := &atlasv2.FTSIndex{}
 	mockStore.
 		EXPECT().
 		SearchIndex(describeOpts.ProjectID, describeOpts.clusterName, describeOpts.indexID).

--- a/internal/cli/atlas/search/index_opts.go
+++ b/internal/cli/atlas/search/index_opts.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/file"
 	"github.com/spf13/afero"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 const defaultAnalyzer = "lucene.standard"
@@ -73,9 +73,9 @@ func (opts *IndexOpts) validateOpts() error {
 	return nil
 }
 
-func (opts *IndexOpts) newSearchIndex() (*atlas.SearchIndex, error) {
+func (opts *IndexOpts) newSearchIndex() (*atlasv2.FTSIndex, error) {
 	if len(opts.filename) > 0 {
-		index := &atlas.SearchIndex{}
+		index := &atlasv2.FTSIndex{}
 		if err := file.Load(opts.fs, opts.filename, index); err != nil {
 			return nil, err
 		}
@@ -86,16 +86,16 @@ func (opts *IndexOpts) newSearchIndex() (*atlas.SearchIndex, error) {
 	if err != nil {
 		return nil, err
 	}
-	i := &atlas.SearchIndex{
-		Analyzer:       opts.analyzer,
+	i := &atlasv2.FTSIndex{
+		Analyzer:       &opts.analyzer,
 		CollectionName: opts.collection,
 		Database:       opts.dbName,
-		Mappings: &atlas.IndexMapping{
-			Dynamic: opts.dynamic,
-			Fields:  &f,
+		Mappings: &atlasv2.FTSMappings{
+			Dynamic: &opts.dynamic,
+			Fields:  f,
 		},
 		Name:           opts.name,
-		SearchAnalyzer: opts.searchAnalyzer,
+		SearchAnalyzer: &opts.searchAnalyzer,
 	}
 	return i, nil
 }
@@ -103,11 +103,11 @@ func (opts *IndexOpts) newSearchIndex() (*atlas.SearchIndex, error) {
 // indexFieldParts index field should be fieldName:analyzer:fieldType.
 const indexFieldParts = 2
 
-func (opts *IndexOpts) indexFields() (map[string]interface{}, error) {
+func (opts *IndexOpts) indexFields() (map[string]map[string]interface{}, error) {
 	if len(opts.fields) == 0 {
 		return nil, nil
 	}
-	fields := make(map[string]interface{})
+	fields := make(map[string]map[string]interface{})
 	for _, p := range opts.fields {
 		f := strings.Split(p, ":")
 		if len(f) != indexFieldParts {

--- a/internal/cli/atlas/search/list.go
+++ b/internal/cli/atlas/search/list.go
@@ -87,6 +87,8 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	_ = cmd.Flags().MarkDeprecated(flag.Page, deprecatedFlagMessage)
+	_ = cmd.Flags().MarkDeprecated(flag.Limit, deprecatedFlagMessage)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/search/list.go
+++ b/internal/cli/atlas/search/list.go
@@ -50,7 +50,7 @@ var listTemplate = `ID	NAME	DATABASE	COLLECTION{{range .}}
 `
 
 func (opts *ListOpts) Run() error {
-	r, err := opts.store.SearchIndexes(opts.ConfigProjectID(), opts.clusterName, opts.dbName, opts.collName, opts.NewListOptions())
+	r, err := opts.store.SearchIndexes(opts.ConfigProjectID(), opts.clusterName, opts.dbName, opts.collName)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/atlas/search/list_test.go
+++ b/internal/cli/atlas/search/list_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestList_Run(t *testing.T) {
@@ -32,7 +32,7 @@ func TestList_Run(t *testing.T) {
 		store: mockStore,
 	}
 
-	var expected []*mongodbatlas.SearchIndex
+	var expected []atlasv2.FTSIndex
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/atlas/search/list_test.go
+++ b/internal/cli/atlas/search/list_test.go
@@ -36,7 +36,7 @@ func TestList_Run(t *testing.T) {
 
 	mockStore.
 		EXPECT().
-		SearchIndexes(listOpts.ProjectID, listOpts.clusterName, listOpts.dbName, listOpts.collName, listOpts.NewListOptions()).
+		SearchIndexes(listOpts.ProjectID, listOpts.clusterName, listOpts.dbName, listOpts.collName).
 		Return(expected, nil).
 		Times(1)
 

--- a/internal/cli/atlas/search/update_test.go
+++ b/internal/cli/atlas/search/update_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {
@@ -37,7 +37,7 @@ func TestUpdateOpts_Run(t *testing.T) {
 		updateOpts.name = testName
 		updateOpts.id = "1"
 
-		expected := &mongodbatlas.SearchIndex{}
+		expected := &atlasv2.FTSIndex{}
 
 		request, err := updateOpts.newSearchIndex()
 		if err != nil {
@@ -65,7 +65,7 @@ func TestUpdateOpts_Run(t *testing.T) {
 		updateOpts.filename = fileName
 		updateOpts.fs = appFS
 
-		expected := &mongodbatlas.SearchIndex{}
+		expected := &atlasv2.FTSIndex{}
 
 		request, err := updateOpts.newSearchIndex()
 		if err != nil {

--- a/internal/mocks/mock_search.go
+++ b/internal/mocks/mock_search.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
+	mongodbatlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 // MockSearchIndexLister is a mock of SearchIndexLister interface.
@@ -35,10 +36,10 @@ func (m *MockSearchIndexLister) EXPECT() *MockSearchIndexListerMockRecorder {
 }
 
 // SearchIndexes mocks base method.
-func (m *MockSearchIndexLister) SearchIndexes(arg0, arg1, arg2, arg3 string, arg4 *mongodbatlas.ListOptions) ([]*mongodbatlas.SearchIndex, error) {
+func (m *MockSearchIndexLister) SearchIndexes(arg0, arg1, arg2, arg3 string, arg4 *mongodbatlas.ListOptions) ([]mongodbatlasv2.FTSIndex, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SearchIndexes", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].([]*mongodbatlas.SearchIndex)
+	ret0, _ := ret[0].([]mongodbatlasv2.FTSIndex)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -73,10 +74,10 @@ func (m *MockSearchIndexCreator) EXPECT() *MockSearchIndexCreatorMockRecorder {
 }
 
 // CreateSearchIndexes mocks base method.
-func (m *MockSearchIndexCreator) CreateSearchIndexes(arg0, arg1 string, arg2 *mongodbatlas.SearchIndex) (*mongodbatlas.SearchIndex, error) {
+func (m *MockSearchIndexCreator) CreateSearchIndexes(arg0, arg1 string, arg2 *mongodbatlasv2.FTSIndex) (*mongodbatlasv2.FTSIndex, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSearchIndexes", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*mongodbatlas.SearchIndex)
+	ret0, _ := ret[0].(*mongodbatlasv2.FTSIndex)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -111,10 +112,10 @@ func (m *MockSearchIndexDescriber) EXPECT() *MockSearchIndexDescriberMockRecorde
 }
 
 // SearchIndex mocks base method.
-func (m *MockSearchIndexDescriber) SearchIndex(arg0, arg1, arg2 string) (*mongodbatlas.SearchIndex, error) {
+func (m *MockSearchIndexDescriber) SearchIndex(arg0, arg1, arg2 string) (*mongodbatlasv2.FTSIndex, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SearchIndex", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*mongodbatlas.SearchIndex)
+	ret0, _ := ret[0].(*mongodbatlasv2.FTSIndex)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -149,10 +150,10 @@ func (m *MockSearchIndexUpdater) EXPECT() *MockSearchIndexUpdaterMockRecorder {
 }
 
 // UpdateSearchIndexes mocks base method.
-func (m *MockSearchIndexUpdater) UpdateSearchIndexes(arg0, arg1, arg2 string, arg3 *mongodbatlas.SearchIndex) (*mongodbatlas.SearchIndex, error) {
+func (m *MockSearchIndexUpdater) UpdateSearchIndexes(arg0, arg1, arg2 string, arg3 *mongodbatlasv2.FTSIndex) (*mongodbatlasv2.FTSIndex, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSearchIndexes", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*mongodbatlas.SearchIndex)
+	ret0, _ := ret[0].(*mongodbatlasv2.FTSIndex)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mocks/mock_search.go
+++ b/internal/mocks/mock_search.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 	mongodbatlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
@@ -36,18 +35,18 @@ func (m *MockSearchIndexLister) EXPECT() *MockSearchIndexListerMockRecorder {
 }
 
 // SearchIndexes mocks base method.
-func (m *MockSearchIndexLister) SearchIndexes(arg0, arg1, arg2, arg3 string, arg4 *mongodbatlas.ListOptions) ([]mongodbatlasv2.FTSIndex, error) {
+func (m *MockSearchIndexLister) SearchIndexes(arg0, arg1, arg2, arg3 string) ([]mongodbatlasv2.FTSIndex, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchIndexes", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "SearchIndexes", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]mongodbatlasv2.FTSIndex)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchIndexes indicates an expected call of SearchIndexes.
-func (mr *MockSearchIndexListerMockRecorder) SearchIndexes(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockSearchIndexListerMockRecorder) SearchIndexes(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchIndexes", reflect.TypeOf((*MockSearchIndexLister)(nil).SearchIndexes), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchIndexes", reflect.TypeOf((*MockSearchIndexLister)(nil).SearchIndexes), arg0, arg1, arg2, arg3)
 }
 
 // MockSearchIndexCreator is a mock of SearchIndexCreator interface.

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 //go:generate mockgen -destination=../mocks/mock_search.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store SearchIndexLister,SearchIndexCreator,SearchIndexDescriber,SearchIndexUpdater,SearchIndexDeleter
 
 type SearchIndexLister interface {
-	SearchIndexes(string, string, string, string, *atlas.ListOptions) ([]atlasv2.FTSIndex, error)
+	SearchIndexes(string, string, string, string) ([]atlasv2.FTSIndex, error)
 }
 
 type SearchIndexCreator interface {
@@ -45,7 +44,7 @@ type SearchIndexDeleter interface {
 }
 
 // SearchIndexes encapsulate the logic to manage different cloud providers.
-func (s *Store) SearchIndexes(projectID, clusterName, dbName, collName string, _ *atlas.ListOptions) ([]atlasv2.FTSIndex, error) {
+func (s *Store) SearchIndexes(projectID, clusterName, dbName, collName string) ([]atlasv2.FTSIndex, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
 		result, _, err := s.clientv2.AtlasSearchApi.ListAtlasSearchIndexes(s.ctx, projectID, clusterName, collName, dbName).Execute()

--- a/test/e2e/atlas/search_test.go
+++ b/test/e2e/atlas/search_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestSearch(t *testing.T) {
@@ -89,10 +89,10 @@ func TestSearch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
-		var index mongodbatlas.SearchIndex
+		var index atlasv2.FTSIndex
 		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
-			assert.Equal(t, index.Name, indexName)
-			indexID = index.IndexID
+			assert.Equal(t, index.GetName(), indexName)
+			indexID = index.GetIndexID()
 		}
 	})
 
@@ -115,7 +115,7 @@ func TestSearch(t *testing.T) {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
 
-		var indexes []mongodbatlas.SearchIndex
+		var indexes []atlasv2.FTSIndex
 		if err := json.Unmarshal(resp, &indexes); assert.NoError(t, err) {
 			assert.NotEmpty(t, indexes)
 		}
@@ -138,9 +138,9 @@ func TestSearch(t *testing.T) {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
 
-		var index mongodbatlas.SearchIndex
+		var index atlasv2.FTSIndex
 		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
-			assert.Equal(t, indexID, index.IndexID)
+			assert.Equal(t, indexID, index.GetIndexID())
 		}
 	})
 
@@ -195,11 +195,11 @@ func TestSearch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
-		var index mongodbatlas.SearchIndex
+		var index atlasv2.FTSIndex
 		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
 			a := assert.New(t)
-			a.Equal(indexID, index.IndexID)
-			a.Equal(analyzer, index.Analyzer)
+			a.Equal(indexID, index.GetIndexID())
+			a.Equal(analyzer, index.GetAnalyzer())
 		}
 	})
 

--- a/test/e2e/atlas/search_test.go
+++ b/test/e2e/atlas/search_test.go
@@ -303,7 +303,7 @@ func TestSearch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
-		var index mongodbatlas.SearchIndex
+		var index atlasv2.FTSIndex
 		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
 			assert.Equal(t, index.Name, indexName)
 		}
@@ -387,7 +387,7 @@ func TestSearch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
-		var index mongodbatlas.SearchIndex
+		var index atlasv2.FTSIndex
 		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
 			assert.Equal(t, index.Name, indexName)
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-# [CLOUDP-167793](https://jira.mongodb.org/browse/CLOUDP-167793)

EVG Patch: https://spruce.mongodb.com/version/6421cc400ae606fcdcda3b85/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
