### PR TITLE
(DOCSP-30186) Removes extra space that causes an error in the docs builds

### DIFF
--- a/docs/atlascli/command/atlas-dataLakePipelines-availableSnapshots.txt
+++ b/docs/atlascli/command/atlas-dataLakePipelines-availableSnapshots.txt
@@ -12,7 +12,7 @@ atlas dataLakePipelines availableSnapshots
    :depth: 1
    :class: singlecol
 
- Manage available backup snapshots for data lake pipelines.
+Manage available backup snapshots for data lake pipelines.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-dataLakePipelines.txt
+++ b/docs/atlascli/command/atlas-dataLakePipelines.txt
@@ -50,7 +50,7 @@ Related Commands
 ----------------
 
 * :ref:`atlas-dataLakePipelines-availableSchedules` - Manage available schedules for the specified data lake pipeline.
-* :ref:`atlas-dataLakePipelines-availableSnapshots` -  Manage available backup snapshots for data lake pipelines.
+* :ref:`atlas-dataLakePipelines-availableSnapshots` - Manage available backup snapshots for data lake pipelines.
 * :ref:`atlas-dataLakePipelines-create` - Creates a new Data Lake Pipeline.
 * :ref:`atlas-dataLakePipelines-datasets` - Manage datasets for the specified data lake pipeline.
 * :ref:`atlas-dataLakePipelines-delete` - Remove the specified data lake pipeline from your project.

--- a/internal/cli/atlas/datalakepipelines/availablesnapshots/available_snapshots.go
+++ b/internal/cli/atlas/datalakepipelines/availablesnapshots/available_snapshots.go
@@ -26,7 +26,7 @@ func Builder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     use,
 		Aliases: cli.GenerateAliases(use),
-		Short:   " Manage available backup snapshots for data lake pipelines.",
+		Short:   "Manage available backup snapshots for data lake pipelines.",
 	}
 
 	cmd.AddCommand(


### PR DESCRIPTION
## Proposed changes

Removes an extra space in the short description of a command as it causes issues for our Snooty builds on docs

_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-30186

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
