### PR TITLE
CLOUDP-196435 Add local-only setup command UX

### DIFF
--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -122,10 +122,6 @@ Creating your cluster %s [this might take several minutes]
 		return errList
 	}
 
-	if opts.Port == 0 {
-		opts.Port = getPortForNewLocalCluster(containers)
-	}
-
 	if err := opts.validateLocalDeploymentsSettings(containers); err != nil {
 		return err
 	}
@@ -278,18 +274,6 @@ func (opts *SetupOpts) waitConnection(port int) error {
 		time.Sleep(1 * time.Second)
 	}
 	return errors.New("waitConnection failed")
-}
-
-func getPortForNewLocalCluster(existingContainers []podman.Container) int {
-	maxPort := startHostPort - 1
-	for _, c := range existingContainers {
-		for _, p := range c.Ports {
-			if maxPort < p.HostPort {
-				maxPort = p.HostPort
-			}
-		}
-	}
-	return maxPort + 1
 }
 
 func (opts *SetupOpts) promptSettings() error {

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -369,13 +369,20 @@ func (opts *SetupOpts) promptPort() error {
 	return err
 }
 
-func (opts *SetupOpts) validateFlags() error {
+func (opts *SetupOpts) validateDeploymentTypeFlag() error {
 	if opts.DeploymentType == "" && opts.force {
 		return errors.New("flag --type is required when --force is set")
 	}
 
 	if opts.DeploymentType != "" && !strings.EqualFold(opts.DeploymentType, atlasCluster) && !strings.EqualFold(opts.DeploymentType, localCluster) {
 		return fmt.Errorf("invalid deployment type: %s", opts.DeploymentType)
+	}
+
+	return nil
+}
+func (opts *SetupOpts) validateFlags() error {
+	if err := opts.validateDeploymentTypeFlag(); err != nil {
+		return err
 	}
 
 	if opts.DeploymentName != "" {

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -548,6 +548,7 @@ func (opts *SetupOpts) Run(_ context.Context) error {
 
 	fmt.Fprintf(opts.OutWriter, `Cluster created!
 Connection string: %s
+
 `, cs)
 
 	return opts.runConnectWith(cs)

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -365,6 +365,13 @@ func (opts *SetupOpts) promptPort() error {
 	return err
 }
 
+func (opts *SetupOpts) validateConnectWith() error {
+	if opts.connectWith != "" && opts.connectWith != mongoshConnect && opts.connectWith != skipConnect {
+		return fmt.Errorf("connectWith flag unsupported: %s", opts.connectWith)
+	}
+	return nil
+}
+
 func (opts *SetupOpts) validateAndPromptDeploymentType() error {
 	if opts.DeploymentType == "" {
 		if err := opts.selectDeploymentType(); err != nil {
@@ -436,6 +443,10 @@ func (opts *SetupOpts) validateAndPromptPort() error {
 }
 
 func (opts *SetupOpts) promptConnect() error {
+	if opts.connectWith != "" {
+		return nil
+	}
+
 	p := &survey.Select{
 		Message: fmt.Sprintf("How would you like to connect to %s?", opts.DeploymentName),
 		Options: connectWithOptions,
@@ -448,6 +459,10 @@ func (opts *SetupOpts) promptConnect() error {
 }
 
 func (opts *SetupOpts) validateAndPrompt() error {
+	if err := opts.validateConnectWith(); err != nil {
+		return err
+	}
+
 	if err := opts.validateAndPromptDeploymentType(); err != nil {
 		return err
 	}
@@ -544,6 +559,7 @@ func SetupBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DeploymentType, flag.TypeFlag, "", usage.DeploymentType)
 	cmd.Flags().IntVar(&opts.Port, flag.Port, 0, usage.MongodPort)
 	cmd.Flags().StringVar(&opts.MdbVersion, flag.MDBVersion, "", usage.MDBVersion)
+	cmd.Flags().StringVar(&opts.connectWith, flag.ConnectWith, "", usage.ConnectWith)
 
 	cmd.Flags().BoolVarP(&opts.debug, flag.Debug, flag.DebugShort, false, usage.Debug)
 

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -45,8 +45,8 @@ const (
 	startHostPort      = 37017
 	internalMongodPort = 27017
 	internalMongotPort = 27027
-	localCluster       = "LOCAL"
-	atlasCluster       = "ATLAS"
+	localCluster       = "local"
+	atlasCluster       = "atlas"
 	mdb6               = "6.0"
 	mdb7               = "7.0"
 	replicaSetName     = "rs-localdev"
@@ -102,7 +102,9 @@ func (opts *SetupOpts) initPodmanClient() error {
 }
 
 func (opts *SetupOpts) createLocalDeployment() error {
-	fmt.Fprintf(os.Stderr, "Creating your cluster %s [this might take several minutes]\n", opts.DeploymentName)
+	fmt.Fprintf(os.Stderr, `
+Creating your cluster %s [this might take several minutes]
+`, opts.DeploymentName)
 	opts.start()
 
 	defer opts.stop()
@@ -493,10 +495,12 @@ func (opts *SetupOpts) validateAndPrompt() error {
 	}
 
 	if opts.setDefaultSettings() {
-		templatewriter.Print(os.Stderr, `[Default Settings]
+		templatewriter.Print(os.Stderr, `
+[Default Settings]
 Cluster Name	{{.DeploymentName}}
 MongoDB Version	{{.MdbVersion}}
 Port	{{.Port}}
+
 `, opts)
 
 		if !opts.force {

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -35,6 +35,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mongosh"
 	"github.com/mongodb/mongodb-atlas-cli/internal/podman"
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
+	"github.com/mongodb/mongodb-atlas-cli/internal/templatewriter"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
 )
@@ -443,7 +444,19 @@ func (opts *SetupOpts) validateAndPrompt() error {
 		return err
 	}
 
-	return opts.validateAndPromptPort()
+	if err := opts.validateAndPromptPort(); err != nil {
+		return err
+	}
+
+	if opts.settings == defaultSettings {
+		templatewriter.Print(os.Stderr, `[Default Settings]
+Cluster Name	{{.DeploymentName}}
+MongoDB Version	{{.MdbVersion}}
+Port	{{.Port}}
+`, opts)
+	}
+
+	return nil
 }
 
 func (opts *SetupOpts) Run(_ context.Context) error {

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -321,7 +321,7 @@ func (opts *SetupOpts) promptDeploymentName() error {
 	}))
 }
 
-func (opts *SetupOpts) selectMdbVersion() error {
+func (opts *SetupOpts) promptMdbVersion() error {
 	p := &survey.Select{
 		Message: "MongoDB Version",
 		Options: mdbVersions,
@@ -518,7 +518,7 @@ Port	{{.Port}}
 			return err
 		}
 
-		if err := opts.selectMdbVersion(); err != nil {
+		if err := opts.promptMdbVersion(); err != nil {
 			return err
 		}
 

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -89,6 +89,7 @@ type SetupOpts struct {
 	debug        bool
 	settings     string
 	connectWith  string
+	force        bool
 	s            *spinner.Spinner
 }
 
@@ -369,6 +370,10 @@ func (opts *SetupOpts) promptPort() error {
 }
 
 func (opts *SetupOpts) validateFlags() error {
+	if opts.DeploymentType == "" && opts.force {
+		return errors.New("flag --type is required when --force is set")
+	}
+
 	if opts.DeploymentType != "" && !strings.EqualFold(opts.DeploymentType, atlasCluster) && !strings.EqualFold(opts.DeploymentType, localCluster) {
 		return fmt.Errorf("invalid deployment type: %s", opts.DeploymentType)
 	}
@@ -487,8 +492,10 @@ MongoDB Version	{{.MdbVersion}}
 Port	{{.Port}}
 `, opts)
 
-		if err := opts.promptSettings(); err != nil {
-			return err
+		if !opts.force {
+			if err := opts.promptSettings(); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -566,6 +573,7 @@ func SetupBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.connectWith, flag.ConnectWith, "", usage.ConnectWith)
 
 	cmd.Flags().BoolVarP(&opts.debug, flag.Debug, flag.DebugShort, false, usage.Debug)
+	cmd.Flags().BoolVar(&opts.force, flag.Force, false, usage.Force)
 
 	_ = cmd.RegisterFlagCompletionFunc(flag.MDBVersion, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return mdbVersions, cobra.ShellCompDirectiveDefault

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -564,11 +564,13 @@ func SetupBuilder() *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.debug, flag.Debug, flag.DebugShort, false, usage.Debug)
 
 	_ = cmd.RegisterFlagCompletionFunc(flag.MDBVersion, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{mdb6, mdb7}, cobra.ShellCompDirectiveDefault
+		return mdbVersions, cobra.ShellCompDirectiveDefault
 	})
 	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{localCluster, atlasCluster}, cobra.ShellCompDirectiveDefault
+		return deploymentTypes, cobra.ShellCompDirectiveDefault
 	})
-
+	_ = cmd.RegisterFlagCompletionFunc(flag.ConnectWith, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return connectWithOptions, cobra.ShellCompDirectiveDefault
+	})
 	return cmd
 }

--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -276,13 +276,14 @@ func shouldCheckCredentials(cmd *cobra.Command) bool {
 		}
 	}
 	skipFor := []string{
-		fmt.Sprintf("%s %s", atlas, "completion"), // completion commands do not require credentials
-		fmt.Sprintf("%s %s", atlas, "config"),     // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "auth"),       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "login"),      // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "setup"),      // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "register"),   // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "quickstart"), // command supports login
+		fmt.Sprintf("%s %s", atlas, "completion"),  // completion commands do not require credentials
+		fmt.Sprintf("%s %s", atlas, "config"),      // user wants to set credentials
+		fmt.Sprintf("%s %s", atlas, "auth"),        // user wants to set credentials
+		fmt.Sprintf("%s %s", atlas, "login"),       // user wants to set credentials
+		fmt.Sprintf("%s %s", atlas, "setup"),       // user wants to set credentials
+		fmt.Sprintf("%s %s", atlas, "register"),    // user wants to set credentials
+		fmt.Sprintf("%s %s", atlas, "quickstart"),  // command supports login
+		fmt.Sprintf("%s %s", atlas, "deployments"), // command supports local
 	}
 	for _, p := range skipFor {
 		if strings.HasPrefix(cmd.CommandPath(), p) {

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -360,4 +360,5 @@ const (
 	Value                                     = "value"                                     // Value flag
 	OverrunPolicy                             = "overrunPolicy"                             // OverrunPolicy flag
 	AuthorizedEmail                           = "authorizedEmail"                           // authorizedEmail flag
+	ConnectWith                               = "connectWith"                               // connectWith flag
 )

--- a/internal/mongosh/mongosh.go
+++ b/internal/mongosh/mongosh.go
@@ -47,7 +47,10 @@ func SetTelemetry(enable bool) error {
 }
 
 func Run(username, password, mongoURI string) error {
-	return execCommand("-u", username, "-p", password, mongoURI)
+	if username != "" && password != "" {
+		return execCommand("-u", username, "-p", password, mongoURI)
+	}
+	return execCommand(mongoURI)
 }
 
 func Exec(debug bool, args ...string) error {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -448,4 +448,5 @@ dbName and collection are required only for built-in roles.`
 	AuthorizedEmail                           = "Email address of a security or legal representative."
 	DeploymentType                            = "Type of the deployment that you want to create. Valid values are ATLAS or LOCAL."
 	MongodPort                                = "Port to which the MongoDB server listens to for client connections."
+	ConnectWith                               = "Method of connection. Valid values are mongosh, compass and skip."
 )


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Adding questions based on design

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-196435

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.

Closes #[issue number]
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

https://github.com/mongodb/mongodb-atlas-cli/assets/1765216/f0fd16a0-f04a-47d3-8f28-899f6bef5f31


