### PR TITLE
CLOUDP-169466: Add the message "If you're a MongoDB employee, please ensure you are on the VPN" in the login flow

### DIFF
--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -122,6 +123,9 @@ func (opts *LoginOpts) LoginRun(ctx context.Context) error {
 		return err
 	}
 	_, _ = fmt.Fprintf(opts.OutWriter, "Successfully logged in as %s.\n", s)
+	if strings.Contains(s, "@mongodb.com") {
+		_, _ = fmt.Fprint(opts.OutWriter, "If you're a MongoDB employee, please ensure you are on the VPN.\n\n")
+	}
 
 	if opts.SkipConfig {
 		return nil


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-169466
Follow-up of: https://github.com/10gen/mms/pull/71997

Update the login command to include the message `If you're a MongoDB employee, please ensure you are on the VPN` if the user is a MongoDB employee.



<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

## MongoDB Employee:
```bash
atlas auth login --profile local-okta          

To verify your account, copy your one-time verification code:
CFV9-4T8M

Paste the code in the browser when prompted to activate your Atlas CLI. Your code will expire after 10 minutes.

To continue, go to https://account-dev.mongodb.com/account/connect
Successfully logged in as andrea.angiolillo@mongodb.com.
If you're a MongoDB employee, please ensure you are on the VPN.

Now set your default organization and project.
Since you have access to more than 500 organizations, please type the organization ID or the organization name to filter.
? Organization filter: [? for help]
```

## Non-MongoDB employee
```bash
atlas auth login --profile local-okta          

To verify your account, copy your one-time verification code:
CFV9-4T8M

Paste the code in the browser when prompted to activate your Atlas CLI. Your code will expire after 10 minutes.

To continue, go to https://account-dev.mongodb.com/account/connect
Successfully logged in as andrea.angiolillo@test.com.

Now set your default organization and project.
```
