### PR TITLE
(DOCSP-27290) Adds example command for atlas clusters sampleData load

### DIFF
--- a/docs/atlascli/command/atlas-clusters-sampleData-load.txt
+++ b/docs/atlascli/command/atlas-clusters-sampleData-load.txt
@@ -92,3 +92,10 @@ If the command succeeds, the CLI returns output similar to the following sample.
    Sample Data Job <Id> created.
    
 
+Examples
+--------
+
+.. code-block::
+
+   # Load sample data into the cluster named myCluster:
+   atlas clusters sampleData load myCluster --output json

--- a/internal/cli/atlas/clusters/sampledata/load.go
+++ b/internal/cli/atlas/clusters/sampledata/load.go
@@ -65,6 +65,8 @@ func LoadBuilder() *cobra.Command {
 			"clusterNameDesc": "Name of the cluster for which you want to load sample data.",
 			"output":          addTmpl,
 		},
+		Example: fmt.Sprintf(`  # Load sample data into the cluster named myCluster:
+  %s clusters sampleData load myCluster --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,


### PR DESCRIPTION
## Proposed changes

Adds missing example from atlas clusters sampleData load command

_Jira ticket:_

https://jira.mongodb.org/browse/DOCSP-27290

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
