### PR TITLE
CLOUDP-185078: Address AtlasCLI release failure due to Chocolatey push source configuration

### DIFF
--- a/tools/chocolateyupdate/main.go
+++ b/tools/chocolateyupdate/main.go
@@ -21,8 +21,8 @@ import (
 	"os/exec"
 )
 
-func update(path, secret string) error {
-	cmd := exec.Command("choco", "push", path, "--api-key", secret)
+func update(path, secret string, sourcePath string) error {
+	cmd := exec.Command("choco", "push", path, "--api-key", secret, "--source", sourcePath)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
@@ -31,16 +31,18 @@ func update(path, secret string) error {
 
 func main() {
 	var packagePath string
+	var sourcePath string
 	secret := os.Getenv("SECRET_API_KEY")
 
 	flag.StringVar(&packagePath, "path", "", "Chocolatey package path")
+	flag.StringVar(&sourcePath, "source", "https://push.chocolatey.org/", "Chocolatey source path")
 	flag.Parse()
 
 	if packagePath == "" {
 		log.Fatalln("You must specify Chocolatey package path")
 	}
 
-	err := update(packagePath, secret)
+	err := update(packagePath, secret, sourcePath)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Proposed changes
Currently blocking AtlasCLI release 1.7.4

https://evergreen.mongodb.com/task/mongodb_atlas_cli_master_release_atlascli_msi_release_msi__atlascli_v1.7.4_23_06_15_16_38_36

```
Chocolatey v2.0.0  
Default push source configuration is not set. Please pass a source to push to, such as --source=https://push.chocolatey.org/
2023/06/16 09:05:19 exit status 1 
Command 'subprocess.exec' in function 'update choco' failed: process encountered problem: exit code 1. 
Task completed - FAILURE. 
```

[Last release](https://evergreen.mongodb.com/task_log_raw/mongodb_atlas_cli_master_release_atlascli_msi_release_msi__atlascli_v1.7.3_23_06_09_13_48_51/0?type=T#L174) used Chocolatey v1.2.1 
[This release](https://evergreen.mongodb.com/task_log_raw/mongodb_atlas_cli_master_release_atlascli_msi_release_msi__atlascli_v1.7.4_23_06_15_16_38_36/1?type=T#L175 ) used Chocolatey v2.0.0  
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Breaking change introduced with [upgrade-to-chocolatey-v2](https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6#removed-the-chocolatey-community-repository-as-the-default-push-source)



_Jira ticket:_ CLOUDP-185078


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
