### PR TITLE
CLOUDP-195080: Deprecating PointInTimeUTCMillis on atlas backup restore create/start

### DIFF
--- a/docs/atlascli/command/atlas-backups-restores-start.txt
+++ b/docs/atlascli/command/atlas-backups-restores-start.txt
@@ -76,10 +76,10 @@ Options
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
-   * - --pointInTimeUTCMillis
+   * - --pointInTimeUTCSeconds
      - int
      - false
-     - Timestamp in the number of milliseconds that have elapsed since the UNIX epoch that represents the point in time to which your data will be restored. This timestamp must be within the last 24 hours of the current time.
+     - Timestamp in the number of seconds that have elapsed since the UNIX epoch that represents the point in time to which your data will be restored. This timestamp must be within the last 24 hours of the current time.
    * - --projectId
      - string
      - false
@@ -141,7 +141,7 @@ Examples
    # Create a point-in-time restore:
    atlas backup restore start pointInTime \
           --clusterName myDemo \
-          --pointInTimeUTCMillis 1588523147 \
+          --pointInTimeUTCSeconds 1588523147 \
           --targetClusterName myDemo2 \
           --targetProjectId 1a2345b67c8e9a12f3456de7
    

--- a/docs/atlascli/command/atlas-serverless-backups-restores-create.txt
+++ b/docs/atlascli/command/atlas-serverless-backups-restores-create.txt
@@ -64,10 +64,10 @@ Options
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
-   * - --pointInTimeUTCMillis
+   * - --pointInTimeUTCSeconds
      - int
      - false
-     - Timestamp in the number of milliseconds that have elapsed since the UNIX epoch that represents the point in time to which your data will be restored. This timestamp must be within the last 24 hours of the current time.
+     - Timestamp in the number of seconds that have elapsed since the UNIX epoch that represents the point in time to which your data will be restored. This timestamp must be within the last 24 hours of the current time.
    * - --projectId
      - string
      - false
@@ -121,7 +121,7 @@ Examples
    atlas serverless backup restore create \
           --deliveryType pointInTime \
           --clusterName myDemo \
-          --pointInTimeUTCMillis 1588523147 \
+          --pointInTimeUTCSeconds 1588523147 \
           --targetClusterName myDemo2 \
           --targetProjectId 1a2345b67c8e9a12f3456de7
    

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -38,15 +38,15 @@ const (
 type StartOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
-	method               string
-	clusterName          string
-	targetProjectID      string
-	targetClusterName    string
-	oplogTS              int
-	oplogInc             int
-	snapshotID           string
-	pointInTimeUTCMillis int
-	store                store.RestoreJobsCreator
+	method                string
+	clusterName           string
+	targetProjectID       string
+	targetClusterName     string
+	oplogTS               int
+	oplogInc              int
+	snapshotID            string
+	pointInTimeUTCSeconds int
+	store                 store.RestoreJobsCreator
 }
 
 func (opts *StartOpts) initStore(ctx context.Context) func() error {
@@ -90,9 +90,9 @@ func (opts *StartOpts) newCloudProviderSnapshotRestoreJob() *admin.DiskBackupSna
 	if opts.oplogTS != 0 && opts.oplogInc != 0 {
 		request.OplogTs = &opts.oplogTS
 		request.OplogInc = &opts.oplogInc
-	} else if opts.pointInTimeUTCMillis != 0 {
+	} else if opts.pointInTimeUTCSeconds != 0 {
 		// Set only when oplogTS and oplogInc are not set
-		request.PointInTimeUTCSeconds = &opts.pointInTimeUTCMillis
+		request.PointInTimeUTCSeconds = &opts.pointInTimeUTCSeconds
 	}
 
 	return request
@@ -159,7 +159,7 @@ func StartBuilder() *cobra.Command {
   # Create a point-in-time restore:
   %[1]s backup restore start pointInTime \
          --clusterName myDemo \
-         --pointInTimeUTCMillis 1588523147 \
+         --pointInTimeUTCSeconds 1588523147 \
          --targetClusterName myDemo2 \
          --targetProjectId 1a2345b67c8e9a12f3456de7
   
@@ -208,7 +208,9 @@ func StartBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.targetClusterName, flag.TargetClusterName, "", usage.TargetClusterName)
 	cmd.Flags().IntVar(&opts.oplogTS, flag.OplogTS, 0, usage.OplogTS)
 	cmd.Flags().IntVar(&opts.oplogInc, flag.OplogInc, 0, usage.OplogInc)
-	cmd.Flags().IntVar(&opts.pointInTimeUTCMillis, flag.PointInTimeUTCMillis, 0, usage.PointInTimeUTCMillis)
+	cmd.Flags().IntVar(&opts.pointInTimeUTCSeconds, flag.PointInTimeUTCMillis, 0, usage.PointInTimeUTCMillis)
+	_ = cmd.Flags().MarkDeprecated(flag.PointInTimeUTCMillis, fmt.Sprintf("please use --%s instead", flag.PointInTimeUTCSeconds))
+	cmd.Flags().IntVar(&opts.pointInTimeUTCSeconds, flag.PointInTimeUTCSeconds, 0, usage.PointInTimeUTCSeconds)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/serverless/backup/restores/create.go
+++ b/internal/cli/atlas/serverless/backup/restores/create.go
@@ -38,15 +38,15 @@ const (
 type CreateOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
-	deliveryType         string
-	clusterName          string
-	targetProjectID      string
-	targetClusterName    string
-	oplogTS              int
-	oplogInc             int
-	snapshotID           string
-	pointInTimeUTCMillis int
-	store                store.ServerlessRestoreJobsCreator
+	deliveryType          string
+	clusterName           string
+	targetProjectID       string
+	targetClusterName     string
+	oplogTS               int
+	oplogInc              int
+	snapshotID            string
+	pointInTimeUTCSeconds int
+	store                 store.ServerlessRestoreJobsCreator
 }
 
 func (opts *CreateOpts) initStore(ctx context.Context) func() error {
@@ -92,9 +92,9 @@ func (opts *CreateOpts) newCloudProviderSnapshotRestoreJob() *atlasv2.Serverless
 	if opts.oplogTS != 0 && opts.oplogInc != 0 {
 		request.OplogTs = &opts.oplogTS
 		request.OplogInc = &opts.oplogInc
-	} else if opts.pointInTimeUTCMillis != 0 {
+	} else if opts.pointInTimeUTCSeconds != 0 {
 		// Set only when oplogTS and oplogInc are not set
-		request.PointInTimeUTCSeconds = &opts.pointInTimeUTCMillis
+		request.PointInTimeUTCSeconds = &opts.pointInTimeUTCSeconds
 	}
 
 	return request
@@ -158,7 +158,7 @@ func CreateBuilder() *cobra.Command {
   %[1]s serverless backup restore create \
          --deliveryType pointInTime \
          --clusterName myDemo \
-         --pointInTimeUTCMillis 1588523147 \
+         --pointInTimeUTCSeconds 1588523147 \
          --targetClusterName myDemo2 \
          --targetProjectId 1a2345b67c8e9a12f3456de7
   
@@ -213,7 +213,9 @@ func CreateBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.targetClusterName, flag.TargetClusterName, "", usage.TargetClusterName)
 	cmd.Flags().IntVar(&opts.oplogTS, flag.OplogTS, 0, usage.OplogTS)
 	cmd.Flags().IntVar(&opts.oplogInc, flag.OplogInc, 0, usage.OplogInc)
-	cmd.Flags().IntVar(&opts.pointInTimeUTCMillis, flag.PointInTimeUTCMillis, 0, usage.PointInTimeUTCMillis)
+	cmd.Flags().IntVar(&opts.pointInTimeUTCSeconds, flag.PointInTimeUTCMillis, 0, usage.PointInTimeUTCMillis)
+	_ = cmd.Flags().MarkDeprecated(flag.PointInTimeUTCMillis, fmt.Sprintf("please use --%s instead", flag.PointInTimeUTCSeconds))
+	cmd.Flags().IntVar(&opts.pointInTimeUTCSeconds, flag.PointInTimeUTCSeconds, 0, usage.PointInTimeUTCSeconds)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -159,6 +159,7 @@ const (
 	OplogTS                                   = "oplogTs"                                   // OplogTS flag
 	OplogInc                                  = "oplogInc"                                  // OplogInc flag
 	PointInTimeUTCMillis                      = "pointInTimeUTCMillis"                      // PointInTimeUTCMillis flag
+	PointInTimeUTCSeconds                     = "pointInTimeUTCSeconds"                     // PointInTimeUTCSeconds flag
 	Expires                                   = "expires"                                   // Expires flag
 	MaxDownloads                              = "maxDownloads"                              // MaxDownloads flag
 	ExpirationHours                           = "expirationHours"                           // ExpirationHours flag

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -316,6 +316,7 @@ dbName and collection are required only for built-in roles.`
 	OplogTS                                   = "Oplog timestamp given as a timestamp in the number of seconds that have elapsed since the UNIX Epoch. When paired with oplogInc, they represent the point in time to which your data will be restored."
 	OplogInc                                  = "32-bit incrementing ordinal that represents operations within a given second. When paired with oplogTs, they represent the point in time to which your data will be restored."
 	PointInTimeUTCMillis                      = "Timestamp in the number of milliseconds that have elapsed since the UNIX epoch that represents the point in time to which your data will be restored. This timestamp must be within the last 24 hours of the current time."
+	PointInTimeUTCSeconds                     = "Timestamp in the number of seconds that have elapsed since the UNIX epoch that represents the point in time to which your data will be restored. This timestamp must be within the last 24 hours of the current time."
 	Expires                                   = "Timestamp in ISO 8601 date and time format after which the URL is no longer available. For use only with download restore jobs."
 	ExpirationHours                           = "Number of hours the download URL is valid once the restore job is complete. For use only with download restore jobs."
 	MaxDownloads                              = "Number of times the download URL can be used. This value must be 1 or greater. For use only with download restore jobs."


### PR DESCRIPTION
Deprecated misleading pointInTimeUTCMillis flag to indicate values are expected in seconds.
