### PR TITLE
fix: ts root command example

### DIFF
--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -59,6 +59,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/users"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/auth"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/figautocomplete"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli/ts"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/homebrew"
@@ -226,6 +227,7 @@ Use the --help flag with any command for more info on that command.`,
 		kubernetes.Builder(),
 		datafederation.Builder(),
 		auditing.Builder(),
+		ts.Builder(),
 	)
 
 	rootCmd.PersistentFlags().StringVarP(&profile, flag.Profile, flag.ProfileShort, "", usage.ProfileAtlasCLI)

--- a/internal/cli/ts/sample.go
+++ b/internal/cli/ts/sample.go
@@ -1,0 +1,60 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ts
+
+import (
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
+	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
+	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
+	"github.com/spf13/cobra"
+)
+
+type SampleOpts struct {
+	cli.GlobalOpts
+	cli.OutputOpts
+}
+
+
+func (opts *SampleOpts) Run() error {
+	// TODO make example call to API
+	return opts.Print(opts.ConfigProjectID())
+}
+
+// mongocli atlas accessList(s) list --projectId projectId [--page N] [--limit N].
+func SampleBuilder() *cobra.Command {
+	opts := &SampleOpts{}
+	cmd := &cobra.Command{
+		Use:     "sample",
+		Short:   "",
+		Long:    "",
+		Args:    require.NoArgs,
+		Example: ``,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return opts.PreRunE(
+				opts.ValidateProjectID,
+			)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())
+
+	return cmd
+}

--- a/internal/cli/ts/sample.go
+++ b/internal/cli/ts/sample.go
@@ -27,18 +27,16 @@ type SampleOpts struct {
 	cli.OutputOpts
 }
 
-
 func (opts *SampleOpts) Run() error {
-	// TODO make example call to API
+	// make example call to API
 	return opts.Print(opts.ConfigProjectID())
 }
 
-// mongocli atlas accessList(s) list --projectId projectId [--page N] [--limit N].
 func SampleBuilder() *cobra.Command {
 	opts := &SampleOpts{}
 	cmd := &cobra.Command{
 		Use:     "sample",
-		Short:   "",
+		Short:   "sample",
 		Long:    "",
 		Args:    require.NoArgs,
 		Example: ``,

--- a/internal/cli/ts/ts.go
+++ b/internal/cli/ts/ts.go
@@ -1,0 +1,33 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ts
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Builder() *cobra.Command {
+	const use = "ts"
+	cmd := &cobra.Command{
+		Use:     use,
+		Hidden: true,
+		Short:   "Internal Support Commands",
+	}
+	cmd.AddCommand(
+		SampleBuilder(),
+	)
+
+	return cmd
+}

--- a/internal/cli/ts/ts.go
+++ b/internal/cli/ts/ts.go
@@ -21,9 +21,9 @@ import (
 func Builder() *cobra.Command {
 	const use = "ts"
 	cmd := &cobra.Command{
-		Use:     use,
+		Use:    use,
 		Hidden: true,
-		Short:   "Internal Support Commands",
+		Short:  "Internal Support Commands",
 	}
 	cmd.AddCommand(
 		SampleBuilder(),


### PR DESCRIPTION
Example for ts root command. Not indented to be merged - can be reused during the work