### PR TITLE
Approach for enforcing each unit tests to verify table format by default and without extensive manual mocking

### DIFF
--- a/internal/cli/atlas/backup/snapshots/__snapshots__/list_test.snap
+++ b/internal/cli/atlas/backup/snapshots/__snapshots__/list_test.snap
@@ -1,0 +1,13 @@
+
+[TestList_Run - 1]
+ID          TYPE         STATUS       CREATED AT                      EXPIRES AT
+NCEDUSB     aJiM         ZdBdAaR      0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC
+oXcSJ       hSuLlqw      khCxBJnVI    0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC
+AUcYNM      YYXZfvj      ZvLQDQRyT    0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC
+CVthPqiv    qQrf         xOLQxjxI     0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC
+kCLpo       uQaKWQ       ripnwmP      0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC
+dYhY        qUpvnboSuG   kRBke        0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC
+fOrCsmhb    dUQZHgAonF   zXzX         0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC
+cWjJDmNzH   svxwFa       mkuemSqmxK   0001-01-01 00:00:00 +0000 UTC   0001-01-01 00:00:00 +0000 UTC
+
+---

--- a/internal/cli/atlas/backup/snapshots/list_test.go
+++ b/internal/cli/atlas/backup/snapshots/list_test.go
@@ -17,9 +17,13 @@
 package snapshots
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201001/admin"
 )
@@ -27,12 +31,19 @@ import (
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockSnapshotsLister(ctrl)
+	buf := new(bytes.Buffer)
+	expected := &atlasv2.PaginatedCloudBackupReplicaSet{
+	}
 
-	expected := &atlasv2.PaginatedCloudBackupReplicaSet{}
+	gofakeit.Struct(&expected)
 
 	listOpts := &ListOpts{
 		store:       mockStore,
 		clusterName: "Cluster0",
+		OutputOpts: cli.OutputOpts{
+			Template:  listTemplate,
+			OutWriter: buf,
+		},
 	}
 
 	mockStore.
@@ -44,4 +55,6 @@ func TestList_Run(t *testing.T) {
 	if err := listOpts.Run(); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
+
+	snaps.MatchSnapshot(t ,buf.String())
 }

--- a/internal/cli/atlas/integrations/__snapshots__/describe_test.snap
+++ b/internal/cli/atlas/integrations/__snapshots__/describe_test.snap
@@ -1,0 +1,6 @@
+
+[TestDescribe_Run - 1]
+TYPE    API TOKEN   TEAM       CHANNEL
+SLACK   testToken   testTeam   testChannel
+
+---

--- a/internal/cli/atlas/integrations/__snapshots__/list_test.snap
+++ b/internal/cli/atlas/integrations/__snapshots__/list_test.snap
@@ -1,0 +1,7 @@
+
+[TestDBUserList_Run - 1]
+TYPE
+DATADOG
+MICROSOFT_TEAMS
+
+---

--- a/internal/cli/atlas/integrations/describe_test.go
+++ b/internal/cli/atlas/integrations/describe_test.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201001/admin"
 )
 
@@ -59,9 +59,7 @@ func TestDescribe_Run(t *testing.T) {
 	if err := describeOpts.Run(); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
-	assert.Equal(t, `TYPE    API TOKEN   TEAM       CHANNEL
-SLACK   testToken   testTeam   testChannel
-`, buf.String())
+	snaps.MatchSnapshot(t ,buf.String())
 	t.Log(buf.String())
 }
 

--- a/internal/cli/atlas/integrations/list_test.go
+++ b/internal/cli/atlas/integrations/list_test.go
@@ -20,13 +20,13 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201001/admin"
 )
 
@@ -68,10 +68,7 @@ func TestDBUserList_Run(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	assert.Equal(t, `TYPE
-DATADOG
-MICROSOFT_TEAMS
-`, buf.String())
+	snaps.MatchSnapshot(t ,buf.String())
 	t.Log(buf.String())
 }
 


### PR DESCRIPTION
## Why

Atlas CLI needs to have tests for:
- Ensuring table format is correct out of the box for every list command with minimal boilerplate
- Contract tests for API changes.

Writing unit tests for the moment requires a lot of boilerplate and is going to cause long-term maintenance issues. 
Tests written manually become operating system dependant and hard to maintain.
In this PR I'm proposing using thrid party library that solves that problem.

## Approaches

In this scenario I'm using 2 approaches:


1. Inline objects + snapshots (integrations tests) Preferred.
2. Faked objects + snapshots (  reduces friction for us and makes our unit tests simple)


For long term we can explore: (proposal)

4. example objects generated in the SDK under test folder.
5. Remove table templates and use headers in sdk https://github.com/lensesio/tableprinter/blob/master/_examples/1_simple/main.go