### PR TITLE
chore: add vscode config to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ gon_arm64.json
 
 # Tool generated files
 *.idea
+*.vscode
 


### PR DESCRIPTION
If we do not want vscode specific configuration in the repository we need to add configuration to gitignore as otherwise it can be pushed my mistake. 