### PR TITLE
CLOUDP-167778: migrate 'cloud migration service' CLI stores to v2 sdk

### DIFF
--- a/docs/atlascli/command/atlas-liveMigrations-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-create.txt
@@ -118,5 +118,5 @@ If the command succeeds, the CLI returns output similar to the following sample.
 .. code-block::
 
    ID     PROJECT ID              SOURCE PROJECT ID   STATUS
-   <ID>   <Destination.GroupID>   <Source.GroupID>    <Status>
+   <Id>   <Destination.GroupId>   <Source.GroupId>    <Status>
 

--- a/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation-create.txt
@@ -118,5 +118,5 @@ If the command succeeds, the CLI returns output similar to the following sample.
 .. code-block::
 
    ID     PROJECT ID   SOURCE PROJECT ID   STATUS
-   <ID>   <GroupID>    <SourceGroupID>     <Status>
+   <Id>   <GroupId>    <SourceGroupId>     <Status>
 

--- a/docs/atlascli/command/atlas-liveMigrations-validation-describe.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-validation-describe.txt
@@ -76,5 +76,5 @@ If the command succeeds, the CLI returns output similar to the following sample.
 .. code-block::
 
    ID     PROJECT ID   SOURCE PROJECT ID   STATUS
-   <ID>   <GroupID>    <SourceGroupID>     <Status>
+   <Id>   <GroupId>    <SourceGroupId>     <Status>
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-create.txt
@@ -118,5 +118,5 @@ If the command succeeds, the CLI returns output similar to the following sample.
 .. code-block::
 
    ID     PROJECT ID              SOURCE PROJECT ID   STATUS
-   <ID>   <Destination.GroupID>   <Source.GroupID>    <Status>
+   <Id>   <Destination.GroupId>   <Source.GroupId>    <Status>
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-create.txt
@@ -118,5 +118,5 @@ If the command succeeds, the CLI returns output similar to the following sample.
 .. code-block::
 
    ID     PROJECT ID   SOURCE PROJECT ID   STATUS
-   <ID>   <GroupID>    <SourceGroupID>     <Status>
+   <Id>   <GroupId>    <SourceGroupId>     <Status>
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-validation-describe.txt
@@ -76,5 +76,5 @@ If the command succeeds, the CLI returns output similar to the following sample.
 .. code-block::
 
    ID     PROJECT ID   SOURCE PROJECT ID   STATUS
-   <ID>   <GroupID>    <SourceGroupID>     <Status>
+   <Id>   <GroupId>    <SourceGroupId>     <Status>
 

--- a/internal/cli/atlas/livemigrations/create.go
+++ b/internal/cli/atlas/livemigrations/create.go
@@ -37,7 +37,7 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 }
 
 var createTemplate = `ID	PROJECT ID	SOURCE PROJECT ID	STATUS
-{{.ID}}	{{.Destination.GroupID}}	{{.Source.GroupID}}	{{.Status}}`
+{{.Id}}	{{.Destination.GroupId}}	{{.Source.GroupId}}	{{.Status}}`
 
 func (opts *CreateOpts) Run() error {
 	if err := opts.Prompt(); err != nil {

--- a/internal/cli/atlas/livemigrations/create_test.go
+++ b/internal/cli/atlas/livemigrations/create_test.go
@@ -25,14 +25,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestLiveMigrationCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationCreator(ctrl)
 
-	expected := mongodbatlas.LiveMigration{}
+	expected := atlasv2.LiveMigrationResponse{}
 
 	createOpts := &CreateOpts{
 		LiveMigrationsOpts: options.LiveMigrationsOpts{

--- a/internal/cli/atlas/livemigrations/describe.go
+++ b/internal/cli/atlas/livemigrations/describe.go
@@ -41,7 +41,7 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 }
 
 var describeTemplate = `ID	PROJECT ID	SOURCE PROJECT ID	STATUS
-{{.ID}}	{{.Destination.GroupID}}	{{.Source.GroupID}}	{{.Status}}`
+{{.Id}}	{{.Destination.GroupId}}	{{.Source.GroupId}}	{{.Status}}`
 
 func (opts *DescribeOpts) Run() error {
 	r, err := opts.store.LiveMigrationDescribe(opts.ConfigProjectID(), opts.liveMigrationID)

--- a/internal/cli/atlas/livemigrations/describe_test.go
+++ b/internal/cli/atlas/livemigrations/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestLiveMigrationDescribeOpts_Run(t *testing.T) {
@@ -36,7 +36,7 @@ func TestLiveMigrationDescribeOpts_Run(t *testing.T) {
 	}
 
 	mockStore.
-		EXPECT().LiveMigrationDescribe(opts.ProjectID, opts.liveMigrationID).Return(&mongodbatlas.LiveMigration{}, nil).
+		EXPECT().LiveMigrationDescribe(opts.ProjectID, opts.liveMigrationID).Return(&atlasv2.LiveMigrationResponse{}, nil).
 		Times(1)
 
 	if err := opts.Run(); err != nil {

--- a/internal/cli/atlas/livemigrations/link/create.go
+++ b/internal/cli/atlas/livemigrations/link/create.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 var createTemplate = "Link-token '{{.LinkToken}}' successfully created.\n"
@@ -54,9 +54,9 @@ func (opts *CreateOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *CreateOpts) newTokenCreateRequest() *mongodbatlas.TokenCreateRequest {
-	return &mongodbatlas.TokenCreateRequest{
-		AccessListIPs: opts.accessListIP,
+func (opts *CreateOpts) newTokenCreateRequest() *atlasv2.TargetOrgRequest {
+	return &atlasv2.TargetOrgRequest{
+		AccessListIps: opts.accessListIP,
 	}
 }
 

--- a/internal/cli/atlas/livemigrations/link/create_test.go
+++ b/internal/cli/atlas/livemigrations/link/create_test.go
@@ -23,15 +23,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestLinkTokenCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLinkTokenCreator(ctrl)
 
-	expected := &mongodbatlas.LinkToken{}
-
+	expected := &atlasv2.TargetOrg{}
 	createOpts := &CreateOpts{
 		GlobalOpts:   cli.GlobalOpts{OrgID: "1"},
 		accessListIP: []string{"1.2.3.4", "5.6.7.8"},

--- a/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
+++ b/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 type LiveMigrationsOpts struct {
@@ -45,23 +45,23 @@ type LiveMigrationsOpts struct {
 	DestinationDropEnabled      bool
 }
 
-func (opts *LiveMigrationsOpts) NewCreateRequest() *mongodbatlas.LiveMigration {
-	return &mongodbatlas.LiveMigration{
-		Source: &mongodbatlas.Source{
+func (opts *LiveMigrationsOpts) NewCreateRequest() *atlasv2.LiveMigrationRequest {
+	return &atlasv2.LiveMigrationRequest{
+		Source: atlasv2.Source{
 			ClusterName:           opts.SourceClusterName,
-			GroupID:               opts.SourceProjectID,
-			Username:              opts.SourceUsername,
-			Password:              opts.SourcePassword,
-			SSL:                   &opts.SourceSSL,
-			CACertificatePath:     opts.SourceCACertificatePath,
-			ManagedAuthentication: &opts.SourceManagedAuthentication,
+			GroupId:               opts.SourceProjectID,
+			Username:              &opts.SourceUsername,
+			Password:              &opts.SourcePassword,
+			Ssl:                   opts.SourceSSL,
+			CaCertificatePath:     &opts.SourceCACertificatePath,
+			ManagedAuthentication: opts.SourceManagedAuthentication,
 		},
-		Destination: &mongodbatlas.Destination{
+		Destination: atlasv2.Destination{
 			ClusterName: opts.DestinationClusterName,
-			GroupID:     opts.ConfigProjectID(),
+			GroupId:     opts.ConfigProjectID(),
 		},
 		MigrationHosts: opts.MigrationHosts,
-		DropEnabled:    &opts.DestinationDropEnabled,
+		DropEnabled:    opts.DestinationDropEnabled,
 	}
 }
 

--- a/internal/cli/atlas/livemigrations/validation/create.go
+++ b/internal/cli/atlas/livemigrations/validation/create.go
@@ -37,7 +37,7 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 }
 
 var createTemplate = `ID	PROJECT ID	SOURCE PROJECT ID	STATUS
-{{.ID}}	{{.GroupID}}	{{.SourceGroupID}}	{{.Status}}`
+{{.Id}}	{{.GroupId}}	{{.SourceGroupId}}	{{.Status}}`
 
 func (opts *CreateOpts) Run() error {
 	if err := opts.Prompt(); err != nil {

--- a/internal/cli/atlas/livemigrations/validation/create_test.go
+++ b/internal/cli/atlas/livemigrations/validation/create_test.go
@@ -25,14 +25,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestLiveMigrationValidationCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationValidationsCreator(ctrl)
 
-	expected := mongodbatlas.Validation{}
+	expected := atlasv2.Validation{}
 
 	createOpts := &CreateOpts{
 		LiveMigrationsOpts: options.LiveMigrationsOpts{

--- a/internal/cli/atlas/livemigrations/validation/describe.go
+++ b/internal/cli/atlas/livemigrations/validation/describe.go
@@ -41,7 +41,7 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 }
 
 var describeTemplate = `ID	PROJECT ID	SOURCE PROJECT ID	STATUS
-{{.ID}}	{{.GroupID}}	{{.SourceGroupID}}	{{.Status}}`
+{{.Id}}	{{.GroupId}}	{{.SourceGroupId}}	{{.Status}}`
 
 func (opts *DescribeOpts) Run() error {
 	r, err := opts.store.GetValidationStatus(opts.ConfigProjectID(), opts.validationID)

--- a/internal/cli/atlas/livemigrations/validation/describe_test.go
+++ b/internal/cli/atlas/livemigrations/validation/describe_test.go
@@ -24,14 +24,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestValidationDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationValidationsDescriber(ctrl)
 
-	expected := mongodbatlas.Validation{}
+	expected := atlasv2.Validation{}
 
 	describeOpts := &DescribeOpts{
 		GlobalOpts:   cli.GlobalOpts{ProjectID: "2"},

--- a/internal/mocks/mock_live_migration_link_tokens.go
+++ b/internal/mocks/mock_live_migration_link_tokens.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
+	mongodbatlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 // MockLinkTokenCreator is a mock of LinkTokenCreator interface.
@@ -35,10 +35,10 @@ func (m *MockLinkTokenCreator) EXPECT() *MockLinkTokenCreatorMockRecorder {
 }
 
 // CreateLinkToken mocks base method.
-func (m *MockLinkTokenCreator) CreateLinkToken(arg0 string, arg1 *mongodbatlas.TokenCreateRequest) (*mongodbatlas.LinkToken, error) {
+func (m *MockLinkTokenCreator) CreateLinkToken(arg0 string, arg1 *mongodbatlasv2.TargetOrgRequest) (*mongodbatlasv2.TargetOrg, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLinkToken", arg0, arg1)
-	ret0, _ := ret[0].(*mongodbatlas.LinkToken)
+	ret0, _ := ret[0].(*mongodbatlasv2.TargetOrg)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mocks/mock_live_migration_validations.go
+++ b/internal/mocks/mock_live_migration_validations.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
+	mongodbatlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 // MockLiveMigrationValidationsCreator is a mock of LiveMigrationValidationsCreator interface.
@@ -35,10 +36,10 @@ func (m *MockLiveMigrationValidationsCreator) EXPECT() *MockLiveMigrationValidat
 }
 
 // CreateValidation mocks base method.
-func (m *MockLiveMigrationValidationsCreator) CreateValidation(arg0 string, arg1 *mongodbatlas.LiveMigration) (*mongodbatlas.Validation, error) {
+func (m *MockLiveMigrationValidationsCreator) CreateValidation(arg0 string, arg1 *mongodbatlasv2.LiveMigrationRequest) (*mongodbatlasv2.Validation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateValidation", arg0, arg1)
-	ret0, _ := ret[0].(*mongodbatlas.Validation)
+	ret0, _ := ret[0].(*mongodbatlasv2.Validation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -111,10 +112,10 @@ func (m *MockLiveMigrationValidationsDescriber) EXPECT() *MockLiveMigrationValid
 }
 
 // GetValidationStatus mocks base method.
-func (m *MockLiveMigrationValidationsDescriber) GetValidationStatus(arg0, arg1 string) (*mongodbatlas.Validation, error) {
+func (m *MockLiveMigrationValidationsDescriber) GetValidationStatus(arg0, arg1 string) (*mongodbatlasv2.Validation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValidationStatus", arg0, arg1)
-	ret0, _ := ret[0].(*mongodbatlas.Validation)
+	ret0, _ := ret[0].(*mongodbatlasv2.Validation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mocks/mock_live_migrations.go
+++ b/internal/mocks/mock_live_migrations.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
+	mongodbatlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 // MockLiveMigrationCreator is a mock of LiveMigrationCreator interface.
@@ -35,10 +35,10 @@ func (m *MockLiveMigrationCreator) EXPECT() *MockLiveMigrationCreatorMockRecorde
 }
 
 // LiveMigrationCreate mocks base method.
-func (m *MockLiveMigrationCreator) LiveMigrationCreate(arg0 string, arg1 *mongodbatlas.LiveMigration) (*mongodbatlas.LiveMigration, error) {
+func (m *MockLiveMigrationCreator) LiveMigrationCreate(arg0 string, arg1 *mongodbatlasv2.LiveMigrationRequest) (*mongodbatlasv2.LiveMigrationResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LiveMigrationCreate", arg0, arg1)
-	ret0, _ := ret[0].(*mongodbatlas.LiveMigration)
+	ret0, _ := ret[0].(*mongodbatlasv2.LiveMigrationResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -73,10 +73,10 @@ func (m *MockLiveMigrationDescriber) EXPECT() *MockLiveMigrationDescriberMockRec
 }
 
 // LiveMigrationDescribe mocks base method.
-func (m *MockLiveMigrationDescriber) LiveMigrationDescribe(arg0, arg1 string) (*mongodbatlas.LiveMigration, error) {
+func (m *MockLiveMigrationDescriber) LiveMigrationDescribe(arg0, arg1 string) (*mongodbatlasv2.LiveMigrationResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LiveMigrationDescribe", arg0, arg1)
-	ret0, _ := ret[0].(*mongodbatlas.LiveMigration)
+	ret0, _ := ret[0].(*mongodbatlasv2.LiveMigrationResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/store/live_migration.go
+++ b/internal/store/live_migration.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 //go:generate mockgen -destination=../mocks/mock_live_migration_validations.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store LiveMigrationValidationsCreator,LiveMigrationCutoverCreator,LiveMigrationValidationsDescriber
 
 type LiveMigrationValidationsCreator interface {
-	CreateValidation(string, *atlas.LiveMigration) (*atlas.Validation, error)
+	CreateValidation(string, *atlasv2.LiveMigrationRequest) (*atlasv2.Validation, error)
 }
 
 type LiveMigrationCutoverCreator interface {
@@ -33,14 +34,14 @@ type LiveMigrationCutoverCreator interface {
 }
 
 type LiveMigrationValidationsDescriber interface {
-	GetValidationStatus(string, string) (*atlas.Validation, error)
+	GetValidationStatus(string, string) (*atlasv2.Validation, error)
 }
 
 // CreateValidation encapsulate the logic to manage different cloud providers.
-func (s *Store) CreateValidation(groupID string, liveMigration *atlas.LiveMigration) (*atlas.Validation, error) {
+func (s *Store) CreateValidation(groupID string, liveMigration *atlasv2.LiveMigrationRequest) (*atlasv2.Validation, error) {
 	switch s.service {
 	case config.CloudService:
-		result, _, err := s.client.(*atlas.Client).LiveMigration.CreateValidation(s.ctx, groupID, liveMigration)
+		result, _, err := s.clientv2.CloudMigrationServiceApi.ValidateMigration(s.ctx, groupID).LiveMigrationRequest(*liveMigration).Execute()
 		return result, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
@@ -59,10 +60,10 @@ func (s *Store) CreateLiveMigrationCutover(groupID, liveMigrationID string) (*at
 }
 
 // GetValidationStatus encapsulate the logic to manage different cloud providers.
-func (s *Store) GetValidationStatus(groupID, liveMigrationID string) (*atlas.Validation, error) {
+func (s *Store) GetValidationStatus(groupID, liveMigrationID string) (*atlasv2.Validation, error) {
 	switch s.service {
 	case config.CloudService:
-		result, _, err := s.client.(*atlas.Client).LiveMigration.GetValidationStatus(context.Background(), groupID, liveMigrationID)
+		result, _, err := s.clientv2.CloudMigrationServiceApi.GetValidationStatus(context.Background(), groupID, liveMigrationID).Execute()
 		return result, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)

--- a/internal/store/live_migration_link_tokens.go
+++ b/internal/store/live_migration_link_tokens.go
@@ -18,14 +18,14 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_live_migration_link_tokens.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store LinkTokenCreator,LinkTokenDeleter
 
 type LinkTokenCreator interface {
-	CreateLinkToken(string, *atlas.TokenCreateRequest) (*atlas.LinkToken, error)
+	CreateLinkToken(string, *atlasv2.TargetOrgRequest) (*atlasv2.TargetOrg, error)
 }
 
 type LinkTokenDeleter interface {
@@ -38,10 +38,10 @@ type LinkTokenStore interface {
 }
 
 // CreateLinkToken encapsulate the logic to manage different cloud providers.
-func (s *Store) CreateLinkToken(orgID string, linkToken *atlas.TokenCreateRequest) (*atlas.LinkToken, error) {
+func (s *Store) CreateLinkToken(orgID string, linkToken *atlasv2.TargetOrgRequest) (*atlasv2.TargetOrg, error) {
 	switch s.service {
 	case config.CloudService:
-		result, _, err := s.client.(*atlas.Client).LiveMigration.CreateLinkToken(s.ctx, orgID, linkToken)
+		result, _, err := s.clientv2.CloudMigrationServiceApi.CreateLinkToken(s.ctx, orgID).TargetOrgRequest(*linkToken).Execute()
 		return result, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
@@ -52,7 +52,7 @@ func (s *Store) CreateLinkToken(orgID string, linkToken *atlas.TokenCreateReques
 func (s *Store) DeleteLinkToken(orgID string) error {
 	switch s.service {
 	case config.CloudService:
-		_, err := s.client.(*atlas.Client).LiveMigration.DeleteLinkToken(s.ctx, orgID)
+		_, _, err := s.clientv2.CloudMigrationServiceApi.DeleteLinkToken(s.ctx, orgID).Execute()
 		return err
 	case config.OpsManagerService, config.CloudManagerService:
 		_, err := s.client.(*opsmngr.Client).LiveMigration.DeleteConnection(s.ctx, orgID)

--- a/internal/store/live_migrations.go
+++ b/internal/store/live_migrations.go
@@ -19,24 +19,24 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 //go:generate mockgen -destination=../mocks/mock_live_migrations.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store LiveMigrationCreator,LiveMigrationDescriber
 
 type LiveMigrationCreator interface {
-	LiveMigrationCreate(string, *atlas.LiveMigration) (*atlas.LiveMigration, error)
+	LiveMigrationCreate(string, *atlasv2.LiveMigrationRequest) (*atlasv2.LiveMigrationResponse, error)
 }
 
 type LiveMigrationDescriber interface {
-	LiveMigrationDescribe(string, string) (*atlas.LiveMigration, error)
+	LiveMigrationDescribe(string, string) (*atlasv2.LiveMigrationResponse, error)
 }
 
 // LiveMigrationCreate encapsulates the logic to manage different cloud providers.
-func (s *Store) LiveMigrationCreate(groupID string, liveMigration *atlas.LiveMigration) (*atlas.LiveMigration, error) {
+func (s *Store) LiveMigrationCreate(groupID string, liveMigrationRequest *atlasv2.LiveMigrationRequest) (*atlasv2.LiveMigrationResponse, error) {
 	switch s.service {
 	case config.CloudService:
-		result, _, err := s.client.(*atlas.Client).LiveMigration.Create(s.ctx, groupID, liveMigration)
+		result, _, err := s.clientv2.CloudMigrationServiceApi.CreatePushMigration(context.Background(), groupID).LiveMigrationRequest(*liveMigrationRequest).Execute()
 		return result, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
@@ -44,10 +44,10 @@ func (s *Store) LiveMigrationCreate(groupID string, liveMigration *atlas.LiveMig
 }
 
 // LiveMigrationDescribe encapsulates the logic to manage different cloud providers.
-func (s *Store) LiveMigrationDescribe(groupID, migrationID string) (*atlas.LiveMigration, error) {
+func (s *Store) LiveMigrationDescribe(groupID, migrationID string) (*atlasv2.LiveMigrationResponse, error) {
 	switch s.service {
 	case config.CloudService:
-		result, _, err := s.client.(*atlas.Client).LiveMigration.Get(context.Background(), groupID, migrationID)
+		result, _, err := s.clientv2.CloudMigrationServiceApi.GetPushMigration(context.Background(), groupID, migrationID).Execute()
 		return result, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Upgrade of sdk to v2 for:
- live_migration
- live_migration_link_tokens
- live_migrations

Excludes migration of CreateLiveMigrationCutover, which is missing the Validation model in the responseBody 
(to be addressed in a separate PR)

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-167778

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
