### PR TITLE
CLOUDP-179267: Fix operator single namespace installation

### DIFF
--- a/internal/kubernetes/operator/install_resources.go
+++ b/internal/kubernetes/operator/install_resources.go
@@ -201,13 +201,9 @@ func (ir *InstallResources) addServiceAccount(ctx context.Context, config map[st
 func (ir *InstallResources) addRoles(ctx context.Context, config map[string]interface{}, namespace string, watch []string) error {
 	namespaces := map[string]struct{}{namespace: {}}
 
-	if value, ok := config["metadata"]; ok {
-		if metadata, ok := value.(map[string]interface{}); ok {
-			if name, ok := metadata["name"]; ok && name != leaderElectionRoleName {
-				for _, watchedNamespace := range watch {
-					namespaces[watchedNamespace] = struct{}{}
-				}
-			}
+	if !isLeaderElectionResource(config, leaderElectionRoleName) {
+		for _, watchedNamespace := range watch {
+			namespaces[watchedNamespace] = struct{}{}
 		}
 	}
 
@@ -249,13 +245,9 @@ func (ir *InstallResources) addClusterRole(ctx context.Context, config map[strin
 func (ir *InstallResources) addRoleBindings(ctx context.Context, config map[string]interface{}, namespace string, watch []string) error {
 	namespaces := map[string]struct{}{namespace: {}}
 
-	if value, ok := config["metadata"]; ok {
-		if metadata, ok := value.(map[string]interface{}); ok {
-			if name, ok := metadata["name"]; ok && name != leaderElectionRoleBindingName {
-				for _, watchedNamespace := range watch {
-					namespaces[watchedNamespace] = struct{}{}
-				}
-			}
+	if !isLeaderElectionResource(config, leaderElectionRoleBindingName) {
+		for _, watchedNamespace := range watch {
+			namespaces[watchedNamespace] = struct{}{}
 		}
 	}
 
@@ -381,4 +373,23 @@ func joinNamespaces(namespace string, watched []string) string {
 	}
 
 	return strings.Join(list, ",")
+}
+
+func isLeaderElectionResource(config map[string]interface{}, leaderElectionId string) bool {
+	value, ok := config["metadata"]
+	if !ok {
+		return false
+	}
+
+	metadata, ok := value.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	name, ok := metadata["name"]
+	if !ok {
+		return false
+	}
+
+	return name == leaderElectionId
 }

--- a/internal/kubernetes/operator/install_resources.go
+++ b/internal/kubernetes/operator/install_resources.go
@@ -375,7 +375,7 @@ func joinNamespaces(namespace string, watched []string) string {
 	return strings.Join(list, ",")
 }
 
-func isLeaderElectionResource(config map[string]interface{}, leaderElectionId string) bool {
+func isLeaderElectionResource(config map[string]interface{}, leaderElectionID string) bool {
 	value, ok := config["metadata"]
 	if !ok {
 		return false
@@ -391,5 +391,5 @@ func isLeaderElectionResource(config map[string]interface{}, leaderElectionId st
 		return false
 	}
 
-	return name == leaderElectionId
+	return name == leaderElectionID
 }

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -688,6 +688,8 @@ func listPrivateEndpointsByProject(t *testing.T, cliPath, projectID, provider st
 }
 
 func deletePrivateEndpoint(t *testing.T, cliPath, projectID, provider, endpointID string) {
+	t.Helper()
+
 	cmd := exec.Command(cliPath,
 		privateEndpointsEntity,
 		provider,

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -672,6 +672,19 @@ func deleteAllPrivateEndpoints(t *testing.T, cliPath, projectID, provider string
 		cmd.Env = os.Environ()
 		resp, err = cmd.CombinedOutput()
 		assert.NoError(t, err, string(resp))
+
+		require.NotEmpty(t, endpointID)
+		cmd = exec.Command(cliPath,
+			privateEndpointsEntity,
+			provider,
+			"watch",
+			endpointID,
+			"--projectId",
+			projectID,
+		)
+		cmd.Env = os.Environ()
+		resp, err = cmd.CombinedOutput()
+		assert.NoError(t, err, string(resp))
 	}
 }
 

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -652,7 +652,7 @@ func deleteAllPrivateEndpoints(t *testing.T, cliPath, projectID, provider string
 	}
 
 	clear := false
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for attempt := 0; attempt < 10; attempt++ {
 		privateEndpoints = listPrivateEndpointsByProject(t, cliPath, projectID, provider)
 		if len(privateEndpoints) == 0 {
 			t.Logf("all %s private endpoints successfully deleted", provider)
@@ -660,7 +660,7 @@ func deleteAllPrivateEndpoints(t *testing.T, cliPath, projectID, provider string
 			break
 		}
 
-		time.Sleep(poolInterval)
+		time.Sleep(10 * time.Second)
 	}
 
 	require.True(t, clear)

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -706,6 +706,16 @@ func TestProjectWithPrivateEndpoint_Azure(t *testing.T) {
 		expectedProject.Spec.PrivateEndpoints[0].ID = createdNetworkPeer.GetId()
 
 		cmd = exec.Command(cliPath,
+			privateEndpointsEntity,
+			azureEntity,
+			"watch",
+			createdNetworkPeer.GetId(),
+			"--projectId", generator.projectID)
+		cmd.Env = os.Environ()
+		_, err = cmd.CombinedOutput()
+		require.NoError(t, err)
+
+		cmd = exec.Command(cliPath,
 			"kubernetes",
 			"config",
 			"generate",

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -124,7 +124,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	})
 
 	t.Run("should install latest major version of operator in its own namespace with namespaced config", func(t *testing.T) {
-		clusterName := "install-namespaced"
+		clusterName := "single-namespace"
 		operatorWatch1 := "atlas-watch1"
 		operatorWatch2 := "atlas-watch2"
 		operator := setupCluster(t, clusterName, operatorNamespace, operatorWatch1, operatorWatch2)

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -146,6 +146,27 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		checkDeployment(t, operator, operatorNamespace)
 	})
 
+	t.Run("should install latest major version of operator in a single namespaced config", func(t *testing.T) {
+		clusterName := "install-namespaced"
+		operator := setupCluster(t, clusterName, operatorNamespace)
+		context := fmt.Sprintf("kind-%s", clusterName)
+
+		cmd := exec.Command(cliPath,
+			"kubernetes",
+			"operator",
+			"install",
+			"--operatorVersion", features.LatestOperatorMajorVersion,
+			"--targetNamespace", operatorNamespace,
+			"--watchNamespace", operatorNamespace,
+			"--kubeContext", context)
+		cmd.Env = os.Environ()
+		resp, inErr := cmd.CombinedOutput()
+		req.NoError(inErr, string(resp))
+		a.Equal("Atlas Kubernetes Operator installed successfully\n", string(resp))
+
+		checkDeployment(t, operator, operatorNamespace)
+	})
+
 	t.Run("should install operator starting a new project", func(t *testing.T) {
 		clusterName := "install-new-project"
 		operator := setupCluster(t, clusterName, operatorNamespace)


### PR DESCRIPTION
## Proposed changes

`kubernetes operator install` fails when configuring the installation of a single targeted and watched namespace.
This PR deduplicates configurable namespaces to proper configure the operator installation.

_Jira ticket:_ [CLOUDP-179267](https://jira.mongodb.org/browse/CLOUDP-179267)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
