### PR TITLE
CLOUDP-171555 Adjust test timeout for backup restores

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -307,6 +307,17 @@ post:
       working_dir: src/github.com/mongodb/mongodb-atlas-cli/build/ci
       binary: ./clean-up-cloud-manager.sh
       args: ['-h', 'hosts.json']
+  - command: s3.put
+    params:
+      aws_key: ${download_center_aws_key}
+      aws_secret: ${download_center_aws_secret}
+      local_files_include_filter:
+        - src/github.com/mongodb/mongodb-atlas-cli/*.xml
+      remote_file: mongocli/
+      bucket: mongodb-mongocli-build
+      permissions: public-read
+      content_type: ${content_type|application/octet-stream}
+      display_name: xunit_results
   - command: attach.xunit_results
     params:
       files: ["src/github.com/mongodb/mongodb-atlas-cli/*.xml"]
@@ -1262,7 +1273,6 @@ tasks:
           E2E_TAGS: atlas,backup,snapshot
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
-          E2E_TIMEOUT: 3h
   - name: atlas_backups_schedule_e2e
     tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
@@ -1283,7 +1293,6 @@ tasks:
           E2E_TAGS: atlas,backup,schedule
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
-          E2E_TIMEOUT: 3h
   - name: atlas_backups_exports_buckets_e2e
     tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
@@ -1304,7 +1313,6 @@ tasks:
           E2E_TAGS: atlas,backup,exports,buckets
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
-          E2E_TIMEOUT: 3h
   - name: atlas_backups_exports_jobs_e2e
     tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
@@ -1325,7 +1333,6 @@ tasks:
           E2E_TAGS: atlas,backup,exports,jobs
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
-          E2E_TIMEOUT: 3h
   - name: atlas_backups_serverless_e2e
     tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
@@ -1347,7 +1354,6 @@ tasks:
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_SERVERLESS_INSTANCE_NAME: ${e2e_serverless_instance_name}
-          E2E_TIMEOUT: 3h
   - name: atlas_backups_restores_e2e
     tags: [ "e2e","backup","atlas" ]
     must_have_test_results: true
@@ -1358,6 +1364,7 @@ tasks:
     commands:
       - func: "install gotestsum"
       - func: "e2e test"
+        timeout_secs: 10800 # 3 hours
         vars:
           MCLI_ORG_ID: ${atlas_org_id}
           MCLI_PROJECT_ID: ${atlas_project_id}

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -307,17 +307,6 @@ post:
       working_dir: src/github.com/mongodb/mongodb-atlas-cli/build/ci
       binary: ./clean-up-cloud-manager.sh
       args: ['-h', 'hosts.json']
-  - command: s3.put
-    params:
-      aws_key: ${download_center_aws_key}
-      aws_secret: ${download_center_aws_secret}
-      local_files_include_filter:
-        - src/github.com/mongodb/mongodb-atlas-cli/*.xml
-      remote_file: mongocli/
-      bucket: mongodb-mongocli-build
-      permissions: public-read
-      content_type: ${content_type|application/octet-stream}
-      display_name: xunit_results
   - command: attach.xunit_results
     params:
       files: ["src/github.com/mongodb/mongodb-atlas-cli/*.xml"]


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Adjust test timeout for backup restores, all examples I've found that passed with a red on evergreen had a context canceled message meaning a timeout, extending it on the evergreen task.

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-171555

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.

Closes #[issue number]
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
moving forward to extend the timeout of a task we should extend both together:
- E2E_TIMEOUT this is sent to the gotestsum -timeout ${E2E_TIMEOUT}
- timeout_secs: evergreen config to override (per task) main `exec_timeout_secs`