### PR TITLE
CLOUDP-196563: Add Docker Container Metric to Amplitude Atlas CLI Telemetry

### DIFF
--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -281,6 +281,13 @@ func withSignal(s string) eventOpt {
 	}
 }
 
+func withUserAgent() eventOpt {
+	return func(event Event) {
+		event.Properties["UserAgent"] = config.UserAgent
+		event.Properties["HostName"] = config.HostName
+	}
+}
+
 func newEvent(opts ...eventOpt) Event {
 	var event = Event{
 		Timestamp: time.Now(),

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -136,6 +136,14 @@ func TestWithOS(t *testing.T) {
 	a.Equal(e.Properties["arch"], runtime.GOARCH)
 }
 
+func TestWithUserAgent(t *testing.T) {
+	e := newEvent(withUserAgent())
+
+	a := assert.New(t)
+	a.Equal(e.Properties["UserAgent"], config.UserAgent)
+	a.Equal(e.Properties["HostName"], config.HostName)
+}
+
 func TestWithAuthMethod(t *testing.T) {
 	config.ToolName = config.AtlasCLI
 	t.Run("api key", func(t *testing.T) {

--- a/internal/telemetry/tracker.go
+++ b/internal/telemetry/tracker.go
@@ -88,6 +88,7 @@ func (t *tracker) defaultCommandOptions() []eventOpt {
 		withOrgID(t.cmd, config.Default()),
 		withTerminal(t.cmd),
 		withInstaller(t.installer),
+		withUserAgent(),
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Adds UserAgent and HostName to the DefaultCommandOptions in the CLI telemetry to make them visible in Amplitude.

_Jira ticket:_ CLOUDP-196563

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes CLOUDP-196563

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
