### PR TITLE
CLOUDP-177800: e2e_atlas_clusters Failure

### DIFF
--- a/internal/store/logs.go
+++ b/internal/store/logs.go
@@ -16,10 +16,11 @@ package store
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
-	"io"
 )
 
 //go:generate mockgen -destination=../mocks/mock_logs.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store LogsDownloader,LogJobsDownloader,LogCollector,LogJobLister,LogJobDeleter

--- a/internal/store/logs.go
+++ b/internal/store/logs.go
@@ -16,14 +16,10 @@ package store
 
 import (
 	"fmt"
-	"io"
-	"path/filepath"
-	"strconv"
-	"strings"
-
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
+	"io"
 )
 
 //go:generate mockgen -destination=../mocks/mock_logs.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store LogsDownloader,LogJobsDownloader,LogCollector,LogJobLister,LogJobDeleter
@@ -85,23 +81,7 @@ func (s *Store) Collect(groupID string, newLog *opsmngr.LogCollectionJob) (*opsm
 func (s *Store) DownloadLog(groupID, host, name string, out io.Writer, opts *atlas.DateRangetOptions) error {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		fileBaseName := strings.TrimSuffix(name, filepath.Ext(name))
-		result := s.clientv2.MonitoringAndLogsApi.GetHostLogs(s.ctx, groupID, host, fileBaseName)
-		if opts != nil {
-			if opts.StartDate != "" {
-				start, _ := strconv.ParseInt(opts.StartDate, 10, 64)
-				result = result.StartDate(start)
-			}
-			if opts.EndDate != "" {
-				end, _ := strconv.ParseInt(opts.EndDate, 10, 64)
-				result = result.EndDate(end)
-			}
-		}
-		logs, _, err := result.Execute()
-		if err != nil {
-			return err
-		}
-		_, err = io.Copy(out, logs)
+		_, err := s.client.(*atlas.Client).Logs.Get(s.ctx, groupID, host, name, out, opts)
 		return err
 	default:
 		return fmt.Errorf("%w: %s", errUnsupportedService, s.service)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-# [CLOUDP-177800](https://jira.mongodb.org/browse/CLOUDP-177800)

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
--> Reverting the DownloadLog API migration as the API needs thorough testing and the debug logs have no information about the reason for failure.

Created https://jira.mongodb.org/browse/CLOUDP-178273 to migrate the API to v2
Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
