### PR TITLE
DOCSP-32891: update example with missing flag

### DIFF
--- a/docs/atlascli/command/atlas-alerts-settings-create.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-create.txt
@@ -200,7 +200,7 @@ Examples
    # Create an alert configuration that notifies a user when they join a group for the project with the ID 5df90590f10fab5e33de2305:
    atlas alerts settings create --event JOINED_GROUP --enabled \
    --notificationType USER --notificationEmailEnabled \
-   --notificationUsername john@example.com \
+   --notificationIntervalMin 60 --notificationUsername john@example.com \
    --output json --projectId 5df90590f10fab5e33de2305
    
 .. code-block::

--- a/docs/atlascli/command/atlas-alerts-settings-update.txt
+++ b/docs/atlascli/command/atlas-alerts-settings-update.txt
@@ -220,7 +220,7 @@ Examples
    # Modify the alert configuration with the ID 5d1113b25a115342acc2d1aa so that it notifies a user when they join a group for the project with the ID 5df90590f10fab5e33de2305:
    atlas alerts settings update 5d1113b25a115342acc2d1aa --event JOINED_GROUP --enabled \
  		--notificationType USER --notificationEmailEnabled \
- 		--notificationUsername john@example.com \
+ 		--notificationIntervalMin 60 --notificationUsername john@example.com \
  		--output json --projectId 5df90590f10fab5e33de2305
    
 .. code-block::

--- a/internal/cli/atlas/alerts/settings/create.go
+++ b/internal/cli/atlas/alerts/settings/create.go
@@ -89,7 +89,7 @@ func CreateBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Create an alert configuration that notifies a user when they join a group for the project with the ID 5df90590f10fab5e33de2305:
   %s alerts settings create --event JOINED_GROUP --enabled \
   --notificationType USER --notificationEmailEnabled \
-  --notificationUsername john@example.com \
+  --notificationIntervalMin 60 --notificationUsername john@example.com \
   --output json --projectId 5df90590f10fab5e33de2305
   # Create alert using json file containing alert configuration
   %s alerts settings create 5d1113b25a115342acc2d1aa --file alerts.json`, cli.ExampleAtlasEntryPoint(), cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/alerts/settings/update.go
+++ b/internal/cli/atlas/alerts/settings/update.go
@@ -90,7 +90,7 @@ func UpdateBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Modify the alert configuration with the ID 5d1113b25a115342acc2d1aa so that it notifies a user when they join a group for the project with the ID 5df90590f10fab5e33de2305:
   %s alerts settings update 5d1113b25a115342acc2d1aa --event JOINED_GROUP --enabled \
 		--notificationType USER --notificationEmailEnabled \
-		--notificationUsername john@example.com \
+		--notificationIntervalMin 60 --notificationUsername john@example.com \
 		--output json --projectId 5df90590f10fab5e33de2305
   # Update alert using json file input containing alert configuration
   %s alerts settings update 5d1113b25a115342acc2d1aa --file alerts.json`, cli.ExampleAtlasEntryPoint(), cli.ExampleAtlasEntryPoint()),


### PR DESCRIPTION
## Context

Our examples were always failing validation errors on the backend.


## Future considerations

We might use https://github.com/aerogear/charmil#charmil-validator for validating invalid examples/changed flags on PR level. 