### PR TITLE
CLOUDP-179008: Only create foliage tickets for the task and not test on cleanup

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1315,7 +1315,7 @@ tasks:
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_TIMEOUT: 3h
   - name: atlas_cleanup_e2e
-    tags: [ "e2e","cleanup", "foliage_infrequent_task" ]
+    tags: [ "e2e","cleanup", "foliage_check_task_only" ]
     must_have_test_results: true
     stepback: false
     depends_on:
@@ -1334,7 +1334,7 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,cleanup
   - name: atlas_gov_cleanup_e2e
-    tags: [ "e2e","cleanup" ]
+    tags: [ "e2e","cleanup", "foliage_check_task_only" ]
     must_have_test_results: true
     stepback: false
     depends_on:

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	maxRetryAttempts = 10
+	maxRetryAttempts = 5
 )
 
 // atlasE2ETestGenerator is about providing capabilities to provide projects and clusters for our e2e tests.


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-179008

enable foliage to only open a ticket per task and not per test
