### PR TITLE
CLOUDP-194380: generate stable operations go SDK in atlas CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,9 +222,10 @@ e.g `v20230201001` => `v20230201002`
 ### Stable Methods
 
 Each Go SDK method used in the Atlas CLI should be marked as stable.
-Stable methods are listed in the [operations.stable.json](https://github.com/mongodb/atlas-sdk-go/blob/main/tools/transformer/src/operations.stable.json) file.
+Stable methods are listed in the SDK GO [operations.stable.json](https://github.com/mongodb/atlas-sdk-go/blob/main/tools/transformer/src/operations.stable.json) file.
 
-We have developed automation that lists stable methods:
+We have developed automation that lists stable methods.
+Generate list from Atlas CLI run:
 
 ```
 go run ./tools/sdk-usage/main.go ./internal/store ./operations.stable.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,3 +218,18 @@ Atlas CLI developers should update all imports to new major versions and remove 
 To update simply rename all instances of major version across the repository imports and go.mod files.
 
 e.g `v20230201001` => `v20230201002` 
+
+### Stable Methods
+
+Each Go SDK method used in the Atlas CLI should be marked as stable.
+Stable methods are listed in the [operations.stable.json](https://github.com/mongodb/atlas-sdk-go/blob/main/tools/transformer/src/operations.stable.json) file.
+
+We have developed automation that lists stable methods:
+
+```
+go run ./tools/sdk-usage/main.go ./internal/store ./operations.stable.json
+```
+
+After file is create please create PR directly in the GO SDK containing updated file.
+
+in order to update `operations.stable.json` file in the Go SDK.

--- a/tools/sdk-usage/main.go
+++ b/tools/sdk-usage/main.go
@@ -1,3 +1,17 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -12,6 +26,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+// Generating list of used GO SDK operation IDs
 func main() {
 	argsNumber := 3
 	// Check if the folder path is provided as a command-line argument

--- a/tools/sdk-usage/main.go
+++ b/tools/sdk-usage/main.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// Generating list of used GO SDK operation IDs
+// Generating list of used GO SDK operation IDs.
 func main() {
 	argsNumber := 3
 	// Check if the folder path is provided as a command-line argument

--- a/tools/sdk-usage/main.go
+++ b/tools/sdk-usage/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	// Define the regular expression pattern
-	pattern := `s\.clientv2\.\w+\.(\w+)\(`
+	pattern := `s\.clientv2\.[\w\r\n\s]+\.([\w\r\n\s]+)\(`
 
 	// Compile the regular expression
 	regex, err := regexp.Compile(pattern)
@@ -64,6 +64,7 @@ func main() {
 				if len(match) > 1 {
 					value := match[1]
 					value = strings.TrimSuffix(value, "WithParams")
+					value = strings.TrimSpace(value)
 					value = strings.ToLower(value[:1]) + value[1:]
 					if !slices.Contains(stableIds.StableIds, value) {
 						stableIds.StableIds = append(stableIds.StableIds, value)

--- a/tools/sdk-usage/main.go
+++ b/tools/sdk-usage/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+func main() {
+	// Check if the folder path is provided as a command-line argument
+	if len(os.Args) != 3 {
+		fmt.Println("Usage: go run main.go <folder_path> <output_file>")
+		os.Exit(1)
+	}
+
+	folderPath := os.Args[1]
+	outputFile := os.Args[2]
+
+	if folderPath == "" {
+		fmt.Println("Please provide a folder path")
+		os.Exit(1)
+	}
+	if outputFile == "" {
+		fmt.Println("Please provide an output file")
+		os.Exit(1)
+	}
+
+	// Define the regular expression pattern
+	pattern := `s\.clientv2\.\w+\.(\w+)\(`
+
+	// Compile the regular expression
+	regex, err := regexp.Compile(pattern)
+	if err != nil {
+		fmt.Println("Error compiling regular expression:", err)
+		os.Exit(1)
+	}
+
+	stableIds := StableIds{
+		StableIds: []string{},
+	}
+	// Perform regexp search on all Go files
+	err = filepath.Walk(folderPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) == ".go" {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				fmt.Println("Error reading file:", err)
+				return nil
+			}
+			matches := regex.FindAllStringSubmatch(string(content), -1)
+			for _, match := range matches {
+				if len(match) > 1 {
+					value := match[1]
+					value = strings.TrimSuffix(value, "WithParams")
+					if !slices.Contains(stableIds.StableIds, value){
+						stableIds.StableIds = append(stableIds.StableIds, value)
+					}
+				}
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		fmt.Println("Error walking through directory:", err)
+		os.Exit(1)
+	}
+	sort.Strings(stableIds.StableIds)
+
+	writeStringsToJSONFile(stableIds, outputFile)
+}
+
+func writeStringsToJSONFile(values StableIds, filename string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "    ")
+	err = encoder.Encode(values)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type StableIds struct {
+	StableIds []string `json:"stableIds"`
+}

--- a/tools/sdk-usage/main.go
+++ b/tools/sdk-usage/main.go
@@ -13,8 +13,9 @@ import (
 )
 
 func main() {
+	argsNumber := 3
 	// Check if the folder path is provided as a command-line argument
-	if len(os.Args) != 3 {
+	if len(os.Args) != argsNumber {
 		fmt.Println("Usage: go run main.go <folder_path> <output_file>")
 		os.Exit(1)
 	}
@@ -63,7 +64,7 @@ func main() {
 				if len(match) > 1 {
 					value := match[1]
 					value = strings.TrimSuffix(value, "WithParams")
-					if !slices.Contains(stableIds.StableIds, value){
+					if !slices.Contains(stableIds.StableIds, value) {
 						stableIds.StableIds = append(stableIds.StableIds, value)
 					}
 				}
@@ -78,7 +79,11 @@ func main() {
 	}
 	sort.Strings(stableIds.StableIds)
 
-	writeStringsToJSONFile(stableIds, outputFile)
+	err = writeStringsToJSONFile(stableIds, outputFile)
+	if err != nil {
+		fmt.Println("Error saving operations file:", err)
+		os.Exit(1)
+	}
 }
 
 func writeStringsToJSONFile(values StableIds, filename string) error {

--- a/tools/sdk-usage/main.go
+++ b/tools/sdk-usage/main.go
@@ -64,6 +64,7 @@ func main() {
 				if len(match) > 1 {
 					value := match[1]
 					value = strings.TrimSuffix(value, "WithParams")
+					value = strings.ToLower(value[:1]) + value[1:]
 					if !slices.Contains(stableIds.StableIds, value) {
 						stableIds.StableIds = append(stableIds.StableIds, value)
 					}


### PR DESCRIPTION
Going thru all operations and comparing the list with the atlas SDK is an extremely time-consuming effort. 
Our API changes a lot of we need a way to automate our list of tested SDK methods. 

> NOTE: This change is an improvement for a short-term solution. In the long term, we going to look into reducing reliance on Atlas CLI for SDK testing and stability.

## Verification

I used the generated output of this PR in the https://github.com/mongodb/atlas-sdk-go/pull/161


### Manual testing and operationIds

In future, we can add operations to existing file instead of creating new one.
