### PR TITLE
fix: introduce PR groups for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,25 @@ updates:
       day: tuesday
     reviewers:
       - "mongodb/mongocli"
+    groups:
+      internal-dependencies:
+          patterns:
+            - "go.mongodb.org*" # A single dependency name
+      golang:
+          patterns:
+            - "golang.org*" 
+      kubernetes:
+          patterns:
+            - "*k8s.io*"
+      google:
+          patterns:
+            - "*google.golang.org*"
+      aws:
+          patterns:
+            - "github.com/aws*"
+      azure:
+          patterns:
+            - "github.com/Azure*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
     reviewers:
       - "mongodb/mongocli"
     groups:
-      internal-dependencies:
-          patterns:
-            - "go.mongodb.org*" # A single dependency name
       golang:
           patterns:
             - "golang.org*" 


### PR DESCRIPTION
Just an idea to help us with more frequent and efficient PR reviews.
NOTE: Dependabot is quite limited in that regard. Renovate is much more powerful and also free. 