### PR TITLE
lint: enable wastedassign and usestdlibvars

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,6 +100,8 @@ linters:
     - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
     - unparam # Reports unused function parameters [fast: false, auto-fix: false]
     - unused # (megacheck) Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
+    - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
+    - wastedassign # wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
     - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
 
   # don't enable:
@@ -159,10 +161,8 @@ linters:
   # - tagliatelle # Checks the struct tags. [fast: true, auto-fix: false]
   # - testpackage # linter that makes you use a separate _test package [fast: true, auto-fix: false]
   # - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
-  # - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
   # - varcheck # [deprecated] Finds unused global variables and constants [fast: false, auto-fix: false]
   # - varnamelen # checks that the length of a variable's name matches its scope [fast: false, auto-fix: false]
-  # - wastedassign # wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
   # - wrapcheck # Checks that errors returned from external packages are wrapped [fast: false, auto-fix: false]
   # - wsl # Whitespace Linter - Forces you to use empty lines! [fast: true, auto-fix: false]
 

--- a/tools/sign/main.go
+++ b/tools/sign/main.go
@@ -34,8 +34,10 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
-const pbkdf2Iterations = 1000
-const pbkdf2KeyLength = 16
+const (
+	pbkdf2Iterations = 1000
+	pbkdf2KeyLength  = 16
+)
 
 func generateAuthTokenString(authTokenPassword string) string {
 	salt := []byte(authTokenPassword)
@@ -86,6 +88,9 @@ func generateMultiPartForm(filePath string, fields map[string]string) (buffer *b
 		return nil, "", err
 	}
 	_, err = io.Copy(part, file)
+	if err != nil {
+		return nil, "", err
+	}
 	for k, v := range fields {
 		err = writer.WriteField(k, v)
 		if err != nil {
@@ -136,7 +141,7 @@ func sign(notaryURL, filePath, notarySigningKey, notarySigningComment, notaryAut
 }
 
 func downloadFile(ctx context.Context, url, localPath string) error {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Enable and fix wastedassign and usestdlibvars
wastedassign will catch unused variables and usestdlibvars will favor usage of known standard consts instead of custom values 