### PR TITLE
CLOUDP-179042: Failed Build Variant: mongodb-atlas-cli-master/e2e_atlas_backups

### DIFF
--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -112,7 +112,7 @@ func (g *atlasE2ETestGenerator) generateTeam(prefix string) {
 	})
 }
 
-// generateProject generates a new project and also registers it's deletion on test cleanup.
+// generateProject generates a new project and also registers its deletion on test cleanup.
 func (g *atlasE2ETestGenerator) generateProject(prefix string) {
 	g.t.Helper()
 

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -49,6 +49,14 @@ type atlasE2ETestGenerator struct {
 	t              *testing.T
 }
 
+func (g *atlasE2ETestGenerator) Log(args ...any) {
+	g.t.Log(args...)
+}
+
+func (g *atlasE2ETestGenerator) Logf(format string, args ...any) {
+	g.t.Logf(format, args...)
+}
+
 // newAtlasE2ETestGenerator creates a new instance of atlasE2ETestGenerator struct.
 func newAtlasE2ETestGenerator(t *testing.T) *atlasE2ETestGenerator {
 	t.Helper()
@@ -79,11 +87,11 @@ func (g *atlasE2ETestGenerator) generateTeam(prefix string) {
 
 	g.teamUser, err = getFirstOrgUser()
 	if err != nil {
-		g.t.Fatalf("unexpected error: %v", err)
+		g.t.Fatalf("unexpected error retrieving org user: %v", err)
 	}
 	g.teamID, err = createTeam(g.teamName, g.teamUser)
 	if err != nil {
-		g.t.Fatalf("unexpected error: %v", err)
+		g.t.Fatalf("unexpected error creating team: %v", err)
 	}
 	g.t.Logf("teamID=%s", g.teamID)
 	g.t.Logf("teamName=%s", g.teamName)
@@ -115,7 +123,7 @@ func (g *atlasE2ETestGenerator) generateProject(prefix string) {
 
 	g.projectID, err = createProject(g.projectName)
 	if err != nil {
-		g.t.Fatalf("unexpected error: %v", err)
+		g.t.Fatalf("unexpected error creating project: %v", err)
 	}
 	g.t.Logf("projectID=%s", g.projectID)
 	g.t.Logf("projectName=%s", g.projectName)
@@ -247,18 +255,18 @@ func (g *atlasE2ETestGenerator) generateServerlessCluster() {
 	var err error
 	g.serverlessName, err = deployServerlessInstanceForProject(g.projectID)
 	if err != nil {
-		g.t.Errorf("unexpected error: %v", err)
+		g.t.Errorf("unexpected error deploying serverless instance: %v", err)
 	}
 	g.t.Logf("serverlessName=%s", g.serverlessName)
 
 	g.t.Cleanup(func() {
 		if e := deleteServerlessInstanceForProject(g.projectID, g.serverlessName); e != nil {
-			g.t.Errorf("unexpected error: %v", e)
+			g.t.Errorf("unexpected error deleting serverless instance: %v", e)
 		}
 	})
 }
 
-// generateCluster generates a new cluster and also registers it's deletion on test cleanup.
+// generateCluster generates a new cluster and also registers its deletion on test cleanup.
 func (g *atlasE2ETestGenerator) generateCluster() {
 	g.t.Helper()
 
@@ -273,12 +281,13 @@ func (g *atlasE2ETestGenerator) generateCluster() {
 
 	g.clusterName, g.clusterRegion, err = deployClusterForProject(g.projectID, g.tier, g.enableBackup)
 	if err != nil {
-		g.t.Logf("projectID=%q, clusterName=%q", g.projectID, g.clusterName)
+		g.Logf("projectID=%q, clusterName=%q", g.projectID, g.clusterName)
 		g.t.Errorf("unexpected error deploying cluster: %v", err)
 	}
 	g.t.Logf("clusterName=%s", g.clusterName)
 
 	g.t.Cleanup(func() {
+		g.Logf("Cluster cleanup %q\n", g.projectID)
 		if e := deleteClusterForProject(g.projectID, g.clusterName); e != nil {
 			g.t.Errorf("unexpected error deleting cluster: %v", e)
 		}

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -49,10 +49,19 @@ type atlasE2ETestGenerator struct {
 	t              *testing.T
 }
 
+// Log formats its arguments using default formatting, analogous to Println,
+// and records the text in the error log. For tests, the text will be printed only if
+// the test fails or the -test.v flag is set. For benchmarks, the text is always
+// printed to avoid having performance depend on the value of the -test.v flag.
 func (g *atlasE2ETestGenerator) Log(args ...any) {
 	g.t.Log(args...)
 }
 
+// Logf formats its arguments according to the format, analogous to Printf, and
+// records the text in the error log. A final newline is added if not provided. For
+// tests, the text will be printed only if the test fails or the -test.v flag is
+// set. For benchmarks, the text is always printed to avoid having performance
+// depend on the value of the -test.v flag.
 func (g *atlasE2ETestGenerator) Logf(format string, args ...any) {
 	g.t.Logf(format, args...)
 }
@@ -93,8 +102,8 @@ func (g *atlasE2ETestGenerator) generateTeam(prefix string) {
 	if err != nil {
 		g.t.Fatalf("unexpected error creating team: %v", err)
 	}
-	g.t.Logf("teamID=%s", g.teamID)
-	g.t.Logf("teamName=%s", g.teamName)
+	g.Logf("teamID=%s", g.teamID)
+	g.Logf("teamName=%s", g.teamName)
 	if g.teamID == "" {
 		g.t.Fatal("teamID not created")
 	}
@@ -125,8 +134,8 @@ func (g *atlasE2ETestGenerator) generateProject(prefix string) {
 	if err != nil {
 		g.t.Fatalf("unexpected error creating project: %v", err)
 	}
-	g.t.Logf("projectID=%s", g.projectID)
-	g.t.Logf("projectName=%s", g.projectName)
+	g.Logf("projectID=%s", g.projectID)
+	g.Logf("projectName=%s", g.projectName)
 	if g.projectID == "" {
 		g.t.Fatal("projectID not created")
 	}

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -55,6 +55,11 @@ func newAtlasE2ETestGenerator(t *testing.T) *atlasE2ETestGenerator {
 	return &atlasE2ETestGenerator{t: t}
 }
 
+func newAtlasE2ETestGeneratorWithBackup(t *testing.T) *atlasE2ETestGenerator {
+	t.Helper()
+	return &atlasE2ETestGenerator{t: t, enableBackup: true}
+}
+
 func (g *atlasE2ETestGenerator) generateTeam(prefix string) {
 	g.t.Helper()
 
@@ -268,13 +273,14 @@ func (g *atlasE2ETestGenerator) generateCluster() {
 
 	g.clusterName, g.clusterRegion, err = deployClusterForProject(g.projectID, g.tier, g.enableBackup)
 	if err != nil {
-		g.t.Errorf("unexpected error: %v", err)
+		g.t.Logf("projectID=%q, clusterName=%q", g.projectID, g.clusterName)
+		g.t.Errorf("unexpected error deploying cluster: %v", err)
 	}
 	g.t.Logf("clusterName=%s", g.clusterName)
 
 	g.t.Cleanup(func() {
 		if e := deleteClusterForProject(g.projectID, g.clusterName); e != nil {
-			g.t.Errorf("unexpected error: %v", e)
+			g.t.Errorf("unexpected error deleting cluster: %v", e)
 		}
 	})
 }

--- a/test/e2e/atlas/backup_restores_test.go
+++ b/test/e2e/atlas/backup_restores_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build e2e || (atlas && backup && restores)
 
 package atlas_test
@@ -34,12 +35,13 @@ func TestRestores(t *testing.T) {
 
 	var snapshotID, restoreJobID string
 
-	g := newAtlasE2ETestGenerator(t)
-	g.enableBackup = true
+	g := newAtlasE2ETestGeneratorWithBackup(t)
 	g.generateProjectAndCluster("backupRestores")
+	require.NotEmpty(t, g.clusterName)
 
 	g2 := newAtlasE2ETestGenerator(t)
-	g2.generateProjectAndCluster("backupRestores")
+	g2.generateProjectAndCluster("backupRestores2")
+	require.NotEmpty(t, g2.clusterName)
 
 	t.Run("Create snapshot", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
@@ -141,7 +143,7 @@ func TestRestores(t *testing.T) {
 
 		a := assert.New(t)
 		var result atlasv2.PaginatedCloudBackupRestoreJob
-		if err = json.Unmarshal(resp, &result); a.NoError(err) {
+		if err = json.Unmarshal(resp, &result); a.NoError(err, string(resp)) {
 			a.NotEmpty(result)
 		}
 	})
@@ -164,7 +166,7 @@ func TestRestores(t *testing.T) {
 
 		a := assert.New(t)
 		var result atlasv2.DiskBackupRestoreJob
-		if err = json.Unmarshal(resp, &result); a.NoError(err) {
+		if err = json.Unmarshal(resp, &result); a.NoError(err, string(resp)) {
 			a.NotEmpty(result)
 		}
 	})

--- a/test/e2e/atlas/cleanup_test.go
+++ b/test/e2e/atlas/cleanup_test.go
@@ -18,7 +18,6 @@ package atlas_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -44,24 +43,18 @@ func TestCleanup(t *testing.T) {
 	var projects mongodbatlas.Projects
 	err = json.Unmarshal(resp, &projects)
 	req.NoError(err)
-
+	t.Log(projects)
 	for _, project := range projects.Results {
-		projectID := project.ID
-		t.Run("deleting project "+project.ID, func(t *testing.T) {
-			t.Parallel()
-			if projectID == os.Getenv("MCLI_PROJECT_ID") {
-				t.Skip("skipping project", projectID)
-			}
-			deleteAllNetworkPeers(t, cliPath, projectID, "aws")
-			deleteAllNetworkPeers(t, cliPath, projectID, "gcp")
-			deleteAllNetworkPeers(t, cliPath, projectID, "azure")
-			deleteAllPrivateEndpoints(t, cliPath, projectID, "aws")
-			deleteAllPrivateEndpoints(t, cliPath, projectID, "gcp")
-			deleteAllPrivateEndpoints(t, cliPath, projectID, "azure")
-			deleteClustersForProject(t, cliPath, projectID)
-			deleteProjectWithRetry(t, projectID)
-		})
+		if project.ID == os.Getenv("MCLI_PROJECT_ID") {
+			t.Skip("skipping project", project.ID)
+		}
+		deleteAllNetworkPeers(t, cliPath, project.ID, "aws")
+		deleteAllNetworkPeers(t, cliPath, project.ID, "gcp")
+		deleteAllNetworkPeers(t, cliPath, project.ID, "azure")
+		deleteAllPrivateEndpoints(t, cliPath, project.ID, "aws")
+		deleteAllPrivateEndpoints(t, cliPath, project.ID, "gcp")
+		deleteAllPrivateEndpoints(t, cliPath, project.ID, "azure")
+		deleteClustersForProject(t, cliPath, project.ID)
+		deleteProjectWithRetry(t, project.ID)
 	}
-
-	fmt.Println(projects)
 }

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -587,13 +587,11 @@ func deleteClustersForProject(t *testing.T, cliPath, projectID string) {
 	require.NoError(t, err)
 	var clusters mongodbatlas.AdvancedClustersResponse
 	require.NoError(t, json.Unmarshal(resp, &clusters))
-
 	for _, cluster := range clusters.Results {
-		clusterName := cluster.Name
-		t.Run("deleting cluster "+clusterName, func(t *testing.T) {
-			t.Parallel()
-			assert.NoError(t, deleteClusterForProject(projectID, clusterName))
-		})
+		if cluster.StateName == "DELETING" {
+			continue
+		}
+		assert.NoError(t, deleteClusterForProject(projectID, cluster.Name))
 	}
 }
 
@@ -618,21 +616,18 @@ func deleteAllNetworkPeers(t *testing.T, cliPath, projectID, provider string) {
 	require.NoError(t, err)
 	for _, peer := range networkPeers {
 		peerID := peer.ID
-		t.Run("deleting peer: "+peerID, func(t *testing.T) {
-			t.Parallel()
-			cmd = exec.Command(cliPath,
-				networkingEntity,
-				networkPeeringEntity,
-				"delete",
-				peerID,
-				"--projectId",
-				projectID,
-				"--force",
-			)
-			cmd.Env = os.Environ()
-			resp, err = cmd.CombinedOutput()
-			assert.NoError(t, err, string(resp))
-		})
+		cmd = exec.Command(cliPath,
+			networkingEntity,
+			networkPeeringEntity,
+			"delete",
+			peerID,
+			"--projectId",
+			projectID,
+			"--force",
+		)
+		cmd.Env = os.Environ()
+		resp, err = cmd.CombinedOutput()
+		assert.NoError(t, err, string(resp))
 	}
 }
 
@@ -665,22 +660,18 @@ func deleteAllPrivateEndpoints(t *testing.T, cliPath, projectID, provider string
 			endpointID = v.GetId()
 		}
 		require.NotEmpty(t, endpointID)
-
-		t.Run("deleting endpoint: "+endpointID, func(t *testing.T) {
-			t.Parallel()
-			cmd = exec.Command(cliPath,
-				privateEndpointsEntity,
-				provider,
-				"delete",
-				endpointID,
-				"--projectId",
-				projectID,
-				"--force",
-			)
-			cmd.Env = os.Environ()
-			resp, err = cmd.CombinedOutput()
-			assert.NoError(t, err, string(resp))
-		})
+		cmd = exec.Command(cliPath,
+			privateEndpointsEntity,
+			provider,
+			"delete",
+			endpointID,
+			"--projectId",
+			projectID,
+			"--force",
+		)
+		cmd.Env = os.Environ()
+		resp, err = cmd.CombinedOutput()
+		assert.NoError(t, err, string(resp))
 	}
 }
 

--- a/test/e2e/atlas/online_archives_test.go
+++ b/test/e2e/atlas/online_archives_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build e2e || (atlas && onlinearchive)
 
 package atlas_test
@@ -69,6 +70,10 @@ func TestOnlineArchives(t *testing.T) {
 	t.Run("Delete", func(t *testing.T) {
 		deleteOnlineArchive(t, cliPath, g.projectID, g.clusterName, archiveID)
 	})
+
+	t.Run("Watch", func(t *testing.T) {
+		watchOnlineArchive(t, cliPath, g.projectID, g.clusterName, archiveID)
+	})
 }
 
 func deleteOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
@@ -89,6 +94,20 @@ func deleteOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveI
 	}
 	expected := fmt.Sprintf("Archive '%s' deleted\n", archiveID)
 	assert.Equal(t, string(resp), expected)
+}
+
+func watchOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
+	t.Helper()
+	cmd := exec.Command(cliPath,
+		clustersEntity,
+		onlineArchiveEntity,
+		"watch",
+		archiveID,
+		"--clusterName", clusterName,
+		"--projectId", projectID,
+	)
+	cmd.Env = os.Environ()
+	_ = cmd.Run()
 }
 
 func startOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
@@ -124,7 +143,7 @@ func pauseOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID
 
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
-	// online archive never reaches goal state as the db and collection must exists
+	// online archive never reaches goal state as the db and collection must exist
 	const expectedError = "ONLINE_ARCHIVE_MUST_BE_ACTIVE_TO_PAUSE"
 	if err != nil && !strings.Contains(string(resp), expectedError) {
 		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))

--- a/test/e2e/atlas/quickstart_test.go
+++ b/test/e2e/atlas/quickstart_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build e2e || (atlas && interactive)
 
 package atlas_test
@@ -20,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
@@ -54,17 +54,11 @@ func TestQuickstart(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if !strings.Contains(string(resp), "Cluster created.") {
-			fmt.Println("Cluster was not created see response:")
-			fmt.Println(string(resp))
-			assert.FailNow(t, "Failed to create M0 cluster.")
-		}
-
 		req.NoError(err, string(resp))
+		assert.Contains(t, string(resp), "Cluster created.", string(resp))
 	})
 
-	t.Run("WatchCluster", func(t *testing.T) {
+	t.Run("Watch Cluster", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			clustersEntity,
 			"watch",
@@ -74,12 +68,10 @@ func TestQuickstart(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.NoError(err, string(resp))
-
-		a := assert.New(t)
-		a.Contains(string(resp), "Cluster available")
+		assert.Contains(t, string(resp), "Cluster available")
 	})
 
-	t.Run("DescribeDbUser", func(t *testing.T) {
+	t.Run("Describe DB User", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			dbusersEntity,
 			"describe",
@@ -87,19 +79,16 @@ func TestQuickstart(t *testing.T) {
 			"-o=json",
 			"--projectId", g.projectID,
 		)
-
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
 
 		var user mongodbatlas.DatabaseUser
 		require.NoError(t, json.Unmarshal(resp, &user), string(resp))
-		if user.Username != dbUserUsername {
-			t.Fatalf("expected username to match %v, got %v", dbUserUsername, user.Username)
-		}
+		assert.Equal(t, dbUserUsername, user.Username)
 	})
 
-	t.Run("DeleteCluster", func(t *testing.T) {
+	t.Run("Delete Cluster", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			clustersEntity,
 			"delete",
@@ -112,7 +101,20 @@ func TestQuickstart(t *testing.T) {
 		req.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("Cluster '%s' deleted\n", clusterName)
-		a := assert.New(t)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
+	})
+
+	t.Run("Watch cluster deletion", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			clustersEntity,
+			"watch",
+			clusterName,
+			"--projectId", g.projectID,
+		)
+		cmd.Env = os.Environ()
+		// this command will fail with 404 once the cluster is deleted
+		// we just need to wait for this to close the project
+		resp, _ := cmd.CombinedOutput()
+		t.Log(string(resp))
 	})
 }

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build e2e || (atlas && interactive)
 
 package atlas_test
@@ -20,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
@@ -54,17 +54,11 @@ func TestSetup(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if !strings.Contains(string(resp), "Cluster created.") {
-			fmt.Println("Cluster was not created see response:")
-			fmt.Println(string(resp))
-			assert.FailNow(t, "Failed to create M0 cluster.")
-		}
-
 		req.NoError(err, string(resp))
+		assert.Contains(t, string(resp), "Cluster created.", string(resp))
 	})
 
-	t.Run("WatchCluster", func(t *testing.T) {
+	t.Run("Watch Cluster", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			clustersEntity,
 			"watch",
@@ -74,12 +68,10 @@ func TestSetup(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.NoError(err, string(resp))
-
-		a := assert.New(t)
-		a.Contains(string(resp), "Cluster available")
+		assert.Contains(t, string(resp), "Cluster available")
 	})
 
-	t.Run("DescribeDbUser", func(t *testing.T) {
+	t.Run("Describe DB User", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			dbusersEntity,
 			"describe",
@@ -93,12 +85,10 @@ func TestSetup(t *testing.T) {
 
 		var user mongodbatlas.DatabaseUser
 		require.NoError(t, json.Unmarshal(resp, &user), string(resp))
-		if user.Username != dbUserUsername {
-			t.Fatalf("expected username to match %v, got %v", dbUserUsername, user.Username)
-		}
+		assert.Equal(t, dbUserUsername, user.Username)
 	})
 
-	t.Run("DeleteCluster", func(t *testing.T) {
+	t.Run("Delete Cluster", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			clustersEntity,
 			"delete",
@@ -111,7 +101,20 @@ func TestSetup(t *testing.T) {
 		req.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("Cluster '%s' deleted\n", clusterName)
-		a := assert.New(t)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
+	})
+
+	t.Run("Watch cluster deletion", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			clustersEntity,
+			"watch",
+			clusterName,
+			"--projectId", g.projectID,
+		)
+		cmd.Env = os.Environ()
+		// this command will fail with 404 once the cluster is deleted
+		// we just need to wait for this to close the project
+		resp, _ := cmd.CombinedOutput()
+		t.Log(string(resp))
 	})
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-179042

- Remove some usages of `t.Parallel` as I think they were causing some concurrency issues.
- Wait for cluster deletion on interactive commands, it seems we can't delete projects while clusters are being delete and we need to wait
- Restores not sure how it got fix, added some logs to try and debug and now it passes 



