### PR TITLE
CLOUDP-189213: mongocli om clusters ls doesn't account for explit empty output

### DIFF
--- a/internal/cli/opsmanager/clusters/list.go
+++ b/internal/cli/opsmanager/clusters/list.go
@@ -30,8 +30,7 @@ import (
 type ListOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
-	outputSet bool
-	store     store.CloudManagerClustersLister
+	store store.CloudManagerClustersLister
 }
 
 func (opts *ListOpts) initStore(ctx context.Context) func() error {
@@ -101,7 +100,6 @@ When using an output format the information will be provided by automation.`,
 			)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.outputSet = cmd.Flags().Changed(flag.Output)
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/list.go
+++ b/internal/cli/opsmanager/clusters/list.go
@@ -46,11 +46,6 @@ var listTemplate = `ID	NAME	TYPE	REPLICASET NAME{{range .Results}}
 {{.ID}}	{{.ClusterName}}	{{.TypeName}}	{{.ReplicaSetName}}{{end}}
 `
 
-// listAllTemplate used fetching all clusters for all projects.
-var listAllTemplate = `ID	NAME	TYPE{{range .Results}}{{range .Clusters}}
-{{.ClusterID}}	{{.Name}}	{{.Type}}{{end}}{{end}}
-`
-
 func (opts *ListOpts) Run() error {
 	r, err := opts.clusters()
 	if err != nil {
@@ -60,17 +55,7 @@ func (opts *ListOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *ListOpts) template() string {
-	if opts.ConfigProjectID() == "" {
-		return listAllTemplate
-	}
-	return listTemplate
-}
-
 func (opts *ListOpts) clusters() (interface{}, error) {
-	if opts.ConfigProjectID() == "" {
-		return opts.store.ListAllProjectClusters()
-	}
 	if opts.IsPlainOutput() {
 		return opts.store.ProjectClusters(opts.ConfigProjectID(), nil)
 	}
@@ -83,7 +68,7 @@ func (opts *ListOpts) clusters() (interface{}, error) {
 	return r, nil
 }
 
-// mongocli cloud-manager cluster(s) list --projectId projectId.
+// ListBuilder mongocli cloud-manager cluster(s) list --projectId projectId.
 func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{
@@ -95,7 +80,8 @@ When using an output format the information will be provided by automation.`,
 		Args: require.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
-				opts.InitOutput(cmd.OutOrStdout(), opts.template()),
+				opts.ValidateProjectID,
+				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 				opts.initStore(cmd.Context()),
 			)
 		},

--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -72,6 +72,22 @@ func (opts *OutputOpts) ConfigOutput() string {
 	return opts.Output
 }
 
+func (opts *OutputOpts) IsJSONOutput() bool {
+	return opts.ConfigOutput() == jsonFormat
+}
+
+func (opts *OutputOpts) IsGoTemplate() bool {
+	return opts.ConfigOutput() == goTemplate || opts.ConfigOutput() == goTemplateFile
+}
+
+func (opts *OutputOpts) IsJSONPathOutput() bool {
+	return opts.ConfigOutput() == jsonPath
+}
+
+func (opts *OutputOpts) IsPlainOutput() bool {
+	return !(opts.IsJSONOutput() || opts.IsGoTemplate() || opts.IsJSONPathOutput())
+}
+
 // ConfigWriter returns the io.Writer.
 // If the writer is nil, it defaults to os.Stdout and caches it.
 func (opts *OutputOpts) ConfigWriter() io.Writer {

--- a/test/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/test/e2e/cloud_manager/deploy_replica_set_test.go
@@ -101,6 +101,7 @@ func TestDeployReplicaSet(t *testing.T) {
 			"--projectId=",
 			"-o=json",
 		)
+		t.Setenv("MCLI_PROJECT_ID", "")
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()

--- a/test/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/test/e2e/cloud_manager/deploy_replica_set_test.go
@@ -25,29 +25,27 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/convert"
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDeployReplicaSet(t *testing.T) {
 	cliPath, err := e2e.Bin()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	const testFile = "om-new-cluster.json"
 
 	n, err := e2e.RandInt(1000)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	clusterName := fmt.Sprintf("e2e-cluster-%v", n)
 
 	hostname, err := automationServerHostname(cliPath)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if err := generateRSConfig(testFile, hostname, clusterName, testedMDBVersion, testedMDBFCV); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		generateRSConfig(testFile, hostname, clusterName, testedMDBVersion, testedMDBFCV),
+	)
 
 	t.Run("Apply", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
@@ -59,9 +57,8 @@ func TestDeployReplicaSet(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		if resp, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch", watchAutomation(cliPath))
@@ -76,18 +73,41 @@ func TestDeployReplicaSet(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 		var clusters []*convert.ClusterConfig
-		if err := json.Unmarshal(resp, &clusters); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, json.Unmarshal(resp, &clusters), string(resp))
+		assert.NotEmpty(t, clusters)
+	})
 
-		if len(clusters) == 0 {
-			t.Errorf("expected len(clusters) > 0, got 0\n")
-		}
+	t.Run("List No Output", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			entity,
+			clustersEntity,
+			"ls",
+			"-o=",
+			"-o=json",
+		)
+
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+	})
+
+	t.Run("List No Project", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			entity,
+			clustersEntity,
+			"ls",
+			"--projectId=",
+			"-o=json",
+		)
+
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+		var clusters opsmngr.AllClustersProjects
+		require.NoError(t, json.Unmarshal(resp, &clusters), string(resp))
+		assert.NotEmpty(t, clusters.Results)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -101,25 +121,15 @@ func TestDeployReplicaSet(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
 		var cluster convert.ClusterConfig
-		if err := json.Unmarshal(resp, &cluster); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if cluster.Name != clusterName {
-			t.Errorf("expected %s, got %s\n", clusterName, cluster.Name)
-		}
+		require.NoError(t, json.Unmarshal(resp, &cluster), string(resp))
+		assert.Equal(t, cluster.Name, clusterName)
 	})
 
 	t.Run("Update", func(t *testing.T) {
-		if err := generateRSConfigUpdate(testFile); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
+		require.NoError(t, generateRSConfigUpdate(testFile))
 		cmd := exec.Command(cliPath,
 			entity,
 			clustersEntity,
@@ -131,10 +141,7 @@ func TestDeployReplicaSet(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch", watchAutomation(cliPath))
@@ -149,9 +156,8 @@ func TestDeployReplicaSet(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		if resp, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch", watchAutomation(cliPath))
@@ -166,9 +172,8 @@ func TestDeployReplicaSet(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		if resp, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch", watchAutomation(cliPath))
@@ -183,9 +188,8 @@ func TestDeployReplicaSet(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		if resp, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch", watchAutomation(cliPath))
@@ -200,19 +204,16 @@ func TestDeployReplicaSet(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		if resp, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch", watchAutomation(cliPath))
 
 	t.Run("Stop Monitoring", func(t *testing.T) {
-		hostIDs, err := hostIDs(cliPath)
-		if err != nil {
-			t.Fatalf("unexpected error: %v\n", err)
-		}
-		for _, h := range hostIDs {
+		ids, err := hostIDs(cliPath)
+		require.NoError(t, err)
+		for _, h := range ids {
 			cmd := exec.Command(cliPath,
 				entity,
 				monitoringEntity,
@@ -223,36 +224,26 @@ func TestDeployReplicaSet(t *testing.T) {
 
 			cmd.Env = os.Environ()
 			resp, err := cmd.CombinedOutput()
-
-			if err != nil {
-				t.Errorf("unexpected error: %v, resp: %v\n", err, string(resp))
-			}
+			require.NoError(t, err, string(resp))
 		}
 	})
 }
 
 func TestDeployAndDeleteReplicaSet(t *testing.T) {
 	cliPath, err := e2e.Bin()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	const testFile = "om-new-cluster.json"
 
 	n, err := e2e.RandInt(1000)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	clusterName := fmt.Sprintf("e2e-cluster-%v", n)
-
 	hostname, err := automationServerHostname(cliPath)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if err := generateRSConfig(testFile, hostname, clusterName, testedMDBVersion, testedMDBFCV); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		generateRSConfig(testFile, hostname, clusterName, testedMDBVersion, testedMDBFCV),
+	)
 	t.Run("Apply", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			entity,
@@ -263,9 +254,8 @@ func TestDeployAndDeleteReplicaSet(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		if resp, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch", watchAutomation(cliPath))
@@ -280,8 +270,7 @@ func TestDeployAndDeleteReplicaSet(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		if resp, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v\n", err, string(resp))
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/cloud_manager/deploy_replica_set_test.go
+++ b/test/e2e/cloud_manager/deploy_replica_set_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDeployReplicaSet(t *testing.T) {
@@ -91,24 +90,6 @@ func TestDeployReplicaSet(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-	})
-
-	t.Run("List No Project", func(t *testing.T) {
-		cmd := exec.Command(cliPath,
-			entity,
-			clustersEntity,
-			"ls",
-			"--projectId=",
-			"-o=json",
-		)
-		t.Setenv("MCLI_PROJECT_ID", "")
-
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		require.NoError(t, err, string(resp))
-		var clusters opsmngr.AllClustersProjects
-		require.NoError(t, json.Unmarshal(resp, &clusters), string(resp))
-		assert.NotEmpty(t, clusters.Results)
 	})
 
 	t.Run("Describe", func(t *testing.T) {


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ CLOUDP-189213

Correctly handle empty output (plaintext) when defaulting to json

