### PR TITLE
(DOCSP-29002) Moves the output for one watch command to a template and adds docs output

### DIFF
--- a/docs/atlascli/command/atlas-clusters-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-watch.txt
@@ -82,6 +82,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Cluster available.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-watch.txt
@@ -82,6 +82,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Cluster available.
+   
+
 Examples
 --------
 

--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -36,6 +36,8 @@ type WatchOpts struct {
 	store store.AtlasClusterDescriber
 }
 
+var watchTemplate = "\nCluster available.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -85,12 +87,13 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to watch.",
+			"output":          watchTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nCluster available.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Proposed changes

We're using the output templates for commands to automate the output in the docs. It appears that the watch commands don't use a template in some cases, and just have the output text defined in the PreRunE statement. This PR replaces the output text for 1 watch command with a variable that maps to the same text, which we can also use for docs outputs. I wanted to do this for one command as a test to make sure that this wouldn't cause issues on the engineering side; if this is approved, I'll make this change to the other watch commands when I complete the last docs output PR.

_Jira ticket:_ CLOUDP-#

https://jira.mongodb.org/browse/DOCSP-29002

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
