### PR TITLE
(DOCSP-28637) Adds outputs to docs for describe commands

### DIFF
--- a/docs/atlascli/command/atlas-alerts-describe.txt
+++ b/docs/atlascli/command/atlas-alerts-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     TYPE              METRIC         STATUS
+   <ID>   <EventTypeName>   <MetricName>   <Status>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-describe.txt
@@ -69,6 +69,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     BUCKET NAME    CLOUD PROVIDER    IAM ROLE ID
+   <ID>   <BucketName>   <CloudProvider>   <IAMRoleID>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-describe.txt
@@ -73,6 +73,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     EXPORT BUCKET ID   STATE     SNAPSHOT ID
+   <ID>   <ExportBucketID>   <State>   <SnapshotID>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-backups-snapshots-describe.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     SNAPSHOT TYPE    TYPE     DESCRIPTION     EXPIRES AT
+   <ID>   <SnapshotType>   <Type>   <Description>   <ExpiresAt>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-clusters-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME     MDB VER            STATE
+   <ID>   <Name>   <MongoDBVersion>   <StateName>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     CLUSTER         DATABASE   COLLECTION   STATE
+   <ID>   <ClusterName>   <DBName>   <CollName>   <State>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-clusters-search-indexes-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID          NAME     DATABASE     COLLECTION
+   <IndexID>   <Name>   <Database>   <CollectionName>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-customDns-aws-describe.txt
+++ b/docs/atlascli/command/atlas-customDns-aws-describe.txt
@@ -65,3 +65,14 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ENABLED
+   <Enabled>
+   
+

--- a/docs/atlascli/command/atlas-dataLakes-describe.txt
+++ b/docs/atlascli/command/atlas-dataLakes-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   NAME     STATE
+   <Name>   <State>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-dbusers-describe.txt
+++ b/docs/atlascli/command/atlas-dbusers-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   USERNAME     DATABASE
+   <Username>   <DatabaseName>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-liveMigrations-validation-describe.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation-describe.txt
@@ -67,3 +67,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     PROJECT ID   SOURCE PROJECT ID   STATUS
+   <ID>   <GroupID>    <SourceGroupID>     <Status>
+

--- a/docs/atlascli/command/atlas-maintenanceWindows-describe.txt
+++ b/docs/atlascli/command/atlas-maintenanceWindows-describe.txt
@@ -67,6 +67,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   DAY OF THE WEEK   HOUR OF DAY   START ASAP
+   <DayOfWeek>       <HourOfDay>   <StartASAP>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-organizations-apiKeys-describe.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-describe.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     DESCRIPTION   PUBLIC KEY    PRIVATE KEY
+   <ID>   <Desc>        <PublicKey>   <PrivateKey>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-organizations-describe.txt
+++ b/docs/atlascli/command/atlas-organizations-describe.txt
@@ -77,6 +77,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME
+   <Id>   <Name>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     ENDPOINT SERVICE        STATUS     ERROR
+   <ID>   <EndpointServiceName>   <Status>   <ErrorMessage>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID                      STATUS                  ERROR
+   <InterfaceEndpointID>   <AWSConnectionStatus>   <ErrorMessage>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     ENDPOINT SERVICE           STATUS     ERROR
+   <ID>   <PrivateLinkServiceName>   <Status>   <ErrorMessage>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-interfaces-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID                            IP ADDRESS                   STATUS     ERROR
+   <PrivateEndpointResourceID>   <PrivateEndpointIPAddress>   <Status>   <ErrorMessage>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID             ENDPOINT PROVIDER   TYPE     COMMENT
+   <EndpointID>   <Provider>          <Type>   <Comment>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ENDPOINT              STATUS     DELETE REQUESTED
+   <EndpointGroupName>   <Status>   <DeleteRequested>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID             ENDPOINT PROVIDER   TYPE     COMMENT
+   <EndpointID>   <Provider>          <Type>   <Comment>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-regionalModes-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-regionalModes-describe.txt
@@ -67,6 +67,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ENABLED
+   <Enabled>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-processes-describe.txt
+++ b/docs/atlascli/command/atlas-processes-describe.txt
@@ -79,6 +79,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     REPLICA SET NAME   SHARD NAME    VERSION
+   <ID>   <ReplicaSetName>   <ShardName>   <Version>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-projects-describe.txt
+++ b/docs/atlascli/command/atlas-projects-describe.txt
@@ -77,6 +77,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME
+   <ID>   <Name>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-projects-invitations-describe.txt
+++ b/docs/atlascli/command/atlas-projects-invitations-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     USERNAME     CREATED AT    EXPIRES AT
+   <ID>   <Username>   <CreatedAt>   <ExpiresAt>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-projects-settings-describe.txt
+++ b/docs/atlascli/command/atlas-projects-settings-describe.txt
@@ -63,6 +63,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   COLLECT DATABASE SPECIFICS STATISTICS ENABLED   DATA EXPLORER ENABLED     PERFORMANCE ADVISOR ENABLED     REALTIME PERFORMANCE PANEL ENABLED    SCHEMA ADVISOR ENABLED
+   <IsCollectDatabaseSpecificsStatisticsEnabled>   <IsDataExplorerEnabled>   <IsPerformanceAdvisorEnabled>   <IsRealtimePerformancePanelEnabled>   <IsSchemaAdvisorEnabled>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-serverless-backups-snapshots-describe.txt
+++ b/docs/atlascli/command/atlas-serverless-backups-snapshots-describe.txt
@@ -73,6 +73,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     SNAPSHOT TYPE    TYPE     DESCRIPTION     EXPIRES AT
+   <ID>   <SnapshotType>   <Type>   <Description>   <ExpiresAt>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-serverless-describe.txt
+++ b/docs/atlascli/command/atlas-serverless-describe.txt
@@ -81,3 +81,14 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME     MDB VER            STATE
+   <ID>   <Name>   <MongoDBVersion>   <StateName>
+   
+

--- a/docs/atlascli/command/atlas-teams-describe.txt
+++ b/docs/atlascli/command/atlas-teams-describe.txt
@@ -75,6 +75,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME
+   <ID>   <Name>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-users-describe.txt
+++ b/docs/atlascli/command/atlas-users-describe.txt
@@ -71,6 +71,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     FIRST NAME    LAST NAME    USERNAME     EMAIL
+   <ID>   <FirstName>   <LastName>   <Username>   <EmailAddress>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-alerts-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     TYPE              METRIC         STATUS
+   <ID>   <EventTypeName>   <MetricName>   <Status>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     SNAPSHOT TYPE    TYPE     DESCRIPTION     EXPIRES AT
+   <ID>   <SnapshotType>   <Type>   <Description>   <ExpiresAt>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME     MDB VER            STATE
+   <ID>   <Name>   <MongoDBVersion>   <StateName>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     CLUSTER         DATABASE   COLLECTION   STATE
+   <ID>   <ClusterName>   <DBName>   <CollName>   <State>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID          NAME     DATABASE     COLLECTION
+   <IndexID>   <Name>   <Database>   <CollectionName>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-customDns-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDns-aws-describe.txt
@@ -65,3 +65,14 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ENABLED
+   <Enabled>
+   
+

--- a/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-dataLakes-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   NAME     STATE
+   <Name>   <State>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-dbusers-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   USERNAME     DATABASE
+   <Username>   <DatabaseName>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-describe.txt
@@ -67,3 +67,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     PROJECT ID   SOURCE PROJECT ID   STATUS
+   <ID>   <GroupID>    <SourceGroupID>     <Status>
+

--- a/docs/mongocli/command/mongocli-atlas-maintenanceWindows-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-maintenanceWindows-describe.txt
@@ -67,6 +67,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   DAY OF THE WEEK   HOUR OF DAY   START ASAP
+   <DayOfWeek>       <HourOfDay>   <StartASAP>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     ENDPOINT SERVICE        STATUS     ERROR
+   <ID>   <EndpointServiceName>   <Status>   <ErrorMessage>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID                      STATUS                  ERROR
+   <InterfaceEndpointID>   <AWSConnectionStatus>   <ErrorMessage>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     ENDPOINT SERVICE           STATUS     ERROR
+   <ID>   <PrivateLinkServiceName>   <Status>   <ErrorMessage>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-interfaces-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID                            IP ADDRESS                   STATUS     ERROR
+   <PrivateEndpointResourceID>   <PrivateEndpointIPAddress>   <Status>   <ErrorMessage>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID             ENDPOINT PROVIDER   TYPE     COMMENT
+   <EndpointID>   <Provider>          <Type>   <Comment>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-interfaces-describe.txt
@@ -85,6 +85,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ENDPOINT              STATUS     DELETE REQUESTED
+   <EndpointGroupName>   <Status>   <DeleteRequested>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID             ENDPOINT PROVIDER   TYPE     COMMENT
+   <EndpointID>   <Provider>          <Type>   <Comment>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-describe.txt
@@ -67,6 +67,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ENABLED
+   <Enabled>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-processes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-processes-describe.txt
@@ -79,6 +79,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     REPLICA SET NAME   SHARD NAME    VERSION
+   <ID>   <ReplicaSetName>   <ShardName>   <Version>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-serverless-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-describe.txt
@@ -81,3 +81,14 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME     MDB VER            STATE
+   <ID>   <Name>   <MongoDBVersion>   <StateName>
+   
+

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-describe.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     TYPE              METRIC         STATUS
+   <ID>   <EventTypeName>   <MetricName>   <Status>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-describe.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     DESCRIPTION   PUBLIC KEY    PRIVATE KEY
+   <ID>   <Desc>        <PublicKey>   <PrivateKey>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-describe.txt
@@ -77,6 +77,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME
+   <Id>   <Name>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-iam-organizations-invitations-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-invitations-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     USERNAME     CREATED AT    EXPIRES AT
+   <ID>   <Username>   <CreatedAt>   <ExpiresAt>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-iam-projects-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-describe.txt
@@ -77,6 +77,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME
+   <ID>   <Name>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-iam-projects-invitations-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-invitations-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     USERNAME     CREATED AT    EXPIRES AT
+   <ID>   <Username>   <CreatedAt>   <ExpiresAt>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-iam-teams-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-describe.txt
@@ -75,6 +75,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     NAME
+   <ID>   <Name>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-iam-users-describe.txt
+++ b/docs/mongocli/command/mongocli-iam-users-describe.txt
@@ -71,6 +71,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     FIRST NAME    LAST NAME    USERNAME     EMAIL
+   <ID>   <FirstName>   <LastName>   <Username>   <EmailAddress>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-describe.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-describe.txt
@@ -81,6 +81,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID     TYPE              METRIC         STATUS
+   <ID>   <EventTypeName>   <MetricName>   <Status>
+   
+
 Examples
 --------
 

--- a/internal/cli/alerts/describe.go
+++ b/internal/cli/alerts/describe.go
@@ -67,6 +67,7 @@ func DescribeBuilder() *cobra.Command {
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"alertIdDesc": "Unique identifier of the alert you want to describe.",
+			"output":      describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s alerts describe 5d1113b25a115342acc2d1aa --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/backup/exports/buckets/describe.go
+++ b/internal/cli/atlas/backup/exports/buckets/describe.go
@@ -63,6 +63,9 @@ func DescribeBuilder() *cobra.Command {
 		Short:   "Return one snapshot export bucket.",
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args:    require.NoArgs,
+		Annotations: map[string]string{
+			"output": describeTemplate,
+		},
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup export bucket with the ID dbdb00ca12345678f901a234:
   %s backup exports buckets describe dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/backup/exports/jobs/describe.go
+++ b/internal/cli/atlas/backup/exports/jobs/describe.go
@@ -65,6 +65,9 @@ func DescribeBuilder() *cobra.Command {
 		Short:   "Return one cloud backup export job for your project, cluster and job.",
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:    require.NoArgs,
+		Annotations: map[string]string{
+			"output": describeTemplate,
+		},
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup export job with the ID 5df90590f10fab5e33de2305 for the cluster named Cluster0:
   %s backup exports jobs describe --clusterName Cluster0 --exportID 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/backup/snapshots/describe.go
+++ b/internal/cli/atlas/backup/snapshots/describe.go
@@ -67,6 +67,7 @@ func DescribeBuilder() *cobra.Command {
   %s backups snapshots describe 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to retrieve.",
+			"output":         describeTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/clusters/describe.go
+++ b/internal/cli/atlas/clusters/describe.go
@@ -65,6 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to retrieve.",
+			"output":          describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the cluster named myCluster:
   %s clusters describe myCluster --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/clusters/onlinearchive/describe.go
+++ b/internal/cli/atlas/clusters/onlinearchive/describe.go
@@ -67,6 +67,7 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to retrieve.",
+			"output":        describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
   %s clusters onlineArchives describe 5f189832e26ec075e10c32d3 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/customdns/aws/describe.go
+++ b/internal/cli/atlas/customdns/aws/describe.go
@@ -60,6 +60,9 @@ func DescribeBuilder() *cobra.Command {
 		Short:   "Describe the custom DNS configuration of an Atlas project’s cluster deployed to AWS.",
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"get"},
+		Annotations: map[string]string{
+			"output": describeTemplate,
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -65,6 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"nameDesc": "Name of the federated database instance to retrieve.",
+			"output":   describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the details for the federated database instance named myFDI in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s dataLakes describe myFDI --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/dbusers/describe.go
+++ b/internal/cli/atlas/dbusers/describe.go
@@ -68,6 +68,7 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"get"},
 		Annotations: map[string]string{
 			"usernameDesc": "Username to retrieve from the MongoDB database. The format of the username depends on the user's method of authentication.",
+			"output":       describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the details for the SCRAM SHA-authenticating database user named myDbUser:
   %[1]s dbuser describe myDbUser --authDB admin --output json

--- a/internal/cli/atlas/livemigrations/validation/describe.go
+++ b/internal/cli/atlas/livemigrations/validation/describe.go
@@ -58,9 +58,10 @@ func (opts *DescribeOpts) Run() error {
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:     "describe",
-		Aliases: []string{"get"},
-		Short:   "Return one validation job.",
+		Use:         "describe",
+		Aliases:     []string{"get"},
+		Short:       "Return one validation job.",
+		Annotations: map[string]string{"output": describeTemplate},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/maintenance/describe.go
+++ b/internal/cli/atlas/maintenance/describe.go
@@ -62,6 +62,7 @@ func DescribeBuilder() *cobra.Command {
 		Long: `To learn more about maintenance windows, see https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
+		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the maintenance window for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s maintenanceWindows describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe.go
@@ -72,6 +72,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
+			"output":                describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the AWS private endpoint connection with the ID 5f4fc81c1f03a835c2728ff7 for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws describe 5f4fc81c1f03a835c2728ff7 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -68,6 +68,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"interfaceEndpointIdDesc": "Unique string that identifies the AWS private endpoint interface in AWS.",
+			"output":                  describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the AWS private endpoint interface with the ID 	
 		vpce-00713b5e644e830a3 in AWS for an AWS private endpoint with the ID 5f4fc14da2b47835a58c63a2 in Atlas:

--- a/internal/cli/atlas/privateendpoints/azure/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/describe.go
@@ -67,6 +67,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
+			"output":                describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the Azure private endpoint connection with the ID 5f4fc81c1f03a835c2728ff7 for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure describe 5f4fc81c1f03a835c2728ff7 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
@@ -68,6 +68,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointResourceIdDesc": "Unique string that identifies the Azure private endpoint interface in Azure.",
+			"output":                        describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the Azure private endpoint interface with the ID /subscriptions/4e133d35-e734-4385-a565-c0945567ae346/resourceGroups/rg_95847a959b876e255dbb9b33_dfragd7w/providers/Microsoft.Network/privateEndpoints/cli-test in Azure for an AWS private endpoint with the ID 5f4fc14da2b47835a58c63a2 in Atlas:
   %s privateEndpoints azure interfaces describe /subscriptions/4e133d35-e734-4385-a565-c0945567ae346/resourceGroups/rg_95847a959b876e255dbb9b33_dfragd7w/providers/Microsoft.Network/privateEndpoints/cli-test --endpointServiceId 5f4fc14da2b47835a58c63a2`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
@@ -65,6 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
+			"output":                describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
   %s privateEndpoint dataLake aws describe vpce-abcdefg0123456789 -P myprofile`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/describe.go
+++ b/internal/cli/atlas/privateendpoints/describe.go
@@ -59,10 +59,11 @@ func (opts *DescribeOpts) Run() error {
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:     "describe <ID>",
-		Aliases: []string{"get"},
-		Args:    require.ExactArgs(1),
-		Short:   "Return a specific Private Endpoints for your project.",
+		Use:         "describe <ID>",
+		Aliases:     []string{"get"},
+		Args:        require.ExactArgs(1),
+		Short:       "Return a specific Private Endpoints for your project.",
+		Annotations: map[string]string{"output": describeTemplate},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
@@ -68,6 +68,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"idDesc": "Unique identifier of the private endpoint you want to retrieve.",
+			"output": describeTemplate,
 		},
 		Example: fmt.Sprintf(`  %s privateEndpoints gcp interfaces describe endpoint-1 \
   --endpointServiceId 61eaca605af86411903de1dd`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/privateendpoints/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/describe.go
@@ -60,10 +60,11 @@ func (opts *DescribeOpts) Run() error {
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:     "describe <atlasPrivateEndpointId>",
-		Aliases: []string{"get"},
-		Args:    require.ExactArgs(1),
-		Short:   "Return a specific private endpoint interface for your project.",
+		Use:         "describe <atlasPrivateEndpointId>",
+		Aliases:     []string{"get"},
+		Args:        require.ExactArgs(1),
+		Short:       "Return a specific private endpoint interface for your project.",
+		Annotations: map[string]string{"output": describeTemplate},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.PreRunE(

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
@@ -64,6 +64,7 @@ func DescribeBuilder() *cobra.Command {
 		Long: `Use this command to check whether you can create multiple private resources per region.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
+		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the regionalized private endpoint setting for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/processes/describe.go
+++ b/internal/cli/atlas/processes/describe.go
@@ -67,6 +67,7 @@ func DescribeBuilder() *cobra.Command {
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",
+			"output":            describeTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/search/describe.go
+++ b/internal/cli/atlas/search/describe.go
@@ -67,6 +67,7 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",
+			"output":      describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the search index with the ID 5f1f40842f2ac35f49190c20 for the cluster named myCluster:
   %s clusters search indexes describe 5f1f40842f2ac35f49190c20 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/serverless/backup/snapshots/describe.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/describe.go
@@ -59,10 +59,11 @@ func (opts *DescribeOpts) Run() error {
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:   "describe",
-		Short: "Return the details for the specified snapshot for your project.",
-		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
-		Args:  require.NoArgs,
+		Use:         "describe",
+		Short:       "Return the details for the specified snapshot for your project.",
+		Long:        fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
+		Args:        require.NoArgs,
+		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the details for the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the instance named myDemo:
   %s serverless backups snapshots describe --snapshotId 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/serverless/describe.go
+++ b/internal/cli/atlas/serverless/describe.go
@@ -64,6 +64,7 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Human-readable label that identifies your serverless instance.",
+			"output":           describeTemplate,
 		},
 		Aliases: []string{"get"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/iam/organizations/apikeys/describe.go
+++ b/internal/cli/iam/organizations/apikeys/describe.go
@@ -68,6 +68,7 @@ func DescribeBuilder() *cobra.Command {
 `+fmt.Sprintf(usage.RequiredRole, "Organization Member"), cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies your API key.",
+			"output": describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the organization API key with the ID 5f24084d8dbffa3ad3f21234 for the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys describe 5f24084d8dbffa3ad3f21234 --orgId 5a1b39eec902201990f12345 -output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/organizations/describe.go
+++ b/internal/cli/iam/organizations/describe.go
@@ -71,6 +71,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the organization.",
+			"output": describeTemplateCloud,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the organization with the ID 5e2211c17a3e5a48f5497de3:
   %s organizations describe 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/organizations/invitations/describe.go
+++ b/internal/cli/iam/organizations/invitations/describe.go
@@ -66,6 +66,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",
+			"output":           describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the pending invitation with the ID 5dd56c847a3e5a1f363d424d for the organization with the ID 5f71e5255afec75a3d0f96dc:
   %s organizations invitations describe 5dd56c847a3e5a1f363d424d --orgId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/projects/describe.go
+++ b/internal/cli/iam/projects/describe.go
@@ -66,6 +66,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the project.",
+			"output": describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects describe 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/projects/invitations/describe.go
+++ b/internal/cli/iam/projects/invitations/describe.go
@@ -67,6 +67,7 @@ func DescribeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Annotations: map[string]string{
 			"invitationIdDesc": "Unique 24-digit string that identifies the invitation.",
+			"output":           describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the pending invitation with the ID 5dd56c847a3e5a1f363d424d for the project with the ID 5f71e5255afec75a3d0f96dc:
   %s projects invitations describe 5dd56c847a3e5a1f363d424d --projectId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/iam/projects/settings/describe.go
+++ b/internal/cli/iam/projects/settings/describe.go
@@ -57,9 +57,10 @@ func (opts *DescribeOpts) Run() error {
 func DescribeBuilder() *cobra.Command {
 	opts := &DescribeOpts{}
 	cmd := &cobra.Command{
-		Use:     "describe",
-		Aliases: []string{"get"},
-		Short:   "Retrieve details for settings to the specified project.",
+		Use:         "describe",
+		Aliases:     []string{"get"},
+		Short:       "Retrieve details for settings to the specified project.",
+		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
   %s projects settings describe -P myprofile`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -83,8 +83,9 @@ func (opts *DescribeOpts) validate() error {
 func DescribeBuilder() *cobra.Command {
 	opts := &DescribeOpts{}
 	cmd := &cobra.Command{
-		Use:     "describe",
-		Aliases: []string{"get"},
+		Use:         "describe",
+		Aliases:     []string{"get"},
+		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the the team with the ID 5e44445ef10fab20b49c0f31 in the organization with ID 5e2211c17a3e5a48f5497de3:
   %[1]s teams describe --id 5e44445ef10fab20b49c0f31 --projectId 5e1234c17a3e5a48f5497de3 --output json
   

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -83,8 +83,9 @@ func (opts *DescribeOpts) validate() error {
 func DescribeBuilder() *cobra.Command {
 	opts := &DescribeOpts{}
 	cmd := &cobra.Command{
-		Use:     "describe",
-		Aliases: []string{"get"},
+		Use:         "describe",
+		Aliases:     []string{"get"},
+		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the MongoDB user with the ID 5dd56c847a3e5a1f363d424d:
   %[1]s users describe --id 5dd56c847a3e5a1f363d424d --output json
   


### PR DESCRIPTION
## Proposed changes

Adds outputs to the docs for describe commands where possible with the current template.

_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-28637

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
