### PR TITLE
CLOUDP-200469: Improve wording when file is invalid

### DIFF
--- a/internal/cli/atlas/search/index_opts.go
+++ b/internal/cli/atlas/search/index_opts.go
@@ -26,6 +26,7 @@ import (
 
 const DefaultAnalyzer = "lucene.standard"
 const deprecatedFlagMessage = "please use --file instead"
+const failedToLoadIndexMessage = "failed to parse JSON file due to %s"
 
 type IndexOpts struct {
 	Name           string
@@ -77,7 +78,7 @@ func (opts *IndexOpts) NewSearchIndex() (*atlasv2.ClusterSearchIndex, error) {
 	if len(opts.Filename) > 0 {
 		index := &atlasv2.ClusterSearchIndex{}
 		if err := file.Load(opts.Fs, opts.Filename, index); err != nil {
-			return nil, err
+			return nil, fmt.Errorf(failedToLoadIndexMessage, err.Error())
 		}
 		return index, nil
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

[CLOUDP-200469](https://jira.mongodb.org/browse/CLOUDP-200469)


```shell
~/workp/mongocli CLOUDP-200469 *24 !1 ?1 ❯ atlasdev deployments search index create --file tst.json           1.20 
Error: failed to parse JSON file due to unexpected end of JSON input
~/workp/mongocli CLOUDP-200469 *24 !1 ?1 ❯ atlasdev deployments search index create --file tst.json           1.20 
Error: failed to parse JSON file due to invalid character '}' after object key
```

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
