### PR TITLE
(DOCSP-28640) Adds remaining outputs to docs

### DIFF
--- a/docs/atlascli/command/atlas-alerts-acknowledge.txt
+++ b/docs/atlascli/command/atlas-alerts-acknowledge.txt
@@ -94,6 +94,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Alert '<ID>' acknowledged until <AcknowledgedUntil>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-alerts-settings-disable.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-disable.txt
@@ -80,3 +80,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Alert configuration '<ID>' disabled
+   
+

--- a/docs/atlascli/command/atlas-alerts-settings-enable.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-enable.txt
@@ -80,3 +80,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Alert configuration '<ID>' enabled
+   
+

--- a/docs/atlascli/command/atlas-alerts-unacknowledge.txt
+++ b/docs/atlascli/command/atlas-alerts-unacknowledge.txt
@@ -86,6 +86,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Alert '<ID>' unacknowledged
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-backups-exports-jobs-watch.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-watch.txt
@@ -90,6 +90,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Export completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-backups-restores-start.txt
+++ b/docs/atlascli/command/atlas-backups-restores-start.txt
@@ -113,6 +113,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Restore job '<ID>' successfully started
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-backups-restores-watch.txt
+++ b/docs/atlascli/command/atlas-backups-restores-watch.txt
@@ -89,6 +89,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Restore completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-backups-snapshots-watch.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-watch.txt
@@ -87,6 +87,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Snapshot changes completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-cloudProviders-accessRoles-aws-authorize.txt
+++ b/docs/atlascli/command/atlas-cloudProviders-accessRoles-aws-authorize.txt
@@ -84,3 +84,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   AWS IAM role '<CloudProviderAccessAWSIAMRole.RoleId> successfully authorized.
+   
+

--- a/docs/atlascli/command/atlas-cloudProviders-accessRoles-aws-deauthorize.txt
+++ b/docs/atlascli/command/atlas-cloudProviders-accessRoles-aws-deauthorize.txt
@@ -82,3 +82,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   AWS IAM role successfully deauthorized.
+   
+

--- a/docs/atlascli/command/atlas-clusters-failover.txt
+++ b/docs/atlascli/command/atlas-clusters-failover.txt
@@ -82,6 +82,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Failover test for '<Name>' started
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-clusters-loadSampleData.txt
+++ b/docs/atlascli/command/atlas-clusters-loadSampleData.txt
@@ -82,3 +82,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Sample Data Job <ID> created.
+   
+

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-pause.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-pause.txt
@@ -86,6 +86,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Online archive '<ID>' paused.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-start.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-start.txt
@@ -86,3 +86,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Online archive '<ID>' started.
+   
+

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-watch.txt
@@ -87,6 +87,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Online archive available.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-clusters-pause.txt
+++ b/docs/atlascli/command/atlas-clusters-pause.txt
@@ -83,6 +83,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Pausing cluster '<Name>'.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-clusters-start.txt
+++ b/docs/atlascli/command/atlas-clusters-start.txt
@@ -83,6 +83,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Starting cluster '<Name>'.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-clusters-upgrade.txt
+++ b/docs/atlascli/command/atlas-clusters-upgrade.txt
@@ -108,6 +108,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Upgrading cluster '<Name>'.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-customDns-aws-disable.txt
+++ b/docs/atlascli/command/atlas-customDns-aws-disable.txt
@@ -66,3 +66,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   DNS configuration disabled.
+   
+

--- a/docs/atlascli/command/atlas-customDns-aws-enable.txt
+++ b/docs/atlascli/command/atlas-customDns-aws-enable.txt
@@ -66,3 +66,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   DNS configuration enabled.
+   
+

--- a/docs/atlascli/command/atlas-liveMigrations-cutover.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-cutover.txt
@@ -70,3 +70,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Cutover process '<ID>' successfully started.
+   
+

--- a/docs/atlascli/command/atlas-logs-download.txt
+++ b/docs/atlascli/command/atlas-logs-download.txt
@@ -102,6 +102,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Download of <Name> completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-maintenanceWindows-clear.txt
+++ b/docs/atlascli/command/atlas-maintenanceWindows-clear.txt
@@ -72,6 +72,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Maintenance window removed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-maintenanceWindows-defer.txt
+++ b/docs/atlascli/command/atlas-maintenanceWindows-defer.txt
@@ -68,6 +68,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Maintenance window deferred.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-networking-peering-watch.txt
+++ b/docs/atlascli/command/atlas-networking-peering-watch.txt
@@ -87,6 +87,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Network peering changes completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-organizations-invitations-invite.txt
+++ b/docs/atlascli/command/atlas-organizations-invitations-invite.txt
@@ -90,6 +90,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   User '<Username>' invited.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-performanceAdvisor-slowOperationThreshold-disable.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-slowOperationThreshold-disable.txt
@@ -64,3 +64,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Atlas management of the slow operation disabled
+   
+

--- a/docs/atlascli/command/atlas-performanceAdvisor-slowOperationThreshold-enable.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-slowOperationThreshold-enable.txt
@@ -64,3 +64,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Atlas management of the slow operation enabled
+   
+

--- a/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Private endpoint changes completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-azure-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Private endpoint changes completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-gcp-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   GCP Private endpoint changes completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-regionalModes-disable.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-regionalModes-disable.txt
@@ -68,6 +68,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Regionalized private endpoint setting disabled.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-privateEndpoints-regionalModes-enable.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-regionalModes-enable.txt
@@ -68,6 +68,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Regionalized private endpoint setting enabled.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-projects-apiKeys-assign.txt
+++ b/docs/atlascli/command/atlas-projects-apiKeys-assign.txt
@@ -88,6 +88,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   API Key successfully assigned.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-projects-invitations-invite.txt
+++ b/docs/atlascli/command/atlas-projects-invitations-invite.txt
@@ -90,6 +90,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   User '<Username>' invited.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-projects-teams-add.txt
+++ b/docs/atlascli/command/atlas-projects-teams-add.txt
@@ -88,6 +88,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Team added to the project.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-security-customerCerts-disable.txt
+++ b/docs/atlascli/command/atlas-security-customerCerts-disable.txt
@@ -64,6 +64,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   X.509 configuration for project <Name> was deleted.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-security-ldap-get.txt
+++ b/docs/atlascli/command/atlas-security-ldap-get.txt
@@ -66,6 +66,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   HOSTNAME          PORT          AUTHENTICATION                 AUTHORIZATION
+   <Ldap.Hostname>   <Ldap.Port>   <Ldap.AuthenticationEnabled>   <Ldap.AuthorizationEnabled>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-security-ldap-save.txt
+++ b/docs/atlascli/command/atlas-security-ldap-save.txt
@@ -110,6 +110,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   HOSTNAME          PORT          AUTHENTICATION                 AUTHORIZATION
+   <Ldap.Hostname>   <Ldap.Port>   <Ldap.AuthenticationEnabled>   <Ldap.AuthorizationEnabled>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify-status-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   LDAP Configuration request completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-security-ldap-verify-status.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify-status.txt
@@ -82,6 +82,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   REQUEST ID    PROJECT ID   STATUS
+   <RequestId>   <GroupId>    <Status>
+   
+
 Related Commands
 ----------------
 

--- a/docs/atlascli/command/atlas-security-ldap-verify.txt
+++ b/docs/atlascli/command/atlas-security-ldap-verify.txt
@@ -90,6 +90,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   REQUEST ID    PROJECT ID   STATUS
+   <RequestId>   <GroupId>    <Status>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-serverless-backups-restores-watch.txt
+++ b/docs/atlascli/command/atlas-serverless-backups-restores-watch.txt
@@ -78,6 +78,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Restore completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-serverless-backups-snapshots-watch.txt
+++ b/docs/atlascli/command/atlas-serverless-backups-snapshots-watch.txt
@@ -74,6 +74,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Snapshot changes completed.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-serverless-watch.txt
+++ b/docs/atlascli/command/atlas-serverless-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Instance available.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-teams-users-add.txt
+++ b/docs/atlascli/command/atlas-teams-users-add.txt
@@ -88,6 +88,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   User(s) added to the team.
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-users-invite.txt
+++ b/docs/atlascli/command/atlas-users-invite.txt
@@ -98,6 +98,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   The user '<Username>' has been invited.
+   Invited users do not have access to the project until they accept the invitation.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-aws-authorize.txt
+++ b/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-aws-authorize.txt
@@ -84,3 +84,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   AWS IAM role '<CloudProviderAccessAWSIAMRole.RoleId> successfully authorized.
+   
+

--- a/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-aws-deauthorize.txt
+++ b/docs/mongocli/command/mongocli-atlas-cloudProviders-accessRoles-aws-deauthorize.txt
@@ -82,3 +82,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   AWS IAM role successfully deauthorized.
+   
+

--- a/docs/mongocli/command/mongocli-atlas-clusters-loadSampleData.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-loadSampleData.txt
@@ -82,3 +82,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Sample Data Job <ID> created.
+   
+

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-pause.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-pause.txt
@@ -86,6 +86,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Online archive '<ID>' paused.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-start.txt
@@ -86,3 +86,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Online archive '<ID>' started.
+   
+

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-watch.txt
@@ -87,6 +87,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Online archive available.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-pause.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-pause.txt
@@ -83,6 +83,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Pausing cluster '<Name>'.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-start.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-start.txt
@@ -83,6 +83,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Starting cluster '<Name>'.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-customDns-aws-disable.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDns-aws-disable.txt
@@ -66,3 +66,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   DNS configuration disabled.
+   
+

--- a/docs/mongocli/command/mongocli-atlas-customDns-aws-enable.txt
+++ b/docs/mongocli/command/mongocli-atlas-customDns-aws-enable.txt
@@ -66,3 +66,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   DNS configuration enabled.
+   
+

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-cutover.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-cutover.txt
@@ -70,3 +70,13 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Cutover process '<ID>' successfully started.
+   
+

--- a/docs/mongocli/command/mongocli-atlas-logs-download.txt
+++ b/docs/mongocli/command/mongocli-atlas-logs-download.txt
@@ -102,6 +102,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Download of <Name> completed.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-maintenanceWindows-clear.txt
+++ b/docs/mongocli/command/mongocli-atlas-maintenanceWindows-clear.txt
@@ -72,6 +72,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Maintenance window removed.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-maintenanceWindows-defer.txt
+++ b/docs/mongocli/command/mongocli-atlas-maintenanceWindows-defer.txt
@@ -68,6 +68,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Maintenance window deferred.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-watch.txt
@@ -87,6 +87,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Network peering changes completed.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-aws-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Private endpoint changes completed.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-azure-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   Private endpoint changes completed.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-gcp-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   GCP Private endpoint changes completed.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-disable.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-disable.txt
@@ -68,6 +68,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Regionalized private endpoint setting disabled.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-enable.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-regionalModes-enable.txt
@@ -68,6 +68,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   Regionalized private endpoint setting enabled.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-security-customerCerts-disable.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-customerCerts-disable.txt
@@ -64,6 +64,16 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   X.509 configuration for project <Name> was deleted.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-get.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-get.txt
@@ -66,6 +66,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   HOSTNAME          PORT          AUTHENTICATION                 AUTHORIZATION
+   <Ldap.Hostname>   <Ldap.Port>   <Ldap.AuthenticationEnabled>   <Ldap.AuthorizationEnabled>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-save.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-save.txt
@@ -110,6 +110,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   HOSTNAME          PORT          AUTHENTICATION                 AUTHORIZATION
+   <Ldap.Hostname>   <Ldap.Port>   <Ldap.AuthenticationEnabled>   <Ldap.AuthorizationEnabled>
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status-watch.txt
@@ -83,6 +83,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   
+   LDAP Configuration request completed.
+   
+
 Examples
 --------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify-status.txt
@@ -82,6 +82,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   REQUEST ID    PROJECT ID   STATUS
+   <RequestId>   <GroupId>    <Status>
+   
+
 Related Commands
 ----------------
 

--- a/docs/mongocli/command/mongocli-atlas-security-ldap-verify.txt
+++ b/docs/mongocli/command/mongocli-atlas-security-ldap-verify.txt
@@ -90,6 +90,17 @@ Inherited Options
      - false
      - Human-readable label that identifies the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   REQUEST ID    PROJECT ID   STATUS
+   <RequestId>   <GroupId>    <Status>
+   
+
 Examples
 --------
 

--- a/internal/cli/atlas/alerts/acknowledge.go
+++ b/internal/cli/atlas/alerts/acknowledge.go
@@ -94,6 +94,7 @@ func AcknowledgeBuilder() *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"alertIdDesc": "ID of the alert you want to acknowledge or unacknowledge.",
+			"output":      ackTemplate,
 		},
 		Example: fmt.Sprintf(`  # Acknowledge an alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3 until January 1 2028:
   %s alerts acknowledge 5d1113b25a115342acc2d1aa --until 2028-01-01T20:24:26Z --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/alerts/settings/disable.go
+++ b/internal/cli/atlas/alerts/settings/disable.go
@@ -68,6 +68,7 @@ func DisableBuilder() *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"alertConfigIdDesc": "ID of the alert configuration you want to disable.",
+			"output":            disableTemplate,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.alertID = args[0]

--- a/internal/cli/atlas/alerts/settings/enable.go
+++ b/internal/cli/atlas/alerts/settings/enable.go
@@ -68,6 +68,7 @@ func EnableBuilder() *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"alertConfigIdDesc": "ID of the alert you want to enable.",
+			"output":            enableTemplate,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.alertID = args[0]

--- a/internal/cli/atlas/alerts/unacknowledge.go
+++ b/internal/cli/atlas/alerts/unacknowledge.go
@@ -74,6 +74,7 @@ func UnacknowledgeBuilder() *cobra.Command {
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"alertIdDesc": "Unique ID of the alert you want to unacknowledge.",
+			"output":      unackTemplate,
 		},
 		Example: fmt.Sprintf(`  # Unacknowledge the alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s alerts unacknowledge 5d1113b25a115342acc2d1aa --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/backup/exports/jobs/watch.go
+++ b/internal/cli/atlas/backup/exports/jobs/watch.go
@@ -35,6 +35,8 @@ type WatchOpts struct {
 	store       store.ExportJobsDescriber
 }
 
+var watchTemplate = "\nExport completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -73,6 +75,7 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"bucketIdDesc": "Unique string that identifies the AWS S3 bucket to which you export your snapshots.",
+			"output":       watchTemplate,
 		},
 		Example: fmt.Sprintf(`  # Watch the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the cluster named Cluster0 until it becomes available:
   %s backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
@@ -80,7 +83,7 @@ You can interrupt the command's polling at any time with CTRL-C.
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nExport completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -147,6 +147,7 @@ func StartBuilder() *cobra.Command {
 		ValidArgs: []string{automatedRestore, downloadRestore, pointInTimeRestore},
 		Annotations: map[string]string{
 			"automated|download|pointInTimeDesc": "Type of restore job to create. Valid values include: automated, download, pointInTime. To learn more about types of restore jobs, see https://www.mongodb.com/docs/atlas/backup-restore-cluster/.",
+			"output":                             startTemplate,
 		},
 		Example: fmt.Sprintf(`  # Create an automated restore:
   %[1]s backup restore start automated \

--- a/internal/cli/atlas/backup/restores/watch.go
+++ b/internal/cli/atlas/backup/restores/watch.go
@@ -35,6 +35,8 @@ type WatchOpts struct {
 	store       store.RestoreJobsDescriber
 }
 
+var watchTemplate = "\nRestore completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -72,6 +74,7 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"restoreJobIdDesc": "ID of the restore job.",
+			"output":           watchTemplate,
 		},
 		Example: fmt.Sprintf(`  # Watch the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the cluster named Cluster0 until it becomes available:
   %s backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
@@ -79,7 +82,7 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nRestore completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/backup/snapshots/watch.go
+++ b/internal/cli/atlas/backup/snapshots/watch.go
@@ -35,6 +35,8 @@ type WatchOpts struct {
 	store       store.SnapshotsDescriber
 }
 
+var watchTemplate = "\nSnapshot changes completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -76,12 +78,13 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to watch.",
+			"output":         watchTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nSnapshot changes completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/authorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/authorize.go
@@ -70,6 +70,7 @@ func AuthorizeBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"roleIdDesc": "Unique ID of the role to authorize.",
+			"output":     authorizeTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
@@ -82,6 +82,7 @@ func DeauthorizeBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"roleIdDesc": "Unique ID of the role to authorize.",
+			"output":     deauthorizeSuccess,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))

--- a/internal/cli/atlas/clusters/failover.go
+++ b/internal/cli/atlas/clusters/failover.go
@@ -61,6 +61,7 @@ func FailoverBuilder() *cobra.Command {
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Human-readable label that identifies the cluster to start a failover test for.",
+			"output":          opts.SuccessMessage(),
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {

--- a/internal/cli/atlas/clusters/loadSampleData.go
+++ b/internal/cli/atlas/clusters/loadSampleData.go
@@ -63,6 +63,7 @@ func LoadSampleDataBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster for which you want to load sample data.",
+			"output":          addTmpl,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/clusters/onlinearchive/pause.go
+++ b/internal/cli/atlas/clusters/onlinearchive/pause.go
@@ -70,6 +70,7 @@ func PauseBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to pause.",
+			"output":        pauseTemplate,
 		},
 		Example: fmt.Sprintf(`  # Pause the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
   %s clusters onlineArchives pause 5f189832e26ec075e10c32d3 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/clusters/onlinearchive/start.go
+++ b/internal/cli/atlas/clusters/onlinearchive/start.go
@@ -70,6 +70,7 @@ func StartBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to start.",
+			"output":        startTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/clusters/onlinearchive/watch.go
+++ b/internal/cli/atlas/clusters/onlinearchive/watch.go
@@ -35,6 +35,8 @@ type WatchOpts struct {
 	store       store.OnlineArchiveDescriber
 }
 
+var watchTemplate = "\nOnline archive available.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -77,12 +79,13 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"archiveIdDesc": "Unique identifier of the online archive to watch.",
+			"output":        watchTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nOnline archive available.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/clusters/pause.go
+++ b/internal/cli/atlas/clusters/pause.go
@@ -64,6 +64,7 @@ func PauseBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to pause.",
+			"output":          pauseTmpl,
 		},
 		Example: fmt.Sprintf(`  # Pause the cluster named myCluster for the project with ID 5e2211c17a3e5a48f5497de3:
   %s clusters pause myCluster --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/clusters/start.go
+++ b/internal/cli/atlas/clusters/start.go
@@ -64,6 +64,7 @@ func StartBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to start.",
+			"output":          startTmpl,
 		},
 		Example: fmt.Sprintf(`  # Start a cluster named myCluster for the project with ID 5e2211c17a3e5a48f5497de3:
   %s clusters start myCluster --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/clusters/upgrade.go
+++ b/internal/cli/atlas/clusters/upgrade.go
@@ -138,6 +138,7 @@ func UpgradeBuilder() *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"clusterNameDesc": "Name of the cluster to upgrade.",
+			"output":          upgradeTemplate,
 		},
 	}
 

--- a/internal/cli/atlas/customdns/aws/disable.go
+++ b/internal/cli/atlas/customdns/aws/disable.go
@@ -57,6 +57,9 @@ func DisableBuilder() *cobra.Command {
 		Use:   "disable",
 		Short: "Disable the custom DNS configuration of an Atlas project’s cluster deployed to AWS.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": disableTemplate,
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/customdns/aws/enable.go
+++ b/internal/cli/atlas/customdns/aws/enable.go
@@ -57,6 +57,9 @@ func EnableBuilder() *cobra.Command {
 		Use:   "enable",
 		Short: "Enable the custom DNS configuration of an Atlas project’s cluster deployed to AWS.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": enableTemplate,
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/livemigrations/cutover.go
+++ b/internal/cli/atlas/livemigrations/cutover.go
@@ -58,6 +58,9 @@ func CutoverBuilder() *cobra.Command {
 		Use:   "cutover",
 		Short: "Start the cutover for a push live migration and confirm when the cutover completes. When the cutover completes, the application completes the live migration process and stops synchronizing with the source cluster.",
 		Long:  `To migrate using scripts, use mongomirror instead of the Atlas CLI. To learn more about mongomirror, see https://www.mongodb.com/docs/atlas/reference/mongomirror/.`,
+		Annotations: map[string]string{
+			"output": cutoverTemplate,
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/logs/decrypt.go
+++ b/internal/cli/atlas/logs/decrypt.go
@@ -51,6 +51,8 @@ type DecryptAzureOpts struct {
 	azureSecret   string
 }
 
+var decryptTemplate = "Decrypt of %s to %s completed.\n"
+
 func (opts *DecryptOpts) newDecryption() *decryption.Decryption {
 	return decryption.NewDecryption(
 		decryption.WithAWSOpts(opts.awsOpts.awsAccessKey, opts.awsOpts.awsSecretAccessKey, opts.awsOpts.awsSessionToken),
@@ -85,7 +87,7 @@ func (opts *DecryptOpts) Run() error {
 	}
 
 	if !opts.ShouldDownloadToStdout() {
-		fmt.Printf("Decrypt of %s to %s completed.\n", opts.inFileName, opts.Out)
+		fmt.Printf(decryptTemplate, opts.inFileName, opts.Out)
 	}
 
 	return nil
@@ -99,6 +101,9 @@ func DecryptBuilder() *cobra.Command {
 		Use:    "decrypt",
 		Hidden: true,
 		Short:  "Decrypts an audit log file with the provided AWS, GCP or Azure key management services.",
+		Annotations: map[string]string{
+			"output": decryptTemplate,
+		},
 		Example: `  # Decrypt using AWS credentials:
   atlas logs decrypt --file /path/to/logFile.json --awsAccessKey <accessKey> --awsSecretAccessKey <secretKey> --awsSessionToken <sessionToken>
   # Decrypt using GCP credentials:

--- a/internal/cli/atlas/logs/download.go
+++ b/internal/cli/atlas/logs/download.go
@@ -109,6 +109,7 @@ To find the hostnames for an Atlas project, use the process list command.
 		Annotations: map[string]string{
 			"hostnameDesc": "Label that identifies the host that stores the log files that you want to download.",
 			"mongodb.gz|mongos.gz|mongosqld.gz|mongodb-audit-log.gz|mongos-audit-log.gzDesc": "Log file that you want to return.",
+			"output": downloadMessage,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.host = args[0]

--- a/internal/cli/atlas/maintenance/clear.go
+++ b/internal/cli/atlas/maintenance/clear.go
@@ -74,6 +74,9 @@ func ClearBuilder() *cobra.Command {
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"rm", "delete"},
+		Annotations: map[string]string{
+			"output": clearTemplate,
+		},
 		Example: fmt.Sprintf(`  # Clear the current maintenance window for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s maintenanceWindows clear --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/maintenance/defer.go
+++ b/internal/cli/atlas/maintenance/defer.go
@@ -59,6 +59,9 @@ func DeferBuilder() *cobra.Command {
 		Long: `To learn more about maintenance windows, see https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": deferTemplate,
+		},
 		Example: fmt.Sprintf(`  # Defer scheduled maintenance for one week for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s maintenanceWindows defer --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -34,6 +34,8 @@ type WatchOpts struct {
 	store store.PeeringConnectionDescriber
 }
 
+var watchTemplate = "\nNetwork peering changes completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -85,12 +87,13 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"peerIdDesc": "Unique ID of the network peering connection that you want to watch.",
+			"output":     watchTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nNetwork peering changes completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/organizations/invitations/invite.go
+++ b/internal/cli/atlas/organizations/invitations/invite.go
@@ -77,6 +77,7 @@ func InviteBuilder() *cobra.Command {
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"emailDesc": "Email address that belongs to the user that you want to invite to the organization.",
+			"output":    createTemplate,
 		},
 		Example: fmt.Sprintf(`  # Invite the MongoDB user with the email user@example.com to the organization with the ID 5f71e5255afec75a3d0f96dc with ORG_OWNER access:
   %s organizations invitations invite user@example.com --orgId 5f71e5255afec75a3d0f96dc --role ORG_OWNER --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/performanceadvisor/slowoperationthreshold/disable.go
+++ b/internal/cli/atlas/performanceadvisor/slowoperationthreshold/disable.go
@@ -60,6 +60,9 @@ func DisableBuilder() *cobra.Command {
 		Long: `The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When disabled, the application considers any operation that takes longer than 100 milliseconds to be slow.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": DisableTemplate,
+		},
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/performanceadvisor/slowoperationthreshold/enable.go
+++ b/internal/cli/atlas/performanceadvisor/slowoperationthreshold/enable.go
@@ -60,6 +60,9 @@ func EnableBuilder() *cobra.Command {
 		Long: `The slow operation threshold determines which operations are flagged by the Performance Advisor and Query Profiler. When enabled, the application uses the average execution time for operations on your cluster to determine slow-running queries. As a result, the threshold is more pertinent to your cluster workload. Application-managed slow operation threshold is enabled by default for dedicated clusters (M10+).
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": EnableTemplate,
+		},
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/aws/watch.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch.go
@@ -34,6 +34,8 @@ type WatchOpts struct {
 	store store.PrivateEndpointDescriber
 }
 
+var watchTemplate = "\nPrivate endpoint changes completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -75,12 +77,13 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
+			"output":                watchTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nPrivate endpoint changes completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/azure/watch.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch.go
@@ -34,6 +34,8 @@ type WatchOpts struct {
 	store store.PrivateEndpointDescriber
 }
 
+var watchTemplate = "\nPrivate endpoint changes completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -75,12 +77,13 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
+			"output":                watchTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nPrivate endpoint changes completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/gcp/watch.go
+++ b/internal/cli/atlas/privateendpoints/gcp/watch.go
@@ -34,6 +34,8 @@ type WatchOpts struct {
 	store store.PrivateEndpointDescriber
 }
 
+var watchTemplate = "\nGCP Private endpoint changes completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -72,6 +74,7 @@ You can interrupt the command's polling at any time with CTRL-C.
 ` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
 			"privateEndpointIdDesc": "Unique 22-character alphanumeric string that identifies the private endpoint.",
+			"output":                watchTemplate,
 		},
 		Example: fmt.Sprintf(`  %s privateEndpoint gcp watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
@@ -79,7 +82,7 @@ You can interrupt the command's polling at any time with CTRL-C.
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nGCP Private endpoint changes completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
@@ -59,6 +59,9 @@ func DisableBuilder() *cobra.Command {
 		Long: `This disables the ability to create multiple private resources per region in all cloud service providers for this project.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": disableTemplate,
+		},
 		Example: fmt.Sprintf(`  # Disable the regionalied private endpoint setting in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes disable --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
@@ -59,6 +59,10 @@ func EnableBuilder() *cobra.Command {
 		Long: `This enables the ability to create multiple private resources per region in all cloud service providers for this project.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": enableTemplate,
+		},
+
 		Example: fmt.Sprintf(`  # Enable the regionalied private endpoint setting in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes enable --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/privateendpoints/watch.go
+++ b/internal/cli/atlas/privateendpoints/watch.go
@@ -35,6 +35,8 @@ type WatchOpts struct {
 	store    store.PrivateEndpointDescriberDeprecated
 }
 
+var watchTemplate = "\nPrivate endpoint changes completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -74,8 +76,11 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nPrivate endpoint changes completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
+		},
+		Annotations: map[string]string{
+			"output": watchTemplate,
 		},
 		Example: fmt.Sprintf(`  %s privateEndpoint watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/projects/apikeys/assign.go
+++ b/internal/cli/atlas/projects/apikeys/assign.go
@@ -73,6 +73,7 @@ func AssignBuilder() *cobra.Command {
 To view possible values for the ID argument, run %s organizations apiKeys list.`, cli.ExampleAtlasEntryPoint()),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies your API key.",
+			"output": updateTemplate,
 		},
 		Example: fmt.Sprintf(`  # Assign an organization API key with the ID 5f46ae53d58b421fe3edc115 and grant the GROUP_DATA_ACCESS_READ_WRITE role for the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys assign 5f46ae53d58b421fe3edc115 --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_DATA_ACCESS_READ_WRITE --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/projects/invitations/invite.go
+++ b/internal/cli/atlas/projects/invitations/invite.go
@@ -77,6 +77,7 @@ func InviteBuilder() *cobra.Command {
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"emailDesc": "Email address that belongs to the user that you want to invite to the project.",
+			"output":    createTemplate,
 		},
 		Example: fmt.Sprintf(`  # Invite the MongoDB user with the email user@example.com to the project with the ID 5f71e5255afec75a3d0f96dc with GROUP_READ_ONLY access:
   %s projects invitations invite user@example.com --projectId 5f71e5255afec75a3d0f96dc --role GROUP_READ_ONLY --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/projects/teams/add.go
+++ b/internal/cli/atlas/projects/teams/add.go
@@ -76,6 +76,7 @@ func AddBuilder() *cobra.Command {
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"teamIdDesc": "Unique 24-digit string that identifies the team.",
+			"output":     addTemplate,
 		},
 		Example: fmt.Sprintf(`  # Add the team with the ID 5dd58c647a3e5a6c5bce46c7 to the project with the ID 5e2211c17a3e5a48f5497de3 with GROUP_READ_ONLY project access:
   %s projects teams add 5dd58c647a3e5a6c5bce46c7 --projectId 5e2211c17a3e5a48f5497de3 --role GROUP_READ_ONLY`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/security/customercerts/disable.go
+++ b/internal/cli/atlas/security/customercerts/disable.go
@@ -35,6 +35,8 @@ type DisableOpts struct {
 	confirm bool
 }
 
+var disableTemplate = "X.509 configuration for project %s was deleted.\n"
+
 func (opts *DisableOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -53,7 +55,7 @@ func (opts *DisableOpts) Run() error {
 		return err
 	}
 
-	fmt.Printf("X.509 configuration for project %s was deleted.\n", opts.ConfigProjectID())
+	fmt.Printf(disableTemplate, opts.ConfigProjectID())
 
 	return nil
 }
@@ -76,6 +78,9 @@ func DisableBuilder() *cobra.Command {
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args: require.NoArgs,
+		Annotations: map[string]string{
+			"output": disableTemplate,
+		},
 		Example: fmt.Sprintf(`  # Disable the customer-managed X.509 configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts disable --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/security/ldap/get.go
+++ b/internal/cli/atlas/security/ldap/get.go
@@ -60,6 +60,9 @@ func GetBuilder() *cobra.Command {
 		Use:   "get",
 		Short: "Return the current LDAP configuration details for your project.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": getTemplate,
+		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the current LDAP configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security ldap get --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/security/ldap/save.go
+++ b/internal/cli/atlas/security/ldap/save.go
@@ -134,6 +134,9 @@ func SaveBuilder() *cobra.Command {
 		Use:   "save",
 		Short: "Save an LDAP configuration for your project.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": saveTemplate,
+		},
 		Example: fmt.Sprintf(`  # Save an LDAP server configuration to authenticate and authorize MongoDB users for the host atlas-ldaps-01.ldap.myteam.com: 
   %s security ldap save --authenticationEnabled --authorizationEnabled 
   --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername 

--- a/internal/cli/atlas/security/ldap/status.go
+++ b/internal/cli/atlas/security/ldap/status.go
@@ -65,6 +65,7 @@ func StatusBuilder() *cobra.Command {
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"requestIdDesc": "ID of the request to verify an LDAP configuration.",
+			"output":        verifyStatusTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(

--- a/internal/cli/atlas/security/ldap/verify.go
+++ b/internal/cli/atlas/security/ldap/verify.go
@@ -107,6 +107,9 @@ func VerifyBuilder() *cobra.Command {
 		Use:   "verify",
 		Short: "Request verification of an LDAP configuration for your project.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Annotations: map[string]string{
+			"output": verifyTemplate,
+		},
 		Example: fmt.Sprintf(`  # Request the JSON-formatted verification of the LDAP configuration for the atlas-ldaps-01.ldap.myteam.com host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security ldap verify --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com" --bindPassword changeMe --projectId 5e2211c17a3e5a48f5497de3 --output json
 `, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/security/ldap/watch.go
+++ b/internal/cli/atlas/security/ldap/watch.go
@@ -34,6 +34,8 @@ type WatchOpts struct {
 	store store.LDAPConfigurationDescriber
 }
 
+var watchTemplate = "\nLDAP Configuration request completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -75,12 +77,13 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"requestIdDesc": "ID of the request to verify an LDAP configuration.",
+			"output":        watchTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nLDAP Configuration request completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/serverless/backup/restores/watch.go
+++ b/internal/cli/atlas/serverless/backup/restores/watch.go
@@ -35,6 +35,8 @@ type WatchOpts struct {
 	store       store.ServerlessRestoreJobsDescriber
 }
 
+var watchTemplate = "\nRestore completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -71,13 +73,16 @@ If you run the command in the terminal, it blocks the terminal session until the
 You can interrupt the command's polling at any time with CTRL-C.
 ` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Args: require.NoArgs,
+		Annotations: map[string]string{
+			"output": watchTemplate,
+		},
 		Example: fmt.Sprintf(`  # Watch the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the cluster named Cluster0 until it becomes available:
   %s serverless backup restore watch --restoreJobId 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nRestore completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/serverless/backup/snapshots/watch.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/watch.go
@@ -35,6 +35,8 @@ type WatchOpts struct {
 	store       store.ServerlessSnapshotsDescriber
 }
 
+var watchTemplate = "\nSnapshot changes completed.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -70,6 +72,9 @@ Command finishes once one of the expected statuses are reached.
 If you run the command in the terminal, it blocks the terminal session until the resource status completes or fails.
 You can interrupt the command's polling at any time with CTRL-C.
 ` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
+		Annotations: map[string]string{
+			"output": watchTemplate,
+		},
 		Example: fmt.Sprintf(`  # Watch the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 in the cluster named myDemo until it becomes available:
   %s backups snapshots watch 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
@@ -77,7 +82,7 @@ You can interrupt the command's polling at any time with CTRL-C.
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nSnapshot changes completed.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/serverless/watch.go
+++ b/internal/cli/atlas/serverless/watch.go
@@ -34,6 +34,8 @@ type WatchOpts struct {
 	store store.ServerlessInstanceDescriber
 }
 
+var watchTemplate = "\nInstance available.\n"
+
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
 		var err error
@@ -74,12 +76,13 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"instanceNameDesc": "Name of the instance to watch.",
+			"output":           watchTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
-				opts.InitOutput(cmd.OutOrStdout(), "\nInstance available.\n"),
+				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/atlas/teams/users/add.go
+++ b/internal/cli/atlas/teams/users/add.go
@@ -66,6 +66,7 @@ func AddBuilder() *cobra.Command {
 ` + fmt.Sprintf(usage.RequiredRole, "Organization User Admin"),
 		Annotations: map[string]string{
 			"userIdDesc": "Unique 24-digit string that identifies the user. You can add more than one user at a time by specifying multiple user IDs separated by a space.",
+			"output":     addTemplate,
 		},
 		Example: fmt.Sprintf(`  # Add the users with the IDs 5dd58c647a3e5a6c5bce46c7 and 5dd56c847a3e5a1f363d424d to the team with the ID 5f6a5c6c713184005d72fe6e for the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams users add 5dd58c647a3e5a6c5bce46c7 5dd56c847a3e5a1f363d424d --teamId 5f6a5c6c713184005d72fe6e --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/users/invite.go
+++ b/internal/cli/atlas/users/invite.go
@@ -247,6 +247,9 @@ func InviteBuilder() *cobra.Command {
 		Short: "Create a MongoDB user for your MongoDB application and invite the MongoDB user to your organizations and projects.",
 		Long:  fmt.Sprintf(`A MongoDB user account grants access only to the the MongoDB application. To grant database access, create a database user with %s dbusers create.`, cli.ExampleAtlasEntryPoint()),
 		Args:  require.NoArgs,
+		Annotations: map[string]string{
+			"output": inviteTemplate,
+		},
 		Example: fmt.Sprintf(`  # Create the MongoDB user with the username user@example.com and invite them to the organization with the ID 5dd56c847a3e5a1f363d424d with ORG_OWNER access:
   %[1]s users invite --email user@example.com --username user@example.com --orgRole 5dd56c847a3e5a1f363d424d:ORG_OWNER --firstName Example --lastName User --country US --output json
   


### PR DESCRIPTION
## Proposed changes

Adds remaining outputs to docs for commands that don't yet have them (watch/start/authorize/deauthorize/pause commands, etc)

_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-28640

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code