### PR TITLE
CLOUDP-193348: Add command "atlas backups compliancepolicy setup" L1 support

### DIFF
--- a/internal/cli/atlas/backup/compliancepolicy/compliancepolicy.go
+++ b/internal/cli/atlas/backup/compliancepolicy/compliancepolicy.go
@@ -35,9 +35,9 @@ func Builder() *cobra.Command {
 	cmd := baseCommand()
 
 	cmd.AddCommand(
+		SetupBuilder(),
 		DescribeBuilder(),
 		CopyProtectionBuilder(),
-		SetupBuilder(),
 	)
 
 	return cmd

--- a/internal/cli/atlas/backup/compliancepolicy/compliancepolicy.go
+++ b/internal/cli/atlas/backup/compliancepolicy/compliancepolicy.go
@@ -37,6 +37,7 @@ func Builder() *cobra.Command {
 	cmd.AddCommand(
 		DescribeBuilder(),
 		CopyProtectionBuilder(),
+		SetupBuilder(),
 	)
 
 	return cmd

--- a/internal/cli/atlas/backup/compliancepolicy/compliancepolicy_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/compliancepolicy_test.go
@@ -26,7 +26,7 @@ func TestBuilder(t *testing.T) {
 	test.CmdValidator(
 		t,
 		Builder(),
-		2,
+		3,
 		[]string{},
 	)
 }

--- a/internal/cli/atlas/backup/compliancepolicy/copyprotection.go
+++ b/internal/cli/atlas/backup/compliancepolicy/copyprotection.go
@@ -42,8 +42,7 @@ const (
 	active  = "ACTIVE"
 )
 
-var copyProtectionTemplate = `
-Copy protection has been set to: {{.CopyProtectionEnabled}}
+var copyProtectionTemplate = `Copy protection has been set to: {{.CopyProtectionEnabled}}
 `
 
 func (opts *CopyProtectionOpts) initStore(ctx context.Context) func() error {

--- a/internal/cli/atlas/backup/compliancepolicy/copyprotection.go
+++ b/internal/cli/atlas/backup/compliancepolicy/copyprotection.go
@@ -42,7 +42,9 @@ const (
 	active  = "ACTIVE"
 )
 
-var copyProtectionTemplate = `Copy protection has been set to: {{.CopyProtectionEnabled}}`
+var copyProtectionTemplate = `
+Copy protection has been set to: {{.CopyProtectionEnabled}}
+`
 
 func (opts *CopyProtectionOpts) initStore(ctx context.Context) func() error {
 	return func() error {

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -39,8 +39,7 @@ type SetupOpts struct {
 	confirm bool
 }
 
-var setupTemplate = `
-Your backup compliance policy has been set up with the following configuration:
+var setupTemplate = `Your backup compliance policy has been set up with the following configuration:
 
 Project:	{{.ProjectId}}
 Authorized e-mail:	{{.AuthorizedEmail}}

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -78,9 +78,6 @@ func (opts *SetupOpts) setupWatcher() (bool, error) {
 }
 
 func (opts *SetupOpts) Run() error {
-	if !opts.confirm {
-		return errors.New("this feature is not production ready: to continue, use '--force'")
-	}
 	opts.policy.SetProjectId(opts.ConfigProjectID())
 
 	_, err := opts.store.UpdateCompliancePolicy(opts.ConfigProjectID(), opts.policy)
@@ -124,6 +121,7 @@ func SetupBuilder() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
 	cmd.Flags().StringVarP(&opts.path, flag.File, flag.FileShort, "", usage.BackupCompliancePolicyFile)
 	cmd.Flags().BoolVar(&opts.confirm, flag.Force, false, usage.Force)
+	_ = cmd.Flags().MarkHidden(flag.Force)
 	_ = cmd.MarkFlagRequired(flag.File)
 	return cmd
 }

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -124,6 +124,6 @@ func SetupBuilder() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
 	cmd.Flags().StringVarP(&opts.path, flag.File, flag.FileShort, "", usage.BackupCompliancePolicyFile)
 	cmd.Flags().BoolVar(&opts.confirm, flag.Force, false, usage.Force)
-	cmd.MarkFlagRequired(flag.File)
+	_ = cmd.MarkFlagRequired(flag.File)
 	return cmd
 }

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -32,14 +32,32 @@ import (
 type SetupOpts struct {
 	cli.GlobalOpts
 	cli.WatchOpts
-	policy  *atlasv2.DataProtectionSettings
-	store   store.CompliancePolicy
-	fs      afero.Fs
-	path    string
-	confirm bool
+	policy      *atlasv2.DataProtectionSettings
+	store       store.CompliancePolicy
+	fs          afero.Fs
+	path        string
+	confirm     bool
+	EnableWatch bool
 }
 
-var setupTemplate = `Your backup compliance policy has been set up with the following configuration:
+var setupWatchTemplate = `Your backup compliance policy has been set up with the following configuration:
+
+Project:	{{.ProjectId}}
+Authorized e-mail:	{{.AuthorizedEmail}}
+Copy protection enabled:	{{.CopyProtectionEnabled}}
+Encryption at rest enabled:	{{.EncryptionAtRestEnabled}}
+Point-in-Time restores enabled:	{{.PitEnabled}}
+Restore window days:	{{.RestoreWindowDays}}
+
+POLICIES
+ID	FREQUENCY INTERVAL	FREQUENCY TYPE	RETENTION
+{{- range .ScheduledPolicyItems}}
+{{.Id}}	{{if eq .FrequencyType "hourly"}}{{.FrequencyInterval}}{{else}}-{{end}}	{{.FrequencyType}}	{{.RetentionValue}} {{.RetentionUnit}}
+{{- end}}
+{{if .OnDemandPolicyItem}}{{.OnDemandPolicyItem.Id}}	-	{{.OnDemandPolicyItem.FrequencyType}}	{{.OnDemandPolicyItem.RetentionValue}} {{.OnDemandPolicyItem.RetentionUnit}}{{end}}
+`
+
+var setupTemplate = `Your backup compliance policy is being set up with the following configuration:
 
 Project:	{{.ProjectId}}
 Authorized e-mail:	{{.AuthorizedEmail}}
@@ -77,14 +95,15 @@ func (opts *SetupOpts) setupWatcher() (bool, error) {
 }
 
 func (opts *SetupOpts) Run() error {
-	opts.policy.SetProjectId(opts.ConfigProjectID())
-
 	_, err := opts.store.UpdateCompliancePolicy(opts.ConfigProjectID(), opts.policy)
 	if err != nil {
 		return err
 	}
-	if err := opts.Watch(opts.setupWatcher); err != nil {
-		return err
+	if opts.EnableWatch {
+		if err := opts.Watch(opts.setupWatcher); err != nil {
+			return err
+		}
+		opts.Template = setupWatchTemplate
 	}
 
 	return opts.Print(opts.policy)
@@ -120,6 +139,7 @@ func SetupBuilder() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
 	cmd.Flags().StringVarP(&opts.path, flag.File, flag.FileShort, "", usage.BackupCompliancePolicyFile)
 	cmd.Flags().BoolVar(&opts.confirm, flag.Force, false, usage.Force)
+	cmd.Flags().BoolVarP(&opts.EnableWatch, flag.EnableWatch, flag.EnableWatchShort, false, usage.EnableWatch)
 	_ = cmd.Flags().MarkHidden(flag.Force)
 	_ = cmd.MarkFlagRequired(flag.File)
 	return cmd

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -139,7 +139,7 @@ func SetupBuilder() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
 	cmd.Flags().StringVarP(&opts.path, flag.File, flag.FileShort, "", usage.BackupCompliancePolicyFile)
 	cmd.Flags().BoolVar(&opts.confirm, flag.Force, false, usage.Force)
-	cmd.Flags().BoolVarP(&opts.EnableWatch, flag.EnableWatch, flag.EnableWatchShort, false, usage.EnableWatch)
+	cmd.Flags().BoolVarP(&opts.EnableWatch, flag.EnableWatch, flag.EnableWatchShort, false, usage.EnableWatchDefault)
 	_ = cmd.Flags().MarkHidden(flag.Force)
 	_ = cmd.MarkFlagRequired(flag.File)
 	return cmd

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -124,6 +124,6 @@ func SetupBuilder() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
 	cmd.Flags().StringVarP(&opts.path, flag.File, flag.FileShort, "", usage.BackupCompliancePolicyFile)
 	cmd.Flags().BoolVar(&opts.confirm, flag.Force, false, usage.Force)
-
+	cmd.MarkFlagRequired(flag.File)
 	return cmd
 }

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -103,7 +103,7 @@ func SetupBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     use,
 		Aliases: cli.GenerateAliases(use),
-		Short:   "Setup the backup compliance policy for your project.",
+		Short:   "Setup the backup compliance policy for your project with a configuration file.",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -1,0 +1,129 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compliancepolicy
+
+import (
+	"context"
+	"errors"
+
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/internal/config"
+	"github.com/mongodb/mongodb-atlas-cli/internal/file"
+	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
+	"github.com/mongodb/mongodb-atlas-cli/internal/store"
+	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201004/admin"
+)
+
+type SetupOpts struct {
+	cli.GlobalOpts
+	cli.WatchOpts
+	policy  *atlasv2.DataProtectionSettings
+	store   store.CompliancePolicy
+	fs      afero.Fs
+	path    string
+	confirm bool
+}
+
+var setupTemplate = `
+Your backup compliance policy has been set up with the following configuration:
+
+Project:	{{.ProjectId}}
+Authorized e-mail:	{{.AuthorizedEmail}}
+Copy protection enabled:	{{.CopyProtectionEnabled}}
+Encryption at rest enabled:	{{.EncryptionAtRestEnabled}}
+Point-in-Time restores enabled:	{{.PitEnabled}}
+Restore window days:	{{.RestoreWindowDays}}
+
+POLICIES
+ID	FREQUENCY INTERVAL	FREQUENCY TYPE	RETENTION
+{{- range .ScheduledPolicyItems}}
+{{.Id}}	{{if eq .FrequencyType "hourly"}}{{.FrequencyInterval}}{{else}}-{{end}}	{{.FrequencyType}}	{{.RetentionValue}} {{.RetentionUnit}}
+{{- end}}
+{{if .OnDemandPolicyItem}}{{.OnDemandPolicyItem.Id}}	-	{{.OnDemandPolicyItem.FrequencyType}}	{{.OnDemandPolicyItem.RetentionValue}} {{.OnDemandPolicyItem.RetentionUnit}}{{end}}
+`
+
+func (opts *SetupOpts) initStore(ctx context.Context) func() error {
+	return func() error {
+		var err error
+		opts.store, err = store.New(store.AuthenticatedPreset(config.Default()), store.WithContext(ctx))
+		return err
+	}
+}
+
+func (opts *SetupOpts) setupWatcher() (bool, error) {
+	res, err := opts.store.DescribeCompliancePolicy(opts.ConfigProjectID())
+	opts.policy = res
+	if err != nil {
+		return false, err
+	}
+	if res.GetState() == "" {
+		return false, errors.New("could not access State field")
+	}
+	return (res.GetState() == active), nil
+}
+
+func (opts *SetupOpts) Run() error {
+	if !opts.confirm {
+		return errors.New("this feature is not production ready: to continue, use '--force'")
+	}
+	opts.policy.SetProjectId(opts.ConfigProjectID())
+
+	_, err := opts.store.UpdateCompliancePolicy(opts.ConfigProjectID(), opts.policy)
+	if err != nil {
+		return err
+	}
+	if err := opts.Watch(opts.setupWatcher); err != nil {
+		return err
+	}
+
+	return opts.Print(opts.policy)
+}
+
+func SetupBuilder() *cobra.Command {
+	opts := &SetupOpts{
+		policy: new(atlasv2.DataProtectionSettings),
+		fs:     afero.NewOsFs(),
+	}
+	use := "setup"
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: cli.GenerateAliases(use),
+		Short:   "Setup the backup compliance policy for your project.",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.PreRunE(
+				opts.ValidateProjectID,
+				opts.initStore(cmd.Context()),
+				opts.InitOutput(cmd.OutOrStdout(), setupTemplate),
+			)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := file.Load(opts.fs, opts.path, opts.policy); err != nil {
+				return err
+			}
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
+	cmd.Flags().StringVarP(&opts.path, flag.File, flag.FileShort, "", usage.BackupCompliancePolicyFile)
+	cmd.Flags().BoolVar(&opts.confirm, flag.Force, false, usage.Force)
+
+	return cmd
+}

--- a/internal/cli/atlas/backup/compliancepolicy/setup_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup_test.go
@@ -35,6 +35,7 @@ func TestSetupBuilder(t *testing.T) {
 			flag.Output,
 			flag.File,
 			flag.Force,
+			flag.EnableWatch,
 		},
 	)
 }
@@ -87,6 +88,36 @@ func TestSetupOpts_Run(t *testing.T) {
 		UpdateCompliancePolicy(opts.ProjectID, opts.policy).
 		Return(expected, nil).
 		Times(1)
+
+	if err := opts.Run(); err != nil {
+		t.Fatalf("run() unexpected error: %v", err)
+	}
+
+	test.VerifyOutputTemplate(t, setupTemplate, expected)
+}
+
+// Verifies the output template when using --watch.
+func TestSetupOpts_WatchRun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockCompliancePolicy(ctrl)
+	state := active
+
+	opts := &SetupOpts{
+		store:       mockStore,
+		confirm:     true,
+		policy:      new(atlasv2.DataProtectionSettings),
+		EnableWatch: true,
+	}
+
+	expected := &atlasv2.DataProtectionSettings{
+		State: &state,
+	}
+
+	mockStore.
+		EXPECT().
+		UpdateCompliancePolicy(opts.ProjectID, opts.policy).
+		Return(expected, nil).
+		Times(1)
 	mockStore.
 		EXPECT().
 		DescribeCompliancePolicy(opts.ProjectID).
@@ -97,5 +128,5 @@ func TestSetupOpts_Run(t *testing.T) {
 		t.Fatalf("run() unexpected error: %v", err)
 	}
 
-	test.VerifyOutputTemplate(t, setupTemplate, expected)
+	test.VerifyOutputTemplate(t, setupWatchTemplate, expected)
 }

--- a/internal/cli/atlas/backup/compliancepolicy/setup_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup_test.go
@@ -39,7 +39,7 @@ func TestSetupBuilder(t *testing.T) {
 	)
 }
 
-// Tests that setupWatcher() returns true when status == "ACTIVE"
+// Tests that setupWatcher() returns true when status == "ACTIVE".
 func TestSetupOpts_Watcher(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCompliancePolicy(ctrl)
@@ -66,7 +66,7 @@ func TestSetupOpts_Watcher(t *testing.T) {
 	assert.True(t, res)
 }
 
-// Verifies the output template
+// Verifies the output template.
 func TestSetupOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCompliancePolicy(ctrl)

--- a/internal/cli/atlas/backup/compliancepolicy/setup_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup_test.go
@@ -1,0 +1,99 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compliancepolicy
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
+	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
+	"github.com/mongodb/mongodb-atlas-cli/internal/test"
+	"github.com/stretchr/testify/assert"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201004/admin"
+)
+
+func TestSetupBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		SetupBuilder(),
+		0,
+		[]string{
+			flag.ProjectID,
+			flag.Output,
+			flag.File,
+			flag.Force,
+		},
+	)
+}
+
+func TestSetupOpts_Watcher(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockCompliancePolicy(ctrl)
+	state := active
+
+	opts := &SetupOpts{
+		store: mockStore,
+	}
+
+	expected := &atlasv2.DataProtectionSettings{
+		State: &state,
+	}
+
+	mockStore.
+		EXPECT().
+		DescribeCompliancePolicy(opts.ProjectID).
+		Return(expected, nil).
+		Times(1)
+
+	res, err := opts.setupWatcher()
+	if err != nil {
+		t.Fatalf("setupWatcher() unexpected error: %v", err)
+	}
+	assert.True(t, res)
+}
+
+func TestSetupOpts_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockCompliancePolicy(ctrl)
+	state := active
+
+	opts := &SetupOpts{
+		store:   mockStore,
+		confirm: true,
+		policy:  new(atlasv2.DataProtectionSettings),
+	}
+
+	expected := &atlasv2.DataProtectionSettings{
+		State: &state,
+	}
+
+	mockStore.
+		EXPECT().
+		UpdateCompliancePolicy(opts.ProjectID, opts.policy).
+		Return(expected, nil).
+		Times(1)
+	mockStore.
+		EXPECT().
+		DescribeCompliancePolicy(opts.ProjectID).
+		Return(expected, nil).
+		Times(1)
+
+	if err := opts.Run(); err != nil {
+		t.Fatalf("run() unexpected error: %v", err)
+	}
+
+	test.VerifyOutputTemplate(t, setupTemplate, expected)
+}

--- a/internal/cli/atlas/backup/compliancepolicy/setup_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup_test.go
@@ -39,6 +39,7 @@ func TestSetupBuilder(t *testing.T) {
 	)
 }
 
+// Tests that setupWatcher() returns true when status == "ACTIVE"
 func TestSetupOpts_Watcher(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCompliancePolicy(ctrl)
@@ -65,6 +66,7 @@ func TestSetupOpts_Watcher(t *testing.T) {
 	assert.True(t, res)
 }
 
+// Verifies the output template
 func TestSetupOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCompliancePolicy(ctrl)

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -439,7 +439,7 @@ dbName and collection are required only for built-in roles.`
 	WatchTimeout                              = "Time in seconds until a watch times out. After a watch times out, the CLI no longer watches the command."
 	CompactResponse                           = "Flag that enables the compact array response structure for a json output. The --compact option returns array objects as top-level responses and allows backward compatibility for scripts based on previous CLI versions. Omitting the --compact option for a json output returns array objects within a 'results' sub-array. You must specify --output json to use this option."
 	DataFederationFile                        = "Path to an optional JSON configuration file that defines data federation settings."
-	BackupCompliancePolicyFile                = "Path to an optional JSON configuration file that defines backup compliance policy settings."
+	BackupCompliancePolicyFile                = "Path to a JSON configuration file that defines backup compliance policy settings."
 	DataFederationType                        = "Type of Federated Database Instances to return."
 	DataFederation                            = "Identifier of the Federated Database Instance."
 	DataFederationQueryLimitValue             = "Value given to the query limit."

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -436,6 +436,7 @@ dbName and collection are required only for built-in roles.`
 	ServerlessTag                             = "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the serverless instance."
 	UpdateWarning                             = " Passing this flag replaces preexisting data."
 	EnableWatch                               = "Watch the command until it completes its execution or the watch times out. To set the time that the watch times out, use the --watchTimeout option."
+	EnableWatchDefault                        = "Watch the command until it completes its execution or the watch times out."
 	WatchTimeout                              = "Time in seconds until a watch times out. After a watch times out, the CLI no longer watches the command."
 	CompactResponse                           = "Flag that enables the compact array response structure for a json output. The --compact option returns array objects as top-level responses and allows backward compatibility for scripts based on previous CLI versions. Omitting the --compact option for a json output returns array objects within a 'results' sub-array. You must specify --output json to use this option."
 	DataFederationFile                        = "Path to an optional JSON configuration file that defines data federation settings."

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -439,6 +439,7 @@ dbName and collection are required only for built-in roles.`
 	WatchTimeout                              = "Time in seconds until a watch times out. After a watch times out, the CLI no longer watches the command."
 	CompactResponse                           = "Flag that enables the compact array response structure for a json output. The --compact option returns array objects as top-level responses and allows backward compatibility for scripts based on previous CLI versions. Omitting the --compact option for a json output returns array objects within a 'results' sub-array. You must specify --output json to use this option."
 	DataFederationFile                        = "Path to an optional JSON configuration file that defines data federation settings."
+	BackupCompliancePolicyFile                = "Path to an optional JSON configuration file that defines backup compliance policy settings."
 	DataFederationType                        = "Type of Federated Database Instances to return."
 	DataFederation                            = "Identifier of the Federated Database Instance."
 	DataFederationQueryLimitValue             = "Value given to the query limit."

--- a/test/README.md
+++ b/test/README.md
@@ -62,6 +62,7 @@
 | `backup schedule update`                    | Y         |           |           | Y         |       |       |
 | `backup compliancepolicy describe`          | Y         |           |           | Y         |       |       |
 | `backup compliancepolicy copyprotection`    | Y         |           |           | Y         |       |       |
+| `backup compliancepolicy setup`             | Y         |           |           | Y         |       |       |
 | `cloudProvider aws accessRoles authorize`   | N         |           |           | Y         |       |       |
 | `cloudProvider aws accessRoles deauthorize` | N         |           |           | Y         |       |       |
 | `cloudProvider aws accessRoles create`      | Y         |           |           | Y         |       |       |

--- a/test/e2e/atlas/backup_compliancepolicy_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_test.go
@@ -125,10 +125,10 @@ func createCompliancePolicyJSONFile(t *testing.T, policy *atlasv2.DataProtection
 
 	jsonData, err := json.Marshal(policy)
 	if err != nil {
-		t.Fatalf("Error marshalling to JSON: %v", err)
+		t.Fatalf("Error marshaling to JSON: %v", err)
 	}
 
-	err = os.WriteFile(path, jsonData, 0777)
+	err = os.WriteFile(path, jsonData, 0600)
 	if err != nil {
 		t.Fatalf("Error writing JSON to file: %v", err)
 	}
@@ -139,6 +139,7 @@ func createCompliancePolicyJSONFile(t *testing.T, policy *atlasv2.DataProtection
 }
 
 func deleteFile(t *testing.T, path string) {
+	t.Helper()
 	if err := os.Remove(path); err != nil {
 		t.Errorf("Error deleting file: %v", err)
 	}

--- a/test/e2e/atlas/backup_compliancepolicy_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_test.go
@@ -125,12 +125,14 @@ func createCompliancePolicyJSONFile(t *testing.T, policy *atlasv2.DataProtection
 
 	jsonData, err := json.Marshal(policy)
 	if err != nil {
-		t.Fatalf("Error marshaling to JSON: %v", err)
+		t.Errorf("Error marshaling to JSON: %v", err)
+		return
 	}
 
 	err = os.WriteFile(path, jsonData, 0600)
 	if err != nil {
-		t.Fatalf("Error writing JSON to file: %v", err)
+		t.Errorf("Error writing JSON to file: %v", err)
+		return
 	}
 
 	t.Cleanup(func() {

--- a/test/e2e/atlas/backup_compliancepolicy_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_test.go
@@ -36,6 +36,42 @@ func TestCompliancePolicy(t *testing.T) {
 	g := newAtlasE2ETestGeneratorWithBackup(t)
 	g.generateProject("compliancePolicy")
 
+	scheduledPolicyItem := atlasv2.DiskBackupApiPolicyItem{
+		FrequencyInterval: 1,
+		FrequencyType:     "daily",
+		RetentionUnit:     "days",
+		RetentionValue:    1,
+	}
+
+	authorizedEmail := "firstname.lastname@example.com"
+
+	policy := &atlasv2.DataProtectionSettings{
+		ScheduledPolicyItems: []atlasv2.DiskBackupApiPolicyItem{scheduledPolicyItem},
+		ProjectId:            &g.projectID,
+		AuthorizedEmail:      &authorizedEmail,
+	}
+	path := "./compliancepolicy.json"
+
+	createCompliancePolicyJSONFile(t, policy, path)
+
+	t.Run("setup", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			compliancepolicyEntity,
+			"setup",
+			"--projectId",
+			g.projectID,
+			"-o=json",
+			"--force",
+			"--file",
+			path,
+		)
+		cmd.Env = os.Environ()
+		resp, outputErr := cmd.CombinedOutput()
+
+		r.NoError(outputErr, string(resp))
+	})
+
 	t.Run("describe", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			backupsEntity,
@@ -80,4 +116,30 @@ func TestCompliancePolicy(t *testing.T) {
 		_, err = cmd.CombinedOutput()
 		r.Error(err)
 	})
+}
+
+// createCompliancePolicyJSONFile creates a new JSON file at the specified path with the specified policy
+// and also registers its deletion on test cleanup.
+func createCompliancePolicyJSONFile(t *testing.T, policy *atlasv2.DataProtectionSettings, path string) {
+	t.Helper()
+
+	jsonData, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatalf("Error marshalling to JSON: %v", err)
+	}
+
+	err = os.WriteFile(path, jsonData, 0777)
+	if err != nil {
+		t.Fatalf("Error writing JSON to file: %v", err)
+	}
+
+	t.Cleanup(func() {
+		deleteFile(t, path)
+	})
+}
+
+func deleteFile(t *testing.T, path string) {
+	if err := os.Remove(path); err != nil {
+		t.Errorf("Error deleting file: %v", err)
+	}
 }

--- a/test/e2e/atlas/backup_compliancepolicy_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_test.go
@@ -54,7 +54,7 @@ func TestCompliancePolicy(t *testing.T) {
 
 	createCompliancePolicyJSONFile(t, policy, path)
 
-	t.Run("setup", func(t *testing.T) {
+	t.Run("setup happy flow", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			backupsEntity,
 			compliancepolicyEntity,


### PR DESCRIPTION
## Proposed changes

Add the command `atlas backups compliancepolicy setup`. 
A confirmation prompt will be added after L1 support has been added for all of the operations.

### Command output
```
$ bin/atlas backups compliancepolicy setup -f ./test.json

Your backup compliance policy has been set up with the following configuration:

Project:                          64b034b236930362b0c8d36b
Authorized e-mail:                firstname.lastname@example.com
Copy protection enabled:          false
Encryption at rest enabled:       false
Point-in-Time restores enabled:   false
Restore window days:              0

POLICIES
ID                         FREQUENCY INTERVAL   FREQUENCY TYPE   RETENTION
64b16beffcaed70cfbd5f520   -                    daily            5 days
64ba452852594888bd5b7070   6                    hourly           2 days
64c795d6401a8ccaea00bf85   -                    ondemand         1 days
```
_Jira ticket:_ CLOUDP-193348



## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code