### PR TITLE
CLOUDP-171557: Failed Test: mongodb-atlas-cli-master-github.com_mongodb_mongodb-atlas-cli_test_e2e_atlas.TestProjectWithPrivateEndpoint_Azure/atlas_kubernetes_e2e/e2e_atlas_kubernetes

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -510,7 +510,7 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,clusters,m0
   - name: atlas_kubernetes_e2e
-    tags: ["e2e","atlas","kubernetes", "assigned_to_jira_team_cloudp_kubernates_atlas"]
+    tags: ["e2e","atlas","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas"]
     must_have_test_results: true
     depends_on:
       - name: atlas_clusters_flags_e2e

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -579,14 +579,14 @@ func deleteAllNetworkPeers(t *testing.T, cliPath, projectID, provider string) {
 	)
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
-	t.Log(string(resp))
+	t.Log("available network peers", string(resp))
 	require.NoError(t, err)
 	var networkPeers []mongodbatlas.Peer
 	err = json.Unmarshal(resp, &networkPeers)
 	require.NoError(t, err)
 	for _, peer := range networkPeers {
 		peerID := peer.ID
-		t.Run("deleting "+peerID, func(t *testing.T) {
+		t.Run("deleting peer: "+peerID, func(t *testing.T) {
 			t.Parallel()
 			cmd = exec.Command(cliPath,
 				networkingEntity,
@@ -623,7 +623,7 @@ func deleteAllPrivateEndpoints(t *testing.T, cliPath, projectID, provider string
 	require.NoError(t, err)
 	for _, endpoint := range privateEndpoints {
 		endpointID := endpoint.ID
-		t.Run("deleting "+endpointID, func(t *testing.T) {
+		t.Run("deleting endpoint: "+endpointID, func(t *testing.T) {
 			t.Parallel()
 			cmd = exec.Command(cliPath,
 				privateEndpointsEntity,

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -95,19 +95,19 @@ func InitialSetupWithTeam(t *testing.T) KubernetesConfigGenerateProjectSuite {
 	s := KubernetesConfigGenerateProjectSuite{
 		t: t,
 	}
-	s.generator = newAtlasE2ETestGenerator(s.t)
+	s.generator = newAtlasE2ETestGenerator(t)
 	s.generator.generateTeam("Kubernetes")
 	s.generator.generateEmptyProject(fmt.Sprintf("Kubernetes-%s", s.generator.projectName))
 	s.expectedProject = referenceProject(s.generator.projectName, targetNamespace, expectedLabels)
 
 	cliPath, err := e2e.AtlasCLIBin()
-	require.NoError(s.t, err)
+	require.NoError(t, err)
 	s.cliPath = cliPath
 
 	s.assertions = assert.New(t)
 
 	// always register atlas entities
-	require.NoError(s.t, atlasV1.AddToScheme(scheme.Scheme))
+	require.NoError(t, atlasV1.AddToScheme(scheme.Scheme))
 	return s
 }
 
@@ -116,18 +116,18 @@ func InitialSetup(t *testing.T) KubernetesConfigGenerateProjectSuite {
 	s := KubernetesConfigGenerateProjectSuite{
 		t: t,
 	}
-	s.generator = newAtlasE2ETestGenerator(s.t)
+	s.generator = newAtlasE2ETestGenerator(t)
 	s.generator.generateEmptyProject(fmt.Sprintf("Kubernetes-%s", s.generator.projectName))
 	s.expectedProject = referenceProject(s.generator.projectName, targetNamespace, expectedLabels)
 
 	cliPath, err := e2e.AtlasCLIBin()
-	require.NoError(s.t, err)
+	require.NoError(t, err)
 	s.cliPath = cliPath
 
 	s.assertions = assert.New(t)
 
 	// always register atlas entities
-	require.NoError(s.t, atlasV1.AddToScheme(scheme.Scheme))
+	require.NoError(t, atlasV1.AddToScheme(scheme.Scheme))
 	return s
 }
 
@@ -607,7 +607,7 @@ func TestProjectWithNetworkPeering(t *testing.T) {
 	expectedProject := s.expectedProject
 	assertions := s.assertions
 
-	atlasCidrBlock := "10.8.0.0/18" //
+	atlasCidrBlock := "10.8.0.0/18"
 	networkPeer := atlasV1.NetworkPeer{
 		ProviderName: provider.ProviderGCP,
 		NetworkName:  "test-network",
@@ -634,7 +634,7 @@ func TestProjectWithNetworkPeering(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		require.NoError(t, err)
+		require.NoError(t, err, string(resp))
 		t.Cleanup(func() {
 			deleteAllNetworkPeers(t, cliPath, generator.projectID, gcpEntity)
 		})
@@ -696,7 +696,7 @@ func TestProjectWithPrivateEndpoint_Azure(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err)
-		s.t.Cleanup(func() {
+		t.Cleanup(func() {
 			deleteAllPrivateEndpoints(t, cliPath, generator.projectID, azureEntity)
 		})
 		var createdNetworkPeer mongodbatlas.PrivateEndpointConnection


### PR DESCRIPTION
## Proposed changes
CLOUDP-171557
Broke this with the clean up improvements, there's some interesting race condition on how k8s was using clean up and needing to not reference an external `t` or the order we clean up gets messed up 
