### PR TITLE
test: remove RS dependency for sharded test

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -997,9 +997,6 @@ tasks:
       - name: compile
         variant: "code_health"
         patch_optional: true
-      - name: cloud_manager_deploy_replica_set_e2e
-        variant: "e2e_cloud_manager_remote"
-        patch_optional: true
     commands:
       - func: "install gotestsum"
       - func: "build mongocli"


### PR DESCRIPTION
Sharded cluster used to depend on RS to avoid concurrent modification of the automation agent but each test now creates a dedicated project so it's safe to run them in parallel