### PR TITLE
CLOUDP-181258: document way to obtain performance advisor processId

### DIFF
--- a/docs/atlascli/command/atlas-performanceAdvisor-namespaces-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-namespaces-list.txt
@@ -60,7 +60,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by retrieving one of the 'id' fields from 'atlas processes list' command.
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. You can obtain a list of possible values from the 'id' field when you run the 'atlas processes list' command.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-performanceAdvisor-namespaces-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-namespaces-list.txt
@@ -60,7 +60,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}.
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-performanceAdvisor-namespaces-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-namespaces-list.txt
@@ -60,7 +60,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by retrieving one of the 'id' fields from 'atlas processes list' command.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
@@ -68,7 +68,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by retrieving one of the 'id' fields from 'atlas processes list' command.
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. You can obtain a list of possible values from the 'id' field when you run the 'atlas processes list' command.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
@@ -68,7 +68,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by retrieving one of the 'id' fields from 'atlas processes list' command.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-slowQueryLogs-list.txt
@@ -68,7 +68,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}.
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-performanceAdvisor-suggestedIndexes-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-suggestedIndexes-list.txt
@@ -70,7 +70,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by retrieving one of the 'id' fields from 'atlas processes list' command.
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. You can obtain a list of possible values from the 'id' field when you run the 'atlas processes list' command.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-performanceAdvisor-suggestedIndexes-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-suggestedIndexes-list.txt
@@ -70,7 +70,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}.
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-performanceAdvisor-suggestedIndexes-list.txt
+++ b/docs/atlascli/command/atlas-performanceAdvisor-suggestedIndexes-list.txt
@@ -70,7 +70,7 @@ Options
    * - --processName
      - string
      - false
-     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'
+     - Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by retrieving one of the 'id' fields from 'atlas processes list' command.
    * - --projectId
      - string
      - false

--- a/internal/cli/atlas/performanceadvisor/namespaces/list.go
+++ b/internal/cli/atlas/performanceadvisor/namespaces/list.go
@@ -105,7 +105,7 @@ If you don't set the duration option or the since option, this command returns d
 	}
 
 	cmd.Flags().StringVar(&opts.HostID, flag.HostID, "", usage.HostID)
-	cmd.Flags().StringVar(&opts.ProcessName, flag.ProcessName, "", usage.ProcessName)
+	cmd.Flags().StringVar(&opts.ProcessName, flag.ProcessName, "", usage.ProcessNameAtlasCLI)
 	cmd.Flags().Int64Var(&opts.since, flag.Since, 0, usage.Since)
 	cmd.Flags().Int64Var(&opts.duration, flag.Duration, 0, usage.Duration)
 

--- a/internal/cli/atlas/performanceadvisor/slowquerylogs/list.go
+++ b/internal/cli/atlas/performanceadvisor/slowquerylogs/list.go
@@ -115,7 +115,7 @@ If you don't set the duration option or the since option, this command returns d
 	const defaultLogLines = 20000
 
 	cmd.Flags().StringVar(&opts.HostID, flag.HostID, "", usage.HostID)
-	cmd.Flags().StringVar(&opts.ProcessName, flag.ProcessName, "", usage.ProcessName)
+	cmd.Flags().StringVar(&opts.ProcessName, flag.ProcessName, "", usage.ProcessNameAtlasCLI)
 	cmd.Flags().Int64Var(&opts.since, flag.Since, 0, usage.Since)
 	cmd.Flags().Int64Var(&opts.duration, flag.Duration, 0, usage.Duration)
 	cmd.Flags().Int64Var(&opts.nLog, flag.NLog, defaultLogLines, usage.NLog)

--- a/internal/cli/atlas/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/atlas/performanceadvisor/suggestedindexes/list.go
@@ -115,7 +115,7 @@ func ListBuilder() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.HostID, flag.HostID, "", usage.HostID)
-	cmd.Flags().StringVar(&opts.ProcessName, flag.ProcessName, "", usage.ProcessName)
+	cmd.Flags().StringVar(&opts.ProcessName, flag.ProcessName, "", usage.ProcessNameAtlasCLI)
 	cmd.Flags().Int64Var(&opts.since, flag.Since, 0, usage.Since)
 	cmd.Flags().Int64Var(&opts.duration, flag.Duration, 0, usage.Duration)
 	cmd.Flags().StringVar(&opts.namespaces, flag.Namespaces, "", usage.SuggestedIndexNamespaces)

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -22,7 +22,7 @@ const (
 	Members                      = "Number of members in the replica set."
 	Shards                       = "Number of shards in the cluster."
 	ProcessName                  = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}."
-	ProcessNameAtlasCLI          = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'"
+	ProcessNameAtlasCLI          = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by retrieving one of the 'id' fields from 'atlas processes list' command."
 	Since                        = "Date and time from which the query retrieves the suggested indexes. Specify as the number of seconds that have elapsed since the UNIX epoch. If you don't set the duration option, this command returns data from the since value to the current time."
 	HostID                       = "Unique identifier for the host of a MongoDB process."
 	Duration                     = "Length of time in milliseconds for which you want to return results. If you set the since option, duration starts at the since date and time. If you don't set the since option, this command returns data from the duration before the current time."

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -22,7 +22,7 @@ const (
 	Members                      = "Number of members in the replica set."
 	Shards                       = "Number of shards in the cluster."
 	ProcessName                  = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}."
-	ProcessNameAtlasCLI 		 = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'"
+	ProcessNameAtlasCLI          = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'"
 	Since                        = "Date and time from which the query retrieves the suggested indexes. Specify as the number of seconds that have elapsed since the UNIX epoch. If you don't set the duration option, this command returns data from the since value to the current time."
 	HostID                       = "Unique identifier for the host of a MongoDB process."
 	Duration                     = "Length of time in milliseconds for which you want to return results. If you set the since option, duration starts at the since date and time. If you don't set the since option, this command returns data from the duration before the current time."

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -22,6 +22,7 @@ const (
 	Members                      = "Number of members in the replica set."
 	Shards                       = "Number of shards in the cluster."
 	ProcessName                  = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}."
+	ProcessNameAtlasCLI 		 = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by running: atlas processes list | jq '.results[].id'"
 	Since                        = "Date and time from which the query retrieves the suggested indexes. Specify as the number of seconds that have elapsed since the UNIX epoch. If you don't set the duration option, this command returns data from the since value to the current time."
 	HostID                       = "Unique identifier for the host of a MongoDB process."
 	Duration                     = "Length of time in milliseconds for which you want to return results. If you set the since option, duration starts at the since date and time. If you don't set the since option, this command returns data from the duration before the current time."

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -22,7 +22,7 @@ const (
 	Members                      = "Number of members in the replica set."
 	Shards                       = "Number of shards in the cluster."
 	ProcessName                  = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}."
-	ProcessNameAtlasCLI          = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. List of possible values can be obtained by retrieving one of the 'id' fields from 'atlas processes list' command."
+	ProcessNameAtlasCLI          = "Unique identifier for the host of a MongoDB process in the following format: {hostname}:{port}. You can obtain a list of possible values from the 'id' field when you run the 'atlas processes list' command."
 	Since                        = "Date and time from which the query retrieves the suggested indexes. Specify as the number of seconds that have elapsed since the UNIX epoch. If you don't set the duration option, this command returns data from the since value to the current time."
 	HostID                       = "Unique identifier for the host of a MongoDB process."
 	Duration                     = "Length of time in milliseconds for which you want to return results. If you set the since option, duration starts at the since date and time. If you don't set the since option, this command returns data from the duration before the current time."


### PR DESCRIPTION
 ## Proposed changes

Adding extended documentation for the atlas cli explaining how to get process values. 

## Motivation

Explain to the users how to get the exact value of the process id.

In the long run we  should consider having dedicated command or introduce suggestions. 