### PR TITLE
CLOUDP-199970: [AtlasCLI] null pointer error when running atlas deployment setups

### DIFF
--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -244,20 +244,17 @@ func (o *client) runPodman(ctx context.Context, arg ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "podman", arg...)
 
 	output, err := cmd.Output() // ignore stderr
-	var exitErr *exec.ExitError
+
 	if o.debug {
 		_, _ = o.outWriter.Write(output)
+
+		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			_, _ = o.outWriter.Write(exitErr.Stderr)
 		}
 	}
 
-	if errors.As(err, &exitErr) {
-		errorMessage := string(exitErr.Stderr)
-		return nil, errors.New(errorMessage)
-	}
-
-	return output, nil
+	return output, err
 }
 
 func (o *client) CreateNetwork(ctx context.Context, name string) ([]byte, error) {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->
_Jira ticket:_ CLOUDP-199970

## Proposed changes
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->
The `atlas deployment setup` fails with a NPE in the `client.Diagnostics` if the user did not run `podman machine init`

```log
goroutine 1 [running]:
--
github.com/mongodb/mongodb-atlas-cli/internal/podman.(*client).Diagnostics(0x0?, {0x104fd2720, 0x14000511230})
/Users/andrea.angiolillo/workspace/mongodb-atlas-cli/internal/podman/client.go:171 +0x460
github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/deployments.(*SetupOpts).planSteps(0x14000996c00, {0x104fd2720?, 0x14000511230?})
/Users/andrea.angiolillo/workspace/mongodb-atlas-cli/internal/cli/atlas/deployments/setup.go:192 +0x38
github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/deployments.(*SetupOpts).createLocalDeployment(0x14000996c00, {0x104fd2720, 0x14000511230})
/Users/andrea.angiolillo/workspace/mongodb-atlas-cli/internal/cli/atlas/deployments/setup.go:218 +0x78
github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/deployments.(*SetupOpts).Run(0x14000996c00, {0x104fd2720, 0x14000511230})
/Users/andrea.angiolillo/workspace/mongodb-atlas-cli/internal/cli/atlas/deployments/setup.go:670 +0xc8
github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/deployments.SetupBuilder.func2(0x140009a2300?, {0x1400098d110?, 0x0?, 0x3?})
/Users/andrea.angiolillo/workspace/mongodb-atlas-cli/internal/cli/atlas/deployments/setup.go:707 +0x2c
github.com/spf13/cobra.(*Command).execute(0x140009a2300, {0x1400098d0b0, 0x3, 0x3})
/Users/andrea.angiolillo/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x5c8
github.com/spf13/cobra.(*Command).ExecuteC(0x1400054a300)
/Users/andrea.angiolillo/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x35c
github.com/spf13/cobra.(*Command).ExecuteContextC(...)
/Users/andrea.angiolillo/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1001
main.Execute()
/Users/andrea.angiolillo/workspace/mongodb-atlas-cli/cmd/atlas/atlas.go:43 +0xbc
main.main()
/Users/andrea.angiolillo/workspace/mongodb-atlas-cli/cmd/atlas/atlas.go:187 +0x7c
```

Fix: 

This piece of code was using `info` even if `info, err := o.machineInspect(ctx)` returned an error
```
	info, err := o.machineInspect(ctx)
	if err != nil {
		d.MachineFound = false
		d.Errors = append(d.Errors, fmt.Errorf("failed to detect podman machine: %w", err).Error())
	}

	d.MachineInfo = info
	d.MachineState = info.State
```


<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
