### PR TITLE
CLOUDP-172920: migrate cutover live migration to sdkv2

### DIFF
--- a/docs/atlascli/command/atlas-liveMigrations-cutover.txt
+++ b/docs/atlascli/command/atlas-liveMigrations-cutover.txt
@@ -77,6 +77,6 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   Cutover process '<ID>' successfully started.
+   Cutover process successfully started.
    
 

--- a/docs/mongocli/command/mongocli-atlas-liveMigrations-cutover.txt
+++ b/docs/mongocli/command/mongocli-atlas-liveMigrations-cutover.txt
@@ -77,6 +77,6 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   Cutover process '<ID>' successfully started.
+   Cutover process successfully started.
    
 

--- a/internal/cli/atlas/livemigrations/cutover.go
+++ b/internal/cli/atlas/livemigrations/cutover.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cutoverTemplate = "Cutover process '{{.ID}}' successfully started.\n"
+var cutoverTemplate = "Cutover process successfully started.\n"
 
 type CutoverOpts struct {
 	cli.GlobalOpts
@@ -43,12 +43,12 @@ func (opts *CutoverOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *CutoverOpts) Run() error {
-	r, err := opts.store.CreateLiveMigrationCutover(opts.ConfigProjectID(), opts.liveMigrationID)
+	err := opts.store.CreateLiveMigrationCutover(opts.ConfigProjectID(), opts.liveMigrationID)
 	if err != nil {
 		return err
 	}
 
-	return opts.Print(r)
+	return opts.Print(nil)
 }
 
 // mongocli atlas liveMigrations|lm cutover [--liveMigrationID liveMigrationId] [--projectId projectId].

--- a/internal/cli/atlas/livemigrations/cutover_test.go
+++ b/internal/cli/atlas/livemigrations/cutover_test.go
@@ -22,21 +22,18 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
 )
 
 func TestCutoverOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockLiveMigrationCutoverCreator(ctrl)
 
-	expected := &mongodbatlas.Validation{}
-
 	opts := &CutoverOpts{
 		store: mockStore,
 	}
 
 	mockStore.
-		EXPECT().CreateLiveMigrationCutover(opts.ConfigProjectID(), opts.liveMigrationID).Return(expected, nil).
+		EXPECT().CreateLiveMigrationCutover(opts.ConfigProjectID(), opts.liveMigrationID).Return(nil).
 		Times(1)
 
 	if err := opts.Run(); err != nil {

--- a/internal/mocks/mock_live_migration_validations.go
+++ b/internal/mocks/mock_live_migration_validations.go
@@ -8,7 +8,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 	mongodbatlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
@@ -74,12 +73,11 @@ func (m *MockLiveMigrationCutoverCreator) EXPECT() *MockLiveMigrationCutoverCrea
 }
 
 // CreateLiveMigrationCutover mocks base method.
-func (m *MockLiveMigrationCutoverCreator) CreateLiveMigrationCutover(arg0, arg1 string) (*mongodbatlas.Validation, error) {
+func (m *MockLiveMigrationCutoverCreator) CreateLiveMigrationCutover(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLiveMigrationCutover", arg0, arg1)
-	ret0, _ := ret[0].(*mongodbatlas.Validation)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // CreateLiveMigrationCutover indicates an expected call of CreateLiveMigrationCutover.

--- a/internal/store/live_migration.go
+++ b/internal/store/live_migration.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	atlasv2 "go.mongodb.org/atlas/mongodbatlasv2"
 )
 
@@ -30,7 +29,7 @@ type LiveMigrationValidationsCreator interface {
 }
 
 type LiveMigrationCutoverCreator interface {
-	CreateLiveMigrationCutover(string, string) (*atlas.Validation, error)
+	CreateLiveMigrationCutover(string, string) error
 }
 
 type LiveMigrationValidationsDescriber interface {
@@ -49,13 +48,13 @@ func (s *Store) CreateValidation(groupID string, liveMigration *atlasv2.LiveMigr
 }
 
 // StartLiveMigrationCutover encapsulate the logic to manage different cloud providers.
-func (s *Store) CreateLiveMigrationCutover(groupID, liveMigrationID string) (*atlas.Validation, error) {
+func (s *Store) CreateLiveMigrationCutover(groupID, liveMigrationID string) error {
 	switch s.service {
 	case config.CloudService:
-		result, _, err := s.client.(*atlas.Client).LiveMigration.Start(s.ctx, groupID, liveMigrationID)
-		return result, err
+		_, err := s.clientv2.CloudMigrationServiceApi.CutoverMigration(s.ctx, groupID, liveMigrationID).Execute()
+		return err
 	default:
-		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
+		return fmt.Errorf("%w: %s", errUnsupportedService, s.service)
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

`CutoverMigration` endpoint returns no response (204 response code only)

The legacy sdk incorrectly returned an empty object of type `Validation`

See CLOUDP-172920 comments for more info 

_Jira ticket:_ CLOUDP-172920
## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
