### PR TITLE
CLOUDP-197667: Add deployments diagnostics command

### DIFF
--- a/internal/cli/atlas/deployments/deployments.go
+++ b/internal/cli/atlas/deployments/deployments.go
@@ -40,6 +40,7 @@ func Builder() *cobra.Command {
 		DeleteBuilder(),
 		ListBuilder(),
 		ConnectBuilder(),
+		DiagnosticsBuilder(),
 	)
 
 	return cmd

--- a/internal/cli/atlas/deployments/deployments_test.go
+++ b/internal/cli/atlas/deployments/deployments_test.go
@@ -26,7 +26,7 @@ func TestBuilder(t *testing.T) {
 	test.CmdValidator(
 		t,
 		Builder(),
-		4,
+		5,
 		[]string{},
 	)
 }

--- a/internal/cli/atlas/deployments/diagnostics.go
+++ b/internal/cli/atlas/deployments/diagnostics.go
@@ -1,0 +1,119 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"context"
+	"runtime"
+
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/deployments/options"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
+	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
+	"github.com/mongodb/mongodb-atlas-cli/internal/log"
+	"github.com/mongodb/mongodb-atlas-cli/internal/podman"
+	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
+	"github.com/spf13/cobra"
+)
+
+type diagnosticsOpts struct {
+	cli.OutputOpts
+	cli.GlobalOpts
+	options.DeploymentOpts
+	podmanClient podman.Client
+	podmanDiag   *podman.Diagnostic
+	machineDiag  *machineDiagnostic
+	podmanLogs   []interface{}
+	mongotLogs   []string
+	mongodLogs   []string
+}
+
+type machineDiagnostic struct {
+	OS   string
+	Arch string
+}
+
+func (opts *diagnosticsOpts) Run(ctx context.Context) error {
+	var err error
+
+	// Machine system info
+	opts.machineDiag = &machineDiagnostic{
+		OS:   runtime.GOOS,
+		Arch: runtime.GOARCH,
+	}
+
+	// Podman system info
+	opts.podmanDiag = opts.podmanClient.Diagnostics(ctx)
+
+	// Podman logs
+	if opts.podmanLogs, err = opts.podmanClient.Logs(ctx); err != nil {
+		return err
+	}
+
+	if opts.DeploymentName != "" {
+		_, _ = log.Warningf("Fetching logs for deployment %s\n", opts.DeploymentName)
+		// ignore error if container does not exist just capture log for that command
+		opts.mongotLogs, _ = opts.podmanClient.ContainerLogs(ctx, opts.LocalMongotHostname())
+		opts.mongodLogs, _ = opts.podmanClient.ContainerLogs(ctx, opts.LocalMongodHostname())
+	}
+
+	diagnosis := map[string]interface{}{
+		"Machine": opts.machineDiag,
+		"Podman":  opts.podmanDiag,
+		"Logs": map[string]interface{}{
+			"Podman": opts.podmanLogs,
+			"Mongot": opts.mongotLogs,
+			"Mongod": opts.mongodLogs,
+		},
+	}
+
+	return opts.Print(diagnosis)
+}
+
+func DiagnosticsBuilder() *cobra.Command {
+	opts := &diagnosticsOpts{
+		podmanDiag:  &podman.Diagnostic{},
+		machineDiag: &machineDiagnostic{},
+	}
+	cmd := &cobra.Command{
+		Use:    "diagnostics",
+		Short:  "Fetch detailed information about all your deployments and system processes.",
+		Hidden: true, // always hidden
+		Args:   require.MaximumNArgs(1),
+		Annotations: map[string]string{
+			"deploymentNameDesc": "Name of the deployment you want to setup.",
+		},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				opts.DeploymentName = args[0]
+			}
+
+			w := cmd.OutOrStdout()
+			opts.podmanClient = podman.NewClient(log.IsDebugLevel(), w)
+
+			return opts.PreRunE(
+				opts.InitOutput(w, ""),
+				opts.InitStore(opts.podmanClient),
+			)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Run(cmd.Context())
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+
+	return cmd
+}

--- a/internal/mocks/mock_podman.go
+++ b/internal/mocks/mock_podman.go
@@ -35,6 +35,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// ContainerLogs mocks base method.
+func (m *MockClient) ContainerLogs(arg0 context.Context, arg1 string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainerLogs", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainerLogs indicates an expected call of ContainerLogs.
+func (mr *MockClientMockRecorder) ContainerLogs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerLogs", reflect.TypeOf((*MockClient)(nil).ContainerLogs), arg0, arg1)
+}
+
 // CopyFileToContainer mocks base method.
 func (m *MockClient) CopyFileToContainer(arg0 context.Context, arg1, arg2, arg3 string) ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -122,6 +137,21 @@ func (m *MockClient) ListImages(arg0 context.Context, arg1 string) ([]*podman.Im
 func (mr *MockClientMockRecorder) ListImages(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockClient)(nil).ListImages), arg0, arg1)
+}
+
+// Logs mocks base method.
+func (m *MockClient) Logs(arg0 context.Context) ([]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Logs", arg0)
+	ret0, _ := ret[0].([]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Logs indicates an expected call of Logs.
+func (mr *MockClientMockRecorder) Logs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*MockClient)(nil).Logs), arg0)
 }
 
 // PullImage mocks base method.
@@ -246,4 +276,19 @@ func (mr *MockClientMockRecorder) StopContainers(arg0 interface{}, arg1 ...inter
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopContainers", reflect.TypeOf((*MockClient)(nil).StopContainers), varargs...)
+}
+
+// Version mocks base method.
+func (m *MockClient) Version(arg0 context.Context) (*podman.Version, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Version", arg0)
+	ret0, _ := ret[0].(*podman.Version)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Version indicates an expected call of Version.
+func (mr *MockClientMockRecorder) Version(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockClient)(nil).Version), arg0)
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-197667](https://jira.mongodb.org/browse/CLOUDP-197667)

```shell
~/workplace/mongocli CLOUDP-197667 *22 ?1 ❯ atlasdev deployments diagnostics  --output json > out.json                                                                                                                             1.20 13:55:17
```
<details>
```
{
  "Logs": {
    "Mongod": null,
    "Mongot": null,
    "Podman": [
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694186411,
        "CreatedAt": "3 days ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "a7151348aa67cb19f33e88f9dcc1c9f943a682d79356cde92e2a049019e40425",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local5305"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local5305"
        ],
        "Pid": 4033,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 58323,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694186411,
        "State": "running",
        "Status": "Up 3 days"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694428668,
        "CreatedAt": "26 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "2b836f44f4c66a1c13d52521bff83b783aa86e9ecbb8a7a532e73e221ab841bf",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local7780"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local7780"
        ],
        "Pid": 11113,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 54257,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694428668,
        "State": "running",
        "Status": "Up 26 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694439882,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "55c898b4d56c092009bd732459069256d93eb91a8811ad1612d50c47b82fda2c",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local4839"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local4839"
        ],
        "Pid": 11810,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57055,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694439882,
        "State": "running",
        "Status": "Up 23 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694440618,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "1cf68912c9df6c1974e342da0c81ae63b6d0b13b9a7147b4968f0f7c42a2c905",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local1657"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local1657"
        ],
        "Pid": 12057,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57488,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694440618,
        "State": "running",
        "Status": "Up 23 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694440958,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "7f3680aa3847c0a3db5069eb186af83c02d27afbf211048a5f07f1aa07c9e774",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local3689"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local3689"
        ],
        "Pid": 12432,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57612,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694440962,
        "State": "running",
        "Status": "Up 23 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694440981,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "6ebaee63e212e2dc0b6103c4c9d05bee7ba5433a853736eb1021640e053781af",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local9191"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local9191"
        ],
        "Pid": 12550,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57620,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694441000,
        "State": "running",
        "Status": "Up 23 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694441265,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "34122b3eb5bf272291333e54025061897b3bd7b02c9ebcdcfaf824912fc54e48",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local8035"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local8035"
        ],
        "Pid": 13093,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57919,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694441266,
        "State": "running",
        "Status": "Up 23 hours"
      }
    ]
  },
  "Machine": {
    "OS": "darwin",
    "Arch": "arm64"
  },
  "Podman": {
    "Installed": true,
    "MachineFound": true,
    "MachineState": "running",
    "MachineInfo": {
      "ConfigPath": {
        "Path": "/Users/bianca.lisle/.config/containers/podman/machine/qemu/podman-machine-default.json"
      },
      "ConnectionInfo": {
        "PodmanSocket": {
          "Path": "/Users/bianca.lisle/.local/share/containers/podman/machine/qemu/podman.sock"
        },
        "PodmanPipe": null
      },
      "Created": "2023-08-09T15:58:48.9874+01:00",
      "Image": {
        "IgnitionFilePath": {
          "Path": "/Users/bianca.lisle/.config/containers/podman/machine/qemu/podman-machine-default.ign"
        },
        "ImageStream": "testing",
        "ImagePath": {
          "Path": "/Users/bianca.lisle/.local/share/containers/podman/machine/qemu/podman-machine-default_fedora-coreos-38.20230806.2.0-qemu.aarch64.qcow2"
        }
      },
      "LastUp": "2023-09-08T14:47:13.057595+01:00",
      "Name": "podman-machine-default",
      "Resources": {
        "CPUs": 1,
        "DiskSize": 100,
        "Memory": 2048
      },
      "SSHConfig": {
        "IdentityPath": "/Users/bianca.lisle/.ssh/podman-machine-default",
        "Port": 60328,
        "RemoteUsername": "core"
      },
      "State": "running",
      "UserModeNetworking": true
    },
    "VersionFound": true,
    "Version": {
      "Client": {
        "APIVersion": "4.6.2",
        "Version": "4.6.2",
        "GoVersion": "go1.21.0",
        "GitCommit": "5db42e86862ef42c59304c38aa583732fd80f178",
        "BuiltTime": "Mon Aug 28 15:55:03 2023",
        "Built": 1693234503,
        "OsArch": "darwin/arm64",
        "Os": "darwin"
      },
      "Server": {
        "APIVersion": "4.6.2",
        "Version": "4.6.2",
        "GoVersion": "go1.20.7",
        "GitCommit": "",
        "BuiltTime": "Mon Aug 28 20:39:14 2023",
        "Built": 1693251554,
        "OsArch": "linux/arm64",
        "Os": "linux"
      }
    },
    "Images": [
      "docker.io/mongodb/mongodb-enterprise-server:7.0-ubi8",
      "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
      "docker.io/mongodb/apix_test:mongot-preview"
    ]
  }
}
```
</details>

```shell
~/workplace/mongocli CLOUDP-197667 *22 ?1 ❯ atlasdev deployments diagnostics local7780 --output json > out.json                                                                                                                7s  1.20 13:54:30
Fetching logs for deployment local7780
```
<details>
<summary>Log  output sample</summary>

```
{
  "Logs": {
    "Mongod": [
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.241Z\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":5760901, \"ctx\":\"-\",\"msg\":\"Applied --setParameter options\",\"attr\":{\"serverParameters\":{\"mongotHost\":{\"default\":\"\",\"value\":\"mongot-local7780:27027\"},\"searchIndexManagementHostAndPort\":{\"default\":\"\",\"value\":\"mongot-local7780:27027\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.291+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":23285,   \"ctx\":\"main\",\"msg\":\"Automatically disabling TLS 1.0, to force-enable TLS 1.0 specify --sslDisabledProtocols 'none'\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.303+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":4915701, \"ctx\":\"main\",\"msg\":\"Initialized wire specification\",\"attr\":{\"spec\":{\"incomingExternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":17},\"incomingInternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":17},\"outgoing\":{\"minWireVersion\":6,\"maxWireVersion\":17},\"isInternalClient\":true}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.342+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":4648601, \"ctx\":\"main\",\"msg\":\"Implicit TCP FastOpen unavailable. If TCP FastOpen is required, set tcpFastOpenServer, tcpFastOpenClient, and tcpFastOpenQueueSize.\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.617+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5123008, \"ctx\":\"main\",\"msg\":\"Successfully registered PrimaryOnlyService\",\"attr\":{\"service\":\"TenantMigrationDonorService\",\"namespace\":\"config.tenantMigrationDonors\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.619+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5123008, \"ctx\":\"main\",\"msg\":\"Successfully registered PrimaryOnlyService\",\"attr\":{\"service\":\"TenantMigrationRecipientService\",\"namespace\":\"config.tenantMigrationRecipients\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.619+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5123008, \"ctx\":\"main\",\"msg\":\"Successfully registered PrimaryOnlyService\",\"attr\":{\"service\":\"ShardSplitDonorService\",\"namespace\":\"config.tenantSplitDonors\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.621+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":5945603, \"ctx\":\"main\",\"msg\":\"Multi threading initialized\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.637+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":4615611, \"ctx\":\"initandlisten\",\"msg\":\"MongoDB starting\",\"attr\":{\"pid\":16,\"port\":27017,\"dbPath\":\"/data/db\",\"architecture\":\"64-bit\",\"host\":\"mongod-local7780\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.643+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":23403,   \"ctx\":\"initandlisten\",\"msg\":\"Build Info\",\"attr\":{\"buildInfo\":{\"version\":\"6.0.9\",\"gitVersion\":\"90c65f9cc8fc4e6664a5848230abaa9b3f3b02f7\",\"openSSLVersion\":\"OpenSSL 1.1.1k  FIPS 25 Mar 2021\",\"modules\":[\"enterprise\"],\"allocator\":\"tcmalloc\",\"environment\":{\"distmod\":\"rhel80\",\"distarch\":\"x86_64\",\"target_arch\":\"x86_64\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.644+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":51765,   \"ctx\":\"initandlisten\",\"msg\":\"Operating System\",\"attr\":{\"os\":{\"name\":\"Red Hat Enterprise Linux release 8.8 (Ootpa)\",\"version\":\"Kernel 6.4.12-200.fc38.aarch64\"}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.644+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":21951,   \"ctx\":\"initandlisten\",\"msg\":\"Options set by command line\",\"attr\":{\"options\":{\"net\":{\"bindIp\":\"*\"},\"replication\":{\"replSet\":\"rs-localdev\"},\"security\":{\"keyFile\":\"/data/configdb/keyfile\",\"transitionToAuth\":true},\"setParameter\":{\"mongotHost\":\"mongot-local7780:27027\",\"searchIndexManagementHostAndPort\":\"mongot-local7780:27027\"},\"storage\":{\"dbPath\":\"/data/db\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:51.665+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":22315,   \"ctx\":\"initandlisten\",\"msg\":\"Opening WiredTiger\",\"attr\":{\"config\":\"create,cache_size=464M,session_max=33000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,remove=true,path=journal,compressor=snappy),builtin_extension_config=(zstd=(compression_level=6)),file_manager=(close_idle_time=600,close_scan_interval=10,close_handle_minimum=2000),statistics_log=(wait=0),json_output=(error,message),verbose=[recovery_progress:1,checkpoint_progress:1,compact_progress:1,backup:0,checkpoint:0,compact:0,evict:0,history_store:0,recovery:0,rts:0,salvage:0,tiered:0,timestamp:0,transaction:0,verify:0,log:0],\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.729+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":4795906, \"ctx\":\"initandlisten\",\"msg\":\"WiredTiger opened\",\"attr\":{\"durationMillis\":1064}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.730+00:00\"},\"s\":\"I\",  \"c\":\"RECOVERY\", \"id\":23987,   \"ctx\":\"initandlisten\",\"msg\":\"WiredTiger recoveryTimestamp\",\"attr\":{\"recoveryTimestamp\":{\"$timestamp\":{\"t\":0,\"i\":0}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.781+00:00\"},\"s\":\"W\",  \"c\":\"CONTROL\",  \"id\":5123300, \"ctx\":\"initandlisten\",\"msg\":\"vm.max_map_count is too low\",\"attr\":{\"currentValue\":65530,\"recommendedMinimum\":838860,\"maxConns\":419430},\"tags\":[\"startupWarnings\"]}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.797+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5853300, \"ctx\":\"initandlisten\",\"msg\":\"current featureCompatibilityVersion value\",\"attr\":{\"featureCompatibilityVersion\":\"unset\",\"context\":\"startup\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.798+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":5071100, \"ctx\":\"initandlisten\",\"msg\":\"Clearing temp directory\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.802+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":20536,   \"ctx\":\"initandlisten\",\"msg\":\"Flow Control is enabled on this deployment\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.807+00:00\"},\"s\":\"I\",  \"c\":\"FTDC\",     \"id\":20625,   \"ctx\":\"initandlisten\",\"msg\":\"Initializing full-time diagnostic data capture\",\"attr\":{\"dataDirectory\":\"/data/db/diagnostic.data\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.903+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.startup_log\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"8c52ba69-8754-4e8d-960c-ebc744e1c50c\"}},\"options\":{\"capped\":true,\"size\":10485760}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.954+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"8c52ba69-8754-4e8d-960c-ebc744e1c50c\"}},\"namespace\":\"local.startup_log\",\"index\":\"_id_\",\"ident\":\"index-1--1505117970824694136\",\"collectionIdent\":\"collection-0--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.965+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015317, \"ctx\":\"initandlisten\",\"msg\":\"Setting new configuration state\",\"attr\":{\"newState\":\"ConfigStartingUp\",\"oldState\":\"ConfigPreStart\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.970+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6005300, \"ctx\":\"initandlisten\",\"msg\":\"Starting up replica set aware services\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.973+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":4939300, \"ctx\":\"monitoring-keys-for-HMAC\",\"msg\":\"Failed to refresh key cache\",\"attr\":{\"error\":\"ReadConcernMajorityNotAvailableYet: Read concern majority reads are currently not possible.\",\"nextWakeupMillis\":200}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.978+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":4280500, \"ctx\":\"initandlisten\",\"msg\":\"Attempting to create internal replication collections\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:52.983+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.replset.oplogTruncateAfterPoint\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"9406c226-d96a-48c1-8620-4ea3292f1edf\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.027+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"9406c226-d96a-48c1-8620-4ea3292f1edf\"}},\"namespace\":\"local.replset.oplogTruncateAfterPoint\",\"index\":\"_id_\",\"ident\":\"index-3--1505117970824694136\",\"collectionIdent\":\"collection-2--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.029+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.replset.minvalid\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"5da714c4-d619-4459-b83d-ec561a0f58d3\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.086+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"5da714c4-d619-4459-b83d-ec561a0f58d3\"}},\"namespace\":\"local.replset.minvalid\",\"index\":\"_id_\",\"ident\":\"index-5--1505117970824694136\",\"collectionIdent\":\"collection-4--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.096+00:00\"},\"s\":\"W\",  \"c\":\"REPL\",     \"id\":21533,   \"ctx\":\"ftdc\",\"msg\":\"Rollback ID is not initialized yet\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.121+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.replset.election\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"40df706a-fea0-4c6a-b561-9c1d9b591dbe\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.149+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"40df706a-fea0-4c6a-b561-9c1d9b591dbe\"}},\"namespace\":\"local.replset.election\",\"index\":\"_id_\",\"ident\":\"index-7--1505117970824694136\",\"collectionIdent\":\"collection-6--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.166+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":4280501, \"ctx\":\"initandlisten\",\"msg\":\"Attempting to load local voted for document\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.168+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21311,   \"ctx\":\"initandlisten\",\"msg\":\"Did not find local initialized voted for document at startup\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.169+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":4280502, \"ctx\":\"initandlisten\",\"msg\":\"Searching for local Rollback ID document\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.170+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21312,   \"ctx\":\"initandlisten\",\"msg\":\"Did not find local Rollback ID document at startup. Creating one\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.172+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.system.rollback.id\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"a00175e7-7f92-4bf9-921d-fb83645758d4\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.176+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":4939300, \"ctx\":\"monitoring-keys-for-HMAC\",\"msg\":\"Failed to refresh key cache\",\"attr\":{\"error\":\"ReadConcernMajorityNotAvailableYet: Read concern majority reads are currently not possible.\",\"nextWakeupMillis\":400}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.198+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"a00175e7-7f92-4bf9-921d-fb83645758d4\"}},\"namespace\":\"local.system.rollback.id\",\"index\":\"_id_\",\"ident\":\"index-9--1505117970824694136\",\"collectionIdent\":\"collection-8--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.200+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21531,   \"ctx\":\"initandlisten\",\"msg\":\"Initialized the rollback ID\",\"attr\":{\"rbid\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.201+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21313,   \"ctx\":\"initandlisten\",\"msg\":\"Did not find local replica set configuration document at startup\",\"attr\":{\"error\":{\"code\":47,\"codeName\":\"NoMatchingDocument\",\"errmsg\":\"Did not find replica set configuration document in local.system.replset\"}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.201+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015317, \"ctx\":\"initandlisten\",\"msg\":\"Setting new configuration state\",\"attr\":{\"newState\":\"ConfigUninitialized\",\"oldState\":\"ConfigStartingUp\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.203+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"initandlisten\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.system.views\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"50c6c399-c043-4aa3-a9e7-7f7bcbdc7eeb\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.219+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"initandlisten\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"50c6c399-c043-4aa3-a9e7-7f7bcbdc7eeb\"}},\"namespace\":\"local.system.views\",\"index\":\"_id_\",\"ident\":\"index-11--1505117970824694136\",\"collectionIdent\":\"collection-10--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.242+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":22262,   \"ctx\":\"initandlisten\",\"msg\":\"Timestamp monitor starting\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.267+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":40440,   \"ctx\":\"initandlisten\",\"msg\":\"Starting the TopologyVersionObserver\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.269+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":20714,   \"ctx\":\"LogicalSessionCacheRefresh\",\"msg\":\"Failed to refresh session cache, will try again at the next refresh interval\",\"attr\":{\"error\":\"NotYetInitialized: Replication has not yet been configured\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.271+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":40445,   \"ctx\":\"TopologyVersionObserver\",\"msg\":\"Started TopologyVersionObserver\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.280+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":20712,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Sessions collection is not set up; waiting until next sessions reap interval\",\"attr\":{\"error\":\"NamespaceNotFound: config.system.sessions does not exist\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.281+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":23015,   \"ctx\":\"listener\",\"msg\":\"Listening on\",\"attr\":{\"address\":\"/tmp/mongodb-27017.sock\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.281+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":23015,   \"ctx\":\"listener\",\"msg\":\"Listening on\",\"attr\":{\"address\":\"0.0.0.0\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.282+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":23016,   \"ctx\":\"listener\",\"msg\":\"Waiting for connections\",\"attr\":{\"port\":27017,\"ssl\":\"off\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.293+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33506\",\"uuid\":\"6433f530-ef98-4f05-be7a-b25d7df3cf34\",\"connectionId\":1,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.301+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn1\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33506\",\"client\":\"conn1\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.319+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33520\",\"uuid\":\"38e2821b-76fc-4dd9-a1c2-b1630412a64d\",\"connectionId\":2,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.320+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33534\",\"uuid\":\"601c954d-c644-4032-814e-0934bca2e411\",\"connectionId\":3,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.322+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn2\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33520\",\"client\":\"conn2\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.323+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn3\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33534\",\"client\":\"conn3\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.327+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33544\",\"uuid\":\"623fe4e1-ca68-47a0-90b4-7a312815936c\",\"connectionId\":4,\"connectionCount\":4}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.331+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33552\",\"uuid\":\"7424a939-03cf-4ef6-a041-ebca9d247ba2\",\"connectionId\":5,\"connectionCount\":5}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.332+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn4\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33544\",\"client\":\"conn4\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.333+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn5\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33552\",\"client\":\"conn5\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:53.579+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":4939300, \"ctx\":\"monitoring-keys-for-HMAC\",\"msg\":\"Failed to refresh key cache\",\"attr\":{\"error\":\"NotYetInitialized: Cannot use non-local read concern until replica set is finished initializing.\",\"nextWakeupMillis\":600}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.182+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":4939300, \"ctx\":\"monitoring-keys-for-HMAC\",\"msg\":\"Failed to refresh key cache\",\"attr\":{\"error\":\"NotYetInitialized: Cannot use non-local read concern until replica set is finished initializing.\",\"nextWakeupMillis\":800}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.402+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":20883,   \"ctx\":\"conn1\",\"msg\":\"Interrupted operation as its client disconnected\",\"attr\":{\"opId\":96}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.406+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn4\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33544\",\"uuid\":\"623fe4e1-ca68-47a0-90b4-7a312815936c\",\"connectionId\":4,\"connectionCount\":4}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.407+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn5\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33552\",\"uuid\":\"7424a939-03cf-4ef6-a041-ebca9d247ba2\",\"connectionId\":5,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.407+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn2\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33520\",\"uuid\":\"38e2821b-76fc-4dd9-a1c2-b1630412a64d\",\"connectionId\":2,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.408+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn3\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33534\",\"uuid\":\"601c954d-c644-4032-814e-0934bca2e411\",\"connectionId\":3,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.412+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn1\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33506\",\"uuid\":\"6433f530-ef98-4f05-be7a-b25d7df3cf34\",\"connectionId\":1,\"connectionCount\":0}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.731+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33566\",\"uuid\":\"d3e419b6-a1fc-4f83-93f5-f12a1844ec2a\",\"connectionId\":6,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.733+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn6\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33566\",\"client\":\"conn6\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.745+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33578\",\"uuid\":\"f0044fd2-4d9c-456f-8a9a-7410ad455e35\",\"connectionId\":7,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.746+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33592\",\"uuid\":\"a9235dbd-e79b-4f5b-931a-6a3528564a38\",\"connectionId\":8,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.747+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn7\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33578\",\"client\":\"conn7\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.748+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn8\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33592\",\"client\":\"conn8\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.750+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33598\",\"uuid\":\"62aeb486-b64a-40e3-814f-080e51b67a4a\",\"connectionId\":9,\"connectionCount\":4}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.753+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn9\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33598\",\"client\":\"conn9\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.887+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21356,   \"ctx\":\"conn9\",\"msg\":\"replSetInitiate admin command received from client\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.887+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015317, \"ctx\":\"conn9\",\"msg\":\"Setting new configuration state\",\"attr\":{\"newState\":\"ConfigInitiating\",\"oldState\":\"ConfigUninitialized\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.889+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"conn9\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"admin.system.version\",\"uuidDisposition\":\"provided\",\"uuid\":{\"uuid\":{\"$uuid\":\"f7e113d2-9b8c-47eb-8eef-f596d5e7d007\"}},\"options\":{\"uuid\":{\"$uuid\":\"f7e113d2-9b8c-47eb-8eef-f596d5e7d007\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.906+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"conn9\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"f7e113d2-9b8c-47eb-8eef-f596d5e7d007\"}},\"namespace\":\"admin.system.version\",\"index\":\"_id_\",\"ident\":\"index-13--1505117970824694136\",\"collectionIdent\":\"collection-12--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.909+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":20459,   \"ctx\":\"conn9\",\"msg\":\"Setting featureCompatibilityVersion\",\"attr\":{\"newVersion\":\"6.0\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.909+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5853300, \"ctx\":\"conn9\",\"msg\":\"current featureCompatibilityVersion value\",\"attr\":{\"featureCompatibilityVersion\":\"6.0\",\"context\":\"setFCV\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.910+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":4915702, \"ctx\":\"conn9\",\"msg\":\"Updated wire specification\",\"attr\":{\"oldSpec\":{\"incomingExternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":17},\"incomingInternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":17},\"outgoing\":{\"minWireVersion\":6,\"maxWireVersion\":17},\"isInternalClient\":true},\"newSpec\":{\"incomingExternalClient\":{\"minWireVersion\":0,\"maxWireVersion\":17},\"incomingInternalClient\":{\"minWireVersion\":17,\"maxWireVersion\":17},\"outgoing\":{\"minWireVersion\":17,\"maxWireVersion\":17},\"isInternalClient\":true}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.910+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22991,   \"ctx\":\"conn9\",\"msg\":\"Skip closing connection for connection\",\"attr\":{\"connectionId\":9}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.910+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22991,   \"ctx\":\"conn9\",\"msg\":\"Skip closing connection for connection\",\"attr\":{\"connectionId\":8}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.911+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22991,   \"ctx\":\"conn9\",\"msg\":\"Skip closing connection for connection\",\"attr\":{\"connectionId\":7}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.911+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22991,   \"ctx\":\"conn9\",\"msg\":\"Skip closing connection for connection\",\"attr\":{\"connectionId\":6}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.936+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21357,   \"ctx\":\"conn9\",\"msg\":\"replSetInitiate config object parses ok\",\"attr\":{\"numMembers\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.942+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21251,   \"ctx\":\"conn9\",\"msg\":\"Creating replication oplog\",\"attr\":{\"oplogSizeMB\":4730}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.942+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"conn9\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.oplog.rs\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"ba2a672d-7338-4360-bbf1-993281908077\"}},\"options\":{\"capped\":true,\"size\":4959766732,\"autoIndexId\":false}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.951+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":22383,   \"ctx\":\"conn9\",\"msg\":\"The size storer reports that the oplog contains\",\"attr\":{\"numRecords\":0,\"dataSize\":0}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:54.952+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":22382,   \"ctx\":\"conn9\",\"msg\":\"WiredTiger record store oplog processing finished\",\"attr\":{\"durationMillis\":0}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.043+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":4939300, \"ctx\":\"monitoring-keys-for-HMAC\",\"msg\":\"Failed to refresh key cache\",\"attr\":{\"error\":\"NotYetInitialized: Cannot use non-local read concern until replica set is finished initializing.\",\"nextWakeupMillis\":1000}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.044+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"conn9\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.system.replset\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"413b088f-fb3e-4725-ac9b-4748ecdc77f7\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.071+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"conn9\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"413b088f-fb3e-4725-ac9b-4748ecdc77f7\"}},\"namespace\":\"local.system.replset\",\"index\":\"_id_\",\"ident\":\"index-16--1505117970824694136\",\"collectionIdent\":\"collection-15--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.102+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5872101, \"ctx\":\"conn9\",\"msg\":\"Taking a stable checkpoint for replSetInitiate\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.103+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5872100, \"ctx\":\"conn9\",\"msg\":\"Updating commit point for initiate\",\"attr\":{\"_lastCommittedOpTimeAndWallTime\":\"{ ts: Timestamp(1694428675, 1), t: -1 }, 2023-09-11T10:37:55.071+00:00\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.106+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":22310,   \"ctx\":\"conn9\",\"msg\":\"Triggering the first stable checkpoint\",\"attr\":{\"initialDataTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":1}},\"prevStableTimestamp\":{\"$timestamp\":{\"t\":0,\"i\":0}},\"currStableTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":1}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.120+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015317, \"ctx\":\"conn9\",\"msg\":\"Setting new configuration state\",\"attr\":{\"newState\":\"ConfigSteady\",\"oldState\":\"ConfigInitiating\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.122+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21392,   \"ctx\":\"conn9\",\"msg\":\"New replica set config in use\",\"attr\":{\"config\":{\"_id\":\"rs-localdev\",\"version\":1,\"term\":0,\"members\":[{\"_id\":0,\"host\":\"mongod-local7780:27017\",\"arbiterOnly\":false,\"buildIndexes\":true,\"hidden\":false,\"priority\":1,\"tags\":{},\"horizons\":{\"external\":\"localhost:54257\"},\"secondaryDelaySecs\":0,\"votes\":1}],\"protocolVersion\":1,\"writeConcernMajorityJournalDefault\":true,\"settings\":{\"chainingAllowed\":true,\"heartbeatIntervalMillis\":2000,\"heartbeatTimeoutSecs\":10,\"electionTimeoutMillis\":10000,\"catchUpTimeoutMillis\":-1,\"catchUpTakeoverDelayMillis\":30000,\"getLastErrorModes\":{},\"getLastErrorDefaults\":{\"w\":1,\"wtimeout\":0},\"replicaSetId\":{\"$oid\":\"64feee026a202760384f8210\"}}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.124+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21393,   \"ctx\":\"conn9\",\"msg\":\"Found self in config\",\"attr\":{\"hostAndPort\":\"mongod-local7780:27017\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.124+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21358,   \"ctx\":\"conn9\",\"msg\":\"Replica set state transition\",\"attr\":{\"newState\":\"STARTUP2\",\"oldState\":\"STARTUP\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.126+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21306,   \"ctx\":\"conn9\",\"msg\":\"Starting replication storage threads\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.129+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":4280512, \"ctx\":\"conn9\",\"msg\":\"No initial sync required. Attempting to begin steady replication\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.130+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21358,   \"ctx\":\"conn9\",\"msg\":\"Replica set state transition\",\"attr\":{\"newState\":\"RECOVERING\",\"oldState\":\"STARTUP2\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.131+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"conn9\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"local.replset.initialSyncId\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"d2a2b153-bdc3-43cd-9d08-be33f09e2b8d\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.149+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"conn9\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"d2a2b153-bdc3-43cd-9d08-be33f09e2b8d\"}},\"namespace\":\"local.replset.initialSyncId\",\"index\":\"_id_\",\"ident\":\"index-18--1505117970824694136\",\"collectionIdent\":\"collection-17--1505117970824694136\",\"commitTimestamp\":null}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.153+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21299,   \"ctx\":\"conn9\",\"msg\":\"Starting replication fetcher thread\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.153+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21300,   \"ctx\":\"conn9\",\"msg\":\"Starting replication applier thread\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.154+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21224,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Starting oplog application\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.154+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21301,   \"ctx\":\"conn9\",\"msg\":\"Starting replication reporter thread\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.163+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn9\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"local.system.replset\",\"appName\":\"mongosh 2.0.0\",\"command\":{\"replSetInitiate\":{\"_id\":\"rs-localdev\",\"version\":1,\"configsvr\":false,\"members\":[{\"_id\":0,\"host\":\"mongod-local7780:27017\",\"horizons\":{\"external\":\"localhost:54257\"}}]},\"lsid\":{\"id\":{\"$uuid\":\"4e57b744-9389-4039-ba6a-df00e2a3a9c1\"}},\"$db\":\"admin\"},\"numYields\":0,\"queryHash\":\"17830885\",\"reslen\":38,\"locks\":{\"ParallelBatchWriterMode\":{\"acquireCount\":{\"r\":11}},\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":4,\"w\":8}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":12}},\"Global\":{\"acquireCount\":{\"r\":4,\"w\":6,\"W\":2}},\"Database\":{\"acquireCount\":{\"r\":2,\"w\":6,\"R\":1}},\"Collection\":{\"acquireCount\":{\"r\":2,\"w\":5}},\"Mutex\":{\"acquireCount\":{\"r\":12}},\"oplog\":{\"acquireCount\":{\"w\":1}}},\"flowControl\":{\"acquireCount\":5,\"timeAcquiringMicros\":43},\"readConcern\":{\"level\":\"local\",\"provenance\":\"implicitDefault\"},\"storage\":{},\"remote\":\"10.89.3.2:33598\",\"protocol\":\"op_msg\",\"durationMillis\":269}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.170+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21358,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Replica set state transition\",\"attr\":{\"newState\":\"SECONDARY\",\"oldState\":\"RECOVERING\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.173+00:00\"},\"s\":\"I\",  \"c\":\"ELECTION\", \"id\":4615652, \"ctx\":\"OplogApplier-0\",\"msg\":\"Starting an election, since we've seen no PRIMARY in election timeout period\",\"attr\":{\"electionTimeoutPeriodMillis\":10000}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.174+00:00\"},\"s\":\"I\",  \"c\":\"ELECTION\", \"id\":21438,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Conducting a dry run election to see if we could be elected\",\"attr\":{\"currentTerm\":0}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.175+00:00\"},\"s\":\"I\",  \"c\":\"ELECTION\", \"id\":21444,   \"ctx\":\"ReplCoord-0\",\"msg\":\"Dry election run succeeded, running for election\",\"attr\":{\"newTerm\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.178+00:00\"},\"s\":\"I\",  \"c\":\"ELECTION\", \"id\":6015300, \"ctx\":\"ReplCoord-0\",\"msg\":\"Storing last vote document in local storage for my election\",\"attr\":{\"lastVote\":{\"term\":1,\"candidateIndex\":0}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.184+00:00\"},\"s\":\"I\",  \"c\":\"ELECTION\", \"id\":21450,   \"ctx\":\"ReplCoord-1\",\"msg\":\"Election succeeded, assuming primary role\",\"attr\":{\"term\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.185+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21358,   \"ctx\":\"ReplCoord-1\",\"msg\":\"Replica set state transition\",\"attr\":{\"newState\":\"PRIMARY\",\"oldState\":\"SECONDARY\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.187+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21106,   \"ctx\":\"ReplCoord-1\",\"msg\":\"Resetting sync source to empty\",\"attr\":{\"previousSyncSource\":\":27017\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.188+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21359,   \"ctx\":\"ReplCoord-1\",\"msg\":\"Entering primary catch-up mode\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.188+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015304, \"ctx\":\"ReplCoord-1\",\"msg\":\"Skipping primary catchup since we are the only node in the replica set.\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.188+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21363,   \"ctx\":\"ReplCoord-1\",\"msg\":\"Exited primary catch-up mode\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.188+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21107,   \"ctx\":\"ReplCoord-1\",\"msg\":\"Stopping replication producer\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.189+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21239,   \"ctx\":\"ReplBatcher\",\"msg\":\"Oplog buffer has been drained\",\"attr\":{\"term\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.189+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21239,   \"ctx\":\"ReplBatcher\",\"msg\":\"Oplog buffer has been drained\",\"attr\":{\"term\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.191+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21343,   \"ctx\":\"RstlKillOpThread\",\"msg\":\"Starting to kill user operations\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.191+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21344,   \"ctx\":\"RstlKillOpThread\",\"msg\":\"Stopped killing user operations\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.191+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21340,   \"ctx\":\"RstlKillOpThread\",\"msg\":\"State transition ops metrics\",\"attr\":{\"metrics\":{\"lastStateTransition\":\"stepUp\",\"userOpsKilled\":0,\"userOpsRunning\":1}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.192+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":4508103, \"ctx\":\"OplogApplier-0\",\"msg\":\"Increment the config term via reconfig\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.192+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015313, \"ctx\":\"OplogApplier-0\",\"msg\":\"Replication config state is Steady, starting reconfig\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.193+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015317, \"ctx\":\"OplogApplier-0\",\"msg\":\"Setting new configuration state\",\"attr\":{\"newState\":\"ConfigReconfiguring\",\"oldState\":\"ConfigSteady\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.197+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21353,   \"ctx\":\"OplogApplier-0\",\"msg\":\"replSetReconfig config object parses ok\",\"attr\":{\"numMembers\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.197+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":51814,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Persisting new config to disk\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.200+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015315, \"ctx\":\"OplogApplier-0\",\"msg\":\"Persisted new config to disk\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.200+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015317, \"ctx\":\"OplogApplier-0\",\"msg\":\"Setting new configuration state\",\"attr\":{\"newState\":\"ConfigSteady\",\"oldState\":\"ConfigReconfiguring\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.201+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21392,   \"ctx\":\"OplogApplier-0\",\"msg\":\"New replica set config in use\",\"attr\":{\"config\":{\"_id\":\"rs-localdev\",\"version\":1,\"term\":1,\"members\":[{\"_id\":0,\"host\":\"mongod-local7780:27017\",\"arbiterOnly\":false,\"buildIndexes\":true,\"hidden\":false,\"priority\":1,\"tags\":{},\"horizons\":{\"external\":\"localhost:54257\"},\"secondaryDelaySecs\":0,\"votes\":1}],\"protocolVersion\":1,\"writeConcernMajorityJournalDefault\":true,\"settings\":{\"chainingAllowed\":true,\"heartbeatIntervalMillis\":2000,\"heartbeatTimeoutSecs\":10,\"electionTimeoutMillis\":10000,\"catchUpTimeoutMillis\":-1,\"catchUpTakeoverDelayMillis\":30000,\"getLastErrorModes\":{},\"getLastErrorDefaults\":{\"w\":1,\"wtimeout\":0},\"replicaSetId\":{\"$oid\":\"64feee026a202760384f8210\"}}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.201+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21393,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Found self in config\",\"attr\":{\"hostAndPort\":\"mongod-local7780:27017\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.202+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015310, \"ctx\":\"OplogApplier-0\",\"msg\":\"Starting to transition to primary.\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.206+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"OplogApplier-0\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"config.transactions\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"2e4b6639-84e2-4308-8175-16d453edb006\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.222+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"2e4b6639-84e2-4308-8175-16d453edb006\"}},\"namespace\":\"config.transactions\",\"index\":\"_id_\",\"ident\":\"index-20--1505117970824694136\",\"collectionIdent\":\"collection-19--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":3}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.236+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"2e4b6639-84e2-4308-8175-16d453edb006\"}},\"namespace\":\"config.transactions\",\"index\":\"parent_lsid\",\"ident\":\"index-21--1505117970824694136\",\"collectionIdent\":\"collection-19--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":4}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.240+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"OplogApplier-0\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"config.image_collection\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"6df4c01b-0f89-4efa-9463-bdbb9ac91285\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.257+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"6df4c01b-0f89-4efa-9463-bdbb9ac91285\"}},\"namespace\":\"config.image_collection\",\"index\":\"_id_\",\"ident\":\"index-23--1505117970824694136\",\"collectionIdent\":\"collection-22--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":5}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.264+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015309, \"ctx\":\"OplogApplier-0\",\"msg\":\"Logging transition to primary to oplog on stepup\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.275+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20657,   \"ctx\":\"OplogApplier-0\",\"msg\":\"IndexBuildsCoordinator::onStepUp - this node is stepping up to primary\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.276+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"OplogApplier-0\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"config.system.indexBuilds\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"4035b62f-4040-4d75-aab9-97631d521acb\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.293+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"4035b62f-4040-4d75-aab9-97631d521acb\"}},\"namespace\":\"config.system.indexBuilds\",\"index\":\"_id_\",\"ident\":\"index-25--1505117970824694136\",\"collectionIdent\":\"collection-24--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":7}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.296+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"OplogApplier-0\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"config.system.preimages\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"4361787b-bd79-42d6-8e7c-effac3c4ce26\"}},\"options\":{\"clusteredIndex\":true}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.307+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":21331,   \"ctx\":\"OplogApplier-0\",\"msg\":\"Transition to primary complete; database writes are now permitted\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.309+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":6015306, \"ctx\":\"OplogApplier-0\",\"msg\":\"Applier already left draining state, exiting.\"}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.314+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"monitoring-keys-for-HMAC\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"admin.system.keys\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"518c371e-058a-4809-917e-ee6705f1222e\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.343+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"TenantMigrationDonorService-0\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"config.tenantMigrationDonors\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"b115691f-420d-4d4b-8ba4-1af9df11095f\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.343+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"TenantMigrationRecipientService-0\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"config.tenantMigrationRecipients\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"cf40e728-19f5-47e2-90c9-cdd4bff4b493\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.347+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5123005, \"ctx\":\"ShardSplitDonorService-0\",\"msg\":\"Rebuilding PrimaryOnlyService due to stepUp\",\"attr\":{\"service\":\"ShardSplitDonorService\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.360+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"monitoring-keys-for-HMAC\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"518c371e-058a-4809-917e-ee6705f1222e\"}},\"namespace\":\"admin.system.keys\",\"index\":\"_id_\",\"ident\":\"index-28--1505117970824694136\",\"collectionIdent\":\"collection-27--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":9}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.400+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"TenantMigrationRecipientService-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"cf40e728-19f5-47e2-90c9-cdd4bff4b493\"}},\"namespace\":\"config.tenantMigrationRecipients\",\"index\":\"_id_\",\"ident\":\"index-32--1505117970824694136\",\"collectionIdent\":\"collection-30--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":14}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.401+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"TenantMigrationDonorService-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"b115691f-420d-4d4b-8ba4-1af9df11095f\"}},\"namespace\":\"config.tenantMigrationDonors\",\"index\":\"_id_\",\"ident\":\"index-31--1505117970824694136\",\"collectionIdent\":\"collection-29--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":13}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.403+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"TenantMigrationDonorService-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"b115691f-420d-4d4b-8ba4-1af9df11095f\"}},\"namespace\":\"config.tenantMigrationDonors\",\"index\":\"TenantMigrationDonorTTLIndex\",\"ident\":\"index-33--1505117970824694136\",\"collectionIdent\":\"collection-29--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":13}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.404+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"TenantMigrationRecipientService-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"cf40e728-19f5-47e2-90c9-cdd4bff4b493\"}},\"namespace\":\"config.tenantMigrationRecipients\",\"index\":\"TenantMigrationRecipientTTLIndex\",\"ident\":\"index-34--1505117970824694136\",\"collectionIdent\":\"collection-30--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":14}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.407+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5123005, \"ctx\":\"TenantMigrationRecipientService-1\",\"msg\":\"Rebuilding PrimaryOnlyService due to stepUp\",\"attr\":{\"service\":\"TenantMigrationRecipientService\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.412+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"TenantMigrationDonorService-0\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"config.external_validation_keys\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"1f65d912-1c4e-4a66-aabb-f30e33c1e966\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.435+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"TenantMigrationDonorService-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"1f65d912-1c4e-4a66-aabb-f30e33c1e966\"}},\"namespace\":\"config.external_validation_keys\",\"index\":\"_id_\",\"ident\":\"index-36--1505117970824694136\",\"collectionIdent\":\"collection-35--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":16}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.436+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"TenantMigrationDonorService-0\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"1f65d912-1c4e-4a66-aabb-f30e33c1e966\"}},\"namespace\":\"config.external_validation_keys\",\"index\":\"ExternalKeysTTLIndex\",\"ident\":\"index-37--1505117970824694136\",\"collectionIdent\":\"collection-35--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428675,\"i\":16}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.438+00:00\"},\"s\":\"I\",  \"c\":\"REPL\",     \"id\":5123005, \"ctx\":\"TenantMigrationDonorService-1\",\"msg\":\"Rebuilding PrimaryOnlyService due to stepUp\",\"attr\":{\"service\":\"TenantMigrationDonorService\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:55.505+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"monitoring-keys-for-HMAC\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.system.keys\",\"command\":{\"insert\":\"system.keys\",\"bypassDocumentValidation\":false,\"ordered\":true,\"documents\":[{\"purpose\":\"HMAC\",\"key\":{\"$binary\":{\"base64\":\"JyT61C2DdlKGq7B/KKOHXFT1wzY=\",\"subType\":\"0\"}},\"expiresAt\":{\"$timestamp\":{\"t\":1702204675,\"i\":0}},\"_id\":7277515744529612806}],\"writeConcern\":{\"w\":\"majority\",\"wtimeout\":60000},\"$db\":\"admin\"},\"ninserted\":1,\"keysInserted\":1,\"numYields\":0,\"reslen\":230,\"locks\":{\"ParallelBatchWriterMode\":{\"acquireCount\":{\"r\":3}},\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":2,\"w\":3}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":4},\"acquireWaitCount\":{\"w\":1},\"timeAcquiringMicros\":{\"w\":31793}},\"Global\":{\"acquireCount\":{\"r\":2,\"w\":3}},\"Database\":{\"acquireCount\":{\"w\":3}},\"Collection\":{\"acquireCount\":{\"w\":3}},\"Mutex\":{\"acquireCount\":{\"r\":5}}},\"flowControl\":{\"acquireCount\":3,\"timeAcquiringMicros\":26},\"writeConcern\":{\"w\":\"majority\",\"wtimeout\":60000,\"provenance\":\"clientSupplied\"},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":233}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.042+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn9\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33598\",\"uuid\":\"62aeb486-b64a-40e3-814f-080e51b67a4a\",\"connectionId\":9,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.042+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn7\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33578\",\"uuid\":\"f0044fd2-4d9c-456f-8a9a-7410ad455e35\",\"connectionId\":7,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.042+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn8\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33592\",\"uuid\":\"a9235dbd-e79b-4f5b-931a-6a3528564a38\",\"connectionId\":8,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.042+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":20883,   \"ctx\":\"conn6\",\"msg\":\"Interrupted operation as its client disconnected\",\"attr\":{\"opId\":273}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.047+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn6\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33566\",\"uuid\":\"d3e419b6-a1fc-4f83-93f5-f12a1844ec2a\",\"connectionId\":6,\"connectionCount\":0}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.396+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33608\",\"uuid\":\"7c1fdf0e-10f0-4448-b8db-a58bf1cce225\",\"connectionId\":10,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.398+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn10\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33608\",\"client\":\"conn10\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.407+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33622\",\"uuid\":\"01822960-b364-4bc8-ace2-9685fc9091ab\",\"connectionId\":11,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.407+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33636\",\"uuid\":\"f024d092-6ce1-4425-a9b7-867df1cb19cb\",\"connectionId\":12,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.408+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn11\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33622\",\"client\":\"conn11\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.410+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn12\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33636\",\"client\":\"conn12\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.413+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33642\",\"uuid\":\"36e4059d-d205-4874-a3cf-2875a7c4ccc8\",\"connectionId\":13,\"connectionCount\":4}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.415+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.2:33654\",\"uuid\":\"6423b337-2e59-4b8a-b116-9d746b2648d2\",\"connectionId\":14,\"connectionCount\":5}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.416+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn13\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33642\",\"client\":\"conn13\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.418+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn14\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.2:33654\",\"client\":\"conn14\",\"doc\":{\"application\":{\"name\":\"mongosh 2.0.0\"},\"driver\":{\"name\":\"nodejs|mongosh\",\"version\":\"6.0.0|2.0.0\"},\"platform\":\"Node.js v20.6.0, LE\",\"os\":{\"name\":\"darwin\",\"architecture\":\"arm64\",\"version\":\"21.6.0\",\"type\":\"Darwin\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.579+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"conn13\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"admin.atlascli\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"dc78ef00-a8b1-450c-9a73-1a1c9db347de\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:56.595+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"conn13\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"dc78ef00-a8b1-450c-9a73-1a1c9db347de\"}},\"namespace\":\"admin.atlascli\",\"index\":\"_id_\",\"ident\":\"index-39--1505117970824694136\",\"collectionIdent\":\"collection-38--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428676,\"i\":1}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:57.489+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":20883,   \"ctx\":\"conn10\",\"msg\":\"Interrupted operation as its client disconnected\",\"attr\":{\"opId\":322}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:57.492+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn11\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33622\",\"uuid\":\"01822960-b364-4bc8-ace2-9685fc9091ab\",\"connectionId\":11,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:57.491+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn13\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33642\",\"uuid\":\"36e4059d-d205-4874-a3cf-2875a7c4ccc8\",\"connectionId\":13,\"connectionCount\":4}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:57.492+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn14\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33654\",\"uuid\":\"6423b337-2e59-4b8a-b116-9d746b2648d2\",\"connectionId\":14,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:57.492+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn12\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33636\",\"uuid\":\"f024d092-6ce1-4425-a9b7-867df1cb19cb\",\"connectionId\":12,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:37:57.496+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn10\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.2:33608\",\"uuid\":\"7c1fdf0e-10f0-4448-b8db-a58bf1cce225\",\"connectionId\":10,\"connectionCount\":0}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:19.871+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":63,\"after activeIndexBuilds\":63,\"after asserts\":63,\"after batchedDeletes\":63,\"after bucketCatalog\":63,\"after catalogStats\":227,\"after connections\":227,\"after electionMetrics\":272,\"after encryptionAtRest\":275,\"after extra_info\":275,\"after flowControl\":298,\"after globalLock\":299,\"after indexBulkBuilder\":299,\"after indexStats\":299,\"after locks\":427,\"after logicalSessionRecordCache\":475,\"after mirroredReads\":475,\"after network\":475,\"after opLatencies\":487,\"after opcounters\":487,\"after opcountersRepl\":487,\"after oplog\":514,\"after oplogTruncation\":514,\"after readConcernCounters\":514,\"after repl\":538,\"after scramCache\":538,\"after security\":559,\"after storageEngine\":559,\"after tcmalloc\":704,\"after tenantMigrations\":704,\"after trafficRecording\":704,\"after transactions\":704,\"after transportSecurity\":704,\"after twoPhaseCommitCoordinator\":704,\"after wiredTiger\":812,\"at end\":1517}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:55.298+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.3:35910\",\"uuid\":\"0df9c44f-dce9-441d-8295-417a258bf0ae\",\"connectionId\":15,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:55.305+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.3:35922\",\"uuid\":\"11e208d4-2e7a-4c5a-8da5-4915f866db2b\",\"connectionId\":16,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:55.429+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn15\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.3:35910\",\"client\":\"conn15\",\"doc\":{\"driver\":{\"name\":\"mongo-java-driver|sync\",\"version\":\"4.4.2\"},\"os\":{\"type\":\"Linux\",\"name\":\"Linux\",\"architecture\":\"amd64\",\"version\":\"6.4.12-200.fc38.aarch64\"},\"platform\":\"Java/Eclipse Adoptium/11.0.14+9\",\"application\":{\"name\":\"mongot initial sync and session refresh\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:55.431+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn16\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.3:35922\",\"client\":\"conn16\",\"doc\":{\"driver\":{\"name\":\"mongo-java-driver|sync\",\"version\":\"4.4.2\"},\"os\":{\"type\":\"Linux\",\"name\":\"Linux\",\"architecture\":\"amd64\",\"version\":\"6.4.12-200.fc38.aarch64\"},\"platform\":\"Java/Eclipse Adoptium/11.0.14+9\",\"application\":{\"name\":\"mongot initial sync and session refresh\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:55.941+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.3:35934\",\"uuid\":\"168900c2-01e3-40ea-96af-e216b33bf698\",\"connectionId\":17,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:55.947+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.3:35944\",\"uuid\":\"b41961a9-0665-4f2e-a9f0-0b6bb26a77bb\",\"connectionId\":18,\"connectionCount\":4}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:56.040+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn18\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.3:35944\",\"client\":\"conn18\",\"doc\":{\"driver\":{\"name\":\"mongo-java-driver|reactive-streams\",\"version\":\"4.4.2\"},\"os\":{\"type\":\"Linux\",\"name\":\"Linux\",\"architecture\":\"amd64\",\"version\":\"6.4.12-200.fc38.aarch64\"},\"platform\":\"Java/Eclipse Adoptium/11.0.14+9\",\"application\":{\"name\":\"mongot steady state\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:38:56.043+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn17\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.3:35934\",\"client\":\"conn17\",\"doc\":{\"driver\":{\"name\":\"mongo-java-driver|reactive-streams\",\"version\":\"4.4.2\"},\"os\":{\"type\":\"Linux\",\"name\":\"Linux\",\"architecture\":\"amd64\",\"version\":\"6.4.12-200.fc38.aarch64\"},\"platform\":\"Java/Eclipse Adoptium/11.0.14+9\",\"application\":{\"name\":\"mongot steady state\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:42:53.284+00:00\"},\"s\":\"I\",  \"c\":\"CONTROL\",  \"id\":20712,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Sessions collection is not set up; waiting until next sessions reap interval\",\"attr\":{\"error\":\"NamespaceNotFound: config.system.sessions does not exist\"}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:42:53.292+00:00\"},\"s\":\"I\",  \"c\":\"STORAGE\",  \"id\":20320,   \"ctx\":\"LogicalSessionCacheRefresh\",\"msg\":\"createCollection\",\"attr\":{\"namespace\":\"config.system.sessions\",\"uuidDisposition\":\"generated\",\"uuid\":{\"uuid\":{\"$uuid\":\"39f470cb-6b61-46bb-a7f9-924d09a00a54\"}},\"options\":{}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:42:53.325+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"LogicalSessionCacheRefresh\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"39f470cb-6b61-46bb-a7f9-924d09a00a54\"}},\"namespace\":\"config.system.sessions\",\"index\":\"_id_\",\"ident\":\"index-41--1505117970824694136\",\"collectionIdent\":\"collection-40--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428973,\"i\":2}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:42:53.326+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":20345,   \"ctx\":\"LogicalSessionCacheRefresh\",\"msg\":\"Index build: done building\",\"attr\":{\"buildUUID\":null,\"collectionUUID\":{\"uuid\":{\"$uuid\":\"39f470cb-6b61-46bb-a7f9-924d09a00a54\"}},\"namespace\":\"config.system.sessions\",\"index\":\"lsidTTLIndex\",\"ident\":\"index-42--1505117970824694136\",\"collectionIdent\":\"collection-40--1505117970824694136\",\"commitTimestamp\":{\"$timestamp\":{\"t\":1694428973,\"i\":2}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T10:46:59.570+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":0,\"after activeIndexBuilds\":0,\"after asserts\":0,\"after batchedDeletes\":0,\"after bucketCatalog\":0,\"after catalogStats\":483,\"after connections\":483,\"after electionMetrics\":543,\"after encryptionAtRest\":615,\"after extra_info\":615,\"after flowControl\":615,\"after globalLock\":700,\"after indexBulkBuilder\":767,\"after indexStats\":767,\"after locks\":767,\"after logicalSessionRecordCache\":767,\"after mirroredReads\":767,\"after network\":1187,\"after opLatencies\":1267,\"after opcounters\":1267,\"after opcountersRepl\":1267,\"after oplog\":1267,\"after oplogTruncation\":1267,\"after readConcernCounters\":1267,\"after repl\":1268,\"after scramCache\":1268,\"after security\":1300,\"after storageEngine\":1300,\"after tcmalloc\":1310,\"after tenantMigrations\":1310,\"after trafficRecording\":1310,\"after transactions\":1310,\"after transportSecurity\":1310,\"after twoPhaseCommitCoordinator\":1320,\"after wiredTiger\":1350,\"at end\":1545}}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:52.171+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn16\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:35922\",\"protocol\":\"op_msg\",\"durationMillis\":185}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:52.422+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn18\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:35944\",\"protocol\":\"op_msg\",\"durationMillis\":213}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:54.614+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn15\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694430758,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:35910\",\"protocol\":\"op_msg\",\"durationMillis\":537}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:54.737+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn17\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694430758,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:35934\",\"protocol\":\"op_msg\",\"durationMillis\":1081}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:55.202+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.system.sessions\",\"command\":{\"listIndexes\":\"system.sessions\",\"cursor\":{},\"$db\":\"config\"},\"numYields\":0,\"reslen\":370,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":1}},\"Global\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":1}}},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":343}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:56.035+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.system.sessions\",\"command\":{\"find\":\"system.sessions\",\"filter\":{\"_id\":{\"$in\":[{\"id\":{\"$uuid\":\"f9840147-f527-4e6f-b777-0f5fa900c75f\"},\"uid\":{\"$binary\":{\"base64\":\"47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\",\"subType\":\"0\"}}}]}},\"projection\":{\"_id\":1},\"batchSize\":1,\"singleBatch\":true,\"limit\":1,\"readConcern\":{},\"$db\":\"config\"},\"planSummary\":\"IXSCAN { _id: 1 }\",\"keysExamined\":1,\"docsExamined\":0,\"cursorExhausted\":true,\"numYields\":0,\"nreturned\":1,\"queryHash\":\"95EC281A\",\"planCacheKey\":\"B48F4DEE\",\"queryFramework\":\"classic\",\"reslen\":321,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":4}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":1}},\"Global\":{\"acquireCount\":{\"r\":4}},\"Database\":{\"acquireCount\":{\"r\":1}},\"Collection\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":2}}},\"readConcern\":{\"provenance\":\"implicitDefault\"},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":207}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:56.244+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":5479200, \"ctx\":\"TTLMonitor\",\"msg\":\"Deleted expired documents using index\",\"attr\":{\"namespace\":\"config.system.sessions\",\"index\":\"lsidTTLIndex\",\"numDeleted\":6,\"durationMillis\":1564}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:56.590+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.transactions\",\"command\":{\"find\":\"transactions\",\"filter\":{\"lastWriteDate\":{\"$lt\":{\"$date\":\"2023-09-11T10:42:55.257Z\"}}},\"projection\":{\"_id\":1},\"sort\":{\"_id\":1},\"readConcern\":{},\"$db\":\"config\"},\"planSummary\":\"IXSCAN { _id: 1 }\",\"keysExamined\":1,\"docsExamined\":1,\"cursorExhausted\":true,\"numYields\":1,\"nreturned\":1,\"queryHash\":\"C8660328\",\"planCacheKey\":\"6B6211C4\",\"queryFramework\":\"classic\",\"reslen\":318,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":7}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":1}},\"Global\":{\"acquireCount\":{\"r\":7}},\"Database\":{\"acquireCount\":{\"r\":1}},\"Collection\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":3}}},\"readConcern\":{\"provenance\":\"implicitDefault\"},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":376}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:57.486+00:00\"},\"s\":\"I\",  \"c\":\"WRITE\",    \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"remove\",\"ns\":\"config.image_collection\",\"command\":{\"q\":{\"_id\":{\"id\":{\"$uuid\":\"f9840147-f527-4e6f-b777-0f5fa900c75f\"},\"uid\":{\"$binary\":{\"base64\":\"47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\",\"subType\":\"0\"}}}},\"limit\":1},\"planSummary\":\"IDHACK\",\"keysExamined\":0,\"docsExamined\":0,\"ndeleted\":0,\"numYields\":0,\"locks\":{\"ParallelBatchWriterMode\":{\"acquireCount\":{\"r\":1}},\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":10,\"w\":1}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":3}},\"Global\":{\"acquireCount\":{\"r\":10,\"w\":1}},\"Database\":{\"acquireCount\":{\"r\":2,\"w\":1}},\"Collection\":{\"acquireCount\":{\"r\":2,\"w\":1}},\"Mutex\":{\"acquireCount\":{\"r\":5}}},\"flowControl\":{\"acquireCount\":1,\"timeAcquiringMicros\":51},\"storage\":{},\"durationMillis\":438}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:57.521+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.$cmd\",\"command\":{\"delete\":\"image_collection\",\"bypassDocumentValidation\":false,\"ordered\":false,\"$db\":\"config\"},\"numYields\":0,\"reslen\":230,\"locks\":{\"ParallelBatchWriterMode\":{\"acquireCount\":{\"r\":1}},\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":12,\"w\":1}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":4}},\"Global\":{\"acquireCount\":{\"r\":12,\"w\":1}},\"Database\":{\"acquireCount\":{\"r\":2,\"w\":1}},\"Collection\":{\"acquireCount\":{\"r\":2,\"w\":1}},\"Mutex\":{\"acquireCount\":{\"r\":5}}},\"flowControl\":{\"acquireCount\":1,\"timeAcquiringMicros\":51},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":494}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:57.805+00:00\"},\"s\":\"I\",  \"c\":\"WRITE\",    \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"remove\",\"ns\":\"config.transactions\",\"command\":{\"q\":{\"_id\":{\"id\":{\"$uuid\":\"f9840147-f527-4e6f-b777-0f5fa900c75f\"},\"uid\":{\"$binary\":{\"base64\":\"47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\",\"subType\":\"0\"}}}},\"limit\":1},\"planSummary\":\"IDHACK\",\"keysExamined\":1,\"docsExamined\":1,\"ndeleted\":1,\"keysDeleted\":2,\"numYields\":1,\"locks\":{\"ParallelBatchWriterMode\":{\"acquireCount\":{\"r\":3}},\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":13,\"w\":3}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":6}},\"Global\":{\"acquireCount\":{\"r\":13,\"w\":3}},\"Database\":{\"acquireCount\":{\"r\":2,\"w\":3}},\"Collection\":{\"acquireCount\":{\"r\":2,\"w\":3}},\"Mutex\":{\"acquireCount\":{\"r\":6}}},\"flowControl\":{\"acquireCount\":3,\"timeAcquiringMicros\":85},\"storage\":{},\"durationMillis\":199}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:12:57.812+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.$cmd\",\"command\":{\"delete\":\"transactions\",\"bypassDocumentValidation\":false,\"ordered\":false,\"$db\":\"config\"},\"numYields\":1,\"reslen\":230,\"locks\":{\"ParallelBatchWriterMode\":{\"acquireCount\":{\"r\":3}},\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":14,\"w\":3}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":6}},\"Global\":{\"acquireCount\":{\"r\":14,\"w\":3}},\"Database\":{\"acquireCount\":{\"r\":2,\"w\":3}},\"Collection\":{\"acquireCount\":{\"r\":2,\"w\":3}},\"Mutex\":{\"acquireCount\":{\"r\":6}}},\"flowControl\":{\"acquireCount\":3,\"timeAcquiringMicros\":85},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":208}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:13:03.753+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn16\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:35922\",\"protocol\":\"op_msg\",\"durationMillis\":375}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:13:04.999+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn18\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:35944\",\"protocol\":\"op_msg\",\"durationMillis\":311}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:13:26.444+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":24,\"after activeIndexBuilds\":38,\"after asserts\":38,\"after batchedDeletes\":38,\"after bucketCatalog\":38,\"after catalogStats\":38,\"after connections\":50,\"after electionMetrics\":50,\"after encryptionAtRest\":51,\"after extra_info\":51,\"after flowControl\":58,\"after globalLock\":58,\"after indexBulkBuilder\":58,\"after indexStats\":66,\"after locks\":66,\"after logicalSessionRecordCache\":66,\"after mirroredReads\":66,\"after network\":66,\"after opLatencies\":66,\"after opcounters\":66,\"after opcountersRepl\":66,\"after oplog\":67,\"after oplogTruncation\":67,\"after readConcernCounters\":67,\"after repl\":86,\"after scramCache\":86,\"after security\":86,\"after storageEngine\":86,\"after tcmalloc\":593,\"after tenantMigrations\":593,\"after trafficRecording\":593,\"after transactions\":593,\"after transportSecurity\":593,\"after twoPhaseCommitCoordinator\":593,\"after wiredTiger\":1218,\"at end\":1428}}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:13:26.842+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn17\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694430788,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:35934\",\"protocol\":\"op_msg\",\"durationMillis\":193}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:13:26.838+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn15\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694430798,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:35910\",\"protocol\":\"op_msg\",\"durationMillis\":472}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:13:27.761+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn18\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:35944\",\"protocol\":\"op_msg\",\"durationMillis\":960}}",
      "{\"t\":{\"$date\":\"2023-09-11T11:13:35.216+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":0,\"after activeIndexBuilds\":0,\"after asserts\":0,\"after batchedDeletes\":0,\"after bucketCatalog\":0,\"after catalogStats\":0,\"after connections\":0,\"after electionMetrics\":0,\"after encryptionAtRest\":19,\"after extra_info\":19,\"after flowControl\":19,\"after globalLock\":44,\"after indexBulkBuilder\":44,\"after indexStats\":44,\"after locks\":44,\"after logicalSessionRecordCache\":44,\"after mirroredReads\":44,\"after network\":97,\"after opLatencies\":97,\"after opcounters\":97,\"after opcountersRepl\":97,\"after oplog\":97,\"after oplogTruncation\":97,\"after readConcernCounters\":97,\"after repl\":123,\"after scramCache\":123,\"after security\":168,\"after storageEngine\":340,\"after tcmalloc\":441,\"after tenantMigrations\":441,\"after trafficRecording\":459,\"after transactions\":459,\"after transportSecurity\":459,\"after twoPhaseCommitCoordinator\":459,\"after wiredTiger\":851,\"at end\":1144}}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:08:15.951+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":171,\"after activeIndexBuilds\":273,\"after asserts\":273,\"after batchedDeletes\":273,\"after bucketCatalog\":287,\"after catalogStats\":297,\"after connections\":297,\"after electionMetrics\":297,\"after encryptionAtRest\":298,\"after extra_info\":317,\"after flowControl\":472,\"after globalLock\":546,\"after indexBulkBuilder\":546,\"after indexStats\":546,\"after locks\":561,\"after logicalSessionRecordCache\":561,\"after mirroredReads\":572,\"after network\":854,\"after opLatencies\":854,\"after opcounters\":854,\"after opcountersRepl\":854,\"after oplog\":856,\"after oplogTruncation\":856,\"after readConcernCounters\":856,\"after repl\":909,\"after scramCache\":909,\"after security\":909,\"after storageEngine\":955,\"after tcmalloc\":1037,\"after tenantMigrations\":1037,\"after trafficRecording\":1037,\"after transactions\":1037,\"after transportSecurity\":1037,\"after twoPhaseCommitCoordinator\":1037,\"after wiredTiger\":1060,\"at end\":1094}}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:44:49.786+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn18\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:35944\",\"protocol\":\"op_msg\",\"durationMillis\":131}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:01.214+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":5479200, \"ctx\":\"TTLMonitor\",\"msg\":\"Deleted expired documents using index\",\"attr\":{\"namespace\":\"config.tenantMigrationRecipients\",\"index\":\"TenantMigrationRecipientTTLIndex\",\"numDeleted\":0,\"durationMillis\":677}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:02.795+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn17\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694439884,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:35934\",\"protocol\":\"op_msg\",\"durationMillis\":1086}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:04.681+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn15\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694439884,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:35910\",\"protocol\":\"op_msg\",\"durationMillis\":1877}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:12.038+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn18\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:35944\",\"protocol\":\"op_msg\",\"durationMillis\":497}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:16.038+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn16\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:35922\",\"protocol\":\"op_msg\",\"durationMillis\":243}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.686+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":208,\"after activeIndexBuilds\":224,\"after asserts\":224,\"after batchedDeletes\":224,\"after bucketCatalog\":224,\"after catalogStats\":224,\"after connections\":224,\"after electionMetrics\":284,\"after encryptionAtRest\":342,\"after extra_info\":342,\"after flowControl\":342,\"after globalLock\":342,\"after indexBulkBuilder\":342,\"after indexStats\":342,\"after locks\":342,\"after logicalSessionRecordCache\":438,\"after mirroredReads\":438,\"after network\":759,\"after opLatencies\":784,\"after opcounters\":784,\"after opcountersRepl\":784,\"after oplog\":784,\"after oplogTruncation\":811,\"after readConcernCounters\":811,\"after repl\":1314,\"after scramCache\":1314,\"after security\":1336,\"after storageEngine\":1336,\"after tcmalloc\":1731,\"after tenantMigrations\":1731,\"after trafficRecording\":1731,\"after transactions\":1731,\"after transportSecurity\":1786,\"after twoPhaseCommitCoordinator\":1786,\"after wiredTiger\":2910,\"at end\":7447}}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.883+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":20883,   \"ctx\":\"conn16\",\"msg\":\"Interrupted operation as its client disconnected\",\"attr\":{\"opId\":163365}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.888+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn15\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.3:35910\",\"uuid\":\"0df9c44f-dce9-441d-8295-417a258bf0ae\",\"connectionId\":15,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.935+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn16\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\"},\"numYields\":0,\"ok\":0,\"errMsg\":\"operation was interrupted\",\"errName\":\"ClientDisconnect\",\"errCode\":279,\"reslen\":242,\"locks\":{},\"remote\":\"10.89.3.3:35922\",\"protocol\":\"op_msg\",\"durationMillis\":702}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.939+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22989,   \"ctx\":\"conn16\",\"msg\":\"Error sending response to client. Ending connection from remote\",\"attr\":{\"error\":{\"code\":6,\"codeName\":\"HostUnreachable\",\"errmsg\":\"Connection reset by peer\"},\"remote\":\"10.89.3.3:35922\",\"connectionId\":16}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.955+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn16\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.3:35922\",\"uuid\":\"11e208d4-2e7a-4c5a-8da5-4915f866db2b\",\"connectionId\":16,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.964+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":20883,   \"ctx\":\"conn18\",\"msg\":\"Interrupted operation as its client disconnected\",\"attr\":{\"opId\":163345}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.975+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22989,   \"ctx\":\"conn18\",\"msg\":\"Error sending response to client. Ending connection from remote\",\"attr\":{\"error\":{\"code\":6,\"codeName\":\"HostUnreachable\",\"errmsg\":\"Connection reset by peer\"},\"remote\":\"10.89.3.3:35944\",\"connectionId\":18}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:22.979+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn18\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.3:35944\",\"uuid\":\"b41961a9-0665-4f2e-a9f0-0b6bb26a77bb\",\"connectionId\":18,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:23.961+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.3:58610\",\"uuid\":\"85dc6b6f-e4c5-4822-b1e6-2b6295069ebc\",\"connectionId\":19,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:24.074+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn19\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.3:58610\",\"client\":\"conn19\",\"doc\":{\"driver\":{\"name\":\"mongo-java-driver|reactive-streams\",\"version\":\"4.4.2\"},\"os\":{\"type\":\"Linux\",\"name\":\"Linux\",\"architecture\":\"amd64\",\"version\":\"6.4.12-200.fc38.aarch64\"},\"platform\":\"Java/Eclipse Adoptium/11.0.14+9\",\"application\":{\"name\":\"mongot steady state\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:24.208+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.3:58620\",\"uuid\":\"d1645692-74ed-4e2c-8d84-ab366ff3bd51\",\"connectionId\":20,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:24.225+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn20\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.3:58620\",\"client\":\"conn20\",\"doc\":{\"driver\":{\"name\":\"mongo-java-driver|sync\",\"version\":\"4.4.2\"},\"os\":{\"type\":\"Linux\",\"name\":\"Linux\",\"architecture\":\"amd64\",\"version\":\"6.4.12-200.fc38.aarch64\"},\"platform\":\"Java/Eclipse Adoptium/11.0.14+9\",\"application\":{\"name\":\"mongot initial sync and session refresh\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:32.926+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22943,   \"ctx\":\"listener\",\"msg\":\"Connection accepted\",\"attr\":{\"remote\":\"10.89.3.3:45694\",\"uuid\":\"cc7add2b-570e-446e-8fa3-4ab73fc72208\",\"connectionId\":21,\"connectionCount\":4}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:45:32.938+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":51800,   \"ctx\":\"conn21\",\"msg\":\"client metadata\",\"attr\":{\"remote\":\"10.89.3.3:45694\",\"client\":\"conn21\",\"doc\":{\"driver\":{\"name\":\"mongo-java-driver|sync\",\"version\":\"4.4.2\"},\"os\":{\"type\":\"Linux\",\"name\":\"Linux\",\"architecture\":\"amd64\",\"version\":\"6.4.12-200.fc38.aarch64\"},\"platform\":\"Java/Eclipse Adoptium/11.0.14+9\",\"application\":{\"name\":\"mongot initial sync and session refresh\"}}}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:09.892+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":5479200, \"ctx\":\"TTLMonitor\",\"msg\":\"Deleted expired documents using index\",\"attr\":{\"namespace\":\"config.external_validation_keys\",\"index\":\"ExternalKeysTTLIndex\",\"numDeleted\":0,\"durationMillis\":2816}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:12.049+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":5479200, \"ctx\":\"TTLMonitor\",\"msg\":\"Deleted expired documents using index\",\"attr\":{\"namespace\":\"config.system.sessions\",\"index\":\"lsidTTLIndex\",\"numDeleted\":0,\"durationMillis\":437}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:11.639+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn20\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694439884,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:58620\",\"protocol\":\"op_msg\",\"durationMillis\":494}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:13.294+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":5479200, \"ctx\":\"TTLMonitor\",\"msg\":\"Deleted expired documents using index\",\"attr\":{\"namespace\":\"config.tenantMigrationDonors\",\"index\":\"TenantMigrationDonorTTLIndex\",\"numDeleted\":0,\"durationMillis\":274}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:13.374+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn19\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694439917,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:58610\",\"protocol\":\"op_msg\",\"durationMillis\":196}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:13.826+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":120,\"after activeIndexBuilds\":461,\"after asserts\":461,\"after batchedDeletes\":461,\"after bucketCatalog\":461,\"after catalogStats\":461,\"after connections\":461,\"after electionMetrics\":586,\"after encryptionAtRest\":1275,\"after extra_info\":2310,\"after flowControl\":2310,\"after globalLock\":2310,\"after indexBulkBuilder\":2310,\"after indexStats\":2310,\"after locks\":2494,\"after logicalSessionRecordCache\":2494,\"after mirroredReads\":2556,\"after network\":2556,\"after opLatencies\":2556,\"after opcounters\":2556,\"after opcountersRepl\":2556,\"after oplog\":2557,\"after oplogTruncation\":2557,\"after readConcernCounters\":2625,\"after repl\":2698,\"after scramCache\":2736,\"after security\":2736,\"after storageEngine\":2736,\"after tcmalloc\":3123,\"after tenantMigrations\":3123,\"after trafficRecording\":3123,\"after transactions\":3176,\"after transportSecurity\":3176,\"after twoPhaseCommitCoordinator\":3176,\"after wiredTiger\":4057,\"at end\":6336}}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:17.205+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn21\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694440630,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:45694\",\"protocol\":\"op_msg\",\"durationMillis\":2300}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:17.836+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn17\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694440618,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:35934\",\"protocol\":\"op_msg\",\"durationMillis\":2855}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:36.696+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn17\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694440630,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:35934\",\"protocol\":\"op_msg\",\"durationMillis\":3218}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:35.419+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn20\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694439884,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:58620\",\"protocol\":\"op_msg\",\"durationMillis\":2047}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:36.491+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn21\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot initial sync and session refresh\",\"command\":{\"hello\":1,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694440630,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":770,\"locks\":{},\"remote\":\"10.89.3.3:45694\",\"protocol\":\"op_msg\",\"durationMillis\":3281}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:46.872+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"conn19\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"admin.$cmd\",\"appName\":\"mongot steady state\",\"command\":{\"hello\":1,\"helloOk\":true,\"topologyVersion\":{\"processId\":{\"$oid\":\"64feedff6a202760384f81e6\"},\"counter\":6},\"maxAwaitTimeMS\":10000,\"$db\":\"admin\",\"$clusterTime\":{\"clusterTime\":{\"$timestamp\":{\"t\":1694439917,\"i\":1}},\"signature\":{\"hash\":{\"$binary\":{\"base64\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"subType\":\"0\"}},\"keyId\":0}}},\"numYields\":0,\"reslen\":780,\"locks\":{},\"remote\":\"10.89.3.3:58610\",\"protocol\":\"op_msg\",\"durationMillis\":814}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:47.060+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":20883,   \"ctx\":\"conn20\",\"msg\":\"Interrupted operation as its client disconnected\",\"attr\":{\"opId\":173863}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:47.076+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn17\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.3:35934\",\"uuid\":\"168900c2-01e3-40ea-96af-e216b33bf698\",\"connectionId\":17,\"connectionCount\":3}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:47.156+00:00\"},\"s\":\"I\",  \"c\":\"-\",        \"id\":20883,   \"ctx\":\"conn19\",\"msg\":\"Interrupted operation as its client disconnected\",\"attr\":{\"opId\":173865}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:47.172+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn21\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.3:45694\",\"uuid\":\"cc7add2b-570e-446e-8fa3-4ab73fc72208\",\"connectionId\":21,\"connectionCount\":2}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:47.268+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22989,   \"ctx\":\"conn19\",\"msg\":\"Error sending response to client. Ending connection from remote\",\"attr\":{\"error\":{\"code\":9001,\"codeName\":\"SocketException\",\"errmsg\":\"Broken pipe\"},\"remote\":\"10.89.3.3:58610\",\"connectionId\":19}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:47.280+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22989,   \"ctx\":\"conn20\",\"msg\":\"Error sending response to client. Ending connection from remote\",\"attr\":{\"error\":{\"code\":9001,\"codeName\":\"SocketException\",\"errmsg\":\"Broken pipe\"},\"remote\":\"10.89.3.3:58620\",\"connectionId\":20}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:47.301+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn20\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.3:58620\",\"uuid\":\"d1645692-74ed-4e2c-8d84-ab366ff3bd51\",\"connectionId\":20,\"connectionCount\":1}}",
      "{\"t\":{\"$date\":\"2023-09-11T13:57:47.312+00:00\"},\"s\":\"I\",  \"c\":\"NETWORK\",  \"id\":22944,   \"ctx\":\"conn19\",\"msg\":\"Connection ended\",\"attr\":{\"remote\":\"10.89.3.3:58610\",\"uuid\":\"85dc6b6f-e4c5-4822-b1e6-2b6295069ebc\",\"connectionId\":19,\"connectionCount\":0}}",
      "{\"t\":{\"$date\":\"2023-09-11T14:02:52.393+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":1,\"after activeIndexBuilds\":1,\"after asserts\":1,\"after batchedDeletes\":1,\"after bucketCatalog\":1,\"after catalogStats\":1,\"after connections\":1,\"after electionMetrics\":1,\"after encryptionAtRest\":1,\"after extra_info\":1,\"after flowControl\":1,\"after globalLock\":1,\"after indexBulkBuilder\":1,\"after indexStats\":1,\"after locks\":1,\"after logicalSessionRecordCache\":1,\"after mirroredReads\":1,\"after network\":1,\"after opLatencies\":1,\"after opcounters\":1,\"after opcountersRepl\":1,\"after oplog\":144,\"after oplogTruncation\":144,\"after readConcernCounters\":187,\"after repl\":265,\"after scramCache\":265,\"after security\":276,\"after storageEngine\":359,\"after tcmalloc\":359,\"after tenantMigrations\":359,\"after trafficRecording\":359,\"after transactions\":359,\"after transportSecurity\":359,\"after twoPhaseCommitCoordinator\":359,\"after wiredTiger\":1558,\"at end\":2293}}}",
      "{\"t\":{\"$date\":\"2023-09-11T14:03:07.840+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.system.sessions\",\"command\":{\"listIndexes\":\"system.sessions\",\"cursor\":{},\"$db\":\"config\"},\"numYields\":0,\"reslen\":370,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":1}},\"Global\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":1}}},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":6036}}",
      "{\"t\":{\"$date\":\"2023-09-11T14:03:09.639+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheRefresh\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.system.sessions\",\"command\":{\"listIndexes\":\"system.sessions\",\"cursor\":{},\"$db\":\"config\"},\"numYields\":0,\"reslen\":370,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":2}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":1}},\"Global\":{\"acquireCount\":{\"r\":2}},\"Database\":{\"acquireCount\":{\"r\":1}},\"Collection\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":1}}},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":6695}}",
      "{\"t\":{\"$date\":\"2023-09-11T14:03:21.293+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.transactions\",\"command\":{\"find\":\"transactions\",\"filter\":{\"lastWriteDate\":{\"$lt\":{\"$date\":\"2023-09-11T13:33:20.872Z\"}}},\"projection\":{\"_id\":1},\"sort\":{\"_id\":1},\"readConcern\":{},\"$db\":\"config\"},\"planSummary\":\"IXSCAN { _id: 1 }\",\"keysExamined\":0,\"docsExamined\":0,\"cursorExhausted\":true,\"numYields\":0,\"nreturned\":0,\"queryHash\":\"C8660328\",\"planCacheKey\":\"6B6211C4\",\"queryFramework\":\"classic\",\"reslen\":233,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":4}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":1}},\"Global\":{\"acquireCount\":{\"r\":4}},\"Database\":{\"acquireCount\":{\"r\":1}},\"Collection\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":2}}},\"readConcern\":{\"provenance\":\"implicitDefault\"},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":179}}",
      "{\"t\":{\"$date\":\"2023-09-11T14:07:53.652+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheRefresh\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.system.sessions\",\"command\":{\"listIndexes\":\"system.sessions\",\"cursor\":{},\"$db\":\"config\"},\"numYields\":0,\"reslen\":370,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":2}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":1}},\"Global\":{\"acquireCount\":{\"r\":2}},\"Database\":{\"acquireCount\":{\"r\":1}},\"Collection\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":1}}},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":107}}",
      "{\"t\":{\"$date\":\"2023-09-11T14:08:07.769+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":0,\"after activeIndexBuilds\":0,\"after asserts\":0,\"after batchedDeletes\":0,\"after bucketCatalog\":0,\"after catalogStats\":0,\"after connections\":0,\"after electionMetrics\":0,\"after encryptionAtRest\":55,\"after extra_info\":90,\"after flowControl\":171,\"after globalLock\":247,\"after indexBulkBuilder\":247,\"after indexStats\":247,\"after locks\":321,\"after logicalSessionRecordCache\":321,\"after mirroredReads\":339,\"after network\":339,\"after opLatencies\":339,\"after opcounters\":339,\"after opcountersRepl\":339,\"after oplog\":342,\"after oplogTruncation\":342,\"after readConcernCounters\":342,\"after repl\":391,\"after scramCache\":391,\"after security\":406,\"after storageEngine\":406,\"after tcmalloc\":507,\"after tenantMigrations\":507,\"after trafficRecording\":507,\"after transactions\":507,\"after transportSecurity\":507,\"after twoPhaseCommitCoordinator\":507,\"after wiredTiger\":889,\"at end\":1627}}}",
      "{\"t\":{\"$date\":\"2023-09-11T14:08:16.895+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":1,\"after activeIndexBuilds\":1,\"after asserts\":1,\"after batchedDeletes\":1,\"after bucketCatalog\":1,\"after catalogStats\":1,\"after connections\":1,\"after electionMetrics\":1,\"after encryptionAtRest\":2,\"after extra_info\":2,\"after flowControl\":2,\"after globalLock\":2,\"after indexBulkBuilder\":2,\"after indexStats\":86,\"after locks\":86,\"after logicalSessionRecordCache\":86,\"after mirroredReads\":86,\"after network\":86,\"after opLatencies\":86,\"after opcounters\":138,\"after opcountersRepl\":138,\"after oplog\":138,\"after oplogTruncation\":174,\"after readConcernCounters\":174,\"after repl\":527,\"after scramCache\":710,\"after security\":725,\"after storageEngine\":725,\"after tcmalloc\":800,\"after tenantMigrations\":800,\"after trafficRecording\":800,\"after transactions\":800,\"after transportSecurity\":800,\"after twoPhaseCommitCoordinator\":800,\"after wiredTiger\":1190,\"at end\":3868}}}",
      "{\"t\":{\"$date\":\"2023-09-11T14:08:23.219+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":0,\"after activeIndexBuilds\":0,\"after asserts\":0,\"after batchedDeletes\":0,\"after bucketCatalog\":0,\"after catalogStats\":0,\"after connections\":0,\"after electionMetrics\":0,\"after encryptionAtRest\":1,\"after extra_info\":1,\"after flowControl\":1,\"after globalLock\":1,\"after indexBulkBuilder\":1,\"after indexStats\":1,\"after locks\":1,\"after logicalSessionRecordCache\":1,\"after mirroredReads\":1,\"after network\":10,\"after opLatencies\":10,\"after opcounters\":10,\"after opcountersRepl\":10,\"after oplog\":10,\"after oplogTruncation\":10,\"after readConcernCounters\":10,\"after repl\":11,\"after scramCache\":11,\"after security\":11,\"after storageEngine\":11,\"after tcmalloc\":132,\"after tenantMigrations\":132,\"after trafficRecording\":132,\"after transactions\":132,\"after transportSecurity\":132,\"after twoPhaseCommitCoordinator\":132,\"after wiredTiger\":182,\"at end\":1095}}}",
      "{\"t\":{\"$date\":\"2023-09-11T17:00:08.133+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":0,\"after activeIndexBuilds\":0,\"after asserts\":0,\"after batchedDeletes\":0,\"after bucketCatalog\":0,\"after catalogStats\":0,\"after connections\":0,\"after electionMetrics\":0,\"after encryptionAtRest\":1,\"after extra_info\":1,\"after flowControl\":1,\"after globalLock\":1,\"after indexBulkBuilder\":371,\"after indexStats\":371,\"after locks\":372,\"after logicalSessionRecordCache\":481,\"after mirroredReads\":481,\"after network\":481,\"after opLatencies\":481,\"after opcounters\":481,\"after opcountersRepl\":481,\"after oplog\":482,\"after oplogTruncation\":532,\"after readConcernCounters\":532,\"after repl\":541,\"after scramCache\":563,\"after security\":563,\"after storageEngine\":563,\"after tcmalloc\":577,\"after tenantMigrations\":577,\"after trafficRecording\":577,\"after transactions\":577,\"after transportSecurity\":577,\"after twoPhaseCommitCoordinator\":577,\"after wiredTiger\":759,\"at end\":1099}}}",
      "{\"t\":{\"$date\":\"2023-09-11T17:41:36.497+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":6,\"after activeIndexBuilds\":6,\"after asserts\":6,\"after batchedDeletes\":6,\"after bucketCatalog\":6,\"after catalogStats\":6,\"after connections\":6,\"after electionMetrics\":6,\"after encryptionAtRest\":7,\"after extra_info\":7,\"after flowControl\":7,\"after globalLock\":7,\"after indexBulkBuilder\":20,\"after indexStats\":20,\"after locks\":20,\"after logicalSessionRecordCache\":41,\"after mirroredReads\":41,\"after network\":41,\"after opLatencies\":41,\"after opcounters\":41,\"after opcountersRepl\":41,\"after oplog\":51,\"after oplogTruncation\":51,\"after readConcernCounters\":51,\"after repl\":53,\"after scramCache\":53,\"after security\":53,\"after storageEngine\":53,\"after tcmalloc\":4990,\"after tenantMigrations\":4990,\"after trafficRecording\":4990,\"after transactions\":4990,\"after transportSecurity\":4990,\"after twoPhaseCommitCoordinator\":5045,\"after wiredTiger\":5405,\"at end\":5672}}}",
      "{\"t\":{\"$date\":\"2023-09-11T17:51:55.229+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":0,\"after activeIndexBuilds\":0,\"after asserts\":0,\"after batchedDeletes\":0,\"after bucketCatalog\":0,\"after catalogStats\":0,\"after connections\":0,\"after electionMetrics\":0,\"after encryptionAtRest\":14,\"after extra_info\":14,\"after flowControl\":14,\"after globalLock\":14,\"after indexBulkBuilder\":14,\"after indexStats\":14,\"after locks\":14,\"after logicalSessionRecordCache\":14,\"after mirroredReads\":14,\"after network\":14,\"after opLatencies\":14,\"after opcounters\":25,\"after opcountersRepl\":25,\"after oplog\":25,\"after oplogTruncation\":25,\"after readConcernCounters\":25,\"after repl\":26,\"after scramCache\":26,\"after security\":26,\"after storageEngine\":26,\"after tcmalloc\":40,\"after tenantMigrations\":40,\"after trafficRecording\":40,\"after transactions\":40,\"after transportSecurity\":40,\"after twoPhaseCommitCoordinator\":40,\"after wiredTiger\":63,\"at end\":1206}}}",
      "{\"t\":{\"$date\":\"2023-09-12T08:05:21.433+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheReap\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.system.sessions\",\"command\":{\"listIndexes\":\"system.sessions\",\"cursor\":{},\"$db\":\"config\"},\"numYields\":0,\"reslen\":370,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":1}},\"Global\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":1}}},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":331}}",
      "{\"t\":{\"$date\":\"2023-09-12T08:05:21.427+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":51803,   \"ctx\":\"LogicalSessionCacheRefresh\",\"msg\":\"Slow query\",\"attr\":{\"type\":\"command\",\"ns\":\"config.system.sessions\",\"command\":{\"listIndexes\":\"system.sessions\",\"cursor\":{},\"$db\":\"config\"},\"numYields\":0,\"reslen\":370,\"locks\":{\"FeatureCompatibilityVersion\":{\"acquireCount\":{\"r\":2}},\"ReplicationStateTransition\":{\"acquireCount\":{\"w\":1}},\"Global\":{\"acquireCount\":{\"r\":2}},\"Database\":{\"acquireCount\":{\"r\":1}},\"Collection\":{\"acquireCount\":{\"r\":1}},\"Mutex\":{\"acquireCount\":{\"r\":1}}},\"storage\":{},\"protocol\":\"op_msg\",\"durationMillis\":288}}",
      "{\"t\":{\"$date\":\"2023-09-12T08:05:21.463+00:00\"},\"s\":\"I\",  \"c\":\"INDEX\",    \"id\":5479200, \"ctx\":\"TTLMonitor\",\"msg\":\"Deleted expired documents using index\",\"attr\":{\"namespace\":\"config.external_validation_keys\",\"index\":\"ExternalKeysTTLIndex\",\"numDeleted\":0,\"durationMillis\":408}}",
      "{\"t\":{\"$date\":\"2023-09-12T11:44:20.336+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":1,\"after activeIndexBuilds\":1,\"after asserts\":1,\"after batchedDeletes\":1,\"after bucketCatalog\":564,\"after catalogStats\":564,\"after connections\":564,\"after electionMetrics\":564,\"after encryptionAtRest\":565,\"after extra_info\":565,\"after flowControl\":565,\"after globalLock\":565,\"after indexBulkBuilder\":565,\"after indexStats\":565,\"after locks\":565,\"after logicalSessionRecordCache\":565,\"after mirroredReads\":565,\"after network\":738,\"after opLatencies\":738,\"after opcounters\":738,\"after opcountersRepl\":738,\"after oplog\":795,\"after oplogTruncation\":795,\"after readConcernCounters\":795,\"after repl\":827,\"after scramCache\":827,\"after security\":827,\"after storageEngine\":827,\"after tcmalloc\":847,\"after tenantMigrations\":847,\"after trafficRecording\":847,\"after transactions\":847,\"after transportSecurity\":847,\"after twoPhaseCommitCoordinator\":847,\"after wiredTiger\":1246,\"at end\":1246}}}",
      "{\"t\":{\"$date\":\"2023-09-12T12:43:37.815+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":914,\"after activeIndexBuilds\":914,\"after asserts\":914,\"after batchedDeletes\":1125,\"after bucketCatalog\":1125,\"after catalogStats\":1125,\"after connections\":1125,\"after electionMetrics\":1125,\"after encryptionAtRest\":1155,\"after extra_info\":1155,\"after flowControl\":1155,\"after globalLock\":1155,\"after indexBulkBuilder\":1155,\"after indexStats\":1155,\"after locks\":1170,\"after logicalSessionRecordCache\":1180,\"after mirroredReads\":1180,\"after network\":1180,\"after opLatencies\":1180,\"after opcounters\":1180,\"after opcountersRepl\":1180,\"after oplog\":1207,\"after oplogTruncation\":1207,\"after readConcernCounters\":1207,\"after repl\":1215,\"after scramCache\":1215,\"after security\":1215,\"after storageEngine\":1215,\"after tcmalloc\":1267,\"after tenantMigrations\":1267,\"after trafficRecording\":1267,\"after transactions\":1267,\"after transportSecurity\":1267,\"after twoPhaseCommitCoordinator\":1267,\"after wiredTiger\":1322,\"at end\":1358}}}",
      "{\"t\":{\"$date\":\"2023-09-12T12:51:37.566+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":12,\"after activeIndexBuilds\":342,\"after asserts\":596,\"after batchedDeletes\":596,\"after bucketCatalog\":596,\"after catalogStats\":596,\"after connections\":596,\"after electionMetrics\":596,\"after encryptionAtRest\":597,\"after extra_info\":597,\"after flowControl\":597,\"after globalLock\":597,\"after indexBulkBuilder\":597,\"after indexStats\":597,\"after locks\":597,\"after logicalSessionRecordCache\":729,\"after mirroredReads\":784,\"after network\":784,\"after opLatencies\":784,\"after opcounters\":784,\"after opcountersRepl\":784,\"after oplog\":889,\"after oplogTruncation\":889,\"after readConcernCounters\":889,\"after repl\":890,\"after scramCache\":890,\"after security\":890,\"after storageEngine\":1071,\"after tcmalloc\":1197,\"after tenantMigrations\":1197,\"after trafficRecording\":1197,\"after transactions\":1197,\"after transportSecurity\":1197,\"after twoPhaseCommitCoordinator\":1197,\"after wiredTiger\":1213,\"at end\":1423}}}",
      "{\"t\":{\"$date\":\"2023-09-12T12:51:42.434+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":0,\"after activeIndexBuilds\":0,\"after asserts\":0,\"after batchedDeletes\":0,\"after bucketCatalog\":0,\"after catalogStats\":0,\"after connections\":0,\"after electionMetrics\":0,\"after encryptionAtRest\":1316,\"after extra_info\":1836,\"after flowControl\":1836,\"after globalLock\":1869,\"after indexBulkBuilder\":1869,\"after indexStats\":1869,\"after locks\":1879,\"after logicalSessionRecordCache\":1879,\"after mirroredReads\":1879,\"after network\":1879,\"after opLatencies\":1879,\"after opcounters\":1879,\"after opcountersRepl\":1879,\"after oplog\":1914,\"after oplogTruncation\":1932,\"after readConcernCounters\":1932,\"after repl\":1942,\"after scramCache\":1942,\"after security\":1942,\"after storageEngine\":1975,\"after tcmalloc\":1986,\"after tenantMigrations\":1986,\"after trafficRecording\":1986,\"after transactions\":1986,\"after transportSecurity\":1986,\"after twoPhaseCommitCoordinator\":1986,\"after wiredTiger\":2031,\"at end\":2046}}}",
      "{\"t\":{\"$date\":\"2023-09-12T12:51:48.004+00:00\"},\"s\":\"I\",  \"c\":\"COMMAND\",  \"id\":20499,   \"ctx\":\"ftdc\",\"msg\":\"serverStatus was very slow\",\"attr\":{\"timeStats\":{\"after basic\":0,\"after activeIndexBuilds\":0,\"after asserts\":0,\"after batchedDeletes\":0,\"after bucketCatalog\":0,\"after catalogStats\":0,\"after connections\":0,\"after electionMetrics\":51,\"after encryptionAtRest\":178,\"after extra_info\":358,\"after flowControl\":432,\"after globalLock\":432,\"after indexBulkBuilder\":432,\"after indexStats\":432,\"after locks\":448,\"after logicalSessionRecordCache\":448,\"after mirroredReads\":448,\"after network\":448,\"after opLatencies\":448,\"after opcounters\":448,\"after opcountersRepl\":448,\"after oplog\":605,\"after oplogTruncation\":605,\"after readConcernCounters\":605,\"after repl\":613,\"after scramCache\":717,\"after security\":717,\"after storageEngine\":717,\"after tcmalloc\":717,\"after tenantMigrations\":717,\"after trafficRecording\":717,\"after transactions\":717,\"after transportSecurity\":717,\"after twoPhaseCommitCoordinator\":737,\"after wiredTiger\":2626,\"at end\":3465}}}",
      ""
    ],
    "Mongot": [
      "2023-09-11T10:38:28.914+0000 I MONGOT [main] [com.xgen.mongot.Mongot] [Starting Mongot - Mongot Version: local]",
      "2023-09-11T10:38:32.379+0000 I MONGOT [main] [c.xgen.mongot.util.security.Security] installing FIPS security providers",
      "2023-09-11T10:38:44.933+0000 I MONGOT [main] [com.xgen.mongot.Mongot] Bootstrapping with mongod connection mongod-local7780:27017",
      "2023-09-11T10:38:45.768+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] refreshExecutorThreads not configured, defaulting to 1.",
      "2023-09-11T10:38:45.777+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] numMaxMergeThreads not configured, defaulting to 1.",
      "2023-09-11T10:38:45.796+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] numMaxMerges not configured, defaulting to 1.",
      "2023-09-11T10:38:45.819+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] ramBufferSizeMb not configured, defaulting to 20.0.",
      "2023-09-11T10:38:45.827+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] nrtCacheEnabled not configured, defaulting to false.",
      "2023-09-11T10:38:45.831+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] nrtTotalCacheSizeMb not configured, defaulting to 15.0.",
      "2023-09-11T10:38:45.844+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] nrtMaxMergeSizeMb not configured, defaulting to 1.5.",
      "2023-09-11T10:38:45.860+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] maxMergedSegmentSize not configured, defaulting to 473.7 MiB.",
      "2023-09-11T10:38:45.869+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] concurrentSearchExecutorThreads not configured, defaulting to 1.",
      "2023-09-11T10:38:45.874+0000 I MONGOT [main] [c.x.m.i.lucene.config.LuceneConfig] using Lucene Version 9.7.0.",
      "2023-09-11T10:38:45.919+0000 I MONGOT [main] [c.x.m.r.m.MongoDbReplicationConfig] numConcurrentInitialSyncs not configured, defaulting to 1.",
      "2023-09-11T10:38:45.922+0000 I MONGOT [main] [c.x.m.r.m.MongoDbReplicationConfig] numConcurrentChangeStreams not configured, defaulting to 2.",
      "2023-09-11T10:38:45.925+0000 I MONGOT [main] [c.x.m.r.m.MongoDbReplicationConfig] numIndexingThreads not configured, defaulting to 1.",
      "2023-09-11T10:38:45.929+0000 I MONGOT [main] [c.x.m.r.m.MongoDbReplicationConfig] changeStreamMaxTimeMs not configured, defaulting to 1000.",
      "2023-09-11T10:38:45.938+0000 I MONGOT [main] [c.x.m.r.mongodb.DurabilityConfig] numCommittingThreads not configured, defaulting to 1.",
      "2023-09-11T10:38:46.199+0000 I MONGOT [main] [c.x.m.i.lucene.LuceneGlobalSettings] Lucene max clause count set to: 1024",
      "2023-09-11T10:38:54.523+0000 I MONGOT [main] [org.mongodb.driver.cluster] Cluster created with settings {hosts=[mongod-local7780:27017], mode=SINGLE, requiredClusterType=UNKNOWN, serverSelectionTimeout='10000 ms'}",
      "2023-09-11T10:38:55.552+0000 I MONGOT [InitialSyncDispatcher] [c.x.m.r.m.i.InitialSyncQueue$InitialSyncDispatcher] 0 queued initial syncs.",
      "2023-09-11T10:38:55.679+0000 I MONGOT [main] [org.mongodb.driver.cluster] Cluster created with settings {hosts=[mongod-local7780:27017], mode=SINGLE, requiredClusterType=UNKNOWN, serverSelectionTimeout='10000 ms'}",
      "2023-09-11T10:38:55.686+0000 I MONGOT [cluster-rtt-ClusterId{value='64feee3e42bc572d9827499a', description='null'}-mongod-local7780:27017] [org.mongodb.driver.connection] Opened connection [connectionId{localValue:2, serverValue:15}] to mongod-local7780:27017",
      "2023-09-11T10:38:55.686+0000 I MONGOT [cluster-ClusterId{value='64feee3e42bc572d9827499a', description='null'}-mongod-local7780:27017] [org.mongodb.driver.connection] Opened connection [connectionId{localValue:1, serverValue:16}] to mongod-local7780:27017",
      "2023-09-11T10:38:55.907+0000 I MONGOT [cluster-ClusterId{value='64feee3e42bc572d9827499a', description='null'}-mongod-local7780:27017] [org.mongodb.driver.cluster] Monitor thread successfully connected to server with description ServerDescription{address=mongod-local7780:27017, type=REPLICA_SET_PRIMARY, state=CONNECTED, ok=true, minWireVersion=0, maxWireVersion=17, maxDocumentSize=16777216, logicalSessionTimeoutMinutes=30, roundTripTimeNanos=356860925, setName='rs-localdev', canonicalAddress=mongod-local7780:27017, hosts=[mongod-local7780:27017], passives=[], arbiters=[], primary='mongod-local7780:27017', tagSet=TagSet{[]}, electionId=7fffffff0000000000000001, setVersion=1, topologyVersion=TopologyVersion{processId=64feedff6a202760384f81e6, counter=6}, lastWriteDate=Mon Sep 11 10:38:46 UTC 2023, lastUpdateTimeNanos=247811591980632}",
      "2023-09-11T10:38:56.098+0000 I MONGOT [cluster-rtt-ClusterId{value='64feee3f42bc572d9827499b', description='null'}-mongod-local7780:27017] [org.mongodb.driver.connection] Opened connection [connectionId{localValue:4, serverValue:17}] to mongod-local7780:27017",
      "2023-09-11T10:38:56.101+0000 I MONGOT [cluster-ClusterId{value='64feee3f42bc572d9827499b', description='null'}-mongod-local7780:27017] [org.mongodb.driver.connection] Opened connection [connectionId{localValue:3, serverValue:18}] to mongod-local7780:27017",
      "2023-09-11T10:38:56.112+0000 I MONGOT [cluster-ClusterId{value='64feee3f42bc572d9827499b', description='null'}-mongod-local7780:27017] [org.mongodb.driver.cluster] Monitor thread successfully connected to server with description ServerDescription{address=mongod-local7780:27017, type=REPLICA_SET_PRIMARY, state=CONNECTED, ok=true, minWireVersion=0, maxWireVersion=17, maxDocumentSize=16777216, logicalSessionTimeoutMinutes=30, roundTripTimeNanos=136994573, setName='rs-localdev', canonicalAddress=mongod-local7780:27017, hosts=[mongod-local7780:27017], passives=[], arbiters=[], primary='mongod-local7780:27017', tagSet=TagSet{[]}, electionId=7fffffff0000000000000001, setVersion=1, topologyVersion=TopologyVersion{processId=64feedff6a202760384f81e6, counter=6}, lastWriteDate=Mon Sep 11 10:38:46 UTC 2023, lastUpdateTimeNanos=247812024434716}",
      "2023-09-11T10:38:56.415+0000 I MONGOT [SynonymSyncDispatcher] [c.x.m.r.m.synonyms.SynonymManager] 0 queued synonym syncs.",
      "2023-09-11T10:38:56.467+0000 I MONGOT [main] [c.x.m.c.manager.DefaultConfigManager] Initializing",
      "2023-09-11T10:38:56.514+0000 I MONGOT [main] [c.x.m.c.manager.DefaultConfigManager] No config journal found, nothing to initialize",
      "2023-09-11T10:38:59.238+0000 I MONGOT [main] [c.x.m.s.tcp.server.AbstractTcpServer] Starting query server on address 0.0.0.0/0.0.0.0:27027",
      "2023-09-11T10:38:59.246+0000 I MONGOT [main] [c.x.m.s.tcp.server.MessageServer] starting on 0.0.0.0/0.0.0.0:27027",
      "2023-09-11T13:45:23.307+0000 I MONGOT [cluster-ClusterId{value='64feee3f42bc572d9827499b', description='null'}-mongod-local7780:27017] [org.mongodb.driver.cluster] Exception in monitor thread while connecting to server mongod-local7780:27017",
      "com.mongodb.MongoSocketReadTimeoutException: Timeout while receiving message",
      "\tat com.mongodb.internal.connection.AsynchronousChannelStream$BasicCompletionHandler.failed(AsynchronousChannelStream.java:263)",
      "\tat com.mongodb.internal.connection.AsynchronousChannelStream$BasicCompletionHandler.failed(AsynchronousChannelStream.java:233)",
      "\tat java.base/sun.nio.ch.Invoker.invokeUnchecked(Invoker.java:129)",
      "\tat java.base/sun.nio.ch.Invoker$2.run(Invoker.java:219)",
      "\tat java.base/sun.nio.ch.AsynchronousChannelGroupImpl$1.run(AsynchronousChannelGroupImpl.java:112)",
      "\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)",
      "\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)",
      "\tat java.base/java.lang.Thread.run(Thread.java:829)",
      "Caused by: java.nio.channels.InterruptedByTimeoutException: null",
      "\tat java.base/sun.nio.ch.UnixAsynchronousSocketChannelImpl$1.run(UnixAsynchronousSocketChannelImpl.java:465)",
      "\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)",
      "\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)",
      "\tat java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)",
      "\t... 3 common frames omitted",
      "2023-09-11T13:45:23.299+0000 I MONGOT [cluster-ClusterId{value='64feee3e42bc572d9827499a', description='null'}-mongod-local7780:27017] [org.mongodb.driver.cluster] Exception in monitor thread while connecting to server mongod-local7780:27017",
      "com.mongodb.MongoSocketReadTimeoutException: Timeout while receiving message",
      "\tat com.mongodb.internal.connection.InternalStreamConnection.translateReadException(InternalStreamConnection.java:701)",
      "\tat com.mongodb.internal.connection.InternalStreamConnection.receiveMessageWithAdditionalTimeout(InternalStreamConnection.java:579)",
      "\tat com.mongodb.internal.connection.InternalStreamConnection.receiveCommandMessageResponse(InternalStreamConnection.java:415)",
      "\tat com.mongodb.internal.connection.InternalStreamConnection.receive(InternalStreamConnection.java:374)",
      "\tat com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitorRunnable.lookupServerDescription(DefaultServerMonitor.java:216)",
      "\tat com.mongodb.internal.connection.DefaultServerMonitor$ServerMonitorRunnable.run(DefaultServerMonitor.java:152)",
      "\tat java.base/java.lang.Thread.run(Thread.java:829)",
      "Caused by: java.net.SocketTimeoutException: Read timed out",
      "\tat java.base/java.net.SocketInputStream.socketRead0(Native Method)",
      "\tat java.base/java.net.SocketInputStream.socketRead(SocketInputStream.java:115)",
      "\tat java.base/java.net.SocketInputStream.read(SocketInputStream.java:168)",
      "\tat java.base/java.net.SocketInputStream.read(SocketInputStream.java:140)",
      "\tat com.mongodb.internal.connection.SocketStream.read(SocketStream.java:109)",
      "\tat com.mongodb.internal.connection.SocketStream.read(SocketStream.java:131)",
      "\tat com.mongodb.internal.connection.InternalStreamConnection.receiveResponseBuffers(InternalStreamConnection.java:718)",
      "\tat com.mongodb.internal.connection.InternalStreamConnection.receiveMessageWithAdditionalTimeout(InternalStreamConnection.java:576)",
      "\t... 5 common frames omitted",
      "2023-09-11T13:45:24.246+0000 I MONGOT [cluster-ClusterId{value='64feee3f42bc572d9827499b', description='null'}-mongod-local7780:27017] [org.mongodb.driver.connection] Opened connection [connectionId{localValue:5, serverValue:19}] to mongod-local7780:27017",
      "2023-09-11T13:45:24.281+0000 I MONGOT [cluster-ClusterId{value='64feee3f42bc572d9827499b', description='null'}-mongod-local7780:27017] [org.mongodb.driver.cluster] Monitor thread successfully connected to server with description ServerDescription{address=mongod-local7780:27017, type=REPLICA_SET_PRIMARY, state=CONNECTED, ok=true, minWireVersion=0, maxWireVersion=17, maxDocumentSize=16777216, logicalSessionTimeoutMinutes=30, roundTripTimeNanos=244472941, setName='rs-localdev', canonicalAddress=mongod-local7780:27017, hosts=[mongod-local7780:27017], passives=[], arbiters=[], primary='mongod-local7780:27017', tagSet=TagSet{[]}, electionId=7fffffff0000000000000001, setVersion=1, topologyVersion=TopologyVersion{processId=64feedff6a202760384f81e6, counter=6}, lastWriteDate=Mon Sep 11 13:45:17 UTC 2023, lastUpdateTimeNanos=259000154804418}",
      "2023-09-11T13:45:24.301+0000 I MONGOT [cluster-ClusterId{value='64feee3e42bc572d9827499a', description='null'}-mongod-local7780:27017] [org.mongodb.driver.connection] Opened connection [connectionId{localValue:6, serverValue:20}] to mongod-local7780:27017",
      "2023-09-11T13:45:24.308+0000 I MONGOT [cluster-ClusterId{value='64feee3e42bc572d9827499a', description='null'}-mongod-local7780:27017] [org.mongodb.driver.cluster] Monitor thread successfully connected to server with description ServerDescription{address=mongod-local7780:27017, type=REPLICA_SET_PRIMARY, state=CONNECTED, ok=true, minWireVersion=0, maxWireVersion=17, maxDocumentSize=16777216, logicalSessionTimeoutMinutes=30, roundTripTimeNanos=59040268, setName='rs-localdev', canonicalAddress=mongod-local7780:27017, hosts=[mongod-local7780:27017], passives=[], arbiters=[], primary='mongod-local7780:27017', tagSet=TagSet{[]}, electionId=7fffffff0000000000000001, setVersion=1, topologyVersion=TopologyVersion{processId=64feedff6a202760384f81e6, counter=6}, lastWriteDate=Mon Sep 11 13:45:17 UTC 2023, lastUpdateTimeNanos=259000198254698}",
      "2023-09-11T13:45:32.949+0000 I MONGOT [cluster-rtt-ClusterId{value='64feee3e42bc572d9827499a', description='null'}-mongod-local7780:27017] [org.mongodb.driver.connection] Opened connection [connectionId{localValue:7, serverValue:21}] to mongod-local7780:27017",
      ""
    ],
    "Podman": [
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694186411,
        "CreatedAt": "3 days ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "a7151348aa67cb19f33e88f9dcc1c9f943a682d79356cde92e2a049019e40425",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local5305"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local5305"
        ],
        "Pid": 4033,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 58323,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694186411,
        "State": "running",
        "Status": "Up 3 days"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694428668,
        "CreatedAt": "26 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "2b836f44f4c66a1c13d52521bff83b783aa86e9ecbb8a7a532e73e221ab841bf",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local7780"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local7780"
        ],
        "Pid": 11113,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 54257,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694428668,
        "State": "running",
        "Status": "Up 26 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694439882,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "55c898b4d56c092009bd732459069256d93eb91a8811ad1612d50c47b82fda2c",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local4839"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local4839"
        ],
        "Pid": 11810,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57055,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694439882,
        "State": "running",
        "Status": "Up 23 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694440618,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "1cf68912c9df6c1974e342da0c81ae63b6d0b13b9a7147b4968f0f7c42a2c905",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local1657"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local1657"
        ],
        "Pid": 12057,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57488,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694440618,
        "State": "running",
        "Status": "Up 23 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694440958,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "7f3680aa3847c0a3db5069eb186af83c02d27afbf211048a5f07f1aa07c9e774",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local3689"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local3689"
        ],
        "Pid": 12432,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57612,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694440962,
        "State": "running",
        "Status": "Up 23 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694440981,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "6ebaee63e212e2dc0b6103c4c9d05bee7ba5433a853736eb1021640e053781af",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local9191"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local9191"
        ],
        "Pid": 12550,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57620,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694441000,
        "State": "running",
        "Status": "Up 23 hours"
      },
      {
        "AutoRemove": false,
        "Command": [
          "/bin/sh",
          "-c",
          "echo $KEYFILECONTENTS \u003e $KEYFILE \u0026\u0026 \\\n                   chmod 400 $KEYFILE \u0026\u0026 \\\n                   python3 /usr/local/bin/docker-entrypoint.py \\\n                                          --transitionToAuth \\\n                                          --dbpath $DBPATH \\\n                                          --keyFile $KEYFILE \\\n                                          --replSet $REPLSETNAME \\\n                                          --setParameter \"mongotHost=$MONGOTHOST\" \\\n                                          --setParameter \"searchIndexManagementHostAndPort=$MONGOTHOST\""
        ],
        "Created": 1694441265,
        "CreatedAt": "23 hours ago",
        "ExitCode": 0,
        "Exited": false,
        "ExitedAt": -62135596800,
        "Id": "34122b3eb5bf272291333e54025061897b3bd7b02c9ebcdcfaf824912fc54e48",
        "Image": "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
        "ImageID": "780c708e556e78c44a698008249ba54fe13ee83324138f7d86050854c1867327",
        "IsInfra": false,
        "Labels": {
          "architecture": "x86_64",
          "build-date": "2023-08-23T06:31:54",
          "com.redhat.component": "ubi8-container",
          "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
          "description": "Container configured with a standalone instance of MongoDB",
          "distribution-scope": "public",
          "io.buildah.version": "1.29.0",
          "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
          "io.k8s.display-name": "Red Hat Universal Base Image 8",
          "io.openshift.expose-services": "",
          "io.openshift.tags": "base rhel8",
          "maintainer": "support@mongodb.com",
          "name": "MongoDB Standalone",
          "release": "1032.1692772289",
          "summary": "MongoDB Standalone Container",
          "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/images/8.8-1032.1692772289",
          "vcs-ref": "384f2bb33eebab960262e967aa16d01fe2dbebff",
          "vcs-type": "git",
          "vendor": "MongoDB",
          "version": "6.0.9"
        },
        "Mounts": [
          "/data/configdb",
          "/data/db"
        ],
        "Names": [
          "mongod-local8035"
        ],
        "Namespaces": {},
        "Networks": [
          "mdb-local-local8035"
        ],
        "Pid": 13093,
        "Pod": "",
        "PodName": "",
        "Ports": [
          {
            "container_port": 27017,
            "host_ip": "127.0.0.1",
            "host_port": 57919,
            "protocol": "tcp",
            "range": 1
          }
        ],
        "Restarts": 0,
        "Size": null,
        "StartedAt": 1694441266,
        "State": "running",
        "Status": "Up 23 hours"
      }
    ]
  },
  "Machine": {
    "OS": "darwin",
    "Arch": "arm64"
  },
  "Podman": {
    "Installed": true,
    "MachineFound": true,
    "MachineState": "running",
    "MachineInfo": {
      "ConfigPath": {
        "Path": "/Users/bianca.lisle/.config/containers/podman/machine/qemu/podman-machine-default.json"
      },
      "ConnectionInfo": {
        "PodmanSocket": {
          "Path": "/Users/bianca.lisle/.local/share/containers/podman/machine/qemu/podman.sock"
        },
        "PodmanPipe": null
      },
      "Created": "2023-08-09T15:58:48.9874+01:00",
      "Image": {
        "IgnitionFilePath": {
          "Path": "/Users/bianca.lisle/.config/containers/podman/machine/qemu/podman-machine-default.ign"
        },
        "ImageStream": "testing",
        "ImagePath": {
          "Path": "/Users/bianca.lisle/.local/share/containers/podman/machine/qemu/podman-machine-default_fedora-coreos-38.20230806.2.0-qemu.aarch64.qcow2"
        }
      },
      "LastUp": "2023-09-08T14:47:13.057595+01:00",
      "Name": "podman-machine-default",
      "Resources": {
        "CPUs": 1,
        "DiskSize": 100,
        "Memory": 2048
      },
      "SSHConfig": {
        "IdentityPath": "/Users/bianca.lisle/.ssh/podman-machine-default",
        "Port": 60328,
        "RemoteUsername": "core"
      },
      "State": "running",
      "UserModeNetworking": true
    },
    "VersionFound": true,
    "Version": {
      "Client": {
        "APIVersion": "4.6.2",
        "Version": "4.6.2",
        "GoVersion": "go1.21.0",
        "GitCommit": "5db42e86862ef42c59304c38aa583732fd80f178",
        "BuiltTime": "Mon Aug 28 15:55:03 2023",
        "Built": 1693234503,
        "OsArch": "darwin/arm64",
        "Os": "darwin"
      },
      "Server": {
        "APIVersion": "4.6.2",
        "Version": "4.6.2",
        "GoVersion": "go1.20.7",
        "GitCommit": "",
        "BuiltTime": "Mon Aug 28 20:39:14 2023",
        "Built": 1693251554,
        "OsArch": "linux/arm64",
        "Os": "linux"
      }
    },
    "Images": [
      "docker.io/mongodb/mongodb-enterprise-server:7.0-ubi8",
      "docker.io/mongodb/mongodb-enterprise-server:6.0-ubi8",
      "docker.io/mongodb/apix_test:mongot-preview"
    ]
  }
}

```
</details>
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
