### PR TITLE
Cloudp 185931

### DIFF
--- a/test/e2e/atlas/access_lists_test.go
+++ b/test/e2e/atlas/access_lists_test.go
@@ -45,7 +45,7 @@ func TestAccessList(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Create Forever", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"create",
 			entry,
@@ -73,7 +73,7 @@ func TestAccessList(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"ls",
 			"--projectId",
@@ -88,7 +88,7 @@ func TestAccessList(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"describe",
 			entry,
@@ -104,7 +104,7 @@ func TestAccessList(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"delete",
 			entry,
@@ -120,7 +120,7 @@ func TestAccessList(t *testing.T) {
 	})
 
 	t.Run("Create Delete After", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"create",
 			entry,
@@ -148,7 +148,7 @@ func TestAccessList(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"delete",
 			entry,
@@ -164,7 +164,7 @@ func TestAccessList(t *testing.T) {
 	})
 
 	t.Run("Create with CurrentIp", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"create",
 			"--currentIp",
@@ -187,7 +187,7 @@ func TestAccessList(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"delete",
 			currentIPEntry,

--- a/test/e2e/atlas/access_logs_test.go
+++ b/test/e2e/atlas/access_logs_test.go
@@ -39,7 +39,7 @@ func TestAccessLogs(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("List by clusterName", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessLogsEntity,
 			"ls",
 			"--clusterName", g.clusterName,
@@ -54,7 +54,7 @@ func TestAccessLogs(t *testing.T) {
 	})
 
 	t.Run("List by hostname", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessLogsEntity,
 			"ls",
 			"--hostname", h,

--- a/test/e2e/atlas/access_roles_test.go
+++ b/test/e2e/atlas/access_roles_test.go
@@ -37,7 +37,7 @@ func TestAccessRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			cloudProvidersEntity,
 			accessRolesEntity,
 			awsEntity,
@@ -58,7 +58,7 @@ func TestAccessRoles(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			cloudProvidersEntity,
 			accessRolesEntity,
 			"list",

--- a/test/e2e/atlas/alert_settings_test.go
+++ b/test/e2e/atlas/alert_settings_test.go
@@ -36,7 +36,7 @@ func TestAlertConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			configEntity,
 			"create",
@@ -73,7 +73,7 @@ func TestAlertConfig(t *testing.T) {
 	}
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			configEntity,
 			"ls",
@@ -89,7 +89,7 @@ func TestAlertConfig(t *testing.T) {
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			configEntity,
 			"ls",
@@ -106,7 +106,7 @@ func TestAlertConfig(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			configEntity,
 			"update",
@@ -138,14 +138,14 @@ func TestAlertConfig(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath, alertsEntity, configEntity, "delete", alertID, "--force")
+		cmd := exec.Command(cliPath, e2e.DebugFlag, alertsEntity, configEntity, "delete", alertID, "--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List Matcher Fields", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			configEntity,
 			"fields",

--- a/test/e2e/atlas/alerts_test.go
+++ b/test/e2e/atlas/alerts_test.go
@@ -40,7 +40,7 @@ func TestAlerts(t *testing.T) {
 	}
 	// This test should be run before all other tests to grab an alert ID for all others tests
 	t.Run("List with status CLOSED", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			"list",
 			"--status",
@@ -61,7 +61,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("List with status OPEN", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			"list",
 			"--status",
@@ -75,7 +75,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("List with no status", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			"list",
 			"-o=json",
@@ -87,7 +87,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			"describe",
 			alertID,
@@ -107,7 +107,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("Acknowledge", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			"ack",
 			alertID,
@@ -127,7 +127,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("Acknowledge Forever", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			"ack",
 			alertID,
@@ -146,7 +146,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("UnAcknowledge", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			"unack",
 			alertID,

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -374,6 +374,7 @@ func (g *atlasE2ETestGenerator) getProcesses() ([]atlasv2.ApiHostViewAtlas, erro
 	}
 
 	resp, err := g.runCommand(
+		e2e.DebugFlag,
 		processesEntity,
 		"list",
 		"--projectId",
@@ -404,7 +405,9 @@ func (g *atlasE2ETestGenerator) runCommand(args ...string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.Command(cliPath, args...)
+	
+	cmd := exec.Command(cliPath, 
+		args...)
 
 	cmd.Env = os.Environ()
 	return cmd.CombinedOutput()

--- a/test/e2e/atlas/backup_export_buckets_test.go
+++ b/test/e2e/atlas/backup_export_buckets_test.go
@@ -40,7 +40,7 @@ func TestExportBuckets(t *testing.T) {
 	var bucketID string
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			bucketsEntity,
@@ -65,7 +65,7 @@ func TestExportBuckets(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			bucketsEntity,
@@ -84,7 +84,7 @@ func TestExportBuckets(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			bucketsEntity,
@@ -105,7 +105,7 @@ func TestExportBuckets(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			bucketsEntity,

--- a/test/e2e/atlas/backup_export_jobs_test.go
+++ b/test/e2e/atlas/backup_export_jobs_test.go
@@ -48,7 +48,7 @@ func TestExportJobs(t *testing.T) {
 	var snapshotID string
 
 	t.Run("Create cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"create",
 			clusterName,
@@ -70,7 +70,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Watch create cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,
@@ -81,7 +81,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Create bucket", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			bucketsEntity,
@@ -106,7 +106,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Create snapshot", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"create",
@@ -128,7 +128,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Watch snapshot creation", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"watch",
@@ -141,7 +141,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Create job", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			jobsEntity,
@@ -168,7 +168,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Watch create job", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			jobsEntity,
@@ -182,7 +182,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Describe job", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			jobsEntity,
@@ -205,7 +205,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("List jobs", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			exportsEntity,
 			jobsEntity,
@@ -224,7 +224,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Delete snapshot", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"delete",
@@ -238,7 +238,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Watch snapshot deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"watch",
@@ -251,7 +251,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Delete cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"delete",
 			clusterName,
@@ -267,7 +267,7 @@ func TestExportJobs(t *testing.T) {
 	})
 
 	t.Run("Watch delete cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,

--- a/test/e2e/atlas/backup_restores_test.go
+++ b/test/e2e/atlas/backup_restores_test.go
@@ -44,7 +44,7 @@ func TestRestores(t *testing.T) {
 	require.NotEmpty(t, g2.clusterName)
 
 	t.Run("Create snapshot", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"create",
@@ -68,7 +68,7 @@ func TestRestores(t *testing.T) {
 	})
 
 	t.Run("Watch snapshot creation", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"watch",
@@ -83,7 +83,7 @@ func TestRestores(t *testing.T) {
 	})
 
 	t.Run("Restores Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			restoresEntity,
 			"start",
@@ -111,7 +111,7 @@ func TestRestores(t *testing.T) {
 	})
 
 	t.Run("Restores Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			restoresEntity,
 			"watch",
@@ -128,7 +128,7 @@ func TestRestores(t *testing.T) {
 	})
 
 	t.Run("Restores List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			restoresEntity,
 			"list",
@@ -149,7 +149,7 @@ func TestRestores(t *testing.T) {
 	})
 
 	t.Run("Restores Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			restoresEntity,
 			"describe",
@@ -172,7 +172,7 @@ func TestRestores(t *testing.T) {
 	})
 
 	t.Run("Delete snapshot", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"delete",
@@ -188,7 +188,7 @@ func TestRestores(t *testing.T) {
 	})
 
 	t.Run("Watch snapshot deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"watch",

--- a/test/e2e/atlas/backup_schedule_test.go
+++ b/test/e2e/atlas/backup_schedule_test.go
@@ -38,7 +38,7 @@ func TestSchedule(t *testing.T) {
 	var policy *atlasv2.DiskBackupSnapshotSchedule
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			"schedule",
 			"describe",
@@ -58,7 +58,7 @@ func TestSchedule(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			"schedule",
 			"update",
@@ -75,7 +75,7 @@ func TestSchedule(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			"schedule",
 			"delete",

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -42,7 +42,7 @@ func TestServerlessBackup(t *testing.T) {
 	g.generateServerlessCluster()
 
 	t.Run("Snapshot List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			backupsEntity,
 			snapshotsEntity,
@@ -64,7 +64,7 @@ func TestServerlessBackup(t *testing.T) {
 	})
 
 	t.Run("Snapshot Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			backupsEntity,
 			snapshotsEntity,
@@ -87,7 +87,7 @@ func TestServerlessBackup(t *testing.T) {
 	})
 
 	t.Run("Restores Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			backupsEntity,
 			restoresEntity,
@@ -115,7 +115,7 @@ func TestServerlessBackup(t *testing.T) {
 	})
 
 	t.Run("Restores Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			backupsEntity,
 			restoresEntity,
@@ -132,7 +132,7 @@ func TestServerlessBackup(t *testing.T) {
 	})
 
 	t.Run("Restores List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			backupsEntity,
 			restoresEntity,
@@ -152,7 +152,7 @@ func TestServerlessBackup(t *testing.T) {
 	})
 
 	t.Run("Restores Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			backupsEntity,
 			restoresEntity,

--- a/test/e2e/atlas/backup_snapshot_test.go
+++ b/test/e2e/atlas/backup_snapshot_test.go
@@ -41,7 +41,7 @@ func TestSnapshots(t *testing.T) {
 	var snapshotID string
 
 	t.Run("Create cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"create",
 			clusterName,
@@ -63,7 +63,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("Watch create cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,
@@ -74,7 +74,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("Create snapshot", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"create",
@@ -96,7 +96,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("Watch creation", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"watch",
@@ -109,7 +109,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"list",
@@ -128,7 +128,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"describe",
@@ -149,7 +149,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"delete",
@@ -164,7 +164,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("Watch deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"watch",
@@ -177,7 +177,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("Delete cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"delete",
 			clusterName,
@@ -193,7 +193,7 @@ func TestSnapshots(t *testing.T) {
 	})
 
 	t.Run("Watch delete cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,

--- a/test/e2e/atlas/cleanup_test.go
+++ b/test/e2e/atlas/cleanup_test.go
@@ -32,7 +32,7 @@ func TestCleanup(t *testing.T) {
 	cliPath, err := e2e.AtlasCLIBin()
 	req.NoError(err)
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		projectEntity,
 		"list",
 		"-o=json")

--- a/test/e2e/atlas/clusters_file_test.go
+++ b/test/e2e/atlas/clusters_file_test.go
@@ -46,7 +46,7 @@ func TestClustersFile(t *testing.T) {
 	}
 
 	t.Run("Create via file", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"create",
 			clusterFileName,
@@ -65,7 +65,7 @@ func TestClustersFile(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			"--projectId", g.projectID,
@@ -80,7 +80,7 @@ func TestClustersFile(t *testing.T) {
 	})
 
 	t.Run("Update via file", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"update",
 			clusterFileName,
@@ -99,7 +99,7 @@ func TestClustersFile(t *testing.T) {
 	})
 
 	t.Run("Delete file creation", func(t *testing.T) {
-		cmd := exec.Command(cliPath, clustersEntity, "delete", clusterFileName, "--projectId", g.projectID, "--force")
+		cmd := exec.Command(cliPath, e2e.DebugFlag, clustersEntity, "delete", clusterFileName, "--projectId", g.projectID, "--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.NoError(err, string(resp))
@@ -110,7 +110,7 @@ func TestClustersFile(t *testing.T) {
 	})
 
 	t.Run("Watch deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterFileName,

--- a/test/e2e/atlas/clusters_flags_test.go
+++ b/test/e2e/atlas/clusters_flags_test.go
@@ -45,7 +45,7 @@ func TestClustersFlags(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"create",
 			clusterName,
@@ -71,7 +71,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Load Sample Data", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"sampleData",
 			"load",
@@ -91,7 +91,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"ls",
 			"--projectId", g.projectID,
@@ -109,7 +109,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"describe",
 			clusterName,
@@ -128,7 +128,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Describe Connection String", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"cs",
 			"describe",
@@ -149,7 +149,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Update Advanced Configuration Settings", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"advancedSettings",
 			"update",
@@ -164,7 +164,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Describe Advanced Configuration Settings", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"advancedSettings",
 			"describe",
@@ -185,7 +185,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Create Rolling Index", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"indexes",
 			"create",
@@ -201,7 +201,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Fail Delete for Termination Protection enabled", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"delete",
 			clusterName,
@@ -214,7 +214,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"update",
 			clusterName,
@@ -235,7 +235,7 @@ func TestClustersFlags(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath, clustersEntity, "delete", clusterName, "--projectId", g.projectID, "--force", "-w")
+		cmd := exec.Command(cliPath, e2e.DebugFlag, clustersEntity, "delete", clusterName, "--projectId", g.projectID, "--force", "-w")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.NoError(err)

--- a/test/e2e/atlas/clusters_m0_test.go
+++ b/test/e2e/atlas/clusters_m0_test.go
@@ -47,7 +47,7 @@ func TestClustersM0Flags(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"create",
 			clusterName,
@@ -69,7 +69,7 @@ func TestClustersM0Flags(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,
@@ -84,7 +84,7 @@ func TestClustersM0Flags(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"describe",
 			clusterName,
@@ -104,7 +104,7 @@ func TestClustersM0Flags(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"delete",
 			clusterName,
@@ -121,7 +121,7 @@ func TestClustersM0Flags(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,

--- a/test/e2e/atlas/clusters_sharded_test.go
+++ b/test/e2e/atlas/clusters_sharded_test.go
@@ -45,7 +45,7 @@ func TestShardedCluster(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Create sharded cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"create",
 			shardedClusterName,
@@ -72,7 +72,7 @@ func TestShardedCluster(t *testing.T) {
 	})
 
 	t.Run("Delete sharded cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath, clustersEntity, "delete", shardedClusterName, "--projectId", g.projectID, "--force")
+		cmd := exec.Command(cliPath, e2e.DebugFlag, clustersEntity, "delete", shardedClusterName, "--projectId", g.projectID, "--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.NoError(err, string(resp))
@@ -82,7 +82,7 @@ func TestShardedCluster(t *testing.T) {
 	})
 
 	t.Run("Watch deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			shardedClusterName,

--- a/test/e2e/atlas/clusters_upgrade_test.go
+++ b/test/e2e/atlas/clusters_upgrade_test.go
@@ -44,7 +44,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"create",
 			clusterName,
@@ -67,7 +67,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 	})
 
 	t.Run("Watch create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,
@@ -79,7 +79,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 	})
 
 	t.Run("Fail Delete for Termination Protection", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"delete",
 			clusterName,
@@ -92,7 +92,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 	})
 
 	t.Run("Upgrade", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"upgrade",
 			clusterName,
@@ -109,7 +109,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 	})
 
 	t.Run("Watch upgrade", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,
@@ -121,7 +121,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 	})
 
 	t.Run("Ensure upgrade", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"get",
 			clusterName,
@@ -139,7 +139,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"delete",
 			clusterName,
@@ -156,7 +156,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 	})
 
 	t.Run("Watch deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,

--- a/test/e2e/atlas/custom_db_roles_test.go
+++ b/test/e2e/atlas/custom_db_roles_test.go
@@ -45,7 +45,7 @@ func TestDBRoles(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDBRoleEntity,
 			"create",
 			roleName,
@@ -69,7 +69,7 @@ func TestDBRoles(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDBRoleEntity,
 			"ls",
 			"-o=json")
@@ -84,7 +84,7 @@ func TestDBRoles(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDBRoleEntity,
 			"describe",
 			roleName,
@@ -105,7 +105,7 @@ func TestDBRoles(t *testing.T) {
 	})
 
 	t.Run("Update with append", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDBRoleEntity,
 			"update",
 			roleName,
@@ -131,7 +131,7 @@ func TestDBRoles(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDBRoleEntity,
 			"update",
 			roleName,
@@ -151,7 +151,7 @@ func TestDBRoles(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDBRoleEntity,
 			"delete",
 			roleName,

--- a/test/e2e/atlas/custom_dns_test.go
+++ b/test/e2e/atlas/custom_dns_test.go
@@ -35,7 +35,7 @@ func TestCustomDNS(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Enable", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDNSEntity,
 			awsEntity,
 			"enable",
@@ -55,7 +55,7 @@ func TestCustomDNS(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDNSEntity,
 			awsEntity,
 			"describe",
@@ -75,7 +75,7 @@ func TestCustomDNS(t *testing.T) {
 	})
 
 	t.Run("Disable", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDNSEntity,
 			awsEntity,
 			"disable",

--- a/test/e2e/atlas/data_lake_pipelines_test.go
+++ b/test/e2e/atlas/data_lake_pipelines_test.go
@@ -39,7 +39,7 @@ func TestDataLakePipelines(t *testing.T) {
 	g.generateProjectAndCluster("dataLakePipeline")
 
 	t.Run("Load Sample Data", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"sampleData",
 			"load",
@@ -71,7 +71,7 @@ func TestDataLakePipelines(t *testing.T) {
 
 	var snapshotID string
 	t.Run("Generate Snapshot", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			snapshotsEntity,
 			"create", g.clusterName,
@@ -104,7 +104,7 @@ func TestDataLakePipelines(t *testing.T) {
 	var pipelineID, pipelineRunID string
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"create", pipelineName,
 			"--sourceType", "ON_DEMAND_CPS",
@@ -132,7 +132,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"watch", pipelineName,
 			"--projectId", g.projectID)
@@ -143,7 +143,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"describe", pipelineName,
 			"--projectId", g.projectID,
@@ -160,7 +160,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"ls",
 			"--projectId", g.projectID,
@@ -177,7 +177,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"update", pipelineName,
 			"--sinkMetadataProvider", "AWS",
@@ -198,7 +198,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Trigger", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"trigger", pipelineName,
 			"--snapshotId", snapshotID,
@@ -218,7 +218,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Pause", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"pause", pipelineName,
 			"--projectId", g.projectID,
@@ -236,7 +236,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Start", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"start", pipelineName,
 			"--projectId", g.projectID,
@@ -254,7 +254,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Runs List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"runs",
 			"ls",
@@ -273,7 +273,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Runs Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"runs",
 			"describe", pipelineRunID,
@@ -293,7 +293,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Runs Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"runs",
 			"watch", pipelineRunID,
@@ -306,7 +306,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Datasets Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"datasets",
 			"delete", pipelineRunID,
@@ -320,7 +320,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("AvailableSchedules List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"availableschedules",
 			"ls",
@@ -339,7 +339,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("AvailableSnapshots List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"availablesnapshots",
 			"ls",
@@ -358,7 +358,7 @@ func TestDataLakePipelines(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakePipelineEntity,
 			"delete", pipelineName,
 			"--projectId", g.projectID,

--- a/test/e2e/atlas/data_lake_private_endpoint_test.go
+++ b/test/e2e/atlas/data_lake_private_endpoint_test.go
@@ -40,7 +40,7 @@ func TestDataLakePrivateEndpointsAWS(t *testing.T) {
 	vpcID := fmt.Sprintf("vpce-0fcd9d80bbafe%d", 1000+n.Int64())
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			datalakeEntity,
 			awsEntity,
@@ -62,7 +62,7 @@ func TestDataLakePrivateEndpointsAWS(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			datalakeEntity,
 			awsEntity,
@@ -82,7 +82,7 @@ func TestDataLakePrivateEndpointsAWS(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			datalakeEntity,
 			awsEntity,
@@ -102,7 +102,7 @@ func TestDataLakePrivateEndpointsAWS(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			datalakeEntity,
 			awsEntity,

--- a/test/e2e/atlas/data_lake_test.go
+++ b/test/e2e/atlas/data_lake_test.go
@@ -45,7 +45,7 @@ func TestDataLakes(t *testing.T) {
 	r.NotEmpty(roleID)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakeEntity,
 			"create",
 			dataLakeName,
@@ -67,7 +67,7 @@ func TestDataLakes(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakeEntity,
 			"describe",
 			dataLakeName,
@@ -85,7 +85,7 @@ func TestDataLakes(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakeEntity,
 			"ls",
 			"-o=json")
@@ -102,7 +102,7 @@ func TestDataLakes(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		const updateRegion = "VIRGINIA_USA"
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakeEntity,
 			"update",
 			dataLakeName,
@@ -121,7 +121,7 @@ func TestDataLakes(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			datalakeEntity,
 			"delete",
 			dataLakeName,

--- a/test/e2e/atlas/dbusers_certs_test.go
+++ b/test/e2e/atlas/dbusers_certs_test.go
@@ -40,7 +40,7 @@ func TestDBUserCerts(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	t.Run("Create DBUser", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"create",
 			"atlasAdmin",
@@ -64,7 +64,7 @@ func TestDBUserCerts(t *testing.T) {
 	})
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			certsEntity,
 			"create",
@@ -85,7 +85,7 @@ func TestDBUserCerts(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			certsEntity,
 			"list",
@@ -108,7 +108,7 @@ func TestDBUserCerts(t *testing.T) {
 	})
 
 	t.Run("Delete User", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"delete",
 			username,

--- a/test/e2e/atlas/dbusers_test.go
+++ b/test/e2e/atlas/dbusers_test.go
@@ -51,7 +51,7 @@ func TestDBUserWithFlags(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
 		pwd, err := generateRandomBase64String(14)
 		require.NoError(t, err)
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"create",
 			"atlasAdmin",
@@ -66,7 +66,7 @@ func TestDBUserWithFlags(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"ls",
 			"-o=json")
@@ -83,7 +83,7 @@ func TestDBUserWithFlags(t *testing.T) {
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"ls",
 			"-c",
@@ -107,7 +107,7 @@ func TestDBUserWithFlags(t *testing.T) {
 	t.Run("Update", func(t *testing.T) {
 		pwd, err := generateRandomBase64String(14)
 		require.NoError(t, err)
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"update",
 			username,
@@ -141,7 +141,7 @@ func TestDBUsersWithStdin(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
 		pwd, err := generateRandomBase64String(14)
 		require.NoError(t, err)
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"create",
 			"atlasAdmin",
@@ -161,7 +161,7 @@ func TestDBUsersWithStdin(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"update",
 			username,
@@ -203,7 +203,7 @@ func testCreateUserCmd(t *testing.T, cmd *exec.Cmd, username string) {
 func testDescribeUser(t *testing.T, cliPath, username string) {
 	t.Helper()
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		dbusersEntity,
 		"describe",
 		username,
@@ -244,7 +244,7 @@ func testUpdateUserCmd(t *testing.T, cmd *exec.Cmd, username string) {
 func testDeleteUser(t *testing.T, cliPath, dbusersEntity, username string) {
 	t.Helper()
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		dbusersEntity,
 		"delete",
 		username,

--- a/test/e2e/atlas/decryption_aws_test.go
+++ b/test/e2e/atlas/decryption_aws_test.go
@@ -46,7 +46,7 @@ func TestDecryptWithAWS(t *testing.T) {
 	expectedContents, err := filesAWS.ReadFile(decryption.GenerateFileName(awsTestsInputDir, "output"))
 	req.NoError(err)
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		"logs",
 		"decrypt",
 		"--file",

--- a/test/e2e/atlas/decryption_azure_test.go
+++ b/test/e2e/atlas/decryption_azure_test.go
@@ -46,7 +46,7 @@ func TestDecryptWithAzure(t *testing.T) {
 	expectedContents, err := filesAzure.ReadFile(decryption.GenerateFileName(azureTestsInputDir, "output"))
 	req.NoError(err)
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		"logs",
 		"decrypt",
 		"--file",

--- a/test/e2e/atlas/decryption_gcp_test.go
+++ b/test/e2e/atlas/decryption_gcp_test.go
@@ -56,7 +56,7 @@ func TestDecryptWithGCP(t *testing.T) {
 	expectedContents, err := filesGCP.ReadFile(decryption.GenerateFileName(gcpTestsInputDir, "output"))
 	req.NoError(err)
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		"logs",
 		"decrypt",
 		"--file",

--- a/test/e2e/atlas/decryption_localkey_test.go
+++ b/test/e2e/atlas/decryption_localkey_test.go
@@ -46,7 +46,7 @@ func TestDecryptWithLocalKey(t *testing.T) {
 	expectedContents, err := filesLocalKey.ReadFile(decryption.GenerateFileName(localKeyTestsInputDir, "output"))
 	req.NoError(err)
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		"logs",
 		"decrypt",
 		"--file",

--- a/test/e2e/atlas/events_test.go
+++ b/test/e2e/atlas/events_test.go
@@ -32,7 +32,7 @@ func TestEvents(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	t.Run("List Project Events", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			eventsEntity,
 			projectEntity,
 			"list",
@@ -56,7 +56,7 @@ func TestEvents(t *testing.T) {
 	})
 
 	t.Run("List Organization Events", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			eventsEntity,
 			orgEntity,
 			"list",

--- a/test/e2e/atlas/integrations_test.go
+++ b/test/e2e/atlas/integrations_test.go
@@ -46,7 +46,7 @@ func TestIntegrations(t *testing.T) {
 		if IsGov() {
 			t.Skip("Skipping DATADOG integration test, cloudgov does not have an available datadog region")
 		}
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"create",
 			datadogEntity,
@@ -71,7 +71,7 @@ func TestIntegrations(t *testing.T) {
 		n, err := e2e.RandInt(9)
 		require.NoError(t, err)
 		opsGenieKey := "00000000-aaaa-2222-bbbb-3333333333" + n.String() + n.String()
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"create",
 			opsGenieEntity,
@@ -96,7 +96,7 @@ func TestIntegrations(t *testing.T) {
 		n, err := e2e.RandInt(9)
 		require.NoError(t, err)
 		pagerDutyKey := "000000000000000000000000000000" + n.String() + n.String()
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"create",
 			pagerDutyEntity,
@@ -121,7 +121,7 @@ func TestIntegrations(t *testing.T) {
 		n, err := e2e.RandInt(9)
 		require.NoError(t, err)
 		victorOpsKey := "fa07bbc8-eab2-4085-81af-daed47dc1c" + n.String() + n.String()
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"create",
 			victorOpsEntity,
@@ -145,7 +145,7 @@ func TestIntegrations(t *testing.T) {
 	})
 
 	t.Run("Create WEBHOOK", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"create",
 			webhookEntity,
@@ -169,7 +169,7 @@ func TestIntegrations(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"ls",
 			"--projectId",
@@ -187,7 +187,7 @@ func TestIntegrations(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"describe",
 			webhookEntity,
@@ -206,7 +206,7 @@ func TestIntegrations(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"delete",
 			webhookEntity,

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -44,7 +44,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 		g := newAtlasE2ETestGenerator(t)
 		g.generateProject("k8sConfigApplyWrongNs")
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"apply",
@@ -67,7 +67,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 			operator.restoreOperator()
 		})
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"apply",
@@ -89,7 +89,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 			operator.restoreOperatorImage()
 		})
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"apply",
@@ -111,7 +111,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 			operator.startOperator()
 		})
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"apply",
@@ -204,7 +204,7 @@ func setupAtlasResources(t *testing.T) *atlasE2ETestGenerator {
 	cliPath, err := e2e.AtlasCLIBin()
 	require.NoError(t, err)
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		projectsEntity,
 		teamsEntity,
 		"add",
@@ -432,7 +432,7 @@ func referenceExportedDeployment(projectName, clusterName string) *akov1.AtlasDe
 func deleteTeamFromProject(t *testing.T, cliPath, projectID, teamID string) {
 	t.Helper()
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		projectsEntity,
 		teamsEntity,
 		"delete",

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -139,7 +139,7 @@ func TestEmptyProject(t *testing.T) {
 	assertions := s.assertions
 
 	t.Run("Generate valid resources of ONE project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"generate",
@@ -191,7 +191,7 @@ func TestProjectWithNonDefaultSettings(t *testing.T) {
 	expectedProject.Spec.Settings.IsCollectDatabaseSpecificsStatisticsEnabled = pointer.Get(false)
 
 	t.Run("Change project settings and generate", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			settingsEntity,
 			"update",
@@ -256,7 +256,7 @@ func TestProjectWithNonDefaultAlertConf(t *testing.T) {
 	}
 
 	t.Run("Change project alert config and generate", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			alertsEntity,
 			configEntity,
 			"create",
@@ -321,7 +321,7 @@ func TestProjectWithAccessList(t *testing.T) {
 	}
 
 	t.Run("Add access list to the project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			accessListEntity,
 			"create",
 			newIPAccess.IPAddress,
@@ -376,7 +376,7 @@ func TestProjectWithAccessRole(t *testing.T) {
 	}
 
 	t.Run("Add access role to the project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			cloudProvidersEntity,
 			accessRolesEntity,
 			awsEntity,
@@ -441,7 +441,7 @@ func TestProjectWithCustomRole(t *testing.T) {
 	}
 
 	t.Run("Add custom role to the project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			customDBRoleEntity,
 			"create",
 			newCustomRole.Name,
@@ -501,7 +501,7 @@ func TestProjectWithIntegration(t *testing.T) {
 	}
 
 	t.Run("Add integration to the project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			integrationsEntity,
 			"create",
 			datadogEntity,
@@ -560,7 +560,7 @@ func TestProjectWithMaintenanceWindow(t *testing.T) {
 	expectedProject.Spec.AlertConfigurations = defaultMaintenanceWindowAlertConfigs()
 
 	t.Run("Add integration to the project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			maintenanceEntity,
 			"update",
 			"--dayOfWeek",
@@ -618,7 +618,7 @@ func TestProjectWithNetworkPeering(t *testing.T) {
 	}
 
 	t.Run("Add network peer to the project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			networkingEntity,
 			networkPeeringEntity,
 			"create",
@@ -686,7 +686,7 @@ func TestProjectWithPrivateEndpoint_Azure(t *testing.T) {
 	}
 
 	t.Run("Add network peer to the project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			azureEntity,
 			"create",
@@ -767,7 +767,7 @@ func TestProjectAndTeams(t *testing.T) {
 			},
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			teamsEntity,
 			"add",
@@ -1212,7 +1212,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 	require.NoError(t, atlasV1.AddToScheme(scheme.Scheme))
 
 	t.Run("Update backup schedule", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			backupsEntity,
 			"schedule",
 			"update",
@@ -1233,7 +1233,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 	})
 
 	t.Run("Generate valid resources of ONE project and ONE cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"generate",
@@ -1310,7 +1310,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 	})
 
 	t.Run("Generate valid resources of ONE project and TWO clusters", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"generate",
@@ -1360,7 +1360,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 	})
 
 	t.Run("Generate valid resources of ONE project and TWO clusters without listing clusters", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"generate",
@@ -1431,7 +1431,7 @@ func TestKubernetesConfigGenerateSharedCluster(t *testing.T) {
 	require.NoError(t, atlasV1.AddToScheme(scheme.Scheme))
 
 	t.Run("Generate valid resources of ONE project and TWO clusters without listing clusters", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"config",
 			"generate",

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -50,7 +50,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("should failed to install old and not supported version of the operator", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -62,7 +62,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	})
 
 	t.Run("should failed to install a non-existing version of the operator", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -74,7 +74,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	})
 
 	t.Run("should failed when unable to setup connection to the cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -90,7 +90,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		operator := setupCluster(t, clusterName)
 		context := fmt.Sprintf("kind-%s", clusterName)
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -108,7 +108,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		operator := setupCluster(t, clusterName, operatorNamespace)
 		context := fmt.Sprintf("kind-%s", clusterName)
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -130,7 +130,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		operator := setupCluster(t, clusterName, operatorNamespace, operatorWatch1, operatorWatch2)
 		context := fmt.Sprintf("kind-%s", clusterName)
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -151,7 +151,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		operator := setupCluster(t, clusterName, operatorNamespace)
 		context := fmt.Sprintf("kind-%s", clusterName)
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -173,7 +173,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		context := fmt.Sprintf("kind-%s", clusterName)
 		projectName := "MyK8sProject"
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -248,7 +248,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		operator := setupCluster(t, clusterName, operatorNamespace)
 		context := fmt.Sprintf("kind-%s", clusterName)
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"kubernetes",
 			"operator",
 			"install",
@@ -439,7 +439,7 @@ func cleanUpKeys(t *testing.T, operator *operatorHelper, namespace string, cliPa
 		toDelete[secret.Name] = struct{}{}
 	}
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		orgEntity,
 		"apiKeys",
 		"ls",

--- a/test/e2e/atlas/ldap_test.go
+++ b/test/e2e/atlas/ldap_test.go
@@ -44,7 +44,7 @@ func TestLDAPWithFlags(t *testing.T) {
 
 	var requestID string
 	t.Run("Verify", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			securityEntity,
 			ldapEntity,
 			"verify",
@@ -66,7 +66,7 @@ func TestLDAPWithFlags(t *testing.T) {
 	require.NotEmpty(t, requestID)
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			securityEntity,
 			ldapEntity,
 			"verify",
@@ -82,7 +82,7 @@ func TestLDAPWithFlags(t *testing.T) {
 	})
 
 	t.Run("Get Status", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			securityEntity,
 			ldapEntity,
 			"verify",
@@ -104,7 +104,7 @@ func TestLDAPWithFlags(t *testing.T) {
 	})
 
 	t.Run("Save", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			securityEntity,
 			ldapEntity,
 			"save",
@@ -129,7 +129,7 @@ func TestLDAPWithFlags(t *testing.T) {
 	})
 
 	t.Run("Get", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			securityEntity,
 			ldapEntity,
 			"get",
@@ -162,7 +162,7 @@ func TestLDAPWithStdin(t *testing.T) {
 	var requestID string
 
 	t.Run("Verify", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			securityEntity,
 			ldapEntity,
 			"verify",
@@ -185,7 +185,7 @@ func TestLDAPWithStdin(t *testing.T) {
 	require.NotEmpty(t, requestID)
 
 	t.Run("Save", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			securityEntity,
 			ldapEntity,
 			"save",
@@ -218,7 +218,7 @@ func TestLDAPWithStdin(t *testing.T) {
 func testLDAPDelete(t *testing.T, cliPath, projectID string) {
 	t.Helper()
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		securityEntity,
 		ldapEntity,
 		"delete",

--- a/test/e2e/atlas/live_migrations_test.go
+++ b/test/e2e/atlas/live_migrations_test.go
@@ -43,7 +43,7 @@ func TestLinkToken(t *testing.T) {
 	t.Logf("Cleanup complete.")
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			liveMigrationsEntity,
 			"link",
 			"create",
@@ -56,7 +56,7 @@ func TestLinkToken(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			liveMigrationsEntity,
 			"link",
 			"delete",

--- a/test/e2e/atlas/logs_test.go
+++ b/test/e2e/atlas/logs_test.go
@@ -61,7 +61,7 @@ func downloadLogTmpPath(t *testing.T, cliPath, hostname, logFile, projectID stri
 	}
 	filepath := dir + logFile
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		logsEntity,
 		"download",
 		hostname,
@@ -86,7 +86,7 @@ func downloadLogTmpPath(t *testing.T, cliPath, hostname, logFile, projectID stri
 
 func downloadLog(t *testing.T, cliPath, hostname, logFile, projectID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		logsEntity,
 		"download",
 		hostname,

--- a/test/e2e/atlas/maintenance_test.go
+++ b/test/e2e/atlas/maintenance_test.go
@@ -35,7 +35,7 @@ func TestMaintenanceWindows(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			maintenanceEntity,
 			"update",
 			"--dayOfWeek",
@@ -55,7 +55,7 @@ func TestMaintenanceWindows(t *testing.T) {
 	})
 
 	t.Run("describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			maintenanceEntity,
 			"describe",
 			"-o",
@@ -76,7 +76,7 @@ func TestMaintenanceWindows(t *testing.T) {
 	})
 
 	t.Run("clear", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			maintenanceEntity,
 			"clear",
 			"--force",

--- a/test/e2e/atlas/metrics_test.go
+++ b/test/e2e/atlas/metrics_test.go
@@ -57,7 +57,7 @@ func TestMetrics(t *testing.T) {
 
 func process(t *testing.T, cliPath, hostname, projectID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		metricsEntity,
 		"processes",
 		hostname,
@@ -76,7 +76,7 @@ func process(t *testing.T, cliPath, hostname, projectID string) {
 
 func processWithType(t *testing.T, cliPath, hostname, projectID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		metricsEntity,
 		"processes",
 		hostname,
@@ -97,7 +97,7 @@ func processWithType(t *testing.T, cliPath, hostname, projectID string) {
 func databases(t *testing.T, cliPath, hostname, projectID string) {
 	t.Helper()
 	t.Run("databases list", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			metricsEntity,
 			"databases",
 			"list",
@@ -114,7 +114,7 @@ func databases(t *testing.T, cliPath, hostname, projectID string) {
 	})
 
 	t.Run("databases describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			metricsEntity,
 			"databases",
 			"describe",
@@ -137,7 +137,7 @@ func databases(t *testing.T, cliPath, hostname, projectID string) {
 func disks(t *testing.T, cliPath, hostname, projectID string) {
 	t.Helper()
 	t.Run("disks list", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			metricsEntity,
 			"disks",
 			"list",
@@ -154,7 +154,7 @@ func disks(t *testing.T, cliPath, hostname, projectID string) {
 	})
 
 	t.Run("disks describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			metricsEntity,
 			"disks",
 			"describe",

--- a/test/e2e/atlas/online_archives_test.go
+++ b/test/e2e/atlas/online_archives_test.go
@@ -78,7 +78,7 @@ func TestOnlineArchives(t *testing.T) {
 
 func deleteOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		clustersEntity,
 		onlineArchiveEntity,
 		"rm",
@@ -98,7 +98,7 @@ func deleteOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveI
 
 func watchOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		clustersEntity,
 		onlineArchiveEntity,
 		"watch",
@@ -112,7 +112,7 @@ func watchOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID
 
 func startOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		clustersEntity,
 		onlineArchiveEntity,
 		"start",
@@ -132,7 +132,7 @@ func startOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID
 
 func pauseOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		clustersEntity,
 		onlineArchiveEntity,
 		"pause",
@@ -154,7 +154,7 @@ func updateOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveI
 	t.Helper()
 	const expireAfterDays = 4
 	expireAfterDaysStr := fmt.Sprintf("%d", expireAfterDays)
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		clustersEntity,
 		onlineArchiveEntity,
 		"update",
@@ -178,7 +178,7 @@ func updateOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveI
 
 func describeOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		clustersEntity,
 		onlineArchiveEntity,
 		"describe",
@@ -202,7 +202,7 @@ func describeOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiv
 
 func listOnlineArchives(t *testing.T, cliPath, projectID, clusterName string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		clustersEntity,
 		onlineArchiveEntity,
 		"list",
@@ -225,7 +225,7 @@ func listOnlineArchives(t *testing.T, cliPath, projectID, clusterName string) {
 func createOnlineArchive(t *testing.T, cliPath, projectID, clusterName string) string {
 	t.Helper()
 	const dbName = "test"
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		clustersEntity,
 		onlineArchiveEntity,
 		"create",

--- a/test/e2e/atlas/performance_advisor_test.go
+++ b/test/e2e/atlas/performance_advisor_test.go
@@ -39,7 +39,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 	}
 
 	t.Run("List namespaces", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			performanceAdvisorEntity,
 			namespacesEntity,
 			"list",
@@ -55,7 +55,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 	})
 
 	t.Run("List slow query logs", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			performanceAdvisorEntity,
 			slowQueryLogsEntity,
 			"list",
@@ -71,7 +71,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 	})
 
 	t.Run("List suggested indexes", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			performanceAdvisorEntity,
 			suggestedIndexesEntity,
 			"list",
@@ -87,7 +87,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 	})
 
 	t.Run("Enable Managed Slow Operation Threshold", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			performanceAdvisorEntity,
 			slowOperationThresholdEntity,
 			"enable",
@@ -101,7 +101,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 	})
 
 	t.Run("Disable Managed Slow Operation Threshold", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			performanceAdvisorEntity,
 			slowOperationThresholdEntity,
 			"disable",

--- a/test/e2e/atlas/private_endpoint_test.go
+++ b/test/e2e/atlas/private_endpoint_test.go
@@ -52,7 +52,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 	var id string
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			awsEntity,
 			"create",
@@ -73,7 +73,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 	require.NotEmpty(t, id)
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			awsEntity,
 			"watch",
@@ -87,7 +87,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			awsEntity,
 			"describe",
@@ -106,7 +106,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			awsEntity,
 			"ls",
@@ -125,7 +125,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			awsEntity,
 			"delete",
@@ -143,7 +143,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			awsEntity,
 			"watch",
@@ -181,7 +181,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 	var id string
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			azureEntity,
 			"create",
@@ -204,7 +204,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 	}
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			azureEntity,
 			"watch",
@@ -219,7 +219,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			azureEntity,
 			"describe",
@@ -238,7 +238,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			azureEntity,
 			"ls",
@@ -257,7 +257,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			azureEntity,
 			"delete",
@@ -275,7 +275,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			azureEntity,
 			"watch",
@@ -321,7 +321,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 	var id string
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			gcpEntity,
 			"create",
@@ -342,7 +342,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			gcpEntity,
 			"watch",
@@ -357,7 +357,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			gcpEntity,
 			"describe",
@@ -376,7 +376,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			gcpEntity,
 			"ls",
@@ -395,7 +395,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			gcpEntity,
 			"delete",
@@ -413,7 +413,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			gcpEntity,
 			"watch",
@@ -438,7 +438,7 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Enable regionalized private endpoint setting", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			regionalModeEntity,
 			"enable",
@@ -453,7 +453,7 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 	})
 
 	t.Run("Disable regionalized private endpoint setting", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			regionalModeEntity,
 			"disable",
@@ -468,7 +468,7 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 	})
 
 	t.Run("Get regionalized private endpoint setting", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			privateEndpointsEntity,
 			regionalModeEntity,
 			"get",

--- a/test/e2e/atlas/processes_test.go
+++ b/test/e2e/atlas/processes_test.go
@@ -37,7 +37,7 @@ func TestProcesses(t *testing.T) {
 	var processes *atlasv2.PaginatedHostViewAtlas
 
 	t.Run("list", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			processesEntity,
 			"list",
 			"--projectId", g.projectID,
@@ -56,7 +56,7 @@ func TestProcesses(t *testing.T) {
 	})
 
 	t.Run("list compact", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			processesEntity,
 			"list",
 			"-c",
@@ -77,7 +77,7 @@ func TestProcesses(t *testing.T) {
 	})
 
 	t.Run("describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			processesEntity,
 			"describe",
 			processes.Results[0].GetId(),

--- a/test/e2e/atlas/project_settings_test.go
+++ b/test/e2e/atlas/project_settings_test.go
@@ -46,7 +46,7 @@ func TestProjectSettings(t *testing.T) {
 	}()
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			settingsEntity,
 			"get",
@@ -67,7 +67,7 @@ func TestProjectSettings(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			settingsEntity,
 			"update",

--- a/test/e2e/atlas/quickstart_test.go
+++ b/test/e2e/atlas/quickstart_test.go
@@ -44,7 +44,7 @@ func TestQuickstart(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Run", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"quickstart",
 			"--clusterName", clusterName,
 			"--username", dbUserUsername,
@@ -59,7 +59,7 @@ func TestQuickstart(t *testing.T) {
 	})
 
 	t.Run("Watch Cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,
@@ -72,7 +72,7 @@ func TestQuickstart(t *testing.T) {
 	})
 
 	t.Run("Describe DB User", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"describe",
 			dbUserUsername,
@@ -89,7 +89,7 @@ func TestQuickstart(t *testing.T) {
 	})
 
 	t.Run("Delete Cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"delete",
 			clusterName,
@@ -105,7 +105,7 @@ func TestQuickstart(t *testing.T) {
 	})
 
 	t.Run("Watch cluster deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,

--- a/test/e2e/atlas/search_test.go
+++ b/test/e2e/atlas/search_test.go
@@ -44,7 +44,7 @@ func TestSearch(t *testing.T) {
 	var indexID string
 
 	t.Run("Load Sample data", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"sampleData",
 			"load",
@@ -86,7 +86,7 @@ func TestSearch(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			searchEntity,
 			indexEntity,
@@ -111,7 +111,7 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			searchEntity,
 			indexEntity,
@@ -166,7 +166,7 @@ func TestSearch(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			searchEntity,
 			indexEntity,
@@ -193,7 +193,7 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			searchEntity,
 			indexEntity,
@@ -263,7 +263,7 @@ func TestSearch(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			searchEntity,
 			indexEntity,
@@ -375,7 +375,7 @@ func TestSearch(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			searchEntity,
 			indexEntity,
@@ -440,7 +440,7 @@ func TestSearch(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			searchEntity,
 			indexEntity,
@@ -464,7 +464,7 @@ func TestSearch(t *testing.T) {
 	})
 
 	t.Run("list", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			searchEntity,
 			indexEntity,

--- a/test/e2e/atlas/serverless_test.go
+++ b/test/e2e/atlas/serverless_test.go
@@ -40,7 +40,7 @@ func TestServerless(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			"create",
 			clusterName,
@@ -62,7 +62,7 @@ func TestServerless(t *testing.T) {
 	})
 
 	t.Run("Watch", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			"watch",
 			"--projectId", g.projectID,
@@ -77,7 +77,7 @@ func TestServerless(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			"update",
 			clusterName,
@@ -98,7 +98,7 @@ func TestServerless(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			"ls",
 			"--projectId", g.projectID,
@@ -116,7 +116,7 @@ func TestServerless(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			"describe",
 			clusterName,
@@ -152,7 +152,7 @@ func TestServerless(t *testing.T) {
 	})
 
 	t.Run("Watch deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			serverlessEntity,
 			"watch",
 			clusterName,

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -44,7 +44,7 @@ func TestSetup(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Run", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			"setup",
 			"--clusterName", clusterName,
 			"--username", dbUserUsername,
@@ -59,7 +59,7 @@ func TestSetup(t *testing.T) {
 	})
 
 	t.Run("Watch Cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,
@@ -72,7 +72,7 @@ func TestSetup(t *testing.T) {
 	})
 
 	t.Run("Describe DB User", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			dbusersEntity,
 			"describe",
 			dbUserUsername,
@@ -89,7 +89,7 @@ func TestSetup(t *testing.T) {
 	})
 
 	t.Run("Delete Cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"delete",
 			clusterName,
@@ -105,7 +105,7 @@ func TestSetup(t *testing.T) {
 	})
 
 	t.Run("Watch cluster deletion", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			clustersEntity,
 			"watch",
 			clusterName,

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -22,6 +22,9 @@ import (
 	"path/filepath"
 )
 
+// Used for commands that are safe to return debug flag
+const DebugFlag = "--debug "
+
 func Bin() (string, error) {
 	path := os.Getenv("MCLI_E2E_BINARY")
 	cliPath, err := filepath.Abs(path)

--- a/test/e2e/cloud_manager/agent_api_keys_test.go
+++ b/test/e2e/cloud_manager/agent_api_keys_test.go
@@ -38,7 +38,7 @@ func TestAgentAPIKeys(t *testing.T) {
 	}
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			agentsEntity,
 			apiKeys,

--- a/test/e2e/cloud_manager/agents_test.go
+++ b/test/e2e/cloud_manager/agents_test.go
@@ -34,7 +34,7 @@ func TestAgents(t *testing.T) {
 
 	var hostname string
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			agentsEntity,
 			"list",
@@ -56,7 +56,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("Version List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			agentsEntity,
 			"version",
@@ -77,7 +77,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("Enable backup", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			backupEntity,
 			"enable",
@@ -88,7 +88,7 @@ func TestAgents(t *testing.T) {
 		assert.NoError(t, err, string(resp))
 	})
 	t.Run("Disable backup", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			backupEntity,
 			"disable",
@@ -100,7 +100,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("Enable monitoring", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			monitoringEntity,
 			"enable",
@@ -111,7 +111,7 @@ func TestAgents(t *testing.T) {
 		assert.NoError(t, err, string(resp))
 	})
 	t.Run("Disable monitoring", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			monitoringEntity,
 			"disable",

--- a/test/e2e/cloud_manager/alerts_test.go
+++ b/test/e2e/cloud_manager/alerts_test.go
@@ -42,7 +42,7 @@ func TestAlerts(t *testing.T) {
 	a := assert.New(t)
 
 	t.Run("List with status CLOSED", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			alertsEntity,
 			"list",
@@ -65,7 +65,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("List with status OPEN", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			alertsEntity,
 			"list",
@@ -80,7 +80,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			alertsEntity,
 			"describe",
@@ -102,7 +102,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("List with no status", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			alertsEntity,
 			"list",
@@ -121,7 +121,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("List with status CLOSED", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			alertsEntity,
 			"list",
@@ -142,7 +142,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("Acknowledge", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			alertsEntity,
 			"ack",
@@ -164,7 +164,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("Acknowledge Forever", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			alertsEntity,
 			"ack",
@@ -185,7 +185,7 @@ func TestAlerts(t *testing.T) {
 	})
 
 	t.Run("UnAcknowledge", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			alertsEntity,
 			"unack",

--- a/test/e2e/cloud_manager/dbusers_test.go
+++ b/test/e2e/cloud_manager/dbusers_test.go
@@ -48,7 +48,7 @@ func TestDBUsersWithFlags(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			dbUsersEntity,
 			"create",
@@ -61,7 +61,7 @@ func TestDBUsersWithFlags(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			dbUsersEntity,
 			"ls",
@@ -108,7 +108,7 @@ func TestDBUsersWithStdin(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("CreatePassword", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			dbUsersEntity,
 			"create",
@@ -138,7 +138,7 @@ func generateUsername() (string, error) {
 func testEnableSecurity(t *testing.T, cliPath string) {
 	t.Helper()
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		entity,
 		securityEntity,
 		"enable",
@@ -159,7 +159,7 @@ func testEnableSecurity(t *testing.T, cliPath string) {
 func testDelete(t *testing.T, cliPath, username string) {
 	t.Helper()
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		entity,
 		dbUsersEntity,
 		"delete",

--- a/test/e2e/cloud_manager/decryption_aws_test.go
+++ b/test/e2e/cloud_manager/decryption_aws_test.go
@@ -46,7 +46,7 @@ func TestDecryptWithAWS(t *testing.T) {
 	expectedContents, err := filesAWS.ReadFile(decryption.GenerateFileName(awsTestsInputDir, "output"))
 	req.NoError(err)
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		entity,
 		"logs",
 		"decrypt",

--- a/test/e2e/cloud_manager/decryption_kmip_test.go
+++ b/test/e2e/cloud_manager/decryption_kmip_test.go
@@ -78,7 +78,7 @@ func TestDecryptWithKMIP(t *testing.T) {
 			expectedContents, err2 := filesKmip.ReadFile(decryption.GenerateFileNameCase(kmipTestsInputDir, i, "output"))
 			req.NoError(err2, string(expectedContents))
 
-			cmd := exec.Command(cliPath,
+			cmd := exec.Command(cliPath, e2e.DebugFlag,
 				entity,
 				"logs",
 				"decrypt",

--- a/test/e2e/cloud_manager/decryption_localkey_test.go
+++ b/test/e2e/cloud_manager/decryption_localkey_test.go
@@ -62,7 +62,7 @@ func TestDecrypt(t *testing.T) {
 			expectedContents, err := files.ReadFile(decryption.GenerateFileNameCase(localKeyTestsInputDir, i, "output"))
 			req.NoError(err)
 
-			cmd := exec.Command(cliPath,
+			cmd := exec.Command(cliPath, e2e.DebugFlag,
 				entity,
 				"logs",
 				"decrypt",

--- a/test/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/test/e2e/cloud_manager/deploy_replica_set_test.go
@@ -50,7 +50,7 @@ func TestDeployReplicaSet(t *testing.T) {
 	}
 
 	t.Run("Apply", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"apply",
@@ -67,7 +67,7 @@ func TestDeployReplicaSet(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"ls",
@@ -91,7 +91,7 @@ func TestDeployReplicaSet(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"describe",
@@ -120,7 +120,7 @@ func TestDeployReplicaSet(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"update",
@@ -140,7 +140,7 @@ func TestDeployReplicaSet(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Reclaim free space", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"reclaimFreeSpace",
@@ -157,7 +157,7 @@ func TestDeployReplicaSet(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Restart", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"restart",
@@ -174,7 +174,7 @@ func TestDeployReplicaSet(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Shutdown", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"shutdown",
@@ -191,7 +191,7 @@ func TestDeployReplicaSet(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Unmanage", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"unmanage",
@@ -213,7 +213,7 @@ func TestDeployReplicaSet(t *testing.T) {
 			t.Fatalf("unexpected error: %v\n", err)
 		}
 		for _, h := range hostIDs {
-			cmd := exec.Command(cliPath,
+			cmd := exec.Command(cliPath, e2e.DebugFlag,
 				entity,
 				monitoringEntity,
 				"rm",
@@ -254,7 +254,7 @@ func TestDeployAndDeleteReplicaSet(t *testing.T) {
 	}
 
 	t.Run("Apply", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"apply",
@@ -271,7 +271,7 @@ func TestDeployAndDeleteReplicaSet(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Delete Cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"delete",

--- a/test/e2e/cloud_manager/deploy_sharded_cluster_test.go
+++ b/test/e2e/cloud_manager/deploy_sharded_cluster_test.go
@@ -48,7 +48,7 @@ func TestDeployCluster(t *testing.T) {
 	}
 
 	t.Run("Apply", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"apply",
@@ -65,7 +65,7 @@ func TestDeployCluster(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Restart", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"restart",
@@ -82,7 +82,7 @@ func TestDeployCluster(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Reclaim free space", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"reclaimFreeSpace",
@@ -99,7 +99,7 @@ func TestDeployCluster(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Shutdown", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"shutdown",
@@ -116,7 +116,7 @@ func TestDeployCluster(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Unmanage", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"unmanage",
@@ -138,7 +138,7 @@ func TestDeployCluster(t *testing.T) {
 			t.Fatalf("unexpected error: %v\n", err)
 		}
 		for _, h := range hostIDs {
-			cmd := exec.Command(cliPath,
+			cmd := exec.Command(cliPath, e2e.DebugFlag,
 				entity,
 				monitoringEntity,
 				"rm",
@@ -179,7 +179,7 @@ func TestDeployDeleteCluster(t *testing.T) {
 	}
 
 	t.Run("Apply", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"apply",
@@ -196,7 +196,7 @@ func TestDeployDeleteCluster(t *testing.T) {
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Delete Sharded Cluster", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			clustersEntity,
 			"delete",

--- a/test/e2e/cloud_manager/events_test.go
+++ b/test/e2e/cloud_manager/events_test.go
@@ -34,7 +34,7 @@ func TestEvents(t *testing.T) {
 	}
 
 	t.Run("List Project Event", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			eventsEntity,
 			projectsEntity,
@@ -55,7 +55,7 @@ func TestEvents(t *testing.T) {
 	})
 
 	t.Run("List Organization Event", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			eventsEntity,
 			orgsEntity,

--- a/test/e2e/cloud_manager/feature_policies_test.go
+++ b/test/e2e/cloud_manager/feature_policies_test.go
@@ -49,7 +49,7 @@ func TestFeaturePolicies(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			featurePolicies,
 			"update",
@@ -79,7 +79,7 @@ func TestFeaturePolicies(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			featurePolicies,
 			"list",

--- a/test/e2e/cloud_manager/helper_test.go
+++ b/test/e2e/cloud_manager/helper_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/convert"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
+	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -59,7 +60,7 @@ var (
 // automationServerHostname tries to list available server running the automation agent
 // and returns the first available hostname for deployments.
 func automationServerHostname(cliPath string) (string, error) {
-	cmd := exec.Command(cliPath, entity, serversEntity, "list", "-o=json")
+	cmd := exec.Command(cliPath, e2e.DebugFlag, entity, serversEntity, "list", "-o=json")
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
 	if err != nil {
@@ -88,7 +89,7 @@ func (s byLastConf) Less(i, j int) bool {
 }
 
 func hostIDs(cliPath string) ([]string, error) {
-	cmd := exec.Command(cliPath, entity, processesEntity, "list", "-o=json")
+	cmd := exec.Command(cliPath, e2e.DebugFlag, entity, processesEntity, "list", "-o=json")
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
 	if err != nil {
@@ -373,7 +374,7 @@ func generateShardedConfig(filename, hostname, clusterName, version, fcVersion s
 func watchAutomation(cliPath string) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			"automation",
 			"watch",

--- a/test/e2e/cloud_manager/key_providers_test.go
+++ b/test/e2e/cloud_manager/key_providers_test.go
@@ -49,7 +49,7 @@ func TestKeyProviders(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			"logs",
 			"keyProviders",

--- a/test/e2e/cloud_manager/maintenance_test.go
+++ b/test/e2e/cloud_manager/maintenance_test.go
@@ -49,7 +49,7 @@ func TestMaintenanceWindows(t *testing.T) {
 	var maintenanceWindowID string
 
 	t.Run("create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			maintenanceEntity,
 			"create",
@@ -78,7 +78,7 @@ func TestMaintenanceWindows(t *testing.T) {
 	})
 
 	t.Run("describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			maintenanceEntity,
 			"describe",
@@ -100,7 +100,7 @@ func TestMaintenanceWindows(t *testing.T) {
 	})
 
 	t.Run("list", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			maintenanceEntity,
 			"ls",
@@ -121,7 +121,7 @@ func TestMaintenanceWindows(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			maintenanceEntity,
 			"update",
@@ -145,7 +145,7 @@ func TestMaintenanceWindows(t *testing.T) {
 	})
 
 	t.Run("delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			maintenanceEntity,
 			"delete",

--- a/test/e2e/cloud_manager/servers_test.go
+++ b/test/e2e/cloud_manager/servers_test.go
@@ -33,7 +33,7 @@ func TestServers(t *testing.T) {
 	}
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			entity,
 			serversEntity,
 			"list",

--- a/test/e2e/config/autocomplete_test.go
+++ b/test/e2e/config/autocomplete_test.go
@@ -33,7 +33,7 @@ func TestAutocomplete(t *testing.T) {
 	options := []string{"zsh", "bash", "fish", "powershell"}
 	for _, option := range options {
 		t.Run(option, func(t *testing.T) {
-			cmd := exec.Command(cliPath, completionEntity, option)
+			cmd := exec.Command(cliPath, e2e.DebugFlag, completionEntity, option)
 			cmd.Env = os.Environ()
 			if resp, err := cmd.CombinedOutput(); err != nil {
 				t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
@@ -50,7 +50,7 @@ func TestAtlasCLIAutocomplete(t *testing.T) {
 	options := []string{"zsh", "bash", "fish", "powershell"}
 	for _, option := range options {
 		t.Run(option, func(t *testing.T) {
-			cmd := exec.Command(cliPath, completionEntity, option)
+			cmd := exec.Command(cliPath, e2e.DebugFlag, completionEntity, option)
 			cmd.Env = os.Environ()
 			if resp, err := cmd.CombinedOutput(); err != nil {
 				t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -59,7 +59,7 @@ func TestConfig(t *testing.T) {
 		}
 		defer c.Close()
 
-		cmd := exec.Command(cliPath, configEntity, "-P", "e2e-expect")
+		cmd := exec.Command(cliPath, e2e.DebugFlag, configEntity, "-P", "e2e-expect")
 		cmd.Stdin = c.Tty()
 		cmd.Stdout = c.Tty()
 		cmd.Stderr = c.Tty()
@@ -118,7 +118,7 @@ func TestConfig(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath, configEntity, "ls")
+		cmd := exec.Command(cliPath, e2e.DebugFlag, configEntity, "ls")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		if err != nil {
@@ -172,7 +172,7 @@ func TestConfig(t *testing.T) {
 		}
 	})
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath, configEntity, "delete", "renamed", "--force")
+		cmd := exec.Command(cliPath, e2e.DebugFlag, configEntity, "delete", "renamed", "--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -35,7 +35,7 @@ func CreateProject(projectName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, DebugFlag,
 		iamEntity,
 		projectsEntity,
 		"create",
@@ -60,7 +60,7 @@ func deleteProject(projectID string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, DebugFlag,
 		iamEntity,
 		projectsEntity,
 		"delete",

--- a/test/e2e/iam/atlas_org_api_key_access_list_test.go
+++ b/test/e2e/iam/atlas_org_api_key_access_list_test.go
@@ -47,7 +47,7 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 	entry := fmt.Sprintf("192.168.0.%d", n)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			apiKeyAccessListEntity,
@@ -69,7 +69,7 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			apiKeyAccessListEntity,
@@ -93,7 +93,7 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 
 	t.Run("Create Current IP", func(t *testing.T) {
 		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address from access list")
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			apiKeyAccessListEntity,
@@ -122,7 +122,7 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 
 func deleteAtlasAccessListEntry(t *testing.T, cliPath, entry, apiKeyID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		orgEntity,
 		apiKeysEntity,
 		apiKeyAccessListEntity,

--- a/test/e2e/iam/atlas_org_api_keys_test.go
+++ b/test/e2e/iam/atlas_org_api_keys_test.go
@@ -38,7 +38,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 	// This test must run first to grab the ID of the org to later describe
 	t.Run("Create", func(t *testing.T) {
 		desc := "e2e-test-atlas-org"
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			"create",
@@ -63,7 +63,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 	}
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			"ls",
@@ -82,7 +82,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			"ls",
@@ -103,7 +103,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		newDesc := "e2e-test-atlas-org-updated"
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			"updates",
@@ -125,7 +125,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			"describe",
@@ -145,7 +145,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			apiKeysEntity,
 			"rm",

--- a/test/e2e/iam/atlas_org_invitations_test.go
+++ b/test/e2e/iam/atlas_org_invitations_test.go
@@ -41,7 +41,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 	var orgInvitationID string
 
 	t.Run("Invite", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			invitationsEntity,
 			"invite",
@@ -64,7 +64,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			invitationsEntity,
 			"ls",
@@ -82,7 +82,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			invitationsEntity,
 			"get",
@@ -101,7 +101,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("Update by email", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			invitationsEntity,
 			"update",
@@ -124,7 +124,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("Update by ID", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			invitationsEntity,
 			"update",
@@ -145,7 +145,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			invitationsEntity,
 			"delete",

--- a/test/e2e/iam/atlas_orgs_test.go
+++ b/test/e2e/iam/atlas_orgs_test.go
@@ -36,7 +36,7 @@ func TestAtlasOrgs(t *testing.T) {
 	var orgID string
 	// This test must run first to grab the ID of the org to later describe
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			"ls",
 			"-o=json")
@@ -52,7 +52,7 @@ func TestAtlasOrgs(t *testing.T) {
 	require.NotEmpty(t, orgID)
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			"describe",
 			orgID,
@@ -64,7 +64,7 @@ func TestAtlasOrgs(t *testing.T) {
 
 	var userID string
 	t.Run("List Org Users", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			usersEntity,
 			"ls",
@@ -91,7 +91,7 @@ func TestAtlasOrgs(t *testing.T) {
 	)
 	t.Run("Create", func(t *testing.T) {
 		t.Skip("Skipping create org e2e test, exceeded max number of linked orgs. Will reenable post cleanup")
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			"create",
 			orgName,
@@ -123,7 +123,7 @@ func TestAtlasOrgs(t *testing.T) {
 		}
 		t.Setenv("MCLI_PUBLIC_API_KEY", publicAPIKey)
 		t.Setenv("MCLI_PRIVATE_API_KEY", privateAPIKey)
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			orgEntity,
 			"delete",
 			orgID,

--- a/test/e2e/iam/atlas_project_api_keys_test.go
+++ b/test/e2e/iam/atlas_project_api_keys_test.go
@@ -39,7 +39,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 	// This test must run first to grab the ID of the project to later describe
 	t.Run("Create", func(t *testing.T) {
 		const desc = "e2e-test"
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			apiKeysEntity,
 			"create",
@@ -71,7 +71,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 	}()
 
 	t.Run("Assign", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			apiKeysEntity,
 			"assign",
@@ -84,7 +84,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			apiKeysEntity,
 			"ls",
@@ -103,7 +103,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			apiKeysEntity,
 			"ls",
@@ -123,7 +123,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			apiKeysEntity,
 			"rm",

--- a/test/e2e/iam/atlas_project_invitations_test.go
+++ b/test/e2e/iam/atlas_project_invitations_test.go
@@ -47,7 +47,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Invite", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -72,7 +72,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -92,7 +92,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -113,7 +113,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Update by email", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -140,7 +140,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Update by ID", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -166,7 +166,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,

--- a/test/e2e/iam/atlas_project_teams_test.go
+++ b/test/e2e/iam/atlas_project_teams_test.go
@@ -53,7 +53,7 @@ func TestAtlasProjectTeams(t *testing.T) {
 	})
 
 	t.Run("Add", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			teamsEntity,
 			"add",
@@ -82,7 +82,7 @@ func TestAtlasProjectTeams(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			teamsEntity,
 			"update",
@@ -111,7 +111,7 @@ func TestAtlasProjectTeams(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			teamsEntity,
 			"ls",
@@ -130,7 +130,7 @@ func TestAtlasProjectTeams(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			teamsEntity,
 			"delete",

--- a/test/e2e/iam/atlas_projects_test.go
+++ b/test/e2e/iam/atlas_projects_test.go
@@ -43,7 +43,7 @@ func TestAtlasProjects(t *testing.T) {
 	var projectID string
 	t.Run("Create", func(t *testing.T) {
 		// This depends on a ORG_ID ENV
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			"create",
 			projectName,
@@ -65,7 +65,7 @@ func TestAtlasProjects(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			"ls",
 			"-o=json")
@@ -76,7 +76,7 @@ func TestAtlasProjects(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			"describe",
 			projectID,
@@ -88,7 +88,7 @@ func TestAtlasProjects(t *testing.T) {
 	})
 
 	t.Run("Users", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			usersEntity,
 			"ls",
@@ -101,7 +101,7 @@ func TestAtlasProjects(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			"delete",
 			projectID,

--- a/test/e2e/iam/atlas_team_users_test.go
+++ b/test/e2e/iam/atlas_team_users_test.go
@@ -49,7 +49,7 @@ func TestAtlasTeamUsers(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Add", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			usersEntity,
 			"add",
@@ -78,7 +78,7 @@ func TestAtlasTeamUsers(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			usersEntity,
 			"ls",
@@ -96,7 +96,7 @@ func TestAtlasTeamUsers(t *testing.T) {
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			usersEntity,
 			"ls",
@@ -115,7 +115,7 @@ func TestAtlasTeamUsers(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			usersEntity,
 			"delete",

--- a/test/e2e/iam/atlas_teams_test.go
+++ b/test/e2e/iam/atlas_teams_test.go
@@ -48,7 +48,7 @@ func TestAtlasTeams(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			"create",
 			teamName,
@@ -69,7 +69,7 @@ func TestAtlasTeams(t *testing.T) {
 	})
 
 	t.Run("Describe By Id", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			"describe",
 			"--id",
@@ -88,7 +88,7 @@ func TestAtlasTeams(t *testing.T) {
 	})
 
 	t.Run("Describe By Name", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			"describe",
 			"--name",
@@ -107,7 +107,7 @@ func TestAtlasTeams(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			"ls",
 			"-o=json")
@@ -124,7 +124,7 @@ func TestAtlasTeams(t *testing.T) {
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			"ls",
 			"-c",
@@ -142,7 +142,7 @@ func TestAtlasTeams(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			teamsEntity,
 			"delete",
 			teamID,

--- a/test/e2e/iam/atlas_users_test.go
+++ b/test/e2e/iam/atlas_users_test.go
@@ -36,7 +36,7 @@ func TestAtlasUsers(t *testing.T) {
 	var userID string
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			projectsEntity,
 			usersEntity,
 			"list",
@@ -62,7 +62,7 @@ func TestAtlasUsers(t *testing.T) {
 	})
 
 	t.Run("Describe by username", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			usersEntity,
 			"describe",
 			"--username",
@@ -85,7 +85,7 @@ func TestAtlasUsers(t *testing.T) {
 	})
 
 	t.Run("Describe by id", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			usersEntity,
 			"describe",
 			"--id",

--- a/test/e2e/iam/helper_test.go
+++ b/test/e2e/iam/helper_test.go
@@ -52,7 +52,7 @@ func createOrgAPIKey() (string, error) {
 		return "", err
 	}
 
-	cmd := exec.Command(cliPath, iamEntity,
+	cmd := exec.Command(cliPath, e2e.DebugFlag, iamEntity,
 		orgEntity,
 		apiKeysEntity,
 		"create",
@@ -83,7 +83,7 @@ func deleteOrgAPIKey(id string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		iamEntity,
 		orgEntity,
 		apiKeysEntity,
@@ -104,7 +104,7 @@ func createTeam(teamName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		iamEntity,
 		teamsEntity,
 		"create",
@@ -131,7 +131,7 @@ func deleteTeam(teamID string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		iamEntity,
 		teamsEntity,
 		"delete",
@@ -151,7 +151,7 @@ func OrgNUser(n int) (username, userID string, err error) {
 	if err != nil {
 		return "", "", err
 	}
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		iamEntity,
 		orgEntity,
 		usersEntity,

--- a/test/e2e/iam/org_api_key_access_list_test.go
+++ b/test/e2e/iam/org_api_key_access_list_test.go
@@ -47,7 +47,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 	entry := fmt.Sprintf("192.168.0.%d", n)
 
 	t.Run("Create", func(t *testing.T) {
-		cmd := exec.Command(cliPath, iamEntity,
+		cmd := exec.Command(cliPath, e2e.DebugFlag, iamEntity,
 			orgEntity,
 			apiKeysEntity,
 			apiKeyAccessListEntity,
@@ -69,7 +69,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath, iamEntity,
+		cmd := exec.Command(cliPath, e2e.DebugFlag, iamEntity,
 			orgEntity,
 			apiKeysEntity,
 			apiKeyAccessListEntity,
@@ -93,7 +93,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 
 	t.Run("Create Current IP", func(t *testing.T) {
 		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address from access list")
-		cmd := exec.Command(cliPath, iamEntity,
+		cmd := exec.Command(cliPath, e2e.DebugFlag, iamEntity,
 			orgEntity,
 			apiKeysEntity,
 			apiKeyAccessListEntity,
@@ -122,7 +122,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 
 func deleteAccessListEntry(t *testing.T, cliPath, entry, apiKeyID string) {
 	t.Helper()
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		iamEntity,
 		orgEntity,
 		apiKeysEntity,

--- a/test/e2e/iam/org_api_keys_test.go
+++ b/test/e2e/iam/org_api_keys_test.go
@@ -38,7 +38,7 @@ func TestOrgAPIKeys(t *testing.T) {
 	// This test must run first to grab the ID of the org to later describe
 	t.Run("Create", func(t *testing.T) {
 		desc := "e2e-test-org"
-		cmd := exec.Command(cliPath, iamEntity,
+		cmd := exec.Command(cliPath, e2e.DebugFlag, iamEntity,
 			orgEntity,
 			apiKeysEntity,
 			"create",
@@ -63,7 +63,7 @@ func TestOrgAPIKeys(t *testing.T) {
 	}
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			apiKeysEntity,
@@ -84,7 +84,7 @@ func TestOrgAPIKeys(t *testing.T) {
 
 	t.Run("Update", func(t *testing.T) {
 		newDesc := "e2e-test-org-updated"
-		cmd := exec.Command(cliPath, iamEntity,
+		cmd := exec.Command(cliPath, e2e.DebugFlag, iamEntity,
 			orgEntity,
 			apiKeysEntity,
 			"updates",
@@ -106,7 +106,7 @@ func TestOrgAPIKeys(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			apiKeysEntity,
@@ -127,7 +127,7 @@ func TestOrgAPIKeys(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			apiKeysEntity,

--- a/test/e2e/iam/org_invitations_test.go
+++ b/test/e2e/iam/org_invitations_test.go
@@ -41,7 +41,7 @@ func TestOrgInvitations(t *testing.T) {
 	var orgInvitationID string
 
 	t.Run("Invite", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			invitationsEntity,
@@ -65,7 +65,7 @@ func TestOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			invitationsEntity,
@@ -84,7 +84,7 @@ func TestOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			invitationsEntity,
@@ -104,7 +104,7 @@ func TestOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("Update by email", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			invitationsEntity,
@@ -128,7 +128,7 @@ func TestOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("Update by ID", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			invitationsEntity,
@@ -150,7 +150,7 @@ func TestOrgInvitations(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			invitationsEntity,

--- a/test/e2e/iam/orgs_test.go
+++ b/test/e2e/iam/orgs_test.go
@@ -36,7 +36,7 @@ func TestOrgs(t *testing.T) {
 
 	// This test must run first to grab the ID of the org to later describe
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			"ls",
@@ -54,7 +54,7 @@ func TestOrgs(t *testing.T) {
 	require.NotEmpty(t, orgID)
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			"describe",
@@ -66,7 +66,7 @@ func TestOrgs(t *testing.T) {
 	})
 
 	t.Run("List Org Users", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			orgEntity,
 			usersEntity,

--- a/test/e2e/iam/project_api_keys_test.go
+++ b/test/e2e/iam/project_api_keys_test.go
@@ -39,7 +39,7 @@ func TestProjectAPIKeys(t *testing.T) {
 	// This test must run first to grab the ID of the project to later describe
 	t.Run("Create", func(t *testing.T) {
 		const desc = "e2e-test"
-		cmd := exec.Command(cliPath, iamEntity,
+		cmd := exec.Command(cliPath, e2e.DebugFlag, iamEntity,
 			projectsEntity,
 			apiKeysEntity,
 			"create",
@@ -71,7 +71,7 @@ func TestProjectAPIKeys(t *testing.T) {
 	}()
 
 	t.Run("Assign", func(t *testing.T) {
-		cmd := exec.Command(cliPath, iamEntity,
+		cmd := exec.Command(cliPath, e2e.DebugFlag, iamEntity,
 			projectsEntity,
 			apiKeysEntity,
 			"assign",
@@ -84,7 +84,7 @@ func TestProjectAPIKeys(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			apiKeysEntity,
@@ -104,7 +104,7 @@ func TestProjectAPIKeys(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			apiKeysEntity,

--- a/test/e2e/iam/project_invitations_test.go
+++ b/test/e2e/iam/project_invitations_test.go
@@ -47,7 +47,7 @@ func TestProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Invite", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -72,7 +72,7 @@ func TestProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -92,7 +92,7 @@ func TestProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -113,7 +113,7 @@ func TestProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Update by email", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -140,7 +140,7 @@ func TestProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Update by ID", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,
@@ -166,7 +166,7 @@ func TestProjectInvitations(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			invitationsEntity,

--- a/test/e2e/iam/project_teams_test.go
+++ b/test/e2e/iam/project_teams_test.go
@@ -52,7 +52,7 @@ func TestProjectTeams(t *testing.T) {
 	})
 
 	t.Run("Add", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			teamsEntity,
@@ -84,7 +84,7 @@ func TestProjectTeams(t *testing.T) {
 	t.Run("Update", func(t *testing.T) {
 		roleName1 := "GROUP_READ_ONLY"
 		roleName2 := "GROUP_DATA_ACCESS_READ_ONLY"
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			teamsEntity,
@@ -114,7 +114,7 @@ func TestProjectTeams(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			teamsEntity,
@@ -134,7 +134,7 @@ func TestProjectTeams(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			teamsEntity,

--- a/test/e2e/iam/projects_test.go
+++ b/test/e2e/iam/projects_test.go
@@ -43,7 +43,7 @@ func TestProjects(t *testing.T) {
 	var projectID string
 	t.Run("Create", func(t *testing.T) {
 		// This depends on a ORG_ID ENV
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			"create",
@@ -66,7 +66,7 @@ func TestProjects(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			"ls",
@@ -78,7 +78,7 @@ func TestProjects(t *testing.T) {
 	})
 
 	t.Run("Describe", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			"describe",
@@ -91,7 +91,7 @@ func TestProjects(t *testing.T) {
 	})
 
 	t.Run("Users", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			usersEntity,
@@ -105,7 +105,7 @@ func TestProjects(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			projectsEntity,
 			"delete",

--- a/test/e2e/iam/team_users_test.go
+++ b/test/e2e/iam/team_users_test.go
@@ -49,7 +49,7 @@ func TestTeamUsers(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Add", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			teamsEntity,
 			usersEntity,
@@ -79,7 +79,7 @@ func TestTeamUsers(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			teamsEntity,
 			usersEntity,
@@ -98,7 +98,7 @@ func TestTeamUsers(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			teamsEntity,
 			usersEntity,

--- a/test/e2e/iam/teams_test.go
+++ b/test/e2e/iam/teams_test.go
@@ -48,7 +48,7 @@ func TestTeams(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			teamsEntity,
 			"create",
@@ -70,7 +70,7 @@ func TestTeams(t *testing.T) {
 	})
 
 	t.Run("Describe By ID", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			teamsEntity,
 			"describe",
@@ -90,7 +90,7 @@ func TestTeams(t *testing.T) {
 	})
 
 	t.Run("Describe By Name", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			teamsEntity,
 			"describe",
@@ -110,7 +110,7 @@ func TestTeams(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			teamsEntity,
 			"ls",
@@ -128,7 +128,7 @@ func TestTeams(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
+		cmd := exec.Command(cliPath, e2e.DebugFlag,
 			iamEntity,
 			teamsEntity,
 			"delete",

--- a/test/e2e/ops_manager/version_manifest_test.go
+++ b/test/e2e/ops_manager/version_manifest_test.go
@@ -32,7 +32,7 @@ func TestVersionManifest(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	cmd := exec.Command(cliPath,
+	cmd := exec.Command(cliPath, e2e.DebugFlag,
 		"om",
 		"versionManifest",
 		"update",


### PR DESCRIPTION
h4. WHY

Run e2e in debug mode to be able to reason the issues that are happening in e2e tests. 
We are consuming a large amount of time trying to understand e2e flakiness and also some of the changes that happen in the backend

h4. How

We need to be able to enable debug flag on demand and disable this for certain methods. Meaning that debug cannot be applied globally due to some of the commands might print out dev env links that we do not want to be visible. 