### PR TITLE
CLOUDP-187071: Enable autocomplete for proceses in performance advisor

### DIFF
--- a/internal/cli/atlas/clusters/region_tier_autocomplete.go
+++ b/internal/cli/atlas/clusters/region_tier_autocomplete.go
@@ -27,8 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type autoFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
-
 type autoCompleteOpts struct {
 	cli.GlobalOpts
 	providers []string
@@ -36,7 +34,7 @@ type autoCompleteOpts struct {
 	store     store.CloudProviderRegionsLister
 }
 
-func (opts *autoCompleteOpts) autocompleteTier() autoFunc {
+func (opts *autoCompleteOpts) autocompleteTier() cli.AutoFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		opts.parseFlags(cmd)
 		if err := validate.Credentials(); err != nil {
@@ -69,7 +67,6 @@ func (opts *autoCompleteOpts) tierSuggestions(toComplete string) ([]string, erro
 	availableTiers := map[string]bool{}
 	for _, p := range result.Results {
 		for _, i := range p.InstanceSizes {
-			_ = i
 			if _, ok := availableTiers[i.GetName()]; !ok && strings.HasPrefix(i.GetName(), strings.ToUpper(toComplete)) {
 				availableTiers[i.GetName()] = true
 			}
@@ -85,7 +82,7 @@ func (opts *autoCompleteOpts) tierSuggestions(toComplete string) ([]string, erro
 	return suggestion, nil
 }
 
-func (opts *autoCompleteOpts) autocompleteRegion() autoFunc {
+func (opts *autoCompleteOpts) autocompleteRegion() cli.AutoFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		opts.parseFlags(cmd)
 		if err := validate.Credentials(); err != nil {
@@ -116,7 +113,6 @@ func (opts *autoCompleteOpts) regionSuggestions(toComplete string) ([]string, er
 	}
 	availableRegions := map[string]bool{}
 	for _, p := range result.Results {
-		_ = p.InstanceSizes
 		for _, i := range p.InstanceSizes {
 			for _, r := range i.AvailableRegions {
 				if _, ok := availableRegions[r.GetName()]; !ok && strings.HasPrefix(r.GetName(), strings.ToUpper(toComplete)) {

--- a/internal/cli/atlas/performanceadvisor/slowquerylogs/list.go
+++ b/internal/cli/atlas/performanceadvisor/slowquerylogs/list.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/processes"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
@@ -129,6 +130,8 @@ If you don't set the duration option or the since option, this command returns d
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
 
+	autocomplete := &processes.AutoCompleteOpts{}
+	_ = cmd.RegisterFlagCompletionFunc(flag.ProcessName, autocomplete.AutocompleteProcesses())
 	return cmd
 }
 

--- a/internal/cli/atlas/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/atlas/performanceadvisor/suggestedindexes/list.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/processes"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
@@ -126,6 +127,9 @@ func ListBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
+
+	autocomplete := &processes.AutoCompleteOpts{}
+	_ = cmd.RegisterFlagCompletionFunc(flag.ProcessName, autocomplete.AutocompleteProcesses())
 
 	return cmd
 }

--- a/internal/cli/atlas/processes/list.go
+++ b/internal/cli/atlas/processes/list.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
-	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
@@ -64,20 +63,20 @@ func (opts *ListOpts) Run() error {
 }
 
 func (opts *ListOpts) newProcessesListParams() *atlasv2.ListAtlasProcessesApiParams {
-	listOpts := *opts.NewListOptions()
+	listOpts := opts.NewListOptions()
 	processesList := &atlasv2.ListAtlasProcessesApiParams{
 		GroupId: opts.ConfigProjectID(),
 	}
 	if listOpts.PageNum > 0 {
-		processesList.PageNum = pointer.Get(listOpts.PageNum)
+		processesList.PageNum = &listOpts.PageNum
 	}
 	if listOpts.ItemsPerPage > 0 {
-		processesList.ItemsPerPage = pointer.Get(listOpts.ItemsPerPage)
+		processesList.ItemsPerPage = &listOpts.ItemsPerPage
 	}
 	return processesList
 }
 
-// ListBuilder mongocli atlas process(es) list --projectId projectId [--page N] [--limit N].
+// ListBuilder atlas process(es) list --projectId projectId [--page N] [--limit N].
 func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{

--- a/internal/cli/atlas/processes/process_autocomplete.go
+++ b/internal/cli/atlas/processes/process_autocomplete.go
@@ -1,0 +1,97 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processes
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/internal/config"
+	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
+	"github.com/mongodb/mongodb-atlas-cli/internal/store"
+	"github.com/mongodb/mongodb-atlas-cli/internal/validate"
+	"github.com/spf13/cobra"
+	atlasv2 "go.mongodb.org/atlas-sdk/admin"
+)
+
+type AutoCompleteOpts struct {
+	cli.GlobalOpts
+	store store.ProcessLister
+}
+
+func (opts *AutoCompleteOpts) AutocompleteProcesses() cli.AutoFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		opts.parseFlags(cmd)
+		if err := validate.Credentials(); err != nil {
+			cobra.CompErrorln("no credentials")
+			return nil, cobra.ShellCompDirectiveError
+		}
+		if err := opts.ValidateProjectID(); err != nil {
+			cobra.CompErrorln("no project ID")
+			return nil, cobra.ShellCompDirectiveError
+		}
+		if err := opts.initStore(cmd.Context()); err != nil {
+			cobra.CompErrorln("store error: " + err.Error())
+			return nil, cobra.ShellCompDirectiveError
+		}
+		suggestions, err := opts.processSuggestion(toComplete)
+		if err != nil {
+			cobra.CompErrorln("error fetching: " + err.Error())
+			return nil, cobra.ShellCompDirectiveError
+		}
+		return suggestions, cobra.ShellCompDirectiveDefault
+	}
+}
+
+func (opts *AutoCompleteOpts) processSuggestion(toComplete string) ([]string, error) {
+	processesList := &atlasv2.ListAtlasProcessesApiParams{
+		GroupId: opts.ConfigProjectID(),
+	}
+	result, err := opts.store.Processes(processesList)
+	if err != nil {
+		return nil, err
+	}
+	suggestion := make([]string, 0, len(result.Results))
+	for _, p := range result.Results {
+		if !strings.HasPrefix(p.GetId(), toComplete) {
+			continue
+		}
+		suggestion = append(suggestion, p.GetId())
+	}
+	sort.Strings(suggestion)
+	return suggestion, nil
+}
+
+func (opts *AutoCompleteOpts) initStore(ctx context.Context) error {
+	var err error
+	opts.store, err = store.New(store.AuthenticatedPreset(config.Default()), store.WithContext(ctx))
+	return err
+}
+
+func (opts *AutoCompleteOpts) parseFlags(cmd *cobra.Command) {
+	profile := cmd.Flag(flag.Profile).Value.String()
+	if profile != "" {
+		config.SetName(profile)
+	} else if profile = config.GetString(flag.Profile); profile != "" {
+		config.SetName(profile)
+	} else if availableProfiles := config.List(); len(availableProfiles) == 1 {
+		config.SetName(availableProfiles[0])
+	}
+	if project := cmd.Flag(flag.ProjectID).Value.String(); project != "" {
+		opts.ProjectID = project
+	}
+}

--- a/internal/cli/atlas/processes/process_autocomplete_test.go
+++ b/internal/cli/atlas/processes/process_autocomplete_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package processes
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
+	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
+	"github.com/stretchr/testify/require"
+	atlasv2 "go.mongodb.org/atlas-sdk/admin"
+)
+
+func Test_autoCompleteOpts_tierSuggestions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockProcessLister(ctrl)
+
+	au := &AutoCompleteOpts{
+		store: mockStore,
+	}
+	expected := &atlasv2.PaginatedHostViewAtlas{
+		Results: []atlasv2.ApiHostViewAtlas{
+			{
+				Id:       pointer.Get("test.com:27017"),
+				Hostname: pointer.Get("test"),
+				Port:     pointer.Get(27017),
+			},
+		},
+	}
+	mockStore.
+		EXPECT().
+		Processes(&atlasv2.ListAtlasProcessesApiParams{}).
+		Return(expected, nil).
+		Times(1)
+
+	res, err := au.processSuggestion("")
+	require.NoError(t, err)
+	require.Equal(t, []string{"test.com:27017"}, res)
+}

--- a/internal/cli/global_opts.go
+++ b/internal/cli/global_opts.go
@@ -21,8 +21,11 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/prerun"
 	"github.com/mongodb/mongodb-atlas-cli/internal/validate"
+	"github.com/spf13/cobra"
 	"github.com/tangzero/inflector"
 )
+
+type AutoFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
 
 type GlobalOpts struct {
 	OrgID     string


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-187071

## Further comments

Enable autocomplete when doing 

```bash
atlas performanceAdvisor slowQueryLogs list --processName <tab>
```
