### PR TITLE
(DOCSP-29937) Updates the limit flag description

### DIFF
--- a/docs/atlascli/command/atlas-accessLists-list.txt
+++ b/docs/atlascli/command/atlas-accessLists-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-alerts-list.txt
+++ b/docs/atlascli/command/atlas-alerts-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-alerts-settings-list.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-buckets-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-list.txt
@@ -60,7 +60,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-backups-restores-list.txt
+++ b/docs/atlascli/command/atlas-backups-restores-list.txt
@@ -60,7 +60,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-backups-snapshots-list.txt
+++ b/docs/atlascli/command/atlas-backups-snapshots-list.txt
@@ -60,7 +60,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-clusters-list.txt
+++ b/docs/atlascli/command/atlas-clusters-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-clusters-onlineArchives-list.txt
+++ b/docs/atlascli/command/atlas-clusters-onlineArchives-list.txt
@@ -48,7 +48,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-dataLakePipelines-availableSnapshots-list.txt
+++ b/docs/atlascli/command/atlas-dataLakePipelines-availableSnapshots-list.txt
@@ -48,7 +48,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-dbusers-list.txt
+++ b/docs/atlascli/command/atlas-dbusers-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-events-organizations-list.txt
+++ b/docs/atlascli/command/atlas-events-organizations-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - --maxDate
      - string
      - false

--- a/docs/atlascli/command/atlas-events-projects-list.txt
+++ b/docs/atlascli/command/atlas-events-projects-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - --maxDate
      - string
      - false

--- a/docs/atlascli/command/atlas-metrics-databases-describe.txt
+++ b/docs/atlascli/command/atlas-metrics-databases-describe.txt
@@ -73,7 +73,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-metrics-databases-list.txt
+++ b/docs/atlascli/command/atlas-metrics-databases-list.txt
@@ -63,7 +63,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-metrics-disks-describe.txt
+++ b/docs/atlascli/command/atlas-metrics-disks-describe.txt
@@ -75,7 +75,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-metrics-disks-list.txt
+++ b/docs/atlascli/command/atlas-metrics-disks-list.txt
@@ -63,7 +63,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-metrics-processes.txt
+++ b/docs/atlascli/command/atlas-metrics-processes.txt
@@ -71,7 +71,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-networking-containers-list.txt
+++ b/docs/atlascli/command/atlas-networking-containers-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-networking-peering-list.txt
+++ b/docs/atlascli/command/atlas-networking-peering-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-list.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-accessLists-list.txt
@@ -62,7 +62,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/atlascli/command/atlas-organizations-apiKeys-list.txt
+++ b/docs/atlascli/command/atlas-organizations-apiKeys-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/atlascli/command/atlas-organizations-list.txt
+++ b/docs/atlascli/command/atlas-organizations-list.txt
@@ -48,7 +48,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --name
      - string
      - false

--- a/docs/atlascli/command/atlas-organizations-users-list.txt
+++ b/docs/atlascli/command/atlas-organizations-users-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-dataLakes-aws-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-list.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-onlineArchive-aws-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-processes-list.txt
+++ b/docs/atlascli/command/atlas-processes-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-projects-apiKeys-list.txt
+++ b/docs/atlascli/command/atlas-projects-apiKeys-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-projects-list.txt
+++ b/docs/atlascli/command/atlas-projects-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/atlascli/command/atlas-projects-teams-list.txt
+++ b/docs/atlascli/command/atlas-projects-teams-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-projects-users-list.txt
+++ b/docs/atlascli/command/atlas-projects-users-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-serverless-backups-restores-list.txt
+++ b/docs/atlascli/command/atlas-serverless-backups-restores-list.txt
@@ -60,7 +60,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-serverless-backups-snapshots-list.txt
+++ b/docs/atlascli/command/atlas-serverless-backups-snapshots-list.txt
@@ -60,7 +60,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-serverless-list.txt
+++ b/docs/atlascli/command/atlas-serverless-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/atlascli/command/atlas-teams-list.txt
+++ b/docs/atlascli/command/atlas-teams-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-accessLists-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-accessLists-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-alerts-global-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-global-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-alerts-settings-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-restores-list.txt
@@ -60,7 +60,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-backups-snapshots-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-backups-snapshots-list.txt
@@ -60,7 +60,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-clusters-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-onlineArchives-list.txt
@@ -48,7 +48,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-dbusers-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-events-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-events-organizations-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - --maxDate
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-events-projects-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-events-projects-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - --maxDate
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-metrics-databases-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-databases-describe.txt
@@ -73,7 +73,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-metrics-databases-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-databases-list.txt
@@ -63,7 +63,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-metrics-disks-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-disks-describe.txt
@@ -75,7 +75,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-metrics-disks-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-disks-list.txt
@@ -63,7 +63,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
+++ b/docs/mongocli/command/mongocli-atlas-metrics-processes.txt
@@ -71,7 +71,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-networking-containers-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-containers-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-networking-peering-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-networking-peering-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-dataLakes-aws-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-privateEndpoints-onlineArchive-aws-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-processes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-processes-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-serverless-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-serverless-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-agents-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-agents-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-global-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-global-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-alerts-settings-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-backups-checkpoints-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-backups-checkpoints-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-backups-config-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-backups-config-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-backups-restores-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-backups-restores-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-backups-snapshots-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-backups-snapshots-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-events-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-events-organizations-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - --maxDate
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-events-projects-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-events-projects-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - --maxDate
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-featurePolicies-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-metrics-databases-describe.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-metrics-databases-describe.txt
@@ -70,7 +70,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-metrics-databases-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-metrics-databases-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-metrics-disks-describe.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-metrics-disks-describe.txt
@@ -70,7 +70,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-metrics-disks-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-metrics-disks-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-processes-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-processes-list.txt
@@ -46,7 +46,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-cloud-manager-servers-list.txt
+++ b/docs/mongocli/command/mongocli-cloud-manager-servers-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-globalAccessLists-list.txt
+++ b/docs/mongocli/command/mongocli-iam-globalAccessLists-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-globalApiKeys-list.txt
+++ b/docs/mongocli/command/mongocli-iam-globalApiKeys-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-accessLists-list.txt
@@ -62,7 +62,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-organizations-apiKeys-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-apiKeys-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-list.txt
@@ -48,7 +48,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --name
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-organizations-users-list.txt
+++ b/docs/mongocli/command/mongocli-iam-organizations-users-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-projects-apiKeys-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-apiKeys-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-projects-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-projects-teams-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-teams-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-projects-users-list.txt
+++ b/docs/mongocli/command/mongocli-iam-projects-users-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-iam-teams-list.txt
+++ b/docs/mongocli/command/mongocli-iam-teams-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-admin-backups-blockstores-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-admin-backups-blockstores-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-admin-backups-fileSystems-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-admin-backups-fileSystems-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-admin-backups-oplog-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-admin-backups-oplog-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-admin-backups-s3-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-admin-backups-s3-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-admin-backups-sync-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-admin-backups-sync-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-agents-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-agents-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-global-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-global-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-alerts-settings-list.txt
@@ -44,7 +44,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-backups-checkpoints-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-backups-checkpoints-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-backups-config-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-backups-config-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-backups-restores-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-backups-restores-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-backups-snapshots-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-backups-snapshots-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-events-organizations-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-events-organizations-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - --maxDate
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-events-projects-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-events-projects-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - --maxDate
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-featurePolicies-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-featurePolicies-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-metrics-databases-describe.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-metrics-databases-describe.txt
@@ -70,7 +70,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-metrics-databases-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-metrics-databases-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-metrics-disks-describe.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-metrics-disks-describe.txt
@@ -70,7 +70,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-metrics-disks-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-metrics-disks-list.txt
@@ -58,7 +58,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-processes-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-processes-list.txt
@@ -46,7 +46,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-serverUsage-organizations-hosts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-serverUsage-organizations-hosts-list.txt
@@ -46,7 +46,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - --orgId
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-serverUsage-projects-hosts-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-serverUsage-projects-hosts-list.txt
@@ -46,7 +46,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/docs/mongocli/command/mongocli-ops-manager-servers-list.txt
+++ b/docs/mongocli/command/mongocli-ops-manager-servers-list.txt
@@ -42,7 +42,7 @@ Options
    * - --limit
      - int
      - false
-     - Number of items per results page. This value defaults to 100.
+     - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
    * - -o, --output
      - string
      - false

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -45,7 +45,7 @@ const (
 	Status                       = "State of this alert. Valid values are TRACKING, OPEN, CLOSED, and CANCELLED."
 	Until                        = "ISO 8601-formatted time until which the alert has been acknowledged. This command returns this value if a MongoDB user previously acknowledged this alert. After this date, the alert becomes unacknowledged."
 	ConnectionStringType         = "When set to 'private', retrieves the connection string for the network peering endpoint."
-	Limit                        = "Number of items per results page."
+	Limit                        = "Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page."
 	Username                     = "Username that identifies the user. This value must be a valid email address."
 	BackupStatus                 = "Current (or desired) status of the backup configuration."
 	StorageEngine                = "Storage engine used for the backup."


### PR DESCRIPTION
## Proposed changes

There was a support case opened by a customer that didn't realize there was a 500 results/page limit. Added some clarifying text to the limit option to help.

_Jira ticket:_ CLOUDP-#
https://jira.mongodb.org/browse/DOCSP-29937

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
