### PR TITLE
Get latest cli tag with Action

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Set date
         id: set-date
         run: |
@@ -23,7 +21,11 @@ jobs:
           echo DATE=${DATE} >> $GITHUB_ENV
       - name: 'Get latest tag'
         id: get-latest-tag
-        run: echo "::set-output name=tag::$(git tag --list --sort=-version:refname "atlascli*" | head -n 1)"
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: mongodb/mongodb-atlas-cli
+          releases-only: true
+          regex: 'atlascli*'
       - name: Extract version
         run: |
           release_tag=${{ steps.get-latest-tag.outputs.tag }}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Determine latest CLI tag with a GH Action instead of the script that was in place before. Better because:
- no need to fetch the whole repository
- gets rid of the set-output (which will be deprecated soon)
- a bit more explicit what is going on

Successful test run: https://github.com/mongodb/mongodb-atlas-cli/actions/runs/5961619860/job/16171199792

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
