### PR TITLE
fix: clean up atlas user commands

### DIFF
--- a/docs/atlascli/command/atlas-users-invite.txt
+++ b/docs/atlascli/command/atlas-users-invite.txt
@@ -39,7 +39,7 @@ Options
      - Description
    * - --country
      - string
-     - false
+     - true
      - ISO 3166-1 alpha two-letter country code of the user's geographic location. Required for the Atlas CLI.
    * - --email
      - string

--- a/internal/cli/atlas/users/describe.go
+++ b/internal/cli/atlas/users/describe.go
@@ -71,15 +71,10 @@ func (opts *DescribeOpts) validate() error {
 	if opts.id == "" && opts.username == "" {
 		return errors.New("must supply one of 'id' or 'username'")
 	}
-
-	if opts.id != "" && opts.username != "" {
-		return errors.New("cannot supply both 'id' and 'username'")
-	}
-
 	return nil
 }
 
-// mongocli iam user(s) describe --id id --username USERNAME.
+// DescribeBuilder atlas user(s) describe [--id id|--username USERNAME].
 func DescribeBuilder() *cobra.Command {
 	opts := &DescribeOpts{}
 	cmd := &cobra.Command{
@@ -110,6 +105,7 @@ User accounts and API keys with any role can run this command.`,
 
 	cmd.Flags().StringVar(&opts.username, flag.Username, "", usage.Username)
 	cmd.Flags().StringVar(&opts.id, flag.ID, "", usage.UserID)
+	cmd.MarkFlagsMutuallyExclusive(flag.Username, flag.ID)
 
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())

--- a/internal/cli/atlas/users/invite.go
+++ b/internal/cli/atlas/users/invite.go
@@ -95,10 +95,6 @@ func (opts *InviteOpts) Run() error {
 const keyParts = 2
 
 func (opts *InviteOpts) createRoles() ([]atlasv2.CloudAccessRoleAssignment, error) {
-	if !config.IsCloud() {
-		return nil, nil
-	}
-
 	atlasRoles := make([]atlasv2.CloudAccessRoleAssignment, len(opts.orgRoles)+len(opts.projectRoles))
 
 	i := 0
@@ -172,13 +168,11 @@ func newAtlasOrgRole(role string) (atlasv2.CloudAccessRoleAssignment, error) {
 	return atlasRole, nil
 }
 
-// atlas users(s) invite --username username --password password --country country --email email
+// InviteBuilder atlas users(s) invite --username username --password password --country country --email email
 // --mobile mobile --firstName firstName --lastName lastName --team team1,team2 --orgRole orgID:ROLE_NAME
-// --projectRole projectID:ROLE_NAME
-
+// --projectRole projectID:ROLE_NAME.
 func InviteBuilder() *cobra.Command {
 	opts := &InviteOpts{}
-	opts.Template = inviteTemplate
 	cmd := &cobra.Command{
 		Use:   "invite",
 		Short: "Create a MongoDB user for your MongoDB application and invite the MongoDB user to your organizations and projects.",
@@ -193,11 +187,10 @@ func InviteBuilder() *cobra.Command {
   # Create the MongoDB user with the username user@example.com and invite them to the project with the ID 5f71e5255afec75a3d0f96dc with GROUP_READ_ONLY access:
   %[1]s users invite --email user@example.com --username user@example.com --projectRole 5f71e5255afec75a3d0f96dc:GROUP_READ_ONLY --firstName Example --lastName User --country US --output json`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if config.Service() != config.OpsManagerService {
-				_ = cmd.MarkFlagRequired(flag.Country)
-			}
-
-			return prerun.ExecuteE(opts.InitOutput(cmd.OutOrStdout(), ""), opts.InitInput(cmd.InOrStdin()), opts.initStore(cmd.Context()))
+			return prerun.ExecuteE(
+				opts.InitOutput(cmd.OutOrStdout(), inviteTemplate),
+				opts.InitInput(cmd.InOrStdin()),
+				opts.initStore(cmd.Context()))
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Prompt(); err != nil {
@@ -223,6 +216,7 @@ func InviteBuilder() *cobra.Command {
 	_ = cmd.MarkFlagRequired(flag.Email)
 	_ = cmd.MarkFlagRequired(flag.FirstName)
 	_ = cmd.MarkFlagRequired(flag.LastName)
+	_ = cmd.MarkFlagRequired(flag.Country)
 
 	return cmd
 }


### PR DESCRIPTION
## Proposed changes

After moving these commands to be atlas only we can remove some of the conditions we do for ops manager 
