### PR TITLE
CLOUDP-167790: Migrate Maintenance Windows CLI stores to v2 sdk

### DIFF
--- a/internal/cli/atlas/maintenance/describe_test.go
+++ b/internal/cli/atlas/maintenance/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {
@@ -35,7 +35,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		store: mockStore,
 	}
 
-	expected := &mongodbatlas.MaintenanceWindow{}
+	expected := &atlasv2.GroupMaintenanceWindow{}
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/atlas/maintenance/update.go
+++ b/internal/cli/atlas/maintenance/update.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 type UpdateOpts struct {
@@ -54,10 +54,10 @@ func (opts *UpdateOpts) Run() error {
 	return opts.Print(nil)
 }
 
-func (opts *UpdateOpts) newMaintenanceWindow() *atlas.MaintenanceWindow {
-	return &atlas.MaintenanceWindow{
-		DayOfWeek: opts.dayOfWeek,
-		HourOfDay: &opts.hourOfDay,
+func (opts *UpdateOpts) newMaintenanceWindow() *atlasv2.GroupMaintenanceWindow {
+	return &atlasv2.GroupMaintenanceWindow{
+		DayOfWeek: int32(opts.dayOfWeek),
+		HourOfDay: int32(opts.hourOfDay),
 		StartASAP: &opts.startASAP,
 	}
 }

--- a/internal/kubernetes/operator/project/project.go
+++ b/internal/kubernetes/operator/project/project.go
@@ -326,8 +326,8 @@ func buildMaintenanceWindows(mwProvider store.MaintenanceWindowDescriber, projec
 	}
 
 	return operatorProject.MaintenanceWindow{
-		DayOfWeek: mw.DayOfWeek,
-		HourOfDay: pointer.GetOrDefault(mw.HourOfDay, 0),
+		DayOfWeek: int(mw.DayOfWeek),
+		HourOfDay: int(mw.HourOfDay),
 		AutoDefer: pointer.GetOrDefault(mw.AutoDeferOnceEnabled, false),
 		StartASAP: pointer.GetOrDefault(mw.StartASAP, false),
 		Defer:     false,

--- a/internal/kubernetes/operator/project/project_test.go
+++ b/internal/kubernetes/operator/project/project_test.go
@@ -127,11 +127,10 @@ func TestBuildAtlasProject(t *testing.T) {
 			TotalCount: 1,
 		}
 
-		mw := &mongodbatlas.MaintenanceWindow{
+		mw := &atlasv2.GroupMaintenanceWindow{
 			DayOfWeek:            1,
-			HourOfDay:            pointer.Get(10),
+			HourOfDay:            10,
 			StartASAP:            pointer.Get(false),
-			NumberOfDeferrals:    0,
 			AutoDeferOnceEnabled: pointer.Get(false),
 		}
 
@@ -432,8 +431,8 @@ func TestBuildAtlasProject(t *testing.T) {
 					},
 				},
 				MaintenanceWindow: project.MaintenanceWindow{
-					DayOfWeek: mw.DayOfWeek,
-					HourOfDay: pointer.GetOrDefault(mw.HourOfDay, 0),
+					DayOfWeek: int(mw.DayOfWeek),
+					HourOfDay: int(mw.HourOfDay),
 					AutoDefer: pointer.GetOrDefault(mw.AutoDeferOnceEnabled, false),
 					StartASAP: pointer.GetOrDefault(mw.StartASAP, false),
 					Defer:     false,
@@ -1024,11 +1023,10 @@ func Test_buildMaintenanceWindows(t *testing.T) {
 
 	mwProvider := mocks.NewMockMaintenanceWindowDescriber(ctl)
 	t.Run("Can convert maintenance window", func(t *testing.T) {
-		mw := &mongodbatlas.MaintenanceWindow{
+		mw := &atlasv2.GroupMaintenanceWindow{
 			DayOfWeek:            3,
-			HourOfDay:            pointer.Get(10),
+			HourOfDay:            10,
 			StartASAP:            pointer.Get(false),
-			NumberOfDeferrals:    0,
 			AutoDeferOnceEnabled: pointer.Get(false),
 		}
 
@@ -1040,8 +1038,8 @@ func Test_buildMaintenanceWindows(t *testing.T) {
 		}
 
 		expected := project.MaintenanceWindow{
-			DayOfWeek: mw.DayOfWeek,
-			HourOfDay: *mw.HourOfDay,
+			DayOfWeek: int(mw.DayOfWeek),
+			HourOfDay: int(mw.HourOfDay),
 			AutoDefer: *mw.AutoDeferOnceEnabled,
 			StartASAP: *mw.StartASAP,
 			Defer:     false,

--- a/internal/mocks/mock_atlas_operator_project_store.go
+++ b/internal/mocks/mock_atlas_operator_project_store.go
@@ -126,10 +126,10 @@ func (mr *MockAtlasOperatorProjectStoreMockRecorder) Integrations(arg0 interface
 }
 
 // MaintenanceWindow mocks base method.
-func (m *MockAtlasOperatorProjectStore) MaintenanceWindow(arg0 string) (*mongodbatlas.MaintenanceWindow, error) {
+func (m *MockAtlasOperatorProjectStore) MaintenanceWindow(arg0 string) (*mongodbatlasv2.GroupMaintenanceWindow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintenanceWindow", arg0)
-	ret0, _ := ret[0].(*mongodbatlas.MaintenanceWindow)
+	ret0, _ := ret[0].(*mongodbatlasv2.GroupMaintenanceWindow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mocks/mock_maintenance.go
+++ b/internal/mocks/mock_maintenance.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
+	mongodbatlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 	opsmngr "go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -36,7 +36,7 @@ func (m *MockMaintenanceWindowUpdater) EXPECT() *MockMaintenanceWindowUpdaterMoc
 }
 
 // UpdateMaintenanceWindow mocks base method.
-func (m *MockMaintenanceWindowUpdater) UpdateMaintenanceWindow(arg0 string, arg1 *mongodbatlas.MaintenanceWindow) error {
+func (m *MockMaintenanceWindowUpdater) UpdateMaintenanceWindow(arg0 string, arg1 *mongodbatlasv2.GroupMaintenanceWindow) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMaintenanceWindow", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -147,10 +147,10 @@ func (m *MockMaintenanceWindowDescriber) EXPECT() *MockMaintenanceWindowDescribe
 }
 
 // MaintenanceWindow mocks base method.
-func (m *MockMaintenanceWindowDescriber) MaintenanceWindow(arg0 string) (*mongodbatlas.MaintenanceWindow, error) {
+func (m *MockMaintenanceWindowDescriber) MaintenanceWindow(arg0 string) (*mongodbatlasv2.GroupMaintenanceWindow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MaintenanceWindow", arg0)
-	ret0, _ := ret[0].(*mongodbatlas.MaintenanceWindow)
+	ret0, _ := ret[0].(*mongodbatlasv2.GroupMaintenanceWindow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/store/maintenance.go
+++ b/internal/store/maintenance.go
@@ -18,14 +18,14 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_maintenance.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store MaintenanceWindowUpdater,MaintenanceWindowClearer,MaintenanceWindowDeferrer,MaintenanceWindowDescriber,OpsManagerMaintenanceWindowCreator,OpsManagerMaintenanceWindowLister,OpsManagerMaintenanceWindowDeleter,OpsManagerMaintenanceWindowDescriber,OpsManagerMaintenanceWindowUpdater
 
 type MaintenanceWindowUpdater interface {
-	UpdateMaintenanceWindow(string, *atlas.MaintenanceWindow) error
+	UpdateMaintenanceWindow(string, *atlasv2.GroupMaintenanceWindow) error
 }
 
 type MaintenanceWindowClearer interface {
@@ -37,7 +37,7 @@ type MaintenanceWindowDeferrer interface {
 }
 
 type MaintenanceWindowDescriber interface {
-	MaintenanceWindow(string) (*atlas.MaintenanceWindow, error)
+	MaintenanceWindow(string) (*atlasv2.GroupMaintenanceWindow, error)
 }
 
 type OpsManagerMaintenanceWindowCreator interface {
@@ -61,10 +61,10 @@ type OpsManagerMaintenanceWindowUpdater interface {
 }
 
 // UpdateMaintenanceWindow encapsulates the logic to manage different cloud providers.
-func (s *Store) UpdateMaintenanceWindow(projectID string, maintenanceWindow *atlas.MaintenanceWindow) error {
+func (s *Store) UpdateMaintenanceWindow(projectID string, maintenanceWindow *atlasv2.GroupMaintenanceWindow) error {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		_, err := s.client.(*atlas.Client).MaintenanceWindows.Update(s.ctx, projectID, maintenanceWindow)
+		_, err := s.clientv2.MaintenanceWindowsApi.UpdateMaintenanceWindow(s.ctx, projectID).GroupMaintenanceWindow(*maintenanceWindow).Execute()
 		return err
 	default:
 		return fmt.Errorf("%w: %s", errUnsupportedService, s.service)
@@ -75,7 +75,7 @@ func (s *Store) UpdateMaintenanceWindow(projectID string, maintenanceWindow *atl
 func (s *Store) ClearMaintenanceWindow(projectID string) error {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		_, err := s.client.(*atlas.Client).MaintenanceWindows.Reset(s.ctx, projectID)
+		_, err := s.clientv2.MaintenanceWindowsApi.ResetMaintenanceWindow(s.ctx, projectID).Execute()
 		return err
 	default:
 		return fmt.Errorf("%w: %s", errUnsupportedService, s.service)
@@ -86,7 +86,7 @@ func (s *Store) ClearMaintenanceWindow(projectID string) error {
 func (s *Store) DeferMaintenanceWindow(projectID string) error {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		_, err := s.client.(*atlas.Client).MaintenanceWindows.Defer(s.ctx, projectID)
+		_, err := s.clientv2.MaintenanceWindowsApi.DeferMaintenanceWindow(s.ctx, projectID).Execute()
 		return err
 	default:
 		return fmt.Errorf("%w: %s", errUnsupportedService, s.service)
@@ -94,10 +94,10 @@ func (s *Store) DeferMaintenanceWindow(projectID string) error {
 }
 
 // MaintenanceWindow encapsulates the logic to manage different cloud providers.
-func (s *Store) MaintenanceWindow(projectID string) (*atlas.MaintenanceWindow, error) {
+func (s *Store) MaintenanceWindow(projectID string) (*atlasv2.GroupMaintenanceWindow, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		resp, _, err := s.client.(*atlas.Client).MaintenanceWindows.Get(s.ctx, projectID)
+		resp, _, err := s.clientv2.MaintenanceWindowsApi.GetMaintenanceWindow(s.ctx, projectID).Execute()
 		return resp, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)

--- a/test/e2e/atlas/maintenance_test.go
+++ b/test/e2e/atlas/maintenance_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestMaintenanceWindows(t *testing.T) {
@@ -68,10 +68,10 @@ func TestMaintenanceWindows(t *testing.T) {
 		a := assert.New(t)
 		a.NoError(err, string(resp))
 
-		var maintenanceWindow mongodbatlas.MaintenanceWindow
+		var maintenanceWindow atlasv2.GroupMaintenanceWindow
 		if err := json.Unmarshal(resp, &maintenanceWindow); a.NoError(err) {
-			a.Equal(1, maintenanceWindow.DayOfWeek)
-			a.Equal(1, *maintenanceWindow.HourOfDay)
+			a.Equal(int32(1), maintenanceWindow.DayOfWeek)
+			a.Equal(int32(1), maintenanceWindow.HourOfDay)
 		}
 	})
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-# [CLOUDP-167790](https://jira.mongodb.org/browse/CLOUDP-167790)
EVG Patch: https://spruce.mongodb.com/version/642c31ad850e61fcf29ddb68/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
