### PR TITLE
CLOUDP-187063: Override agent for Dockerized AtlasCLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
-ENV CONTAINER=""
+ENV MONGODB_ATLAS_RUNNING_FROM_CONTAINER=""
 
 COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
 [mongodb-org-x86_64-6.0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+ENV BUILD_CONTEXT=container
 
 COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
 [mongodb-org-x86_64-6.0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
-ENV BUILD_CONTEXT=""
+ENV CONTAINER=""
 
 COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
 [mongodb-org-x86_64-6.0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
-ENV MONGODB_ATLAS_RUNNING_FROM_CONTAINER=""
+ENV MONGODB_ATLAS_RUNNING_FROM_CONTAINER=true
 
 COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
 [mongodb-org-x86_64-6.0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
-ENV MONGODB_ATLAS_RUNNING_FROM_CONTAINER=true
+ENV MONGODB_ATLAS_IS_CONTAINERIZED=true
 
 COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
 [mongodb-org-x86_64-6.0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
-ENV BUILD_CONTEXT=container
+ARG BUILD_CONTEXT
 
 COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
 [mongodb-org-x86_64-6.0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
-ARG BUILD_CONTEXT
+ENV BUILD_CONTEXT=""
 
 COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
 [mongodb-org-x86_64-6.0]

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -69,11 +69,14 @@ const (
 	TelemetryEnabledProperty     = "telemetry_enabled"
 	MongoCLI                     = "mongocli"
 	AtlasCLI                     = "atlascli"
+	NativeHostName               = "native"
+	ContainerHostName            = "container"
 )
 
 var (
 	ToolName       = MongoCLI
-	UserAgent      = fmt.Sprintf("%s/%s (%s;%s)", ToolName, version.Version, runtime.GOOS, runtime.GOARCH)
+	HostName       = NativeHostName
+	UserAgent      = fmt.Sprintf("%s/%s (%s;%s;%s)", ToolName, version.Version, runtime.GOOS, runtime.GOARCH, HostName)
 	defaultProfile = newProfile()
 )
 

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -27,18 +27,14 @@ import (
 )
 
 const (
-	timeout                    = 5 * time.Second
-	keepAlive                  = 30 * time.Second
-	maxIdleConns               = 5
-	maxIdleConnsPerHost        = 4
-	idleConnTimeout            = 30 * time.Second
-	expectContinueTimeout      = 1 * time.Second
-	cloudGovServiceURL         = "https://cloud.mongodbgov.com/"
-	userAgentContainerHostName = "container"
-	userAgentNativeHostName    = "native"
+	timeout               = 5 * time.Second
+	keepAlive             = 30 * time.Second
+	maxIdleConns          = 5
+	maxIdleConnsPerHost   = 4
+	idleConnTimeout       = 30 * time.Second
+	expectContinueTimeout = 1 * time.Second
+	cloudGovServiceURL    = "https://cloud.mongodbgov.com/"
 )
-
-var userAgentHostName = userAgentNativeHostName
 
 var defaultTransport = &http.Transport{
 	DialContext: (&net.Dialer{
@@ -63,10 +59,10 @@ const (
 	GovClientID = "0oabtyfelbTBdoucy297" // GovClientID for production
 )
 
-func addUserAgentHostParameter() {
-	if !strings.Contains(config.UserAgent, userAgentHostName) {
-		config.UserAgent = fmt.Sprintf("%s;%s)",
-			strings.TrimSuffix(config.UserAgent, ")"), userAgentHostName)
+func changeHostNameToContainer() {
+	if !strings.Contains(config.UserAgent, config.ContainerHostName) {
+		config.UserAgent = strings.ReplaceAll(config.UserAgent, config.HostName, config.ContainerHostName)
+		config.HostName = config.ContainerHostName
 	}
 }
 
@@ -82,9 +78,8 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 	}
 	runningFromContainer, runningFromContainerIsSet := os.LookupEnv("MONGODB_ATLAS_RUNNING_FROM_CONTAINER")
 	if runningFromContainerIsSet && runningFromContainer == "true" {
-		userAgentHostName = userAgentContainerHostName
+		changeHostNameToContainer()
 	}
-	addUserAgentHostParameter()
 	fmt.Println(config.UserAgent)
 
 	authOpts := []auth.ConfigOpt{

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -80,10 +80,12 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 	if c.ClientID() != "" {
 		id = c.ClientID()
 	}
-	if _, runningFromContainer := os.LookupEnv("MONGODB_ATLAS_RUNNING_FROM_CONTAINER"); runningFromContainer {
+	runningFromContainer, runningFromContainerIsSet := os.LookupEnv("MONGODB_ATLAS_RUNNING_FROM_CONTAINER")
+	if runningFromContainerIsSet && runningFromContainer == "true" {
 		userAgentHostName = userAgentContainerHostName
 	}
 	addUserAgentHostParameter()
+	fmt.Println(config.UserAgent)
 
 	authOpts := []auth.ConfigOpt{
 		auth.SetUserAgent(config.UserAgent),

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -80,7 +80,7 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 	if c.ClientID() != "" {
 		id = c.ClientID()
 	}
-	if _, runningFromContainer := os.LookupEnv("CONTAINER"); runningFromContainer {
+	if _, runningFromContainer := os.LookupEnv("MONGODB_ATLAS_RUNNING_FROM_CONTAINER"); runningFromContainer {
 		userAgentHostName = userAgentContainerHostName
 	}
 	addUserAgentHostParameter()

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -15,7 +15,6 @@
 package oauth
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -80,7 +79,6 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 	if runningFromContainerIsSet && runningFromContainer == "true" {
 		changeHostNameToContainer()
 	}
-	fmt.Println(config.UserAgent)
 
 	authOpts := []auth.ConfigOpt{
 		auth.SetUserAgent(config.UserAgent),

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -65,7 +65,8 @@ const (
 
 func addUserAgentPostfix() {
 	if !strings.Contains(config.UserAgent, userAgentPostfix) {
-		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, userAgentPostfix)
+		config.UserAgent = fmt.Sprintf("%s;%s)",
+			strings.TrimSuffix(config.UserAgent, ")"), userAgentPostfix)
 	}
 }
 

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -27,13 +27,13 @@ import (
 )
 
 const (
-	timeout                   = 5 * time.Second
-	keepAlive                 = 30 * time.Second
-	maxIdleConns              = 5
-	maxIdleConnsPerHost       = 4
-	idleConnTimeout           = 30 * time.Second
-	expectContinueTimeout     = 1 * time.Second
-	cloudGovServiceURL        = "https://cloud.mongodbgov.com/"
+	timeout                    = 5 * time.Second
+	keepAlive                  = 30 * time.Second
+	maxIdleConns               = 5
+	maxIdleConnsPerHost        = 4
+	idleConnTimeout            = 30 * time.Second
+	expectContinueTimeout      = 1 * time.Second
+	cloudGovServiceURL         = "https://cloud.mongodbgov.com/"
 	userAgentContainerHostName = "container"
 	userAgentNativeHostName    = "native"
 )

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -79,7 +79,7 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 	if c.ClientID() != "" {
 		id = c.ClientID()
 	}
-	if _, runningFromContainer := os.LookupEnv("BUILD_CONTEXT"); runningFromContainer {
+	if _, runningFromContainer := os.LookupEnv("CONTAINER"); runningFromContainer {
 		userAgentPostfix = userAgentContainerPostfix
 	}
 	addUserAgentPostfix()

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -63,7 +63,7 @@ const (
 	GovClientID = "0oabtyfelbTBdoucy297" // GovClientID for production
 )
 
-func addUserAgentPostfix() {
+func addUserAgentHostParameter() {
 	if !strings.Contains(config.UserAgent, userAgentPostfix) {
 		config.UserAgent = fmt.Sprintf("%s;%s)",
 			strings.TrimSuffix(config.UserAgent, ")"), userAgentPostfix)
@@ -83,7 +83,7 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 	if _, runningFromContainer := os.LookupEnv("CONTAINER"); runningFromContainer {
 		userAgentPostfix = userAgentContainerPostfix
 	}
-	addUserAgentPostfix()
+	addUserAgentHostParameter()
 
 	authOpts := []auth.ConfigOpt{
 		auth.SetUserAgent(config.UserAgent),

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -27,13 +27,13 @@ import (
 )
 
 const (
-	timeout               = 5 * time.Second
-	keepAlive             = 30 * time.Second
-	maxIdleConns          = 5
-	maxIdleConnsPerHost   = 4
-	idleConnTimeout       = 30 * time.Second
-	expectContinueTimeout = 1 * time.Second
-	cloudGovServiceURL    = "https://cloud.mongodbgov.com/"
+	timeout                   = 5 * time.Second
+	keepAlive                 = 30 * time.Second
+	maxIdleConns              = 5
+	maxIdleConnsPerHost       = 4
+	idleConnTimeout           = 30 * time.Second
+	expectContinueTimeout     = 1 * time.Second
+	cloudGovServiceURL        = "https://cloud.mongodbgov.com/"
 	userAgentContainerPostfix = "container"
 )
 
@@ -64,8 +64,7 @@ const (
 func maybeAddUserAgentPostfix() {
 	_, runningFromContainer := os.LookupEnv("BUILD_CONTEXT")
 
-	if runningFromContainer &&
-		!strings.Contains(config.UserAgent, userAgentContainerPostfix) {
+	if runningFromContainer && !strings.Contains(config.UserAgent, userAgentContainerPostfix) {
 		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, userAgentContainerPostfix)
 	}
 }

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -35,7 +35,10 @@ const (
 	expectContinueTimeout     = 1 * time.Second
 	cloudGovServiceURL        = "https://cloud.mongodbgov.com/"
 	userAgentContainerPostfix = "container"
+	userAgentNativePostfix    = "native"
 )
+
+var userAgentPostfix = userAgentNativePostfix
 
 var defaultTransport = &http.Transport{
 	DialContext: (&net.Dialer{
@@ -60,9 +63,9 @@ const (
 	GovClientID = "0oabtyfelbTBdoucy297" // GovClientID for production
 )
 
-func addUserAgentContainerPostfix() {
-	if !strings.Contains(config.UserAgent, userAgentContainerPostfix) {
-		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, userAgentContainerPostfix)
+func addUserAgentPostfix() {
+	if !strings.Contains(config.UserAgent, userAgentPostfix) {
+		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, userAgentPostfix)
 	}
 }
 
@@ -77,8 +80,9 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 		id = c.ClientID()
 	}
 	if _, runningFromContainer := os.LookupEnv("BUILD_CONTEXT"); runningFromContainer {
-		addUserAgentContainerPostfix()
+		userAgentPostfix = userAgentContainerPostfix
 	}
+	addUserAgentPostfix()
 
 	authOpts := []auth.ConfigOpt{
 		auth.SetUserAgent(config.UserAgent),

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -75,7 +75,7 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 	if c.ClientID() != "" {
 		id = c.ClientID()
 	}
-	runningFromContainer, runningFromContainerIsSet := os.LookupEnv("MONGODB_ATLAS_RUNNING_FROM_CONTAINER")
+	runningFromContainer, runningFromContainerIsSet := os.LookupEnv("MONGODB_ATLAS_IS_CONTAINERIZED")
 	if runningFromContainerIsSet && runningFromContainer == "true" {
 		changeHostNameToContainer()
 	}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -34,11 +34,11 @@ const (
 	idleConnTimeout           = 30 * time.Second
 	expectContinueTimeout     = 1 * time.Second
 	cloudGovServiceURL        = "https://cloud.mongodbgov.com/"
-	userAgentContainerPostfix = "container"
-	userAgentNativePostfix    = "native"
+	userAgentContainerHostName = "container"
+	userAgentNativeHostName    = "native"
 )
 
-var userAgentPostfix = userAgentNativePostfix
+var userAgentHostName = userAgentNativeHostName
 
 var defaultTransport = &http.Transport{
 	DialContext: (&net.Dialer{
@@ -64,9 +64,9 @@ const (
 )
 
 func addUserAgentHostParameter() {
-	if !strings.Contains(config.UserAgent, userAgentPostfix) {
+	if !strings.Contains(config.UserAgent, userAgentHostName) {
 		config.UserAgent = fmt.Sprintf("%s;%s)",
-			strings.TrimSuffix(config.UserAgent, ")"), userAgentPostfix)
+			strings.TrimSuffix(config.UserAgent, ")"), userAgentHostName)
 	}
 }
 
@@ -81,7 +81,7 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 		id = c.ClientID()
 	}
 	if _, runningFromContainer := os.LookupEnv("CONTAINER"); runningFromContainer {
-		userAgentPostfix = userAgentContainerPostfix
+		userAgentHostName = userAgentContainerHostName
 	}
 	addUserAgentHostParameter()
 

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -60,11 +60,8 @@ const (
 	GovClientID = "0oabtyfelbTBdoucy297" // GovClientID for production
 )
 
-// Appends user agent if run from container.
-func maybeAddUserAgentPostfix() {
-	_, runningFromContainer := os.LookupEnv("BUILD_CONTEXT")
-
-	if runningFromContainer && !strings.Contains(config.UserAgent, userAgentContainerPostfix) {
+func addUserAgentContainerPostfix() {
+	if !strings.Contains(config.UserAgent, userAgentContainerPostfix) {
 		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, userAgentContainerPostfix)
 	}
 }
@@ -79,7 +76,9 @@ func FlowWithConfig(c ServiceGetter) (*auth.Config, error) {
 	if c.ClientID() != "" {
 		id = c.ClientID()
 	}
-	maybeAddUserAgentPostfix()
+	if _, runningFromContainer := os.LookupEnv("BUILD_CONTEXT"); runningFromContainer {
+		addUserAgentContainerPostfix()
+	}
 
 	authOpts := []auth.ConfigOpt{
 		auth.SetUserAgent(config.UserAgent),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,6 +50,7 @@ const (
 	expectContinueTimeout     = 1 * time.Second
 	versionManifestStaticPath = "https://opsmanager.mongodb.com/"
 	cloudGovServiceURL        = "https://cloud.mongodbgov.com/"
+	userAgentContainerPostfix = "container"
 )
 
 var errUnsupportedService = errors.New("unsupported service")
@@ -270,18 +271,18 @@ func WithContext(ctx context.Context) Option {
 }
 
 // Appends user agent given a build context for telemetry.
-func appendUserAgent(buildContext string) {
-	if !strings.Contains(config.UserAgent, buildContext) {
-		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, buildContext)
+func appendUserAgent() {
+	if !strings.Contains(config.UserAgent, userAgentContainerPostfix) {
+		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, userAgentContainerPostfix)
 	}
 }
 
 // setAtlasClient sets the internal client to use an Atlas client and methods.
 func (s *Store) setAtlasClient(client *http.Client) error {
-	buildContext, buildContextPresent := os.LookupEnv("BUILD_CONTEXT")
+	_, buildContextPresent := os.LookupEnv("BUILD_CONTEXT")
 
 	if buildContextPresent {
-		appendUserAgent(buildContext)
+		appendUserAgent()
 	}
 
 	fmt.Println(config.UserAgent)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,7 +50,6 @@ const (
 	expectContinueTimeout     = 1 * time.Second
 	versionManifestStaticPath = "https://opsmanager.mongodb.com/"
 	cloudGovServiceURL        = "https://cloud.mongodbgov.com/"
-	userAgentContainerPostfix = "container"
 )
 
 var errUnsupportedService = errors.New("unsupported service")
@@ -270,22 +269,8 @@ func WithContext(ctx context.Context) Option {
 	}
 }
 
-// Appends user agent given a build context for telemetry.
-func appendUserAgent() {
-	if !strings.Contains(config.UserAgent, userAgentContainerPostfix) {
-		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, userAgentContainerPostfix)
-	}
-}
-
 // setAtlasClient sets the internal client to use an Atlas client and methods.
 func (s *Store) setAtlasClient(client *http.Client) error {
-	_, buildContextPresent := os.LookupEnv("BUILD_CONTEXT")
-
-	if buildContextPresent {
-		appendUserAgent()
-	}
-
-	fmt.Println(config.UserAgent)
 	opts := []atlas.ClientOpt{atlas.SetUserAgent(config.UserAgent)}
 	if s.baseURL != "" {
 		opts = append(opts, atlas.SetBaseURL(s.baseURL))

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -269,7 +269,7 @@ func WithContext(ctx context.Context) Option {
 	}
 }
 
-// Appends user agent in container context for telemetry.
+// Appends user agent given a build context for telemetry.
 func appendUserAgent(buildContext string) {
 	if !strings.Contains(config.UserAgent, buildContext) {
 		config.UserAgent = fmt.Sprintf("%s-%s", config.UserAgent, buildContext)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -269,8 +269,22 @@ func WithContext(ctx context.Context) Option {
 	}
 }
 
+// Appends user agent in container context for telemetry.
+func appendUserAgent(buildContext string) {
+	if !strings.Contains(config.UserAgent, buildContext) {
+		config.UserAgent = fmt.Sprintf("%s-%s", config.UserAgent, buildContext)
+	}
+}
+
 // setAtlasClient sets the internal client to use an Atlas client and methods.
 func (s *Store) setAtlasClient(client *http.Client) error {
+	buildContext, buildContextPresent := os.LookupEnv("BUILD_CONTEXT")
+
+	if buildContextPresent {
+		appendUserAgent(buildContext)
+	}
+
+	fmt.Println(config.UserAgent)
 	opts := []atlas.ClientOpt{atlas.SetUserAgent(config.UserAgent)}
 	if s.baseURL != "" {
 		opts = append(opts, atlas.SetBaseURL(s.baseURL))

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -272,7 +272,7 @@ func WithContext(ctx context.Context) Option {
 // Appends user agent given a build context for telemetry.
 func appendUserAgent(buildContext string) {
 	if !strings.Contains(config.UserAgent, buildContext) {
-		config.UserAgent = fmt.Sprintf("%s-%s", config.UserAgent, buildContext)
+		config.UserAgent = fmt.Sprintf("%s (%s)", config.UserAgent, buildContext)
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Adds a host parameter to the UserAgent, which defaults to "native". If the CLI is run from the docker container the host parameter is set to "container".

Jira ticket: CLOUDP-187063
Closes: CLOUDP-187063

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

Testing was done manually by using a local throwaway pipeline.
