### PR TITLE
fix: dependabot limit for PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
+    open-pull-requests-limit: 15
     reviewers:
       - "mongodb/mongocli"
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 10
     reviewers:
       - "mongodb/mongocli"
   - package-ecosystem: github-actions


### PR DESCRIPTION
New PRs with updates are never created because of the limits we currently have on dependabot for active PRs. This PR does changes the limit as a short countermeasure.  In the long run, we should consider tweaking our config or check for more powerful tools like renovate 

![Screenshot 2023-08-02 at 19 58 07](https://github.com/mongodb/mongodb-atlas-cli/assets/981838/cbf72cbd-1715-4877-a8f2-ee87e6aebda8)
