### PR TITLE
CLOUDP-197338: [Atlas CLI] "atlas dbusers certs create" doesn't allow downloading the PEM file

### DIFF
--- a/build/ci/library_owners.json
+++ b/build/ci/library_owners.json
@@ -35,7 +35,7 @@
 	"github.com/tangzero/inflector": "mongocli",
 	"github.com/withfig/autocomplete-tools/packages/cobra": "mongocli",
 	"go.mongodb.org/atlas": "mongocli",
-	"go.mongodb.org/atlas-sdk/v20230201006": "mongocli",
+	"go.mongodb.org/atlas-sdk/v20230201007": "mongocli",
 	"go.mongodb.org/mongo-driver": "mongocli",
 	"go.mongodb.org/ops-manager": "mongocli",
 	"golang.org/x/crypto": "mongocli",

--- a/docs/atlascli/command/atlas-dbusers-certs-create.txt
+++ b/docs/atlascli/command/atlas-dbusers-certs-create.txt
@@ -81,7 +81,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   <Certificate>
+   <>
    
 
 Examples

--- a/docs/mongocli/command/mongocli-atlas-dbusers-certs-create.txt
+++ b/docs/mongocli/command/mongocli-atlas-dbusers-certs-create.txt
@@ -81,7 +81,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   <Certificate>
+   <>
    
 
 Examples

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/tangzero/inflector v1.0.0
 	github.com/withfig/autocomplete-tools/packages/cobra v1.2.0
 	go.mongodb.org/atlas v0.31.0
-	go.mongodb.org/atlas-sdk/v20230201006 v20230201006.0.0
+	go.mongodb.org/atlas-sdk/v20230201007 v20230201007.0.0
 	go.mongodb.org/mongo-driver v1.12.1
 	go.mongodb.org/ops-manager v0.53.0
 	golang.org/x/crypto v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -508,8 +508,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.mongodb.org/atlas v0.31.0 h1:NgLqsNYm6wDYeDUO90etw1sl8T1U2DUKu36eUdnrFSI=
 go.mongodb.org/atlas v0.31.0/go.mod h1:L4BKwVx/OeEhOVjCSdgo90KJm4469iv7ZLzQms/EPTg=
-go.mongodb.org/atlas-sdk/v20230201006 v20230201006.0.0 h1:HaY0cmYAlqoC+7iRE0NTPEQyAr2nqdxE9gspMp8Pmyo=
-go.mongodb.org/atlas-sdk/v20230201006 v20230201006.0.0/go.mod h1:Lgqhl8h8m0iqTloSypmqt/Vi8ZIGvx3tXFuu07HPUyk=
+go.mongodb.org/atlas-sdk/v20230201007 v20230201007.0.0 h1:UpEoxbmv7E8refzQ/vYyWThHWWxNg8gSni7NWSgYNJU=
+go.mongodb.org/atlas-sdk/v20230201007 v20230201007.0.0/go.mod h1:OmdUhwx1L6OphcDPWkt4xG6YKsgK8oMSRHAmTPTWDRo=
 go.mongodb.org/mongo-driver v1.12.1 h1:nLkghSU8fQNaK7oUmDhQFsnrtcoNy7Z6LVFKsEecqgE=
 go.mongodb.org/mongo-driver v1.12.1/go.mod h1:/rGBTebI3XYboVmgz+Wv3Bcbl3aD0QF9zl6kDDw18rQ=
 go.mongodb.org/ops-manager v0.53.0 h1:e5MZsqTH+Pr/QQKWr0FHkCnkIjhKxdlES6zdlfN/JLs=

--- a/internal/cli/atlas/accesslists/create.go
+++ b/internal/cli/atlas/accesslists/create.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/time"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/atlas/accesslists/create_test.go
+++ b/internal/cli/atlas/accesslists/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWhitelistCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/accesslists/describe_test.go
+++ b/internal/cli/atlas/accesslists/describe_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWhitelistDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/accesslists/list_test.go
+++ b/internal/cli/atlas/accesslists/list_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWhitelistList_Run(t *testing.T) {

--- a/internal/cli/atlas/accesslogs/list_test.go
+++ b/internal/cli/atlas/accesslogs/list_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAccessLogListClusterName_Run(t *testing.T) {

--- a/internal/cli/atlas/alerts/acknowledge.go
+++ b/internal/cli/atlas/alerts/acknowledge.go
@@ -27,7 +27,7 @@ import (
 	customTime "github.com/mongodb/mongodb-atlas-cli/internal/time"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type AcknowledgeOpts struct {

--- a/internal/cli/atlas/alerts/acknowledge_test.go
+++ b/internal/cli/atlas/alerts/acknowledge_test.go
@@ -25,7 +25,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAcknowledgeBuilder(t *testing.T) {

--- a/internal/cli/atlas/alerts/describe.go
+++ b/internal/cli/atlas/alerts/describe.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type DescribeOpts struct {

--- a/internal/cli/atlas/alerts/describe_test.go
+++ b/internal/cli/atlas/alerts/describe_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/alerts/list.go
+++ b/internal/cli/atlas/alerts/list.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type ListOpts struct {

--- a/internal/cli/atlas/alerts/list_test.go
+++ b/internal/cli/atlas/alerts/list_test.go
@@ -25,7 +25,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/alerts/settings/create.go
+++ b/internal/cli/atlas/alerts/settings/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/alerts/settings/create_test.go
+++ b/internal/cli/atlas/alerts/settings/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/alerts/settings/disable_test.go
+++ b/internal/cli/atlas/alerts/settings/disable_test.go
@@ -25,7 +25,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDisableBuilder(t *testing.T) {

--- a/internal/cli/atlas/alerts/settings/enable_test.go
+++ b/internal/cli/atlas/alerts/settings/enable_test.go
@@ -25,7 +25,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestEnableBuilder(t *testing.T) {

--- a/internal/cli/atlas/alerts/settings/list.go
+++ b/internal/cli/atlas/alerts/settings/list.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type ListOpts struct {

--- a/internal/cli/atlas/alerts/settings/list_test.go
+++ b/internal/cli/atlas/alerts/settings/list_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestConfigList_Run(t *testing.T) {

--- a/internal/cli/atlas/alerts/settings/settings.go
+++ b/internal/cli/atlas/alerts/settings/settings.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/atlas/alerts/settings/update.go
+++ b/internal/cli/atlas/alerts/settings/update.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type UpdateOpts struct {

--- a/internal/cli/atlas/alerts/settings/update_test.go
+++ b/internal/cli/atlas/alerts/settings/update_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdates_Run(t *testing.T) {

--- a/internal/cli/atlas/alerts/unacknowledge.go
+++ b/internal/cli/atlas/alerts/unacknowledge.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type UnacknowledgeOpts struct {

--- a/internal/cli/atlas/alerts/unacknowledge_test.go
+++ b/internal/cli/atlas/alerts/unacknowledge_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUnacknowledge_Run(t *testing.T) {

--- a/internal/cli/atlas/auditing/describe_test.go
+++ b/internal/cli/atlas/auditing/describe_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/compliancepolicy/copyprotection/disable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/copyprotection/disable.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type DisableOpts struct {

--- a/internal/cli/atlas/backup/compliancepolicy/copyprotection/disable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/copyprotection/disable_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDisableBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/compliancepolicy/copyprotection/enable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/copyprotection/enable.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type EnableOpts struct {

--- a/internal/cli/atlas/backup/compliancepolicy/copyprotection/enable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/copyprotection/enable_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestEnableBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/compliancepolicy/describe_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/describe_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/compliancepolicy/enable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/enable.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type EnableOpts struct {

--- a/internal/cli/atlas/backup/compliancepolicy/enable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/enable_test.go
@@ -22,7 +22,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/disable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/disable.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type DisableOpts struct {

--- a/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/disable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/disable_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDisableBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/enable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/enable.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type EnableOpts struct {

--- a/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/enable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/enable_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestEnableBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/enable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/enable.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type EnableOpts struct {

--- a/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/enable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/enable_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestEnableBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/compliancepolicy/policies/describe_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/describe_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type SetupOpts struct {

--- a/internal/cli/atlas/backup/compliancepolicy/setup_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup_test.go
@@ -23,7 +23,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestSetupBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/exports/buckets/create.go
+++ b/internal/cli/atlas/backup/exports/buckets/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/mongodb/mongodb-atlas-cli/internal/validate"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/backup/exports/buckets/create_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/create_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/exports/buckets/describe_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/describe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/exports/buckets/list_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/exports/jobs/create.go
+++ b/internal/cli/atlas/backup/exports/jobs/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/backup/exports/jobs/create_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/create_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/exports/jobs/describe_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/describe_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/exports/jobs/list_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/exports/jobs/watch_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatchBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/restores/describe_test.go
+++ b/internal/cli/atlas/backup/restores/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/restores/list_test.go
+++ b/internal/cli/atlas/backup/restores/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/atlas/backup/restores/start_test.go
+++ b/internal/cli/atlas/backup/restores/start_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestStart_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/restores/watch.go
+++ b/internal/cli/atlas/backup/restores/watch.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type WatchOpts struct {

--- a/internal/cli/atlas/backup/restores/watch_test.go
+++ b/internal/cli/atlas/backup/restores/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatchBuilder(t *testing.T) {

--- a/internal/cli/atlas/backup/schedule/describe_test.go
+++ b/internal/cli/atlas/backup/schedule/describe_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/schedule/update.go
+++ b/internal/cli/atlas/backup/schedule/update.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var updateTemplate = "Snapshot backup policy for cluster '{{.ClusterName}}' updated.\n"

--- a/internal/cli/atlas/backup/schedule/update_test.go
+++ b/internal/cli/atlas/backup/schedule/update_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/snapshots/create.go
+++ b/internal/cli/atlas/backup/snapshots/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/backup/snapshots/create_test.go
+++ b/internal/cli/atlas/backup/snapshots/create_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/snapshots/describe_test.go
+++ b/internal/cli/atlas/backup/snapshots/describe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/snapshots/list_test.go
+++ b/internal/cli/atlas/backup/snapshots/list_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/backup/snapshots/watch_test.go
+++ b/internal/cli/atlas/backup/snapshots/watch_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/authorize_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/authorize_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAuthorizeTemplate(t *testing.T) {

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/create_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/create_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateTemplate(t *testing.T) {

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDeauthorizeTemplate(t *testing.T) {

--- a/internal/cli/atlas/cloudproviders/accessroles/list_test.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/list_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListTemplate_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/advancedsettings/describe_test.go
+++ b/internal/cli/atlas/clusters/advancedsettings/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/advancedsettings/update.go
+++ b/internal/cli/atlas/clusters/advancedsettings/update.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const updateTmpl = "Updating advanced configuration settings of your cluster'.\n"

--- a/internal/cli/atlas/clusters/advancedsettings/update_test.go
+++ b/internal/cli/atlas/clusters/advancedsettings/update_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdate_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/availableregions/list_test.go
+++ b/internal/cli/atlas/clusters/availableregions/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run_NoFlags(t *testing.T) {

--- a/internal/cli/atlas/clusters/clusters.go
+++ b/internal/cli/atlas/clusters/clusters.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/cli/atlas/clusters/clusters_test.go
+++ b/internal/cli/atlas/clusters/clusters_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-test/deep"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/connectionstring/describe_test.go
+++ b/internal/cli/atlas/clusters/connectionstring/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -32,7 +32,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/watchers"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/atlas/clusters/create_test.go
+++ b/internal/cli/atlas/clusters/create_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/describe_test.go
+++ b/internal/cli/atlas/clusters/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/indexes/create.go
+++ b/internal/cli/atlas/clusters/indexes/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/clusters/load_sample_data_test.go
+++ b/internal/cli/atlas/clusters/load_sample_data_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestLoadSampleDataOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/onlinearchive/create.go
+++ b/internal/cli/atlas/clusters/onlinearchive/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/clusters/onlinearchive/create_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/onlinearchive/describe_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/onlinearchive/list_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/onlinearchive/pause.go
+++ b/internal/cli/atlas/clusters/onlinearchive/pause.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type PauseOpts struct {

--- a/internal/cli/atlas/clusters/onlinearchive/pause_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/pause_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestPauseBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/onlinearchive/start.go
+++ b/internal/cli/atlas/clusters/onlinearchive/start.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type StartOpts struct {

--- a/internal/cli/atlas/clusters/onlinearchive/start_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/start_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestStartBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/onlinearchive/update.go
+++ b/internal/cli/atlas/clusters/onlinearchive/update.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type UpdateOpts struct {

--- a/internal/cli/atlas/clusters/onlinearchive/update_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/update_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdateBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/onlinearchive/watch_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/pause_test.go
+++ b/internal/cli/atlas/clusters/pause_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestPause_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/region_tier_autocomplete_test.go
+++ b/internal/cli/atlas/clusters/region_tier_autocomplete_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func Test_autoCompleteOpts_tierSuggestions(t *testing.T) {

--- a/internal/cli/atlas/clusters/sampledata/describe_test.go
+++ b/internal/cli/atlas/clusters/sampledata/describe_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/sampledata/load_test.go
+++ b/internal/cli/atlas/clusters/sampledata/load_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestLoadOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/sampledata/watch_test.go
+++ b/internal/cli/atlas/clusters/sampledata/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/start_test.go
+++ b/internal/cli/atlas/clusters/start_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestStart_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/atlas/clusters/update_test.go
+++ b/internal/cli/atlas/clusters/update_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/spf13/afero"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdate_Run(t *testing.T) {

--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type WatchOpts struct {

--- a/internal/cli/atlas/clusters/watch_test.go
+++ b/internal/cli/atlas/clusters/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/commonerrors/errors.go
+++ b/internal/cli/atlas/commonerrors/errors.go
@@ -17,7 +17,7 @@ package commonerrors
 import (
 	"errors"
 
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var (

--- a/internal/cli/atlas/customdbroles/create.go
+++ b/internal/cli/atlas/customdbroles/create.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const createTemplate = "Custom database role '{{.RoleName}}' successfully created.\n"

--- a/internal/cli/atlas/customdbroles/create_test.go
+++ b/internal/cli/atlas/customdbroles/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/customdbroles/custom_db_roles.go
+++ b/internal/cli/atlas/customdbroles/custom_db_roles.go
@@ -17,7 +17,7 @@ package customdbroles
 import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func Builder() *cobra.Command {

--- a/internal/cli/atlas/customdbroles/custom_db_roles_test.go
+++ b/internal/cli/atlas/customdbroles/custom_db_roles_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBuilder(t *testing.T) {

--- a/internal/cli/atlas/customdbroles/describe_test.go
+++ b/internal/cli/atlas/customdbroles/describe_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/customdbroles/list_test.go
+++ b/internal/cli/atlas/customdbroles/list_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/customdbroles/update.go
+++ b/internal/cli/atlas/customdbroles/update.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const updateTemplate = "Custom database role '{{.RoleName}}' successfully updated.\n"

--- a/internal/cli/atlas/customdbroles/update_test.go
+++ b/internal/cli/atlas/customdbroles/update_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/customdns/aws/describe_test.go
+++ b/internal/cli/atlas/customdns/aws/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/customdns/aws/disable_test.go
+++ b/internal/cli/atlas/customdns/aws/disable_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDisableBuilder(t *testing.T) {

--- a/internal/cli/atlas/customdns/aws/enable_test.go
+++ b/internal/cli/atlas/customdns/aws/enable_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestEnableBuilder(t *testing.T) {

--- a/internal/cli/atlas/datafederation/create.go
+++ b/internal/cli/atlas/datafederation/create.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/datafederation/create_test.go
+++ b/internal/cli/atlas/datafederation/create_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/describe_test.go
+++ b/internal/cli/atlas/datafederation/describe_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/list_test.go
+++ b/internal/cli/atlas/datafederation/list_test.go
@@ -28,7 +28,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/privateendpoints/create.go
+++ b/internal/cli/atlas/datafederation/privateendpoints/create.go
@@ -27,7 +27,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/datafederation/privateendpoints/create_test.go
+++ b/internal/cli/atlas/datafederation/privateendpoints/create_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/privateendpoints/describe_test.go
+++ b/internal/cli/atlas/datafederation/privateendpoints/describe_test.go
@@ -28,7 +28,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/privateendpoints/list_test.go
+++ b/internal/cli/atlas/datafederation/privateendpoints/list_test.go
@@ -28,7 +28,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/querylimits/create.go
+++ b/internal/cli/atlas/datafederation/querylimits/create.go
@@ -27,7 +27,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/datafederation/querylimits/create_test.go
+++ b/internal/cli/atlas/datafederation/querylimits/create_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/querylimits/describe_test.go
+++ b/internal/cli/atlas/datafederation/querylimits/describe_test.go
@@ -28,7 +28,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/querylimits/list_test.go
+++ b/internal/cli/atlas/datafederation/querylimits/list_test.go
@@ -28,7 +28,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/datafederation/update.go
+++ b/internal/cli/atlas/datafederation/update.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type UpdateOpts struct {

--- a/internal/cli/atlas/datafederation/update_test.go
+++ b/internal/cli/atlas/datafederation/update_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdate_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/availableschedules/list_test.go
+++ b/internal/cli/atlas/datalakepipelines/availableschedules/list_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/availablesnapshots/list_test.go
+++ b/internal/cli/atlas/datalakepipelines/availablesnapshots/list_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/create.go
+++ b/internal/cli/atlas/datalakepipelines/create.go
@@ -31,7 +31,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/datalakepipelines/create_test.go
+++ b/internal/cli/atlas/datalakepipelines/create_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/describe_test.go
+++ b/internal/cli/atlas/datalakepipelines/describe_test.go
@@ -28,7 +28,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/list_test.go
+++ b/internal/cli/atlas/datalakepipelines/list_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/pause_test.go
+++ b/internal/cli/atlas/datalakepipelines/pause_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestPause_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/runs/describe_test.go
+++ b/internal/cli/atlas/datalakepipelines/runs/describe_test.go
@@ -28,7 +28,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/runs/list_test.go
+++ b/internal/cli/atlas/datalakepipelines/runs/list_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/runs/watch_test.go
+++ b/internal/cli/atlas/datalakepipelines/runs/watch_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/start_test.go
+++ b/internal/cli/atlas/datalakepipelines/start_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestStart_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/trigger_test.go
+++ b/internal/cli/atlas/datalakepipelines/trigger_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestTrigger_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/update.go
+++ b/internal/cli/atlas/datalakepipelines/update.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type UpdateOpts struct {

--- a/internal/cli/atlas/datalakepipelines/update_test.go
+++ b/internal/cli/atlas/datalakepipelines/update_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdate_Run(t *testing.T) {

--- a/internal/cli/atlas/datalakepipelines/watch_test.go
+++ b/internal/cli/atlas/datalakepipelines/watch_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/dbusers/certs/create.go
+++ b/internal/cli/atlas/dbusers/certs/create.go
@@ -52,7 +52,7 @@ func (opts *CreateOpts) Run() error {
 	return opts.Print(r)
 }
 
-var createTemplate = "{{.Certificate}}\n"
+var createTemplate = "{{.}}\n"
 
 // mongocli atlas dbuser(s) certs create --username <username> [--monthsUntilExpiration number] [--projectId projectId].
 func CreateBuilder() *cobra.Command {

--- a/internal/cli/atlas/dbusers/certs/create_test.go
+++ b/internal/cli/atlas/dbusers/certs/create_test.go
@@ -21,14 +21,13 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"github.com/mongodb/mongodb-atlas-cli/internal/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateBuilder(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockDBUserCertificateCreator(ctrl)
-
-	var expected = &atlasv2.UserCert{}
 
 	username := "to_create"
 	monthsUntilExpiry := 12
@@ -42,10 +41,12 @@ func TestCreateBuilder(t *testing.T) {
 	mockStore.
 		EXPECT().
 		CreateDBUserCertificate(createOpts.ProjectID, username, monthsUntilExpiry).
-		Return(expected, nil).
+		Return("", nil).
 		Times(1)
 
-	if err := createOpts.Run(); err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
-	}
+	require.NoError(t, createOpts.Run())
+}
+
+func TestTemplate(t *testing.T) {
+	test.VerifyOutputTemplate(t, createTemplate, "")
 }

--- a/internal/cli/atlas/dbusers/certs/list_test.go
+++ b/internal/cli/atlas/dbusers/certs/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/mongodb/mongodb-atlas-cli/internal/validate"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/dbusers/create_test.go
+++ b/internal/cli/atlas/dbusers/create_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDBUserCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/dbusers/describe_test.go
+++ b/internal/cli/atlas/dbusers/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/convert"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDBUserDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/dbusers/list_test.go
+++ b/internal/cli/atlas/dbusers/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDBUserList_Run(t *testing.T) {

--- a/internal/cli/atlas/dbusers/update.go
+++ b/internal/cli/atlas/dbusers/update.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const updateTemplate = "Successfully updated database user '{{.Username}}'.\n"

--- a/internal/cli/atlas/dbusers/update_test.go
+++ b/internal/cli/atlas/dbusers/update_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDBUserUpdate_Run(t *testing.T) {

--- a/internal/cli/atlas/deployments/list.go
+++ b/internal/cli/atlas/deployments/list.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/cli/atlas/deployments/list_test.go
+++ b/internal/cli/atlas/deployments/list_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/cli/atlas/events/list.go
+++ b/internal/cli/atlas/events/list.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type EventListOpts struct {

--- a/internal/cli/atlas/events/list_test.go
+++ b/internal/cli/atlas/events/list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/events/orgs_list.go
+++ b/internal/cli/atlas/events/orgs_list.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type orgListOpts struct {

--- a/internal/cli/atlas/events/orgs_list_test.go
+++ b/internal/cli/atlas/events/orgs_list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func Test_orgListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/events/projects_list.go
+++ b/internal/cli/atlas/events/projects_list.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type projectListOpts struct {

--- a/internal/cli/atlas/events/projects_list_test.go
+++ b/internal/cli/atlas/events/projects_list_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func Test_projectListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/integrations/create/datadog.go
+++ b/internal/cli/atlas/integrations/create/datadog.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var datadogType = "DATADOG"

--- a/internal/cli/atlas/integrations/create/datadog_test.go
+++ b/internal/cli/atlas/integrations/create/datadog_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDatadogOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/integrations/create/new_relic.go
+++ b/internal/cli/atlas/integrations/create/new_relic.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var newRelicIntegrationType = "NEW_RELIC"

--- a/internal/cli/atlas/integrations/create/new_relic_test.go
+++ b/internal/cli/atlas/integrations/create/new_relic_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestNewRelicOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/integrations/create/ops_genie.go
+++ b/internal/cli/atlas/integrations/create/ops_genie.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var opsGenieType = "OPS_GENIE"

--- a/internal/cli/atlas/integrations/create/ops_genie_test.go
+++ b/internal/cli/atlas/integrations/create/ops_genie_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestOpsGenieOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/integrations/create/pager_duty.go
+++ b/internal/cli/atlas/integrations/create/pager_duty.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var pagerDutyIntegrationType = "PAGER_DUTY"

--- a/internal/cli/atlas/integrations/create/pager_duty_test.go
+++ b/internal/cli/atlas/integrations/create/pager_duty_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestPagerDutyOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/integrations/create/victor_ops.go
+++ b/internal/cli/atlas/integrations/create/victor_ops.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var victorOpsIntegrationType = "VICTOR_OPS"

--- a/internal/cli/atlas/integrations/create/victor_ops_test.go
+++ b/internal/cli/atlas/integrations/create/victor_ops_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestVictorOpsOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/integrations/create/webhook.go
+++ b/internal/cli/atlas/integrations/create/webhook.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var webhookIntegrationType = "WEBHOOK"

--- a/internal/cli/atlas/integrations/create/webhook_test.go
+++ b/internal/cli/atlas/integrations/create/webhook_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWebhookOpsOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/integrations/describe_test.go
+++ b/internal/cli/atlas/integrations/describe_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // Create Array of templates.

--- a/internal/cli/atlas/integrations/list_test.go
+++ b/internal/cli/atlas/integrations/list_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDBUserList_Run(t *testing.T) {

--- a/internal/cli/atlas/livemigrations/create_test.go
+++ b/internal/cli/atlas/livemigrations/create_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestLiveMigrationCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/livemigrations/describe_test.go
+++ b/internal/cli/atlas/livemigrations/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestLiveMigrationDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/livemigrations/link/create.go
+++ b/internal/cli/atlas/livemigrations/link/create.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var createTemplate = "Link-token '{{.LinkToken}}' successfully created.\n"

--- a/internal/cli/atlas/livemigrations/link/create_test.go
+++ b/internal/cli/atlas/livemigrations/link/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestLinkTokenCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
+++ b/internal/cli/atlas/livemigrations/options/live_migrations_opts.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type LiveMigrationsOpts struct {

--- a/internal/cli/atlas/livemigrations/validation/create_test.go
+++ b/internal/cli/atlas/livemigrations/validation/create_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestLiveMigrationValidationCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/livemigrations/validation/describe_test.go
+++ b/internal/cli/atlas/livemigrations/validation/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestValidationDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/logs/download.go
+++ b/internal/cli/atlas/logs/download.go
@@ -29,7 +29,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type DownloadOpts struct {

--- a/internal/cli/atlas/maintenance/describe_test.go
+++ b/internal/cli/atlas/maintenance/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/maintenance/update.go
+++ b/internal/cli/atlas/maintenance/update.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type UpdateOpts struct {

--- a/internal/cli/atlas/metrics/databases/describe_test.go
+++ b/internal/cli/atlas/metrics/databases/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDatabasesDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/metrics/databases/list_test.go
+++ b/internal/cli/atlas/metrics/databases/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDatabasesListsOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/metrics/disks/describe_test.go
+++ b/internal/cli/atlas/metrics/disks/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDisksDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/metrics/disks/list_test.go
+++ b/internal/cli/atlas/metrics/disks/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDisksListsOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/metrics/processes/processes_test.go
+++ b/internal/cli/atlas/metrics/processes/processes_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const oneMinute = "PT1M"

--- a/internal/cli/atlas/networking/containers/list.go
+++ b/internal/cli/atlas/networking/containers/list.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/cli/atlas/networking/containers/list_test.go
+++ b/internal/cli/atlas/networking/containers/list_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/networking/peering/create/aws.go
+++ b/internal/cli/atlas/networking/peering/create/aws.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type AWSOpts struct {

--- a/internal/cli/atlas/networking/peering/create/aws_test.go
+++ b/internal/cli/atlas/networking/peering/create/aws_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAwsOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/networking/peering/create/azure.go
+++ b/internal/cli/atlas/networking/peering/create/azure.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type AzureOpts struct {

--- a/internal/cli/atlas/networking/peering/create/azure_test.go
+++ b/internal/cli/atlas/networking/peering/create/azure_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAzureOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/networking/peering/create/gcp.go
+++ b/internal/cli/atlas/networking/peering/create/gcp.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type GCPOpts struct {

--- a/internal/cli/atlas/networking/peering/create/gcp_test.go
+++ b/internal/cli/atlas/networking/peering/create/gcp_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestGCPOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/networking/peering/list_test.go
+++ b/internal/cli/atlas/networking/peering/list_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type WatchOpts struct {

--- a/internal/cli/atlas/networking/peering/watch_test.go
+++ b/internal/cli/atlas/networking/peering/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatchBuilder(t *testing.T) {

--- a/internal/cli/atlas/organizations/apikeys/accesslists/create.go
+++ b/internal/cli/atlas/organizations/apikeys/accesslists/create.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const createTemplate = "Created new access list entry(s).\n"

--- a/internal/cli/atlas/organizations/apikeys/accesslists/create_test.go
+++ b/internal/cli/atlas/organizations/apikeys/accesslists/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/apikeys/accesslists/list.go
+++ b/internal/cli/atlas/organizations/apikeys/accesslists/list.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const listTemplate = `IP ADDRESS	CIDR BLOCK	CREATED AT{{range .Results}}

--- a/internal/cli/atlas/organizations/apikeys/accesslists/list_test.go
+++ b/internal/cli/atlas/organizations/apikeys/accesslists/list_test.go
@@ -24,7 +24,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/apikeys/create.go
+++ b/internal/cli/atlas/organizations/apikeys/create.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const createTemplate = `API Key '{{.Id}}' created.

--- a/internal/cli/atlas/organizations/apikeys/create_test.go
+++ b/internal/cli/atlas/organizations/apikeys/create_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/apikeys/describe_test.go
+++ b/internal/cli/atlas/organizations/apikeys/describe_test.go
@@ -23,7 +23,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/apikeys/list_test.go
+++ b/internal/cli/atlas/organizations/apikeys/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/apikeys/update.go
+++ b/internal/cli/atlas/organizations/apikeys/update.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type UpdateOpts struct {

--- a/internal/cli/atlas/organizations/apikeys/update_test.go
+++ b/internal/cli/atlas/organizations/apikeys/update_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/create_atlas.go
+++ b/internal/cli/atlas/organizations/create_atlas.go
@@ -27,7 +27,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var createAtlasTemplate = "Organization '{{.Organization.Id}}' created.\n"

--- a/internal/cli/atlas/organizations/create_atlas_test.go
+++ b/internal/cli/atlas/organizations/create_atlas_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateAtlasBuilder(t *testing.T) {

--- a/internal/cli/atlas/organizations/describe_test.go
+++ b/internal/cli/atlas/organizations/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/invitations/describe_test.go
+++ b/internal/cli/atlas/organizations/invitations/describe_test.go
@@ -24,7 +24,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/invitations/invite.go
+++ b/internal/cli/atlas/organizations/invitations/invite.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const createTemplate = "User '{{.Username}}' invited.\n"

--- a/internal/cli/atlas/organizations/invitations/invite_test.go
+++ b/internal/cli/atlas/organizations/invitations/invite_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/invitations/list.go
+++ b/internal/cli/atlas/organizations/invitations/list.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const listTemplate = `ID	USERNAME	CREATED AT	EXPIRES AT{{range .}}

--- a/internal/cli/atlas/organizations/invitations/list_test.go
+++ b/internal/cli/atlas/organizations/invitations/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/invitations/update.go
+++ b/internal/cli/atlas/organizations/invitations/update.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const updateTemplate = "Invitation {{.Id}} updated.\n"

--- a/internal/cli/atlas/organizations/invitations/update_test.go
+++ b/internal/cli/atlas/organizations/invitations/update_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdate_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/list.go
+++ b/internal/cli/atlas/organizations/list.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const listTemplate = `ID	NAME{{range .Results}}

--- a/internal/cli/atlas/organizations/list_test.go
+++ b/internal/cli/atlas/organizations/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/organizations/users/list_test.go
+++ b/internal/cli/atlas/organizations/users/list_test.go
@@ -25,7 +25,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/performanceadvisor/namespaces/list.go
+++ b/internal/cli/atlas/performanceadvisor/namespaces/list.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const listTemplate = `NAMESPACE	TYPE{{range .Namespaces}}

--- a/internal/cli/atlas/performanceadvisor/namespaces/list_test.go
+++ b/internal/cli/atlas/performanceadvisor/namespaces/list_test.go
@@ -24,7 +24,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestNamespacesList_Run(t *testing.T) {

--- a/internal/cli/atlas/performanceadvisor/slowquerylogs/list.go
+++ b/internal/cli/atlas/performanceadvisor/slowquerylogs/list.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const listTemplate = `NAMESPACE	LINE{{range .SlowQueries}}

--- a/internal/cli/atlas/performanceadvisor/slowquerylogs/list_test.go
+++ b/internal/cli/atlas/performanceadvisor/slowquerylogs/list_test.go
@@ -26,7 +26,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestSlowQueryLogsList_Run(t *testing.T) {

--- a/internal/cli/atlas/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/atlas/performanceadvisor/suggestedindexes/list.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const listTemplate = `ID	NAMESPACE	SUGGESTED INDEX{{range .SuggestedIndexes}}  

--- a/internal/cli/atlas/performanceadvisor/suggestedindexes/list_test.go
+++ b/internal/cli/atlas/performanceadvisor/suggestedindexes/list_test.go
@@ -24,7 +24,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestNamespacesList_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/create.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/privateendpoints/aws/create_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/create_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/list_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/create.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/privateendpoints/azure/create_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/create_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/list_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/create.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/create_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/create_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/list.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/list.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var listTemplate = `ID	ENDPOINT PROVIDER	TYPE	COMMENT{{range .Results}}

--- a/internal/cli/atlas/privateendpoints/datalake/aws/list_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/privateendpoints/gcp/create_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/list_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/watch_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/disable_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/disable_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDisableOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/enable_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/enable_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestEnableOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/processes/describe.go
+++ b/internal/cli/atlas/processes/describe.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const describeTemplate = `ID	REPLICA SET NAME	SHARD NAME	VERSION

--- a/internal/cli/atlas/processes/describe_test.go
+++ b/internal/cli/atlas/processes/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/processes/list.go
+++ b/internal/cli/atlas/processes/list.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const listTemplate = `ID	REPLICA SET NAME	SHARD NAME	VERSION{{range .Results}}

--- a/internal/cli/atlas/processes/list_test.go
+++ b/internal/cli/atlas/processes/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/processes/process_autocomplete.go
+++ b/internal/cli/atlas/processes/process_autocomplete.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/validate"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type AutoCompleteOpts struct {

--- a/internal/cli/atlas/processes/process_autocomplete_test.go
+++ b/internal/cli/atlas/processes/process_autocomplete_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func Test_autoCompleteOpts_tierSuggestions(t *testing.T) {

--- a/internal/cli/atlas/projects/apikeys/assign.go
+++ b/internal/cli/atlas/projects/apikeys/assign.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type AssignOpts struct {

--- a/internal/cli/atlas/projects/apikeys/create.go
+++ b/internal/cli/atlas/projects/apikeys/create.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var createTemplate = `API Key '{{.Id}}' created.

--- a/internal/cli/atlas/projects/apikeys/create_test.go
+++ b/internal/cli/atlas/projects/apikeys/create_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/apikeys/list_test.go
+++ b/internal/cli/atlas/projects/apikeys/list_test.go
@@ -23,7 +23,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/create.go
+++ b/internal/cli/atlas/projects/create.go
@@ -26,7 +26,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const atlasCreateTemplate = "Project '{{.Id}}' created.\n"

--- a/internal/cli/atlas/projects/create_test.go
+++ b/internal/cli/atlas/projects/create_test.go
@@ -24,7 +24,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/invitations/describe_test.go
+++ b/internal/cli/atlas/projects/invitations/describe_test.go
@@ -24,7 +24,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/invitations/invite.go
+++ b/internal/cli/atlas/projects/invitations/invite.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const createTemplate = "User '{{.Username}}' invited.\n"

--- a/internal/cli/atlas/projects/invitations/invite_test.go
+++ b/internal/cli/atlas/projects/invitations/invite_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/invitations/list.go
+++ b/internal/cli/atlas/projects/invitations/list.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const listTemplate = `ID	USERNAME	CREATED AT	EXPIRES AT{{range .}}

--- a/internal/cli/atlas/projects/invitations/list_test.go
+++ b/internal/cli/atlas/projects/invitations/list_test.go
@@ -24,7 +24,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/invitations/update.go
+++ b/internal/cli/atlas/projects/invitations/update.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const updateTemplate = "Invitation {{.Id}} updated.\n"

--- a/internal/cli/atlas/projects/invitations/update_test.go
+++ b/internal/cli/atlas/projects/invitations/update_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdate_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/list_test.go
+++ b/internal/cli/atlas/projects/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/settings/describe_test.go
+++ b/internal/cli/atlas/projects/settings/describe_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/settings/update_test.go
+++ b/internal/cli/atlas/projects/settings/update_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/teams/add.go
+++ b/internal/cli/atlas/projects/teams/add.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const addTemplate = "Team added to the project.\n"

--- a/internal/cli/atlas/projects/teams/add_test.go
+++ b/internal/cli/atlas/projects/teams/add_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAdd_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/teams/list_test.go
+++ b/internal/cli/atlas/projects/teams/list_test.go
@@ -23,7 +23,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/teams/update.go
+++ b/internal/cli/atlas/projects/teams/update.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const updateTemplate = "Team's roles updated.\n"

--- a/internal/cli/atlas/projects/teams/update_test.go
+++ b/internal/cli/atlas/projects/teams/update_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdate_Run(t *testing.T) {

--- a/internal/cli/atlas/projects/users/list_test.go
+++ b/internal/cli/atlas/projects/users/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/search/create_test.go
+++ b/internal/cli/atlas/search/create_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/spf13/afero"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const testName = "default"

--- a/internal/cli/atlas/search/describe_test.go
+++ b/internal/cli/atlas/search/describe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/search/index_opts.go
+++ b/internal/cli/atlas/search/index_opts.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/file"
 	"github.com/spf13/afero"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const defaultAnalyzer = "lucene.standard"

--- a/internal/cli/atlas/search/list_test.go
+++ b/internal/cli/atlas/search/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/search/update_test.go
+++ b/internal/cli/atlas/search/update_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/security/customercerts/create_test.go
+++ b/internal/cli/atlas/security/customercerts/create_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/spf13/afero"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/security/customercerts/describe_test.go
+++ b/internal/cli/atlas/security/customercerts/describe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/security/ldap/get_test.go
+++ b/internal/cli/atlas/security/ldap/get_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestGet_Run(t *testing.T) {

--- a/internal/cli/atlas/security/ldap/save.go
+++ b/internal/cli/atlas/security/ldap/save.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type SaveOpts struct {

--- a/internal/cli/atlas/security/ldap/save_test.go
+++ b/internal/cli/atlas/security/ldap/save_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestSave_Run(t *testing.T) {

--- a/internal/cli/atlas/security/ldap/status_test.go
+++ b/internal/cli/atlas/security/ldap/status_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestVerifyStatus_Run(t *testing.T) {

--- a/internal/cli/atlas/security/ldap/verify.go
+++ b/internal/cli/atlas/security/ldap/verify.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type VerifyOpts struct {

--- a/internal/cli/atlas/security/ldap/verify_test.go
+++ b/internal/cli/atlas/security/ldap/verify_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestVerify_Run(t *testing.T) {

--- a/internal/cli/atlas/security/ldap/watch_test.go
+++ b/internal/cli/atlas/security/ldap/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/backup/restores/create.go
+++ b/internal/cli/atlas/serverless/backup/restores/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/atlas/serverless/backup/restores/create_test.go
+++ b/internal/cli/atlas/serverless/backup/restores/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/backup/restores/describe_test.go
+++ b/internal/cli/atlas/serverless/backup/restores/describe_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/backup/restores/list_test.go
+++ b/internal/cli/atlas/serverless/backup/restores/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/backup/restores/watch.go
+++ b/internal/cli/atlas/serverless/backup/restores/watch.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type WatchOpts struct {

--- a/internal/cli/atlas/serverless/backup/restores/watch_test.go
+++ b/internal/cli/atlas/serverless/backup/restores/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatchBuilder(t *testing.T) {

--- a/internal/cli/atlas/serverless/backup/snapshots/describe_test.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/describe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/backup/snapshots/list_test.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/backup/snapshots/watch_test.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/watch_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/create.go
+++ b/internal/cli/atlas/serverless/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const providerName = "SERVERLESS"

--- a/internal/cli/atlas/serverless/create_test.go
+++ b/internal/cli/atlas/serverless/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/describe_test.go
+++ b/internal/cli/atlas/serverless/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/list_test.go
+++ b/internal/cli/atlas/serverless/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/atlas/serverless/update.go
+++ b/internal/cli/atlas/serverless/update.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type UpdateOpts struct {

--- a/internal/cli/atlas/serverless/update_test.go
+++ b/internal/cli/atlas/serverless/update_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/serverless/watch_test.go
+++ b/internal/cli/atlas/serverless/watch_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/atlas/setup/access_list_setup.go
+++ b/internal/cli/atlas/setup/access_list_setup.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func (opts *Opts) createAccessList() error {

--- a/internal/cli/atlas/setup/cluster_setup.go
+++ b/internal/cli/atlas/setup/cluster_setup.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/search"
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/cli/atlas/setup/dbuser_setup.go
+++ b/internal/cli/atlas/setup/dbuser_setup.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/randgen"
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func (opts *Opts) createDatabaseUser() error {

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -40,7 +40,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/validate"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/atlas/setup/setup_cmd_test.go
+++ b/internal/cli/atlas/setup/setup_cmd_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBuilder(t *testing.T) {

--- a/internal/cli/atlas/teams/create.go
+++ b/internal/cli/atlas/teams/create.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var createTemplate = "Team '{{.Name}}' created.\n"

--- a/internal/cli/atlas/teams/create_test.go
+++ b/internal/cli/atlas/teams/create_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/atlas/teams/describe_test.go
+++ b/internal/cli/atlas/teams/describe_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/atlas/teams/list_test.go
+++ b/internal/cli/atlas/teams/list_test.go
@@ -23,7 +23,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/teams/users/add.go
+++ b/internal/cli/atlas/teams/users/add.go
@@ -25,7 +25,7 @@ import (
 	store "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const addTemplate = "User(s) added to the team.\n"

--- a/internal/cli/atlas/teams/users/add_test.go
+++ b/internal/cli/atlas/teams/users/add_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAdd_Run(t *testing.T) {

--- a/internal/cli/atlas/teams/users/list_test.go
+++ b/internal/cli/atlas/teams/users/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/atlas/users/describe_test.go
+++ b/internal/cli/atlas/users/describe_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/mock/gomock"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run_ByID(t *testing.T) {

--- a/internal/cli/atlas/users/invite.go
+++ b/internal/cli/atlas/users/invite.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var inviteTemplate = "The user '{{.Username}}' has been invited.\nInvited users do not have access to the project until they accept the invitation.\n"

--- a/internal/cli/atlas/users/invite_test.go
+++ b/internal/cli/atlas/users/invite_test.go
@@ -25,7 +25,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestInvite_Run(t *testing.T) {

--- a/internal/cli/default_setter_opts.go
+++ b/internal/cli/default_setter_opts.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/internal/validate"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )

--- a/internal/cli/iam/organizations/list_test.go
+++ b/internal/cli/iam/organizations/list_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/metrics_opt.go
+++ b/internal/cli/metrics_opt.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/cli/mongocli/backup/restores/list_test.go
+++ b/internal/cli/mongocli/backup/restores/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/mongocli/backup/restores/start.go
+++ b/internal/cli/mongocli/backup/restores/start.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/mongocli/backup/restores/start_test.go
+++ b/internal/cli/mongocli/backup/restores/start_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestStart_Run(t *testing.T) {

--- a/internal/cli/mongocli/backup/snapshots/create.go
+++ b/internal/cli/mongocli/backup/snapshots/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CreateOpts struct {

--- a/internal/cli/mongocli/backup/snapshots/create_test.go
+++ b/internal/cli/mongocli/backup/snapshots/create_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/mongocli/backup/snapshots/describe_test.go
+++ b/internal/cli/mongocli/backup/snapshots/describe_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/mongocli/backup/snapshots/list_test.go
+++ b/internal/cli/mongocli/backup/snapshots/list_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/mongocli/backup/snapshots/watch_test.go
+++ b/internal/cli/mongocli/backup/snapshots/watch_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/backup/restores/create.go
+++ b/internal/cli/mongocli/serverless/backup/restores/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/cli/mongocli/serverless/backup/restores/create_test.go
+++ b/internal/cli/mongocli/serverless/backup/restores/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreate_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/backup/restores/describe_test.go
+++ b/internal/cli/mongocli/serverless/backup/restores/describe_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/backup/restores/list_test.go
+++ b/internal/cli/mongocli/serverless/backup/restores/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListOpts_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/backup/restores/watch.go
+++ b/internal/cli/mongocli/serverless/backup/restores/watch.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type WatchOpts struct {

--- a/internal/cli/mongocli/serverless/backup/restores/watch_test.go
+++ b/internal/cli/mongocli/serverless/backup/restores/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatchBuilder(t *testing.T) {

--- a/internal/cli/mongocli/serverless/backup/snapshots/describe_test.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/describe_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/backup/snapshots/list_test.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/list_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestList_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/backup/snapshots/watch_test.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/watch_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/create.go
+++ b/internal/cli/mongocli/serverless/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const providerName = "SERVERLESS"

--- a/internal/cli/mongocli/serverless/create_test.go
+++ b/internal/cli/mongocli/serverless/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCreateOpts_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/describe_test.go
+++ b/internal/cli/mongocli/serverless/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {

--- a/internal/cli/mongocli/serverless/list_test.go
+++ b/internal/cli/mongocli/serverless/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/mongocli/serverless/watch_test.go
+++ b/internal/cli/mongocli/serverless/watch_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestWatch_Run(t *testing.T) {

--- a/internal/cli/output_opts_test.go
+++ b/internal/cli/output_opts_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestOutputOpts_outputTypeAndValue(t *testing.T) {

--- a/internal/convert/custom_db_role.go
+++ b/internal/convert/custom_db_role.go
@@ -17,7 +17,7 @@ package convert
 import (
 	"strings"
 
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/internal/convert/custom_db_role_test.go
+++ b/internal/convert/custom_db_role_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBuildAtlasInheritedRoles(t *testing.T) {

--- a/internal/convert/database_user.go
+++ b/internal/convert/database_user.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	customTime "github.com/mongodb/mongodb-atlas-cli/internal/time"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 

--- a/internal/convert/database_user_test.go
+++ b/internal/convert/database_user_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 

--- a/internal/kubernetes/operator/config_exporter.go
+++ b/internal/kubernetes/operator/config_exporter.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/kubernetes/operator/project"
 	"github.com/mongodb/mongodb-atlas-cli/internal/kubernetes/operator/resources"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"

--- a/internal/kubernetes/operator/config_exporter_test.go
+++ b/internal/kubernetes/operator/config_exporter_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const projectID = "TestProjectID"

--- a/internal/kubernetes/operator/datafederation/datafederation.go
+++ b/internal/kubernetes/operator/datafederation/datafederation.go
@@ -23,7 +23,7 @@ import (
 	atlasV1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/kubernetes/operator/datafederation/datafederation_test.go
+++ b/internal/kubernetes/operator/datafederation/datafederation_test.go
@@ -29,7 +29,7 @@ import (
 	atlasV1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/kubernetes/operator/dbusers/dbusers.go
+++ b/internal/kubernetes/operator/dbusers/dbusers.go
@@ -26,7 +26,7 @@ import (
 	atlasV1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/kubernetes/operator/dbusers/dbusers_test.go
+++ b/internal/kubernetes/operator/dbusers/dbusers_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/kubernetes/operator/deployment/deployment.go
+++ b/internal/kubernetes/operator/deployment/deployment.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/provider"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/common"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/provider"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/internal/kubernetes/operator/project/project.go
+++ b/internal/kubernetes/operator/project/project.go
@@ -29,7 +29,7 @@ import (
 	operatorProject "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/project"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/provider"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/kubernetes/operator/project/project_test.go
+++ b/internal/kubernetes/operator/project/project_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/project"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/provider"
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/mocks/atlas/mock_alert_configuration.go
+++ b/internal/mocks/atlas/mock_alert_configuration.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockAlertConfigurationLister is a mock of AlertConfigurationLister interface.

--- a/internal/mocks/atlas/mock_alerts.go
+++ b/internal/mocks/atlas/mock_alerts.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockAlertDescriber is a mock of AlertDescriber interface.

--- a/internal/mocks/atlas/mock_api_keys.go
+++ b/internal/mocks/atlas/mock_api_keys.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/atlas/mock_api_keys_access_list.go
+++ b/internal/mocks/atlas/mock_api_keys_access_list.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockOrganizationAPIKeyAccessListCreator is a mock of OrganizationAPIKeyAccessListCreator interface.

--- a/internal/mocks/atlas/mock_backup.go
+++ b/internal/mocks/atlas/mock_backup.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockCompliancePolicyDescriber is a mock of CompliancePolicyDescriber interface.

--- a/internal/mocks/atlas/mock_data_federation.go
+++ b/internal/mocks/atlas/mock_data_federation.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockDataFederationLister is a mock of DataFederationLister interface.

--- a/internal/mocks/atlas/mock_data_federation_private_endpoint.go
+++ b/internal/mocks/atlas/mock_data_federation_private_endpoint.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockDataFederationPrivateEndpointLister is a mock of DataFederationPrivateEndpointLister interface.

--- a/internal/mocks/atlas/mock_data_federation_query_limits.go
+++ b/internal/mocks/atlas/mock_data_federation_query_limits.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockDataFederationQueryLimitLister is a mock of DataFederationQueryLimitLister interface.

--- a/internal/mocks/atlas/mock_data_lake_pipelines.go
+++ b/internal/mocks/atlas/mock_data_lake_pipelines.go
@@ -9,7 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/atlas/mock_data_lake_pipelines_runs.go
+++ b/internal/mocks/atlas/mock_data_lake_pipelines_runs.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockPipelineRunsLister is a mock of PipelineRunsLister interface.

--- a/internal/mocks/atlas/mock_events.go
+++ b/internal/mocks/atlas/mock_events.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockOrganizationEventLister is a mock of OrganizationEventLister interface.

--- a/internal/mocks/atlas/mock_organization_invitations.go
+++ b/internal/mocks/atlas/mock_organization_invitations.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockOrganizationInvitationLister is a mock of OrganizationInvitationLister interface.

--- a/internal/mocks/atlas/mock_organizations.go
+++ b/internal/mocks/atlas/mock_organizations.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockOrganizationLister is a mock of OrganizationLister interface.

--- a/internal/mocks/atlas/mock_performance_advisor.go
+++ b/internal/mocks/atlas/mock_performance_advisor.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockPerformanceAdvisorNamespacesLister is a mock of PerformanceAdvisorNamespacesLister interface.

--- a/internal/mocks/atlas/mock_project_invitations.go
+++ b/internal/mocks/atlas/mock_project_invitations.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockProjectInvitationLister is a mock of ProjectInvitationLister interface.

--- a/internal/mocks/atlas/mock_projects.go
+++ b/internal/mocks/atlas/mock_projects.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/atlas/mock_teams.go
+++ b/internal/mocks/atlas/mock_teams.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/atlas/mock_users.go
+++ b/internal/mocks/atlas/mock_users.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_access_logs.go
+++ b/internal/mocks/mock_access_logs.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_access_role.go
+++ b/internal/mocks/mock_access_role.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_atlas_generic_store.go
+++ b/internal/mocks/mock_atlas_generic_store.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_atlas_operator_cluster_store.go
+++ b/internal/mocks/mock_atlas_operator_cluster_store.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_atlas_operator_db_users_store.go
+++ b/internal/mocks/mock_atlas_operator_db_users_store.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_atlas_operator_project_store.go
+++ b/internal/mocks/mock_atlas_operator_project_store.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_auditing.go
+++ b/internal/mocks/mock_auditing.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockAuditingDescriber is a mock of AuditingDescriber interface.

--- a/internal/mocks/mock_cloud_provider_backup.go
+++ b/internal/mocks/mock_cloud_provider_backup.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_cloud_provider_backup_serverless.go
+++ b/internal/mocks/mock_cloud_provider_backup_serverless.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_cloud_provider_regions.go
+++ b/internal/mocks/mock_cloud_provider_regions.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockCloudProviderRegionsLister is a mock of CloudProviderRegionsLister interface.

--- a/internal/mocks/mock_clusters.go
+++ b/internal/mocks/mock_clusters.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 	opsmngr "go.mongodb.org/ops-manager/opsmngr"
 )

--- a/internal/mocks/mock_custom_dns.go
+++ b/internal/mocks/mock_custom_dns.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockCustomDNSEnabler is a mock of CustomDNSEnabler interface.

--- a/internal/mocks/mock_data_federation.go
+++ b/internal/mocks/mock_data_federation.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockDataFederationLister is a mock of DataFederationLister interface.

--- a/internal/mocks/mock_database_roles.go
+++ b/internal/mocks/mock_database_roles.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockDatabaseRoleLister is a mock of DatabaseRoleLister interface.

--- a/internal/mocks/mock_database_users.go
+++ b/internal/mocks/mock_database_users.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -263,10 +263,10 @@ func (m *MockDBUserCertificateCreator) EXPECT() *MockDBUserCertificateCreatorMoc
 }
 
 // CreateDBUserCertificate mocks base method.
-func (m *MockDBUserCertificateCreator) CreateDBUserCertificate(arg0, arg1 string, arg2 int) (*admin.UserCert, error) {
+func (m *MockDBUserCertificateCreator) CreateDBUserCertificate(arg0, arg1 string, arg2 int) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDBUserCertificate", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*admin.UserCert)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/mocks/mock_encryption_at_rest.go
+++ b/internal/mocks/mock_encryption_at_rest.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockEncryptionAtRestDescriber is a mock of EncryptionAtRestDescriber interface.

--- a/internal/mocks/mock_global_cluster.go
+++ b/internal/mocks/mock_global_cluster.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockGlobalClusterDescriber is a mock of GlobalClusterDescriber interface.

--- a/internal/mocks/mock_indexes.go
+++ b/internal/mocks/mock_indexes.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockIndexCreator is a mock of IndexCreator interface.

--- a/internal/mocks/mock_integrations.go
+++ b/internal/mocks/mock_integrations.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockIntegrationCreator is a mock of IntegrationCreator interface.

--- a/internal/mocks/mock_ldap_configurations.go
+++ b/internal/mocks/mock_ldap_configurations.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockLDAPConfigurationVerifier is a mock of LDAPConfigurationVerifier interface.

--- a/internal/mocks/mock_live_migration_link_tokens.go
+++ b/internal/mocks/mock_live_migration_link_tokens.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockLinkTokenCreator is a mock of LinkTokenCreator interface.

--- a/internal/mocks/mock_live_migration_validations.go
+++ b/internal/mocks/mock_live_migration_validations.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockLiveMigrationValidationsCreator is a mock of LiveMigrationValidationsCreator interface.

--- a/internal/mocks/mock_live_migrations.go
+++ b/internal/mocks/mock_live_migrations.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockLiveMigrationCreator is a mock of LiveMigrationCreator interface.

--- a/internal/mocks/mock_logs.go
+++ b/internal/mocks/mock_logs.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	opsmngr "go.mongodb.org/ops-manager/opsmngr"
 )
 

--- a/internal/mocks/mock_maintenance.go
+++ b/internal/mocks/mock_maintenance.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	opsmngr "go.mongodb.org/ops-manager/opsmngr"
 )
 

--- a/internal/mocks/mock_online_archives.go
+++ b/internal/mocks/mock_online_archives.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_peering_connections.go
+++ b/internal/mocks/mock_peering_connections.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_private_endpoints.go
+++ b/internal/mocks/mock_private_endpoints.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockPrivateEndpointLister is a mock of PrivateEndpointLister interface.

--- a/internal/mocks/mock_process_databases.go
+++ b/internal/mocks/mock_process_databases.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_process_disk_measurements.go
+++ b/internal/mocks/mock_process_disk_measurements.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockProcessDiskMeasurementsLister is a mock of ProcessDiskMeasurementsLister interface.

--- a/internal/mocks/mock_process_disks.go
+++ b/internal/mocks/mock_process_disks.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_process_measurements.go
+++ b/internal/mocks/mock_process_measurements.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockProcessMeasurementLister is a mock of ProcessMeasurementLister interface.

--- a/internal/mocks/mock_processes.go
+++ b/internal/mocks/mock_processes.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockProcessLister is a mock of ProcessLister interface.

--- a/internal/mocks/mock_project_ip_access_lists.go
+++ b/internal/mocks/mock_project_ip_access_lists.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_project_settings.go
+++ b/internal/mocks/mock_project_settings.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_search.go
+++ b/internal/mocks/mock_search.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockSearchIndexLister is a mock of SearchIndexLister interface.

--- a/internal/mocks/mock_serverless_instances.go
+++ b/internal/mocks/mock_serverless_instances.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/mocks/mock_serverless_private_endpoints.go
+++ b/internal/mocks/mock_serverless_private_endpoints.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockServerlessPrivateEndpointsLister is a mock of ServerlessPrivateEndpointsLister interface.

--- a/internal/mocks/mock_x509_certificate_store.go
+++ b/internal/mocks/mock_x509_certificate_store.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	admin "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	admin "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 // MockX509CertificateConfDescriber is a mock of X509CertificateConfDescriber interface.

--- a/internal/prompt/config.go
+++ b/internal/prompt/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/validate"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -15,7 +15,7 @@
 package search
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 	"go.mongodb.org/ops-manager/search"

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test/fixture"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/access_logs.go
+++ b/internal/store/access_logs.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/access_role.go
+++ b/internal/store/access_role.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/atlas/alert_configuration.go
+++ b/internal/store/atlas/alert_configuration.go
@@ -16,7 +16,7 @@ package atlas
 
 import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_alert_configuration.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas AlertConfigurationLister,AlertConfigurationCreator,AlertConfigurationDeleter,AlertConfigurationUpdater,MatcherFieldsLister,AlertConfigurationEnabler,AlertConfigurationDisabler

--- a/internal/store/atlas/alerts.go
+++ b/internal/store/atlas/alerts.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_alerts.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas AlertDescriber,AlertLister,AlertAcknowledger

--- a/internal/store/atlas/api_keys.go
+++ b/internal/store/atlas/api_keys.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/atlas/api_keys_access_list.go
+++ b/internal/store/atlas/api_keys_access_list.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_api_keys_access_list.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas OrganizationAPIKeyAccessListCreator,OrganizationAPIKeyAccessListDeleter,OrganizationAPIKeyAccessListLister

--- a/internal/store/atlas/backup.go
+++ b/internal/store/atlas/backup.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CompliancePolicyDescriber interface {

--- a/internal/store/atlas/data_federation.go
+++ b/internal/store/atlas/data_federation.go
@@ -19,7 +19,7 @@ package atlas
 import (
 	"os"
 
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_data_federation.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas DataFederationLister,DataFederationDescriber,DataFederationCreator,DataFederationUpdater,DataFederationDeleter,DataFederationLogDownloader

--- a/internal/store/atlas/data_federation_private_endpoint.go
+++ b/internal/store/atlas/data_federation_private_endpoint.go
@@ -17,7 +17,7 @@
 package atlas
 
 import (
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_data_federation_private_endpoint.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas DataFederationPrivateEndpointLister,DataFederationPrivateEndpointDescriber,DataFederationPrivateEndpointCreator,DataFederationPrivateEndpointDeleter

--- a/internal/store/atlas/data_federation_query_limits.go
+++ b/internal/store/atlas/data_federation_query_limits.go
@@ -17,7 +17,7 @@
 package atlas
 
 import (
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_data_federation_query_limits.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas DataFederationQueryLimitLister,DataFederationQueryLimitDescriber,DataFederationQueryLimitCreator,DataFederationQueryLimitDeleter

--- a/internal/store/atlas/data_lake_pipelines.go
+++ b/internal/store/atlas/data_lake_pipelines.go
@@ -19,7 +19,7 @@ package atlas
 import (
 	"time"
 
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/atlas/data_lake_pipelines_runs.go
+++ b/internal/store/atlas/data_lake_pipelines_runs.go
@@ -17,7 +17,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_data_lake_pipelines_runs.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas PipelineRunsLister,PipelineRunsDescriber

--- a/internal/store/atlas/events.go
+++ b/internal/store/atlas/events.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_events.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas OrganizationEventLister,ProjectEventLister,EventLister

--- a/internal/store/atlas/organization_invitations.go
+++ b/internal/store/atlas/organization_invitations.go
@@ -14,7 +14,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_organization_invitations.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas OrganizationInvitationLister,OrganizationInvitationDeleter,OrganizationInvitationDescriber,OrganizationInvitationUpdater,OrganizationInviter

--- a/internal/store/atlas/organizations.go
+++ b/internal/store/atlas/organizations.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_organizations.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas OrganizationLister,OrganizationDeleter,OrganizationDescriber,OrganizationCreator

--- a/internal/store/atlas/performance_advisor.go
+++ b/internal/store/atlas/performance_advisor.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_performance_advisor.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas PerformanceAdvisorNamespacesLister,PerformanceAdvisorSlowQueriesLister,PerformanceAdvisorIndexesLister,PerformanceAdvisorSlowOperationThresholdEnabler,PerformanceAdvisorSlowOperationThresholdDisabler

--- a/internal/store/atlas/project_invitations.go
+++ b/internal/store/atlas/project_invitations.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../../mocks/atlas/mock_project_invitations.go -package=atlas github.com/mongodb/mongodb-atlas-cli/internal/store/atlas ProjectInvitationLister,ProjectInvitationDescriber,ProjectInvitationDeleter,ProjectInviter,ProjectInvitationUpdater

--- a/internal/store/atlas/projects.go
+++ b/internal/store/atlas/projects.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/atlas/store.go
+++ b/internal/store/atlas/store.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb-forks/digest"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/log"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlasauth "go.mongodb.org/atlas/auth"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )

--- a/internal/store/atlas/teams.go
+++ b/internal/store/atlas/teams.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/atlas/users.go
+++ b/internal/store/atlas/users.go
@@ -15,7 +15,7 @@
 package atlas
 
 import (
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/auditing.go
+++ b/internal/store/auditing.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_auditing.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store AuditingDescriber,AuditingUpdater

--- a/internal/store/cloud_provider_backup.go
+++ b/internal/store/cloud_provider_backup.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/cloud_provider_backup_serverless.go
+++ b/internal/store/cloud_provider_backup_serverless.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/cloud_provider_regions.go
+++ b/internal/store/cloud_provider_regions.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_cloud_provider_regions.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store CloudProviderRegionsLister

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )

--- a/internal/store/custom_dns.go
+++ b/internal/store/custom_dns.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 type CustomDNSEnabler interface {

--- a/internal/store/data_federation.go
+++ b/internal/store/data_federation.go
@@ -16,7 +16,7 @@ package store
 
 import (
 	atlas "github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_data_federation.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store DataFederationLister,DataFederationStore

--- a/internal/store/database_roles.go
+++ b/internal/store/database_roles.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_database_roles.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store DatabaseRoleLister,DatabaseRoleCreator,DatabaseRoleDeleter,DatabaseRoleUpdater,DatabaseRoleDescriber

--- a/internal/store/database_users.go
+++ b/internal/store/database_users.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -50,7 +50,7 @@ type DBUserCertificateLister interface {
 }
 
 type DBUserCertificateCreator interface {
-	CreateDBUserCertificate(string, string, int) (*atlasv2.UserCert, error)
+	CreateDBUserCertificate(string, string, int) (string, error)
 }
 
 // CreateDatabaseUser encapsulate the logic to manage different cloud providers.
@@ -124,15 +124,15 @@ func (s *Store) DBUserCertificates(projectID, username string, opts *atlas.ListO
 }
 
 // CreateDBUserCertificate creates a new Atlas managed certificates for a database user.
-func (s *Store) CreateDBUserCertificate(projectID, username string, monthsUntilExpiration int) (*atlasv2.UserCert, error) {
+func (s *Store) CreateDBUserCertificate(projectID, username string, monthsUntilExpiration int) (string, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
 		userCert := &atlasv2.UserCert{
 			MonthsUntilExpiration: pointer.Get(monthsUntilExpiration),
 		}
-		_, err := s.clientv2.X509AuthenticationApi.CreateDatabaseUserCertificate(s.ctx, projectID, username, userCert).Execute()
-		return userCert, err
+		cert, _, err := s.clientv2.X509AuthenticationApi.CreateDatabaseUserCertificate(s.ctx, projectID, username, userCert).Execute()
+		return cert, err
 	default:
-		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
+		return "", fmt.Errorf("%w: %s", errUnsupportedService, s.service)
 	}
 }

--- a/internal/store/encryption_at_rest.go
+++ b/internal/store/encryption_at_rest.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_encryption_at_rest.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store EncryptionAtRestDescriber

--- a/internal/store/global_cluster.go
+++ b/internal/store/global_cluster.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_global_cluster.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store GlobalClusterDescriber

--- a/internal/store/indexes.go
+++ b/internal/store/indexes.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_indexes.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store IndexCreator

--- a/internal/store/integrations.go
+++ b/internal/store/integrations.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_integrations.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store IntegrationCreator,IntegrationLister,IntegrationDeleter,IntegrationDescriber

--- a/internal/store/ldap_configurations.go
+++ b/internal/store/ldap_configurations.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_ldap_configurations.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store LDAPConfigurationVerifier,LDAPConfigurationDescriber,LDAPConfigurationSaver,LDAPConfigurationDeleter,LDAPConfigurationGetter

--- a/internal/store/live_migration.go
+++ b/internal/store/live_migration.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_live_migration_validations.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store LiveMigrationValidationsCreator,LiveMigrationCutoverCreator,LiveMigrationValidationsDescriber

--- a/internal/store/live_migration_link_tokens.go
+++ b/internal/store/live_migration_link_tokens.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 

--- a/internal/store/live_migrations.go
+++ b/internal/store/live_migrations.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_live_migrations.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store LiveMigrationCreator,LiveMigrationDescriber

--- a/internal/store/logs.go
+++ b/internal/store/logs.go
@@ -19,7 +19,7 @@ import (
 	"io"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 

--- a/internal/store/maintenance.go
+++ b/internal/store/maintenance.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 

--- a/internal/store/online_archives.go
+++ b/internal/store/online_archives.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/organization_invitations.go
+++ b/internal/store/organization_invitations.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )

--- a/internal/store/peering_connections.go
+++ b/internal/store/peering_connections.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/private_endpoints.go
+++ b/internal/store/private_endpoints.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_private_endpoints.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store PrivateEndpointLister,PrivateEndpointDescriber,PrivateEndpointCreator,PrivateEndpointDeleter,InterfaceEndpointDescriber,InterfaceEndpointCreator,InterfaceEndpointDeleter,RegionalizedPrivateEndpointSettingUpdater,RegionalizedPrivateEndpointSettingDescriber,DataLakePrivateEndpointLister,DataLakePrivateEndpointCreator,DataLakePrivateEndpointDeleter,DataLakePrivateEndpointDescriber

--- a/internal/store/process_databases.go
+++ b/internal/store/process_databases.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/process_disk_measurements.go
+++ b/internal/store/process_disk_measurements.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen  -destination=../mocks/mock_process_disk_measurements.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store ProcessDiskMeasurementsLister,ProcessDatabaseMeasurementsLister

--- a/internal/store/process_disks.go
+++ b/internal/store/process_disks.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/process_measurements.go
+++ b/internal/store/process_measurements.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_process_measurements.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store ProcessMeasurementLister

--- a/internal/store/processes.go
+++ b/internal/store/processes.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_processes.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store ProcessLister,ProcessDescriber

--- a/internal/store/project_ip_access_lists.go
+++ b/internal/store/project_ip_access_lists.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/project_settings.go
+++ b/internal/store/project_settings.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_search.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store SearchIndexLister,SearchIndexCreator,SearchIndexDescriber,SearchIndexUpdater,SearchIndexDeleter

--- a/internal/store/serverless_instances.go
+++ b/internal/store/serverless_instances.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/internal/store/serverless_private_endpoints.go
+++ b/internal/store/serverless_private_endpoints.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_serverless_private_endpoints.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store ServerlessPrivateEndpointsLister

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,7 +31,7 @@ import (
 	"github.com/mongodb-forks/digest"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/log"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlasauth "go.mongodb.org/atlas/auth"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"

--- a/internal/store/x509_auth_database_users.go
+++ b/internal/store/x509_auth_database_users.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 //go:generate mockgen -destination=../mocks/mock_x509_certificate_store.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store X509CertificateConfDescriber,X509CertificateConfSaver,X509CertificateConfDisabler

--- a/internal/watchers/watcher.go
+++ b/internal/watchers/watcher.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/test/e2e/atlas/access_lists_test.go
+++ b/test/e2e/atlas/access_lists_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAccessList(t *testing.T) {

--- a/test/e2e/atlas/access_logs_test.go
+++ b/test/e2e/atlas/access_logs_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAccessLogs(t *testing.T) {

--- a/test/e2e/atlas/access_roles_test.go
+++ b/test/e2e/atlas/access_roles_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const aws = "AWS"

--- a/test/e2e/atlas/alert_settings_test.go
+++ b/test/e2e/atlas/alert_settings_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAlertConfig(t *testing.T) {

--- a/test/e2e/atlas/alerts_test.go
+++ b/test/e2e/atlas/alerts_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/test/e2e/atlas/auditing_test.go
+++ b/test/e2e/atlas/auditing_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAuditing(t *testing.T) {

--- a/test/e2e/atlas/backup_compliancepolicy_copyprotection_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_copyprotection_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBackupCompliancePolicyCopyProtection(t *testing.T) {

--- a/test/e2e/atlas/backup_compliancepolicy_describe_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_describe_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBackupCompliancePolicyDescribe(t *testing.T) {

--- a/test/e2e/atlas/backup_compliancepolicy_enable_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_enable_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBackupCompliancePolicyEnable(t *testing.T) {

--- a/test/e2e/atlas/backup_compliancepolicy_pitrestore_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_pitrestore_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBackupCompliancePolicyPointInTimeRestore(t *testing.T) {

--- a/test/e2e/atlas/backup_compliancepolicy_policies_describe_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_policies_describe_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBackupCompliancePolicyPoliciesDescribe(t *testing.T) {

--- a/test/e2e/atlas/backup_compliancepolicy_setup_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_setup_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestBackupCompliancePolicySetup(t *testing.T) {

--- a/test/e2e/atlas/backup_export_buckets_test.go
+++ b/test/e2e/atlas/backup_export_buckets_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestExportBuckets(t *testing.T) {

--- a/test/e2e/atlas/backup_export_jobs_test.go
+++ b/test/e2e/atlas/backup_export_jobs_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/test/e2e/atlas/backup_restores_test.go
+++ b/test/e2e/atlas/backup_restores_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestRestores(t *testing.T) {

--- a/test/e2e/atlas/backup_schedule_test.go
+++ b/test/e2e/atlas/backup_schedule_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestSchedule(t *testing.T) {

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestServerlessBackup(t *testing.T) {

--- a/test/e2e/atlas/backup_snapshot_test.go
+++ b/test/e2e/atlas/backup_snapshot_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/test/e2e/atlas/clusters_file_test.go
+++ b/test/e2e/atlas/clusters_file_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestClustersFile(t *testing.T) {

--- a/test/e2e/atlas/clusters_flags_test.go
+++ b/test/e2e/atlas/clusters_flags_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const writeConcern = "majority"

--- a/test/e2e/atlas/clusters_m0_test.go
+++ b/test/e2e/atlas/clusters_m0_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/test/e2e/atlas/clusters_sharded_test.go
+++ b/test/e2e/atlas/clusters_sharded_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestShardedCluster(t *testing.T) {

--- a/test/e2e/atlas/clusters_upgrade_test.go
+++ b/test/e2e/atlas/clusters_upgrade_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/test/e2e/atlas/custom_db_roles_test.go
+++ b/test/e2e/atlas/custom_db_roles_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/test/e2e/atlas/custom_dns_test.go
+++ b/test/e2e/atlas/custom_dns_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestCustomDNS(t *testing.T) {

--- a/test/e2e/atlas/data_federation_private_endpoint_test.go
+++ b/test/e2e/atlas/data_federation_private_endpoint_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDataFederationPrivateEndpointsAWS(t *testing.T) {

--- a/test/e2e/atlas/data_federation_query_limit_test.go
+++ b/test/e2e/atlas/data_federation_query_limit_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/test/e2e/atlas/data_lake_pipelines_test.go
+++ b/test/e2e/atlas/data_lake_pipelines_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/test/e2e/atlas/dbusers_certs_test.go
+++ b/test/e2e/atlas/dbusers_certs_test.go
@@ -25,20 +25,17 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/dbusers"
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDBUserCerts(t *testing.T) {
 	n, err := e2e.RandInt(1000)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	username := fmt.Sprintf("user%v", n)
 
 	cliPath, err := e2e.AtlasCLIBin()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	t.Run("Create DBUser", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			dbusersEntity,
@@ -51,15 +48,9 @@ func TestDBUserCerts(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
+		require.NoError(t, err, string(resp))
 		var user atlasv2.CloudDatabaseUser
-		if err := json.Unmarshal(resp, &user); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, json.Unmarshal(resp, &user), string(resp))
 		assert.Equal(t, username, user.Username)
 	})
 
@@ -72,16 +63,7 @@ func TestDBUserCerts(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Errorf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
-		var user atlasv2.UserCert
-		if err := json.Unmarshal(resp, &user); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		// assert.Equal(t, username, user.Username)
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -93,18 +75,11 @@ func TestDBUserCerts(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 
 		var users atlasv2.PaginatedUserCert
-		if err := json.Unmarshal(resp, &users); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(users.Results) == 0 {
-			t.Fatalf("expected len(users) > 0, got 0")
-		}
+		require.NoError(t, json.Unmarshal(resp, &users), string(resp))
+		assert.NotEmpty(t, users.Results)
 	})
 
 	t.Run("Delete User", func(t *testing.T) {
@@ -117,10 +92,7 @@ func TestDBUserCerts(t *testing.T) {
 			"$external")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("DB user '%s' deleted\n", username)
 		assert.Equal(t, expected, string(resp))

--- a/test/e2e/atlas/dbusers_certs_test.go
+++ b/test/e2e/atlas/dbusers_certs_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/dbusers"
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestDBUserCerts(t *testing.T) {

--- a/test/e2e/atlas/dbusers_test.go
+++ b/test/e2e/atlas/dbusers_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/test/e2e/atlas/events_test.go
+++ b/test/e2e/atlas/events_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestEvents(t *testing.T) {

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/test/e2e/atlas/integrations_test.go
+++ b/test/e2e/atlas/integrations_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestIntegrations(t *testing.T) {

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1/status"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -29,7 +29,7 @@ import (
 	akov1 "github.com/mongodb/mongodb-atlas-kubernetes/pkg/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apisv1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/e2e/atlas/ldap_test.go
+++ b/test/e2e/atlas/ldap_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 const (

--- a/test/e2e/atlas/maintenance_test.go
+++ b/test/e2e/atlas/maintenance_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestMaintenanceWindows(t *testing.T) {

--- a/test/e2e/atlas/metrics_test.go
+++ b/test/e2e/atlas/metrics_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestMetrics(t *testing.T) {

--- a/test/e2e/atlas/online_archives_test.go
+++ b/test/e2e/atlas/online_archives_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestOnlineArchives(t *testing.T) {

--- a/test/e2e/atlas/private_endpoint_test.go
+++ b/test/e2e/atlas/private_endpoint_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 var regionsAWS = []string{

--- a/test/e2e/atlas/processes_test.go
+++ b/test/e2e/atlas/processes_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestProcesses(t *testing.T) {

--- a/test/e2e/atlas/search_test.go
+++ b/test/e2e/atlas/search_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestSearch(t *testing.T) {

--- a/test/e2e/atlas/serverless_test.go
+++ b/test/e2e/atlas/serverless_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestServerless(t *testing.T) {

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/test/e2e/iam/atlas_org_api_key_access_list_test.go
+++ b/test/e2e/iam/atlas_org_api_key_access_list_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasOrgAPIKeyAccessList(t *testing.T) {

--- a/test/e2e/iam/atlas_org_api_keys_test.go
+++ b/test/e2e/iam/atlas_org_api_keys_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasOrgAPIKeys(t *testing.T) {

--- a/test/e2e/iam/atlas_org_invitations_test.go
+++ b/test/e2e/iam/atlas_org_invitations_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasOrgInvitations(t *testing.T) {

--- a/test/e2e/iam/atlas_orgs_test.go
+++ b/test/e2e/iam/atlas_orgs_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasOrgs(t *testing.T) {

--- a/test/e2e/iam/atlas_project_api_keys_test.go
+++ b/test/e2e/iam/atlas_project_api_keys_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasProjectAPIKeys(t *testing.T) {

--- a/test/e2e/iam/atlas_project_invitations_test.go
+++ b/test/e2e/iam/atlas_project_invitations_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasProjectInvitations(t *testing.T) {

--- a/test/e2e/iam/atlas_project_teams_test.go
+++ b/test/e2e/iam/atlas_project_teams_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasProjectTeams(t *testing.T) {

--- a/test/e2e/iam/atlas_projects_test.go
+++ b/test/e2e/iam/atlas_projects_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas-sdk/v20230201006/admin"
+	"go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasProjects(t *testing.T) {

--- a/test/e2e/iam/atlas_team_users_test.go
+++ b/test/e2e/iam/atlas_team_users_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasTeamUsers(t *testing.T) {

--- a/test/e2e/iam/atlas_teams_test.go
+++ b/test/e2e/iam/atlas_teams_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasTeams(t *testing.T) {

--- a/test/e2e/iam/atlas_users_test.go
+++ b/test/e2e/iam/atlas_users_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestAtlasUsers(t *testing.T) {

--- a/test/e2e/iam/orgs_test.go
+++ b/test/e2e/iam/orgs_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20230201006/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20230201007/admin"
 )
 
 func TestOrgs(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-197338

## Checklist

Updates the SDK to fix an issue with creating x509 certs, this will probably a breaking change of outputs
