### PR TITLE
CLOUDP-192622: Atlas CLI deprecation message referring to mongocli

### DIFF
--- a/internal/cli/atlas/privateendpoints/create.go
+++ b/internal/cli/atlas/privateendpoints/create.go
@@ -84,7 +84,7 @@ func CreateBuilder() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()
 		},
-		Deprecated: "Please use mongocli atlas privateEndpoints aws create [--region region] [--projectId projectId]",
+		Deprecated: "Please use atlas privateEndpoints aws create [--region region] [--projectId projectId]",
 	}
 	cmd.Flags().StringVar(&opts.provider, flag.Provider, "AWS", usage.PrivateEndpointProvider)
 	cmd.Flags().StringVar(&opts.region, flag.Region, "", usage.PrivateEndpointRegion)

--- a/internal/cli/atlas/privateendpoints/delete.go
+++ b/internal/cli/atlas/privateendpoints/delete.go
@@ -68,7 +68,7 @@ func DeleteBuilder() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()
 		},
-		Deprecated: "Please use mongocli atlas privateEndpoints aws delete <ID> [--projectId projectId]",
+		Deprecated: "Please use atlas privateEndpoints aws delete <ID> [--projectId projectId]",
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)

--- a/internal/cli/atlas/privateendpoints/describe.go
+++ b/internal/cli/atlas/privateendpoints/describe.go
@@ -75,7 +75,7 @@ func DescribeBuilder() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()
 		},
-		Deprecated: "Please use mongocli atlas privateEndpoints aws describe <ID> [--projectId projectId]",
+		Deprecated: "Please use atlas privateEndpoints aws describe <ID> [--projectId projectId]",
 	}
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)

--- a/internal/cli/atlas/privateendpoints/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/create.go
@@ -75,7 +75,7 @@ func CreateBuilder() *cobra.Command {
 			opts.interfaceEndpointID = args[0]
 			return opts.Run()
 		},
-		Deprecated: "Please use mongocli atlas privateEndpoints aws interfaces create <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID] [--projectId projectId]",
+		Deprecated: "Please use atlas privateEndpoints aws interfaces create <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID] [--projectId projectId]",
 	}
 	cmd.Flags().StringVar(&opts.privateEndpointID, flag.PrivateEndpointID, "", usage.PrivateEndpointID)
 

--- a/internal/cli/atlas/privateendpoints/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/delete.go
@@ -68,7 +68,7 @@ func DeleteBuilder() *cobra.Command {
 			}
 			return opts.Run()
 		},
-		Deprecated: "Please use mongocli atlas privateEndpoints aws interfaces delete <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID] [--projectId projectId]",
+		Deprecated: "Please use atlas privateEndpoints aws interfaces delete <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID] [--projectId projectId]",
 	}
 
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)

--- a/internal/cli/atlas/privateendpoints/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/describe.go
@@ -76,7 +76,7 @@ func DescribeBuilder() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()
 		},
-		Deprecated: "Please use mongocli atlas privateEndpoints aws interfaces describe <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID] [--projectId projectId]",
+		Deprecated: "Please use atlas privateEndpoints aws interfaces describe <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID] [--projectId projectId]",
 	}
 	cmd.Flags().StringVar(&opts.privateEndpointID, flag.PrivateEndpointID, "", usage.PrivateEndpointID)
 

--- a/internal/cli/atlas/privateendpoints/list.go
+++ b/internal/cli/atlas/privateendpoints/list.go
@@ -76,7 +76,7 @@ func ListBuilder() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.Run()
 		},
-		Deprecated: "Please use mongocli atlas privateEndpoints aws list|ls [--projectId projectId]",
+		Deprecated: "Please use atlas privateEndpoints aws list|ls [--projectId projectId]",
 	}
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)

--- a/internal/cli/atlas/privateendpoints/watch.go
+++ b/internal/cli/atlas/privateendpoints/watch.go
@@ -87,7 +87,7 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 			opts.id = args[0]
 			return opts.Run()
 		},
-		Deprecated: "Please use mongocli atlas privateEndpoints aws watch [--projectId projectId]",
+		Deprecated: "Please use atlas privateEndpoints aws watch [--projectId projectId]",
 	}
 
 	cmd.Flags().StringVar(&opts.provider, flag.Provider, "AWS", usage.PrivateEndpointProvider)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Request from a HELP ticket - Removing `mongocli` from privateendpoints deprecation message 
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-192622

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
