### PR TITLE
fix: move to 20 prs for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     reviewers:
       - "mongodb/mongocli"
   - package-ecosystem: github-actions


### PR DESCRIPTION
10 PRs is not enough 