### PR TITLE
CLOUDP-172413: cloud_provider_backup_serverless Describer cmd migration

### DIFF
--- a/docs/atlascli/command/atlas-serverless-backups-snapshots-describe.txt
+++ b/docs/atlascli/command/atlas-serverless-backups-snapshots-describe.txt
@@ -81,8 +81,8 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID     SNAPSHOT TYPE    TYPE     DESCRIPTION     EXPIRES AT
-   <ID>   <SnapshotType>   <Type>   <Description>   <ExpiresAt>
+   ID     SNAPSHOT TYPE    EXPIRES AT
+   <ID>   <SnapshotType>   <ExpiresAt>
    
 
 Examples

--- a/internal/cli/atlas/serverless/backup/snapshots/describe.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/describe.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const describeTemplate = `ID	SNAPSHOT TYPE	TYPE	DESCRIPTION	EXPIRES AT
-{{.ID}}	{{.SnapshotType}}	{{.Type}}	{{.Description}}	{{.ExpiresAt}}
+const describeTemplate = `ID	SNAPSHOT TYPE	EXPIRES AT
+{{.ID}}	{{.SnapshotType}}	{{.ExpiresAt}}
 `
 
 type DescribeOpts struct {

--- a/internal/cli/atlas/serverless/backup/snapshots/describe_test.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/describe_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessSnapshotsDescriber(ctrl)
 
-	var expected mongodbatlas.CloudProviderSnapshot
+	var expected atlasv2.ServerlessBackupSnapshot
 
 	describeOpts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/atlas/serverless/backup/snapshots/watch.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/watch.go
@@ -50,7 +50,7 @@ func (opts *WatchOpts) watcher() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return result.Status == "completed" || result.Status == "failed", nil
+	return result.GetStatus() == "completed" || result.GetStatus() == "failed", nil
 }
 
 func (opts *WatchOpts) Run() error {

--- a/internal/cli/atlas/serverless/backup/snapshots/watch_test.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/watch_test.go
@@ -21,7 +21,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestWatch_Run(t *testing.T) {
@@ -34,7 +35,7 @@ func TestWatch_Run(t *testing.T) {
 		clusterName: "cluster",
 	}
 
-	expected := &mongodbatlas.CloudProviderSnapshot{Status: "completed"}
+	expected := &atlasv2.ServerlessBackupSnapshot{Status: pointer.Get("completed")}
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/mongocli/serverless/backup/snapshots/describe.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/describe.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const describeTemplate = `ID	SNAPSHOT TYPE	TYPE	DESCRIPTION	EXPIRES AT
-{{.ID}}	{{.SnapshotType}}	{{.Type}}	{{.Description}}	{{.ExpiresAt}}
+const describeTemplate = `ID	SNAPSHOT TYPE	EXPIRES AT
+{{.ID}}	{{.SnapshotType}}	{{.ExpiresAt}}
 `
 
 type DescribeOpts struct {

--- a/internal/cli/mongocli/serverless/backup/snapshots/describe_test.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/describe_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockServerlessSnapshotsDescriber(ctrl)
 
-	var expected mongodbatlas.CloudProviderSnapshot
+	var expected atlasv2.ServerlessBackupSnapshot
 
 	describeOpts := &DescribeOpts{
 		store: mockStore,

--- a/internal/cli/mongocli/serverless/backup/snapshots/watch.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/watch.go
@@ -48,7 +48,7 @@ func (opts *WatchOpts) watcher() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return result.Status == "completed" || result.Status == "failed", nil
+	return result.GetStatus() == "completed" || result.GetStatus() == "failed", nil
 }
 
 func (opts *WatchOpts) Run() error {

--- a/internal/cli/mongocli/serverless/backup/snapshots/watch_test.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/watch_test.go
@@ -21,7 +21,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
+	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
 func TestWatch_Run(t *testing.T) {
@@ -34,7 +35,7 @@ func TestWatch_Run(t *testing.T) {
 		clusterName: "cluster",
 	}
 
-	expected := &mongodbatlas.CloudProviderSnapshot{Status: "completed"}
+	expected := &atlasv2.ServerlessBackupSnapshot{Status: pointer.Get("completed")}
 
 	mockStore.
 		EXPECT().

--- a/internal/mocks/mock_cloud_provider_backup_serverless.go
+++ b/internal/mocks/mock_cloud_provider_backup_serverless.go
@@ -74,10 +74,10 @@ func (m *MockServerlessSnapshotsDescriber) EXPECT() *MockServerlessSnapshotsDesc
 }
 
 // ServerlessSnapshot mocks base method.
-func (m *MockServerlessSnapshotsDescriber) ServerlessSnapshot(arg0, arg1, arg2 string) (*mongodbatlas.CloudProviderSnapshot, error) {
+func (m *MockServerlessSnapshotsDescriber) ServerlessSnapshot(arg0, arg1, arg2 string) (*mongodbatlasv2.ServerlessBackupSnapshot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ServerlessSnapshot", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*mongodbatlas.CloudProviderSnapshot)
+	ret0, _ := ret[0].(*mongodbatlasv2.ServerlessBackupSnapshot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/store/cloud_provider_backup_serverless.go
+++ b/internal/store/cloud_provider_backup_serverless.go
@@ -29,7 +29,7 @@ type ServerlessSnapshotsLister interface {
 }
 
 type ServerlessSnapshotsDescriber interface {
-	ServerlessSnapshot(string, string, string) (*atlas.CloudProviderSnapshot, error)
+	ServerlessSnapshot(string, string, string) (*atlasv2.ServerlessBackupSnapshot, error)
 }
 
 type ServerlessRestoreJobsLister interface {
@@ -56,15 +56,10 @@ func (s *Store) ServerlessSnapshots(projectID, clusterName string, opts *atlas.L
 }
 
 // ServerlessSnapshot encapsulates the logic to manage different cloud providers.
-func (s *Store) ServerlessSnapshot(projectID, instanceName, snapshotID string) (*atlas.CloudProviderSnapshot, error) {
-	o := &atlas.SnapshotReqPathParameters{
-		GroupID:      projectID,
-		SnapshotID:   snapshotID,
-		InstanceName: instanceName,
-	}
+func (s *Store) ServerlessSnapshot(projectID, instanceName, snapshotID string) (*atlasv2.ServerlessBackupSnapshot, error) {
 	switch s.service {
 	case config.CloudService:
-		result, _, err := s.client.(*atlas.Client).CloudProviderSnapshots.GetOneServerlessSnapshot(s.ctx, o)
+		result, _, err := s.clientv2.CloudBackupsApi.GetServerlessBackup(s.ctx, projectID, instanceName, snapshotID).Execute()
 		return result, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
 	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
@@ -81,9 +80,9 @@ func TestServerlessBackup(t *testing.T) {
 		r.NoError(err, string(resp))
 
 		a := assert.New(t)
-		var result mongodbatlas.CloudProviderSnapshot
+		var result atlasv2.ServerlessBackupSnapshot
 		if err = json.Unmarshal(resp, &result); a.NoError(err) {
-			a.Equal(snapshotID, result.ID)
+			a.Equal(snapshotID, result.GetId())
 		}
 	})
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-# [CLOUDP-172413](https://jira.mongodb.org/browse/CLOUDP-172413)
EVG Patch: https://spruce.mongodb.com/version/644bbb8d0305b999d95593e6/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
