### PR TITLE
CLOUDP-181251: Print connection string value

### DIFF
--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -282,7 +282,7 @@ func (opts *Opts) Run() error {
 		return err
 	}
 
-	fmt.Printf("Your connection string: %v\n", cluster.ConnectionStrings.StandardSrv)
+	fmt.Printf("Your connection string: %v\n", cluster.ConnectionStrings.GetStandardSrv())
 
 	if err := opts.loadSampleData(); err != nil {
 		return err


### PR DESCRIPTION
 ## Proposed changes

 Before:
 
 ```
Your connection string: Your connection string: 0x140009692a0 
```

After:
```
Your connection string: Your connection string: mongodb+srv://redacted.net
```

That solves the issue in the CLI.
To prevent from this issue happening again we should:

1. Create documentation recommending users to use Getters
https://github.com/mongodb/atlas-sdk-go/pull/58
2. [Future] Golangci-lint rule for detecting direct field access.
