### PR TITLE
CLOUDP-192357: automation for creation of jira issues in atlas CLI

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,69 @@
+---
+  name: Create JIRA ticket for new issues
+  
+  on:
+    issues:
+      types: [opened]
+      
+  permissions: 
+    issues: write
+    contents: read
+  jobs:
+    jira_task:
+      name: Create Jira issue
+      runs-on: ubuntu-latest
+      steps:
+      - name: Create JIRA ticket
+        id: create
+        shell: bash
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_ASSIGNEE: ${{ secrets.ASSIGNEE_JIRA_TICKET }}
+        run: |
+
+          # Use the tr command to remove the special characters from ISSUE_TITLE
+          ISSUE_TITLE_NO_SPECIAL_CHARS=$(echo "$ISSUE_TITLE" | tr -d '!$&*@#"\047\140')
+          json_response=$(curl --request POST \
+            --url 'https://jira.mongodb.org/rest/api/2/issue' \
+            --header 'Authorization: Bearer '"${JIRA_API_TOKEN}" \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data '{
+              "fields": {
+                  "project": {
+                      "id": "10984"
+                  },
+                  "summary": "HELP Atlas-CLI: '"${ISSUE_TITLE_NO_SPECIAL_CHARS}"'",
+                  "issuetype": {
+                      "id": "12"
+                  },
+                  "customfield_12751": [{
+                          "id": "22222"
+                  }],
+                  "description": "This ticket tracks the following GitHub issue: '"${ISSUE_URL}"'.",
+                  "components": [
+                      {
+                          "id": "32194"
+                      }
+                  ],
+                  "assignee": {
+                    "name": "'"${JIRA_ASSIGNEE}"'"
+                  }
+              }
+            }')
+  
+          echo "Response: ${json_response}"
+  
+          JIRA_TICKET_ID=$(echo "${json_response}" | jq -r '.key')
+  
+          echo "The following JIRA ticket has been created: ${JIRA_TICKET_ID}"
+          echo "jira-ticket-id=${JIRA_TICKET_ID}" >> "${GITHUB_OUTPUT}"
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Thanks for opening this issue. The ticket [${{ steps.create.outputs.jira-ticket-id }}](https://jira.mongodb.org/browse/${{ steps.create.outputs.jira-ticket-id }}) was created for internal tracking.


### PR DESCRIPTION
 Automatically create jira issues for every github issue. All project and assignments are already set properly and tested locally.
 
 
 > NOTE: automation will require setting up the following secrets:
 ```
 JIRA_API_TOKEN: {token}
 ASSIGNEE_JIRA_TICKET: Cloud AtlasCLI Escalation
 ```