### PR TITLE
CLOUDP-183519: introduce custom handling for valid ISO-8601 timestamps

### DIFF
--- a/internal/cli/atlas/accesslists/create.go
+++ b/internal/cli/atlas/accesslists/create.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
@@ -26,6 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
+	"github.com/mongodb/mongodb-atlas-cli/internal/time"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
 	atlasv2 "go.mongodb.org/atlas-sdk/admin"
@@ -58,7 +58,12 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *CreateOpts) Run() error {
-	entry := opts.newProjectIPAccessList()
+	entry, err := opts.newProjectIPAccessList()
+
+	if err != nil {
+		return err
+	}
+
 	r, err := opts.store.CreateProjectIPAccessList(entry)
 
 	if err != nil {
@@ -68,13 +73,16 @@ func (opts *CreateOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *CreateOpts) newProjectIPAccessList() []*atlasv2.NetworkPermissionEntry {
+func (opts *CreateOpts) newProjectIPAccessList() ([]*atlasv2.NetworkPermissionEntry, error) {
 	entry := &atlasv2.NetworkPermissionEntry{
 		GroupId: pointer.Get(opts.ConfigProjectID()),
 		Comment: &opts.comment,
 	}
 	if opts.deleteAfter != "" {
-		deleteAfterDate, _ := time.Parse(time.RFC3339, opts.deleteAfter)
+		deleteAfterDate, err := time.ParseTimestamp(opts.deleteAfter)
+		if err != nil {
+			return nil, err
+		}
 		entry.DeleteAfterDate = &deleteAfterDate
 	}
 	switch opts.entryType {
@@ -85,7 +93,7 @@ func (opts *CreateOpts) newProjectIPAccessList() []*atlasv2.NetworkPermissionEnt
 	case awsSecurityGroup:
 		entry.AwsSecurityGroup = &opts.entry
 	}
-	return []*atlasv2.NetworkPermissionEntry{entry}
+	return []*atlasv2.NetworkPermissionEntry{entry}, nil
 }
 
 func IPAddress() (string, error) {

--- a/internal/cli/atlas/accesslists/create_test.go
+++ b/internal/cli/atlas/accesslists/create_test.go
@@ -38,9 +38,11 @@ func TestWhitelistCreate_Run(t *testing.T) {
 		store:     mockStore,
 	}
 
+	projectIPAccessList, _ := createOpts.newProjectIPAccessList()
+
 	mockStore.
 		EXPECT().
-		CreateProjectIPAccessList(createOpts.newProjectIPAccessList()).Return(expected, nil).
+		CreateProjectIPAccessList(projectIPAccessList).Return(expected, nil).
 		Times(1)
 
 	if err := createOpts.Run(); err != nil {

--- a/internal/cli/atlas/alerts/acknowledge.go
+++ b/internal/cli/atlas/alerts/acknowledge.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
+	customTime "github.com/mongodb/mongodb-atlas-cli/internal/time"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
 	"go.mongodb.org/atlas-sdk/admin"
@@ -75,7 +76,7 @@ func (opts *AcknowledgeOpts) newAcknowledgeRequest() (*admin.AlertViewForNdsGrou
 		const years = 100
 		opts.until = time.Now().AddDate(years, 1, 1).Format(time.RFC3339)
 	}
-	time, err := time.Parse(time.RFC3339, opts.until)
+	time, err := customTime.ParseTimestamp(opts.until)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/atlas/datalakepipelines/availablesnapshots/list.go
+++ b/internal/cli/atlas/datalakepipelines/availablesnapshots/list.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
+	customTime "github.com/mongodb/mongodb-atlas-cli/internal/time"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
 )
@@ -56,14 +57,14 @@ func (opts *ListOpts) initStore(ctx context.Context) func() error {
 
 func convertTime(value string) *time.Time {
 	var result *time.Time
-	if completedAfter, err := time.Parse(time.RFC3339, value); err == nil {
+	if completedAfter, err := customTime.ParseTimestamp(value); err == nil {
 		result = &completedAfter
 	}
 	return result
 }
 
 func (opts *ListOpts) validate() error {
-	if _, err := time.Parse(time.RFC3339, opts.completedAfter); opts.completedAfter != "" && err != nil {
+	if _, err := customTime.ParseTimestamp(opts.completedAfter); opts.completedAfter != "" && err != nil {
 		return fmt.Errorf("%w: expected format 'YYYY-MM-DD' got '%s'", ErrCompletedAfterInvalidFormat, opts.completedAfter)
 	}
 	return nil

--- a/internal/convert/database_user.go
+++ b/internal/convert/database_user.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
+	customTime "github.com/mongodb/mongodb-atlas-cli/internal/time"
 	atlasv2 "go.mongodb.org/atlas-sdk/admin"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
@@ -60,7 +61,7 @@ func buildCollectionName(dbCollection []string) *string {
 }
 
 func ParseDeleteAfter(deleteAfter string) *time.Time {
-	deleteAfterDate, err := time.Parse(time.RFC3339, deleteAfter)
+	deleteAfterDate, err := customTime.ParseTimestamp(deleteAfter)
 
 	if err == nil {
 		return &deleteAfterDate

--- a/internal/pointer/pointer.go
+++ b/internal/pointer/pointer.go
@@ -17,6 +17,7 @@ package pointer
 import (
 	"time"
 
+	customTime "github.com/mongodb/mongodb-atlas-cli/internal/time"
 	"golang.org/x/exp/constraints"
 )
 
@@ -47,7 +48,7 @@ func GetArrayPointerIfNotEmpty(input []string) *[]string {
 
 func StringToTimePointer(value string) *time.Time {
 	var result *time.Time
-	if completedAfter, err := time.Parse(time.RFC3339, value); err == nil {
+	if completedAfter, err := customTime.ParseTimestamp(value); err == nil {
 		result = &completedAfter
 	}
 	return result

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -20,7 +20,6 @@ func ParseTimestamp(timestamp string) (time.Time, error) {
 	layouts := []string{
 		time.RFC3339,
 		"2006-01-02T15:04:05-0700",
-		"2006-01-02T15:04:05Z07:00",
 	}
 
 	var parsedTime time.Time

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -1,0 +1,37 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package time
+
+import "time"
+
+func ParseTimestamp(timestamp string) (time.Time, error) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05-0700",
+		"2006-01-02T15:04:05Z07:00",
+	}
+
+	var parsedTime time.Time
+	var err error
+
+	for _, layout := range layouts {
+		parsedTime, err = time.Parse(layout, timestamp)
+		if err == nil {
+			break
+		}
+	}
+
+	return parsedTime, err
+}

--- a/internal/time/time_test.go
+++ b/internal/time/time_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package time
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_ParseTimestamp(t *testing.T) {
+	testCases := map[string]struct {
+		timestamp string
+		want      time.Time
+		wantErr   bool
+	}{
+		"Valid timestamps in RFC3339 format": {
+			timestamp: "2023-06-17T00:00:00Z",
+			want:      time.Date(2023, 6, 17, 0, 0, 0, 0, time.UTC),
+			wantErr:   false,
+		},
+		"Valid timestamp with custom layout": {
+			timestamp: "2023-06-17T00:00:00-0000",
+			want:      time.Date(2023, 6, 17, 0, 0, 0, 0, time.UTC),
+			wantErr:   false,
+		},
+		"Invalid timestamp": {
+			timestamp: "2023-06-15T18:25:55",
+			want:      time.Time{},
+			wantErr:   true,
+		},
+	}
+
+	for name, tc := range testCases {
+		input := tc.timestamp
+		expected := tc.want
+		wantErr := tc.wantErr
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ts, err := ParseTimestamp(input)
+			if (err != nil) != wantErr {
+				t.Fatalf("parseTimestamp() unexpected error: %v\n", err)
+			}
+			if !ts.Equal(expected) {
+				t.Errorf("parseTimestamp() expected: %s but got: %s", expected, ts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

For v1 SDK, timestamps were sent from the SDK as strings and only parsed once they reached the API 

Since migrating to autogenerated v2 Go SDK, timestamps are sent as `time.Time` structs, meaning we need to parse 

The end result is that we are using a different parser since moving to the v2 SDK, which needs to support some custom layouts that were supported by the API for the v1 SDK


_Jira ticket:_ CLOUDP-183519

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
