### PR TITLE
docs: minimal contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,6 +251,7 @@ For example [list command](https://github.com/mongodb/mongodb-atlas-cli/blob/220
 It is normal to duplicate existing command and edit it for your own needs.
 
 > NOTE: During the development of the commands we recommend setting `Hidden: true` property to make commands invisible to the end users and documentation.
+
 > NOTE: Commands are executing network requests by using `./internal/store` interface that wraps [Atlas Go SDK](https://github.com/mongodb/atlas-sdk-go). 
 Before adding a command please make sure that your api exists in the GO SDK. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ Review and replace command name and arguments depending on the command you are u
 
 ### Contributing New Feature
 
-`Atlas CLI` and `MongoDB CLI` using[Cobra Framework](https://umarcor.github.io/cobra/) framework.
+`Atlas CLI` and `MongoDB CLI` are using the [Cobra Framework](https://umarcor.github.io/cobra/).
 
 Each new feature can be introduced by creating new cobra root command. 
 This command aggregates a number of subcommands that can perform network requests and return results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,6 +256,3 @@ go run ./tools/sdk-usage/main.go ./internal/store ./operations.stable.json
 After the file is created please create PR directly in the GO SDK containing the updated file.
 
 in order to update `operations.stable.json` file in the Go SDK.
-
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ this document describes some guidelines necessary to participate in the communit
   - [Code Contribution Guidelines](#code-contribution-guidelines)
   - [Development Setup](#development-setup)
   - [Building and Testing](#building-and-testing)
+  - [Contributing New Command Group](#contributing-new-command-group)
   - [Adding a New Command](#adding-a-new-command)
   - [Third Party Dependencies](#third-party-dependencies)
 - [Maintainer's Guide](#maintainers-guide)
@@ -132,28 +133,28 @@ Review and replace command name and arguments depending on the command you are u
 
 ```
 
-### Contributing New Feature
+### Contributing New Command Group
 
 `Atlas CLI` and `MongoDB CLI` are using the [Cobra Framework](https://umarcor.github.io/cobra/).
 
-Each new feature can be introduced by creating new cobra root command. 
+Depending on the feature you are building you might choose to:
+
+- Add individual commands to existing groups of commands
+- Add a new command group that provides ability to run nested commands under certain prefix
+
+For a command group, we need to create new cobra root command. 
 This command aggregates a number of subcommands that can perform network requests and return results
 
 For example [teams](https://github.com/mongodb/mongodb-atlas-cli/tree/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams) 
-command root provides the main execution point for `atlas teams`. 
+command root provides the main execution point for `atlas teams` with subcommands like `atlas teams list`
 
 Root command links to a number of child commands. Atlas CLI provides a number of patterns for child commands depending on the type of operation performed.
 Each new feature might cover typical commands like `list` and `describe` along with dedicated actions.
 For example [list command](https://github.com/mongodb/mongodb-atlas-cli/blob/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams/list.go).
-It is normal to duplicate existing command and edit it for your own needs.
+It is normal to duplicate existing commands and edit descriptions and methods for your own needs.
 
-> NOTE: During the development of the commands we recommend setting `Hidden: true` property to make commands invisible to the end users and documentation.
-
-> NOTE: Commands are executing network requests by using `./internal/store` interface that wraps [Atlas Go SDK](https://github.com/mongodb/atlas-sdk-go). 
-Before adding a command please make sure that your api exists in the GO SDK. 
-
-Additionally, after adding new command we need to add it to the root command. 
-To do that please edit `./root/atlas/builder.go` to add your command builder method
+Additionally, after adding new command we need to add it to the main CLI root command. 
+For example please edit `./root/atlas/builder.go` to add your command builder method for Atlas CLI
 
 ### Adding a New Command
 
@@ -170,13 +171,22 @@ For that reason, command arguments tend to match the path and query params of th
 with the last param being a required argument and the rest handled via flag options.
 For commands that create or modify complex data structures, the use of configuration files is preferred over flag options.
 
-Note: we are experimenting with a generator, make sure to try it out in [tools/cli-generator](./tools/cli-generator/)
+
+> NOTE: During the development of the commands we recommend setting `Hidden: true` property to make commands invisible to the end users and documentation.
+
+> NOTE: Commands are executing network requests by using `./internal/store` interface that wraps [Atlas Go SDK](https://github.com/mongodb/atlas-sdk-go). 
+Before adding a command please make sure that your api exists in the GO SDK. 
+
+> NOTE: Atlas CLI provides an experimental generator, make sure to try it out in [tools/cli-generator](./tools/cli-generator/)
 
 ### API Interactions
 
-Atlas CLI and MongoDB CLI use [go-client-mongodb-atlas](https://github.com/mongodb/go-client-mongodb-atlas/) 
+Atlas CLI use [atlas-sdk-go](https://github.com/mongodb/atlas-sdk-go) for all backend integration.
+This SDK is updated automatically based on Atlas OpenAPI file.
+
+MongoDB CLI use [go-client-mongodb-atlas](https://github.com/mongodb/go-client-mongodb-atlas/) 
 and [go-client-mongodb-ops-manager](https://github.com/mongodb/go-client-mongodb-ops-manager/) to interact with Atlas or Ops Manager/Cloud Manager.
-Any new feature should first update the respective client.
+Any new feature requires a manual update from the respective client.
 
 #### How to define flags:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,12 +132,30 @@ Review and replace command name and arguments depending on the command you are u
 
 ```
 
+###  Contributing New Feature
 
-### API Interactions
+Atlas CLI and MongoDB CLI base on [Cobra Framework](https://umarcor.github.io/cobra/).
 
-Atlas CLI and MongoDB CLI use [go-client-mongodb-atlas](https://github.com/mongodb/go-client-mongodb-atlas/) 
-and [go-client-mongodb-ops-manager](https://github.com/mongodb/go-client-mongodb-ops-manager/) to interact with Atlas or Ops Manager/Cloud Manager.
-Any new feature should first update the respective client.
+Each new feature can be introduced by creating new cobra root command. 
+This command aggregates a number of subcommands that can perform network requests and return results
+
+For example [teams](https://github.com/mongodb/mongodb-atlas-cli/tree/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams) 
+command root provides the main execution point for `atlas teams`. 
+
+Root command links to a number of child commands. Atlas CLI provides a number of patterns for child commands depending on the type of operation performed.
+Each new feature might cover typical commands like `list` and `describe` along with dedicated actions.
+For example [list command](https://github.com/mongodb/mongodb-atlas-cli/blob/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams/list.go).
+It is normal to duplicate existing command and edit it for your own needs.
+
+> NOTE: During the development of the commands we recommend setting `Hidden: true` property to make commands invisible to the end users and documentation.
+
+> NOTE: Commands are executing network requests by using `./internal/store` interface that wraps [Atlas Go SDK](https://github.com/mongodb/atlas-sdk-go). 
+Before adding a command please make sure that your api exists in the GO SDK. 
+
+Additionally, after adding new command we need to add it to the root command. 
+To do that please edit `./root/atlas/builder.go` to add your command builder.
+
+For more info please refer to the official Cobra documentation: https://umarcor.github.io/cobra
 
 ### Adding a New Command
 
@@ -156,6 +174,12 @@ with the last param being a required argument and the rest handled via flag opti
 For commands that create or modify complex data structures, the use of configuration files is preferred over flag options.
 
 Note: we are experimenting with a generator, make sure to try it out in [tools/cli-generator](./tools/cli-generator/)
+
+### API Interactions
+
+Atlas CLI and MongoDB CLI use [go-client-mongodb-atlas](https://github.com/mongodb/go-client-mongodb-atlas/) 
+and [go-client-mongodb-ops-manager](https://github.com/mongodb/go-client-mongodb-ops-manager/) to interact with Atlas or Ops Manager/Cloud Manager.
+Any new feature should first update the respective client.
 
 #### How to define flags:
 
@@ -235,28 +259,5 @@ After the file is created please create PR directly in the GO SDK containing the
 
 in order to update `operations.stable.json` file in the Go SDK.
 
-## Contributing Workflow
 
-Atlas CLI and MongoDB CLI base on [Cobra Framework](https://umarcor.github.io/cobra/).
-
-Each new feature can be introduced by creating new cobra root command. 
-This command aggregates a number of subcommands that can perform network requests and return results
-
-For example [teams](https://github.com/mongodb/mongodb-atlas-cli/tree/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams) 
-command root provides the main execution point for `atlas teams`. 
-
-Root command links to a number of child commands. Atlas CLI provides a number of patterns for child commands depending on the type of operation performed.
-Each new feature might cover typical commands like `list` and `describe` along with dedicated actions.
-For example [list command](https://github.com/mongodb/mongodb-atlas-cli/blob/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams/list.go).
-It is normal to duplicate existing command and edit it for your own needs.
-
-> NOTE: During the development of the commands we recommend setting `Hidden: true` property to make commands invisible to the end users and documentation.
-
-> NOTE: Commands are executing network requests by using `./internal/store` interface that wraps [Atlas Go SDK](https://github.com/mongodb/atlas-sdk-go). 
-Before adding a command please make sure that your api exists in the GO SDK. 
-
-Additionally, after adding new command we need to add it to the root command. 
-To do that please edit `./root/atlas/builder.go` to add your command builder.
-
-For more info please refer to the official Cobra documentation: https://umarcor.github.io/cobra
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ The following is a short list of commands that can be run in the root of the pro
 - Run `make` see a list of available targets.
 - Run `make test` to run all unit tests.
 - Run `make lint` to validate against our linting rules.
-- Run `E2E_TAGS=e2e,atlas make e2e-test` will run end to end tests against an Atlas instance,
+- Run `E2E_TAGS=e2e,atlas make e2e-test` will run end-to-end tests against an Atlas instance,
   please make sure to have set `MCLI_*` variables pointing to that instance.
 - Run `E2E_TAGS=cloudmanager,remote,generic make e2e-test` will run end-to-end tests against a Cloud Manager instance.<br />
   Please remember to: (a) have a running automation agent, and (b) set MCLI\_\* variables to point to your Cloud Manager instance.
@@ -93,23 +93,23 @@ If you need a new mock please update or add the `//go:generate` instruction to t
 
 #### Compilation in VSCode
 
-Please add following line to your settings.json file :
+Please add the following line to your settings.json file :
 ```
     "go.buildTags": "unit,e2e",
     "go.testTags": "unit,e2e"
 ```
 
-This will enable compilation for unit test and end to end tests.
+This will enable compilation for unit test and end-to-end tests.
 
 #### Debugging in VSCode
 
-To debut in VSCode you need to create an debug configuration for the command with required arguments.
-Run following commands to 
+To debut in VSCode you need to create a debug configuration for the command with required arguments.
+Run the following commands to 
 
 ```
 touch .vscode/launch.json
 ```
-Then put following configuration into the file.
+Then put the following configuration into the file.
 Review and replace command name and arguments depending on the command you are using.
 
 ```json
@@ -157,8 +157,7 @@ To do that please edit `./root/atlas/builder.go` to add your command builder met
 
 ### Adding a New Command
 
-`atlascli` and `mongocli` use [Cobra](https://github.com/spf13/cobra) as a framework for defining commands,
-in addition to this we have defined a basic structure that should be followed.
+`atlascli` and `mongocli` have defined a basic structure for individual commands that should be followed.
 For a `mongocli scope newCommand` command, a file `internal/cli/scope/new_command.go` should implement:
 
 - A `ScopeNewCommandOpts` struct which handles the different options for the command.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,3 +234,28 @@ go run ./tools/sdk-usage/main.go ./internal/store ./operations.stable.json
 After file is create please create PR directly in the GO SDK containing updated file.
 
 in order to update `operations.stable.json` file in the Go SDK.
+
+## Contributing Workflow
+
+Atlas CLI and MongoDB CLI base on Cobra Framework.
+
+Each new feature can be introduced by creating new cobra root command. 
+This command aggregates number of subcommands that can perform network requests and return results
+
+For example [teams](https://github.com/mongodb/mongodb-atlas-cli/tree/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams) 
+command root provides main execution point for for `atlas teams`. 
+
+Root command links to number of child commands. Atlas CLI provides number of patterns for child commands depending on the operation performed.
+Feature covers typical commands like list, describe along with dedicated actions.
+For example [list command](https://github.com/mongodb/mongodb-atlas-cli/blob/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams/list.go).
+It is normal to duplicate existing command and edit it for your own needs.
+
+> NOTE: During development of the commands we recomend to set `Hidden: true` property to make commands invisible to the end users.
+> NOTE: Commands are executing network requests thru `./internal/store` interface that wraps [Atlas Go SDK](https://github.com/mongodb/atlas-sdk-go). 
+Before adding command please make sure that your api exist in the GO SDK. 
+
+Additionally after adding new command we need to add it to the root command. 
+To do that please edit `./root/atlas/builder.go` to add your command builder.
+
+For more info please refer to official cobra documentation: https://umarcor.github.io/cobra/
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,31 +231,31 @@ Generate list from Atlas CLI run:
 go run ./tools/sdk-usage/main.go ./internal/store ./operations.stable.json
 ```
 
-After file is create please create PR directly in the GO SDK containing updated file.
+After the file is created please create PR directly in the GO SDK containing the updated file.
 
 in order to update `operations.stable.json` file in the Go SDK.
 
 ## Contributing Workflow
 
-Atlas CLI and MongoDB CLI base on Cobra Framework.
+Atlas CLI and MongoDB CLI base on [Cobra Framework](https://umarcor.github.io/cobra/).
 
 Each new feature can be introduced by creating new cobra root command. 
-This command aggregates number of subcommands that can perform network requests and return results
+This command aggregates a number of subcommands that can perform network requests and return results
 
 For example [teams](https://github.com/mongodb/mongodb-atlas-cli/tree/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams) 
-command root provides main execution point for for `atlas teams`. 
+command root provides the main execution point for `atlas teams`. 
 
-Root command links to number of child commands. Atlas CLI provides number of patterns for child commands depending on the operation performed.
-Feature covers typical commands like list, describe along with dedicated actions.
+Root command links to a number of child commands. Atlas CLI provides a number of patterns for child commands depending on the type of operation performed.
+Each new feature might cover typical commands like `list` and `describe` along with dedicated actions.
 For example [list command](https://github.com/mongodb/mongodb-atlas-cli/blob/220c6c73f346f5c711a1c772b17f93a6811efc69/internal/cli/atlas/teams/list.go).
 It is normal to duplicate existing command and edit it for your own needs.
 
-> NOTE: During development of the commands we recomend to set `Hidden: true` property to make commands invisible to the end users.
-> NOTE: Commands are executing network requests thru `./internal/store` interface that wraps [Atlas Go SDK](https://github.com/mongodb/atlas-sdk-go). 
-Before adding command please make sure that your api exist in the GO SDK. 
+> NOTE: During the development of the commands we recommend setting `Hidden: true` property to make commands invisible to the end users and documentation.
+> NOTE: Commands are executing network requests by using `./internal/store` interface that wraps [Atlas Go SDK](https://github.com/mongodb/atlas-sdk-go). 
+Before adding a command please make sure that your api exists in the GO SDK. 
 
-Additionally after adding new command we need to add it to the root command. 
+Additionally, after adding new command we need to add it to the root command. 
 To do that please edit `./root/atlas/builder.go` to add your command builder.
 
-For more info please refer to official cobra documentation: https://umarcor.github.io/cobra/
+For more info please refer to the official Cobra documentation: https://umarcor.github.io/cobra
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,9 @@ Review and replace command name and arguments depending on the command you are u
 
 ```
 
-###  Contributing New Feature
+### Contributing New Feature
 
-Atlas CLI and MongoDB CLI base on [Cobra Framework](https://umarcor.github.io/cobra/).
+`Atlas CLI` and `MongoDB CLI` using[Cobra Framework](https://umarcor.github.io/cobra/) framework.
 
 Each new feature can be introduced by creating new cobra root command. 
 This command aggregates a number of subcommands that can perform network requests and return results
@@ -153,9 +153,7 @@ It is normal to duplicate existing command and edit it for your own needs.
 Before adding a command please make sure that your api exists in the GO SDK. 
 
 Additionally, after adding new command we need to add it to the root command. 
-To do that please edit `./root/atlas/builder.go` to add your command builder.
-
-For more info please refer to the official Cobra documentation: https://umarcor.github.io/cobra
+To do that please edit `./root/atlas/builder.go` to add your command builder method
 
 ### Adding a New Command
 


### PR DESCRIPTION
Kickstarting some of the documentation by explaining patterns we use in the Atlas CLi. 
This is by no means complete but it does provide minimal level of information that one needs to get started.