### PR TITLE
CloudP-187018: atlas setup: add -Y (--default) flag and mark it as deprecated (which also hides the flag)

### DIFF
--- a/internal/cli/atlas/quickstart/quick_start.go
+++ b/internal/cli/atlas/quickstart/quick_start.go
@@ -114,7 +114,7 @@ type Opts struct {
 	LabelValue                  string
 	SkipSampleData              bool
 	SkipMongosh                 bool
-	defaultValue                bool
+	DefaultValue                bool
 	Confirm                     bool
 	CurrentIP                   bool
 	EnableTerminationProtection bool
@@ -565,7 +565,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DBUserPassword, flag.Password, "", usage.DBUserPassword)
 	cmd.Flags().BoolVar(&opts.SkipSampleData, flag.SkipSampleData, false, usage.SkipSampleData)
 	cmd.Flags().BoolVar(&opts.SkipMongosh, flag.SkipMongosh, false, usage.SkipMongosh)
-	cmd.Flags().BoolVarP(&opts.defaultValue, flag.Default, "Y", false, usage.QuickstartDefault)
+	cmd.Flags().BoolVarP(&opts.DefaultValue, flag.Default, "Y", false, usage.QuickstartDefault)
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.ForceQuickstart)
 	cmd.Flags().BoolVar(&opts.CurrentIP, flag.CurrentIP, false, usage.CurrentIPSimplified)
 	cmd.Flags().BoolVar(&opts.EnableTerminationProtection, flag.EnableTerminationProtection, false, usage.EnableTerminationProtection)

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -197,7 +197,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().BoolVar(&qsOpts.CurrentIP, flag.CurrentIP, false, usage.CurrentIPSimplified)
 	cmd.Flags().StringToStringVar(&qsOpts.Tag, flag.Tag, nil, usage.Tag)
 	cmd.Flags().BoolVarP(&qsOpts.DefaultValue, flag.Default, "Y", false, usage.QuickstartDefault)
-	_ = cmd.Flags().MarkHidden(flag.Default)
+	_ = cmd.Flags().MarkDeprecated(flag.Default, "please use --force instead")
 	cmd.Flags().StringVar(&qsOpts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	_ = cmd.Flags().MarkHidden(flag.ProjectID)
 

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -196,7 +196,8 @@ func Builder() *cobra.Command {
 	cmd.Flags().BoolVar(&qsOpts.Confirm, flag.Force, false, usage.Force)
 	cmd.Flags().BoolVar(&qsOpts.CurrentIP, flag.CurrentIP, false, usage.CurrentIPSimplified)
 	cmd.Flags().StringToStringVar(&qsOpts.Tag, flag.Tag, nil, usage.Tag)
-
+	cmd.Flags().BoolVarP(&qsOpts.DefaultValue, flag.Default, "Y", false, usage.QuickstartDefault)
+	_ = cmd.Flags().MarkHidden(flag.Default)
 	cmd.Flags().StringVar(&qsOpts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	_ = cmd.Flags().MarkHidden(flag.ProjectID)
 


### PR DESCRIPTION
## Proposed changes

Flag is marked as deprecated

_Jira ticket:_ CLOUDP-187018

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x]  I have run `make fmt` and formatted my code
