### PR TITLE
CLOUDP-187015: unhide projectId flag in atlas setup command

### DIFF
--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -196,9 +196,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().BoolVar(&qsOpts.Confirm, flag.Force, false, usage.Force)
 	cmd.Flags().BoolVar(&qsOpts.CurrentIP, flag.CurrentIP, false, usage.CurrentIPSimplified)
 	cmd.Flags().StringToStringVar(&qsOpts.Tag, flag.Tag, nil, usage.Tag)
-
 	cmd.Flags().StringVar(&qsOpts.ProjectID, flag.ProjectID, "", usage.ProjectID)
-	_ = cmd.Flags().MarkHidden(flag.ProjectID)
 
 	cmd.MarkFlagsMutuallyExclusive(flag.CurrentIP, flag.AccessListIP)
 


### PR DESCRIPTION
## Proposed changes

`--projectId` is now visible when running `atlas setup --help`.

_Jira ticket:_ CLOUDP-187015

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code