### PR TITLE
CLOUDP-172415: handle client id when using a custom one

### DIFF
--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -85,6 +85,9 @@ func (opts *LoginOpts) SyncWithOAuthAccessProfile(c LoginConfig) func() error {
 		if opts.RefreshToken != "" {
 			opts.config.Set(config.RefreshTokenField, opts.RefreshToken)
 		}
+		if config.ClientID() != "" {
+			opts.config.Set(config.ClientIDField, config.ClientID())
+		}
 
 		// sync OpsManagerURL from command opts (higher priority)
 		// and OpsManagerURL from default profile


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-172415

Found this out while testing a report

Manually tested using a custom client id works again as expected
