### PR TITLE
CLOUDP-186602: add --tag flag to quickstart and setup commands

### DIFF
--- a/docs/atlascli/command/atlas-quickstart.txt
+++ b/docs/atlascli/command/atlas-quickstart.txt
@@ -89,6 +89,10 @@ Options
      - 
      - false
      - Indicates whether to skip loading sample data into your Atlas cluster.
+   * - --tag
+     - stringToString
+     - false
+     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. This value defaults to [].
    * - --tier
      - string
      - false

--- a/docs/atlascli/command/atlas-setup.txt
+++ b/docs/atlascli/command/atlas-setup.txt
@@ -89,6 +89,10 @@ Options
      - 
      - false
      - Indicates whether to skip loading sample data into your Atlas cluster.
+   * - --tag
+     - stringToString
+     - false
+     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. This value defaults to [].
    * - --tier
      - string
      - false

--- a/docs/mongocli/command/mongocli-atlas-quickstart.txt
+++ b/docs/mongocli/command/mongocli-atlas-quickstart.txt
@@ -89,6 +89,10 @@ Options
      - 
      - false
      - Indicates whether to skip loading sample data into your Atlas cluster.
+   * - --tag
+     - stringToString
+     - false
+     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. This value defaults to [].
    * - --tier
      - string
      - false

--- a/internal/cli/atlas/quickstart/cluster_setup.go
+++ b/internal/cli/atlas/quickstart/cluster_setup.go
@@ -112,6 +112,10 @@ func (opts *Opts) newCluster() *atlasv2.AdvancedClusterDescription {
 		TerminationProtectionEnabled: &opts.EnableTerminationProtection,
 	}
 
+	for k, v := range opts.Tag {
+		cluster.Tags = append(cluster.Tags, atlasv2.ResourceTag{Key: pointer.Get(k), Value: pointer.Get(v)})
+	}
+
 	if opts.providerName() != tenant {
 		diskSizeGB := defaultDiskSizeGB(opts.providerName(), opts.Tier)
 		mdbVersion, _ := cli.DefaultMongoDBMajorVersion()

--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -118,6 +118,7 @@ type Opts struct {
 	Confirm                     bool
 	CurrentIP                   bool
 	EnableTerminationProtection bool
+	Tag                         map[string]string
 	store                       store.AtlasClusterQuickStarter
 	shouldRunLogin              bool
 	flags                       *pflag.FlagSet
@@ -135,6 +136,7 @@ type quickstart struct {
 	EnableTerminationProtection bool
 	SkipSampleData              bool
 	SkipMongosh                 bool
+	Tag                         map[string]string
 }
 
 type Flow interface {
@@ -456,6 +458,7 @@ func (opts *Opts) newDefaultValues() (*quickstart, error) {
 
 	values.Tier = opts.Tier
 	values.EnableTerminationProtection = opts.EnableTerminationProtection
+	values.Tag = opts.Tag
 
 	return values, nil
 }
@@ -488,6 +491,7 @@ func (opts *Opts) replaceWithDefaultSettings(values *quickstart) {
 	opts.EnableTerminationProtection = values.EnableTerminationProtection
 	opts.SkipSampleData = values.SkipSampleData
 	opts.SkipMongosh = values.SkipMongosh
+	opts.Tag = values.Tag
 }
 
 func (opts *Opts) interactiveSetup() error {
@@ -565,6 +569,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.ForceQuickstart)
 	cmd.Flags().BoolVar(&opts.CurrentIP, flag.CurrentIP, false, usage.CurrentIPSimplified)
 	cmd.Flags().BoolVar(&opts.EnableTerminationProtection, flag.EnableTerminationProtection, false, usage.EnableTerminationProtection)
+	cmd.Flags().StringToStringVar(&opts.Tag, flag.Tag, nil, usage.Tag)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/quickstart/quick_start_test.go
+++ b/internal/cli/atlas/quickstart/quick_start_test.go
@@ -49,6 +49,7 @@ func TestBuilder(t *testing.T) {
 			flag.EnableTerminationProtection,
 			flag.SkipMongosh,
 			flag.SkipSampleData,
+			flag.Tag,
 		},
 	)
 }
@@ -81,6 +82,7 @@ func TestQuickstartOpts_Run(t *testing.T) {
 		SkipMongosh:    true,
 		SkipSampleData: true,
 		Confirm:        true,
+		Tag:            map[string]string{"env": "test"},
 	}
 	opts.WithFlow(mockFlow)
 

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -195,6 +195,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().BoolVar(&qsOpts.SkipMongosh, flag.SkipMongosh, false, usage.SkipMongosh)
 	cmd.Flags().BoolVar(&qsOpts.Confirm, flag.Force, false, usage.Force)
 	cmd.Flags().BoolVar(&qsOpts.CurrentIP, flag.CurrentIP, false, usage.CurrentIPSimplified)
+	cmd.Flags().StringToStringVar(&qsOpts.Tag, flag.Tag, nil, usage.Tag)
 
 	cmd.Flags().StringVar(&qsOpts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	_ = cmd.Flags().MarkHidden(flag.ProjectID)

--- a/internal/cli/atlas/setup/setup_cmd_test.go
+++ b/internal/cli/atlas/setup/setup_cmd_test.go
@@ -44,6 +44,7 @@ func TestBuilder(t *testing.T) {
 			flag.Password,
 			flag.SkipMongosh,
 			flag.SkipSampleData,
+			flag.Tag,
 		},
 	)
 }


### PR DESCRIPTION
## Proposed changes
add --tag flag to quickstart and setup commands

_Jira ticket:_ CLOUDP-186602

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

