### PR TITLE
CLOUP-187016: Improve e2e test coverage for atlas setup command

### DIFF
--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -89,6 +89,7 @@ const (
 	snapshotsEntity              = "snapshots"
 	restoresEntity               = "restores"
 	teamsEntity                  = "teams"
+	setupEntity                  = "setup"
 )
 
 // AlertConfig constants.

--- a/test/e2e/atlas/setup_fail_test.go
+++ b/test/e2e/atlas/setup_fail_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (atlas && setuptest)
+//go:build e2e || (atlas && interactive)
 
 package atlas_test
 

--- a/test/e2e/atlas/setup_fail_test.go
+++ b/test/e2e/atlas/setup_fail_test.go
@@ -61,7 +61,7 @@ func TestSetupFailing(t *testing.T) {
 
 	t.Run("Invalid Project ID", func(t *testing.T) {
 		// The incorrect ProjectID should be 24 characters long, otherwise
-		// an error will be thrown about incorrect length.
+		// an early error will be thrown about incorrect length.
 		invalidProjectID := "111111111111111111111111"
 		cmd := exec.Command(cliPath,
 			"setup",

--- a/test/e2e/atlas/setup_fail_test.go
+++ b/test/e2e/atlas/setup_fail_test.go
@@ -1,0 +1,77 @@
+// Copyright 2022 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e || (atlas && setuptest)
+
+package atlas_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupFailing(t *testing.T) {
+	g := newAtlasE2ETestGenerator(t)
+	g.generateProject("setup")
+	cliPath, err := e2e.AtlasCLIBin()
+	req := require.New(t)
+	req.NoError(err)
+
+	t.Run("Invalid Public Key", func(t *testing.T) {
+		t.Setenv("MCLI_PUBLIC_API_KEY", "invalid_public_key")
+		cmd := exec.Command(cliPath,
+			"setup",
+			"--skipMongosh",
+			"--skipSampleData",
+			"--force")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		req.Error(err)
+		assert.Contains(t, string(resp), "Unauthorized", "Expected unauthorized error due to invalid public key.")
+	})
+
+	t.Run("Invalid Private Key", func(t *testing.T) {
+		t.Setenv("MCLI_PRIVATE_API_KEY", "invalid_private_key")
+		cmd := exec.Command(cliPath,
+			"setup",
+			"--skipMongosh",
+			"--skipSampleData",
+			"--force")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		req.Error(err)
+		assert.Contains(t, string(resp), "Unauthorized", "Expected unauthorized error due to invalid private key.")
+	})
+
+	t.Run("Invalid Project ID", func(t *testing.T) {
+		// The incorrect ProjectID should be 24 characters long, otherwise
+		// an error will be thrown about incorrect length.
+		invalidProjectID := "111111111111111111111111"
+		cmd := exec.Command(cliPath,
+			"setup",
+			"--skipMongosh",
+			"--skipSampleData",
+			"--projectId", invalidProjectID,
+			"--force")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		req.Error(err)
+		assert.Contains(t, string(resp), "GROUP_NOT_FOUND", "Expected invalid Project ID error")
+	})
+}

--- a/test/e2e/atlas/setup_failure_test.go
+++ b/test/e2e/atlas/setup_failure_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 MongoDB Inc
+// Copyright 2023 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/atlas/setup_failure_test.go
+++ b/test/e2e/atlas/setup_failure_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetupFailing(t *testing.T) {
+func TestSetupFailureFlow(t *testing.T) {
 	g := newAtlasE2ETestGenerator(t)
 	g.generateProject("setup")
 	cliPath, err := e2e.AtlasCLIBin()
@@ -60,7 +60,7 @@ func TestSetupFailing(t *testing.T) {
 	})
 
 	t.Run("Invalid Project ID", func(t *testing.T) {
-		// The incorrect ProjectID should be 24 characters long, otherwise
+		// The invalid ProjectID should be 24 characters long, otherwise
 		// an early error will be thrown about incorrect length.
 		invalidProjectID := "111111111111111111111111"
 		cmd := exec.Command(cliPath,
@@ -72,6 +72,6 @@ func TestSetupFailing(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.Error(err)
-		assert.Contains(t, string(resp), "GROUP_NOT_FOUND", "Expected invalid Project ID error")
+		assert.Contains(t, string(resp), "GROUP_NOT_FOUND", "Expected GROUP_NOT_FOUND (invalid Project ID) error")
 	})
 }

--- a/test/e2e/atlas/setup_failure_test.go
+++ b/test/e2e/atlas/setup_failure_test.go
@@ -36,7 +36,7 @@ func TestSetupFailureFlow(t *testing.T) {
 	t.Run("Invalid Public Key", func(t *testing.T) {
 		t.Setenv("MCLI_PUBLIC_API_KEY", "invalid_public_key")
 		cmd := exec.Command(cliPath,
-			"setup",
+			setupEntity,
 			"--skipMongosh",
 			"--skipSampleData",
 			"--force")
@@ -49,7 +49,7 @@ func TestSetupFailureFlow(t *testing.T) {
 	t.Run("Invalid Private Key", func(t *testing.T) {
 		t.Setenv("MCLI_PRIVATE_API_KEY", "invalid_private_key")
 		cmd := exec.Command(cliPath,
-			"setup",
+			setupEntity,
 			"--skipMongosh",
 			"--skipSampleData",
 			"--force")
@@ -64,7 +64,7 @@ func TestSetupFailureFlow(t *testing.T) {
 		// an early error will be thrown about incorrect length.
 		invalidProjectID := "111111111111111111111111"
 		cmd := exec.Command(cliPath,
-			"setup",
+			setupEntity,
 			"--skipMongosh",
 			"--skipSampleData",
 			"--projectId", invalidProjectID,

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (atlas && interactive)
+//go:build e2e || (atlas && setuptest)
 
 package atlas_test
 
@@ -45,59 +45,6 @@ func TestSetup(t *testing.T) {
 
 	tagKey := "env"
 	tagValue := "e2etest"
-
-	t.Run("Invalid Public Key", func(t *testing.T) {
-		t.Setenv("MCLI_PUBLIC_API_KEY", "invalid_public_key")
-		cmd := exec.Command(cliPath,
-			"setup",
-			"--clusterName", clusterName,
-			"--username", dbUserUsername,
-			"--skipMongosh",
-			"--skipSampleData",
-			"--projectId", g.projectID,
-			"--tag", tagKey+"="+tagValue,
-			"--force")
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		req.Error(err)
-		assert.Contains(t, string(resp), "Unauthorized", "Expected unauthorized error due to invalid public key.")
-	})
-
-	t.Run("Invalid Private Key", func(t *testing.T) {
-		t.Setenv("MCLI_PRIVATE_API_KEY", "invalid_private_key")
-		cmd := exec.Command(cliPath,
-			"setup",
-			"--clusterName", clusterName,
-			"--username", dbUserUsername,
-			"--skipMongosh",
-			"--skipSampleData",
-			"--projectId", g.projectID,
-			"--tag", tagKey+"="+tagValue,
-			"--force")
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		req.Error(err)
-		assert.Contains(t, string(resp), "Unauthorized", "Expected unauthorized error due to invalid private key.")
-	})
-
-	t.Run("Invalid Project ID", func(t *testing.T) {
-		// The incorrect ProjectID should be 24 characters long, otherwise
-		// an error will be thrown about incorrect length.
-		invalidProjectID := "111111111111111111111111"
-		cmd := exec.Command(cliPath,
-			"setup",
-			"--clusterName", clusterName,
-			"--username", dbUserUsername,
-			"--skipMongosh",
-			"--skipSampleData",
-			"--projectId", invalidProjectID,
-			"--tag", tagKey+"="+tagValue,
-			"--force")
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		req.Error(err)
-		assert.Contains(t, string(resp), "GROUP_NOT_FOUND", "Expected invalid Project ID error")
-	})
 
 	t.Run("Run", func(t *testing.T) {
 		cmd := exec.Command(cliPath,

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (atlas && setuptest)
+//go:build e2e || (atlas && interactive)
 
 package atlas_test
 

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -33,7 +33,6 @@ import (
 func TestSetup(t *testing.T) {
 	g := newAtlasE2ETestGenerator(t)
 	g.generateProject("setup")
-
 	cliPath, err := e2e.AtlasCLIBin()
 	req := require.New(t)
 	req.NoError(err)
@@ -46,6 +45,24 @@ func TestSetup(t *testing.T) {
 
 	tagKey := "env"
 	tagValue := "e2etest"
+
+	t.Run("Incorrect Project ID Run", func(t *testing.T) {
+		incorrectProjectID := "111111111111111111111111" // this is 24 characters long, otherwise it will return an error early
+		cmd := exec.Command(cliPath,
+			"setup",
+			"--clusterName", clusterName,
+			"--username", dbUserUsername,
+			"--skipMongosh",
+			"--skipSampleData",
+			"--projectId", incorrectProjectID,
+			"--tag", tagKey+"="+tagValue,
+			"--force")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		req.Error(err)
+		t.Logf("response: %v", string(resp))
+		assert.Contains(t, string(resp), "GROUP_NOT_FOUND", "Expected incorrect Project ID error")
+	})
 
 	t.Run("Run", func(t *testing.T) {
 		cmd := exec.Command(cliPath,

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -45,18 +45,18 @@ func TestSetup(t *testing.T) {
 
 	tagKey := "env"
 	tagValue := "e2etest"
-	randomAccessListIP := "21.150.105.221"
+	arbitraryAccessListIP := "21.150.105.221"
 
 	t.Run("Run", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
-			"setup",
+			setupEntity,
 			"--clusterName", clusterName,
 			"--username", dbUserUsername,
 			"--skipMongosh",
 			"--skipSampleData",
 			"--projectId", g.projectID,
 			"--tag", tagKey+"="+tagValue,
-			"--accessListIp", randomAccessListIP,
+			"--accessListIp", arbitraryAccessListIP,
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
@@ -78,9 +78,8 @@ func TestSetup(t *testing.T) {
 		var entries *atlasv2.PaginatedNetworkAccess
 		err = json.Unmarshal(resp, &entries)
 		req.NoError(err)
-
-		found := false
-		req.Contains(entries.Results[i].GetIpAddress(), randomAccessListIP)
+		req.Len(entries.Results, 1, "Expected 1 IP in list of IP's")
+		req.Contains(entries.Results[0].GetIpAddress(), arbitraryAccessListIP, "IP from list does not match added IP")
 	})
 
 	t.Run("Watch Cluster", func(t *testing.T) {

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -46,22 +46,57 @@ func TestSetup(t *testing.T) {
 	tagKey := "env"
 	tagValue := "e2etest"
 
-	t.Run("Incorrect Project ID Run", func(t *testing.T) {
-		incorrectProjectID := "111111111111111111111111" // this is 24 characters long, otherwise it will return an error early
+	t.Run("Invalid Public Key", func(t *testing.T) {
+		t.Setenv("MCLI_PUBLIC_API_KEY", "invalid_public_key")
 		cmd := exec.Command(cliPath,
 			"setup",
 			"--clusterName", clusterName,
 			"--username", dbUserUsername,
 			"--skipMongosh",
 			"--skipSampleData",
-			"--projectId", incorrectProjectID,
+			"--projectId", g.projectID,
 			"--tag", tagKey+"="+tagValue,
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		req.Error(err)
-		t.Logf("response: %v", string(resp))
-		assert.Contains(t, string(resp), "GROUP_NOT_FOUND", "Expected incorrect Project ID error")
+		assert.Contains(t, string(resp), "Unauthorized", "Expected unauthorized error due to invalid public key.")
+	})
+
+	t.Run("Invalid Private Key", func(t *testing.T) {
+		t.Setenv("MCLI_PRIVATE_API_KEY", "invalid_private_key")
+		cmd := exec.Command(cliPath,
+			"setup",
+			"--clusterName", clusterName,
+			"--username", dbUserUsername,
+			"--skipMongosh",
+			"--skipSampleData",
+			"--projectId", g.projectID,
+			"--tag", tagKey+"="+tagValue,
+			"--force")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		req.Error(err)
+		assert.Contains(t, string(resp), "Unauthorized", "Expected unauthorized error due to invalid private key.")
+	})
+
+	t.Run("Invalid Project ID", func(t *testing.T) {
+		// The incorrect ProjectID should be 24 characters long, otherwise
+		// an error will be thrown about incorrect length.
+		invalidProjectID := "111111111111111111111111"
+		cmd := exec.Command(cliPath,
+			"setup",
+			"--clusterName", clusterName,
+			"--username", dbUserUsername,
+			"--skipMongosh",
+			"--skipSampleData",
+			"--projectId", invalidProjectID,
+			"--tag", tagKey+"="+tagValue,
+			"--force")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		req.Error(err)
+		assert.Contains(t, string(resp), "GROUP_NOT_FOUND", "Expected invalid Project ID error")
 	})
 
 	t.Run("Run", func(t *testing.T) {

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -45,7 +45,7 @@ func TestSetup(t *testing.T) {
 
 	tagKey := "env"
 	tagValue := "e2etest"
-	accessListIP := "21.150.105.221" // randomly generated IP
+	randomAccessListIP := "21.150.105.221"
 
 	t.Run("Run", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
@@ -56,7 +56,7 @@ func TestSetup(t *testing.T) {
 			"--skipSampleData",
 			"--projectId", g.projectID,
 			"--tag", tagKey+"="+tagValue,
-			"--accessListIp", accessListIP,
+			"--accessListIp", randomAccessListIP,
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
@@ -81,7 +81,7 @@ func TestSetup(t *testing.T) {
 
 		found := false
 		for i := range entries.Results {
-			if entries.Results[i].GetIpAddress() == accessListIP {
+			if entries.Results[i].GetIpAddress() == randomAccessListIP {
 				found = true
 				break
 			}

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -80,14 +80,7 @@ func TestSetup(t *testing.T) {
 		req.NoError(err)
 
 		found := false
-		for i := range entries.Results {
-			if entries.Results[i].GetIpAddress() == randomAccessListIP {
-				found = true
-				break
-			}
-		}
-
-		req.True(found)
+		req.Contains(entries.Results[i].GetIpAddress(), randomAccessListIP)
 	})
 
 	t.Run("Watch Cluster", func(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

Failure flow tests that were added:
- invalid projectID test
- invalid public key test
- invalid private key test

Flags that are now tested:
- `--accessListIp`
- `--projectId`

A full description of changes can be found in the JIRA ticket.

_Jira ticket:_ CLOUDP-187016

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

Not sure if I should supplement the `test/README.md` since none of the other commands have variations with flags and/or environment variables.