### PR TITLE
CLOUDP-201089: group deployments commands

### DIFF
--- a/internal/cli/atlas/deployments/connect.go
+++ b/internal/cli/atlas/deployments/connect.go
@@ -105,9 +105,10 @@ func (opts *ConnectOpts) Run(ctx context.Context) error {
 func ConnectBuilder() *cobra.Command {
 	opts := &ConnectOpts{}
 	cmd := &cobra.Command{
-		Use:   "connect [deploymentName]",
-		Short: "Connect to a deployment.",
-		Args:  require.MaximumNArgs(1),
+		Use:     "connect [deploymentName]",
+		Short:   "Connect to a deployment.",
+		Args:    require.MaximumNArgs(1),
+		GroupID: "local",
 		Annotations: map[string]string{
 			"deploymentNameDesc": "Name of the deployment that you want to connect to.",
 		},

--- a/internal/cli/atlas/deployments/delete.go
+++ b/internal/cli/atlas/deployments/delete.go
@@ -72,6 +72,7 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete [deploymentName]",
 		Short:   "Delete a deployment.",
 		Aliases: []string{"rm"},
+		GroupID: "local",
 		Args:    require.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"deploymentNameDesc": "Name of the deployment that you want to delete.",

--- a/internal/cli/atlas/deployments/deployments.go
+++ b/internal/cli/atlas/deployments/deployments.go
@@ -36,6 +36,9 @@ func Builder() *cobra.Command {
 		Short:   "Manage cloud and local deployments.",
 	}
 
+	cmd.AddGroup(&cobra.Group{ID: "all", Title: "Cloud and local deployments commands:"})
+	cmd.AddGroup(&cobra.Group{ID: "local", Title: "Local deployments commands:"})
+
 	cmd.AddCommand(
 		SetupBuilder(),
 		DeleteBuilder(),

--- a/internal/cli/atlas/deployments/list.go
+++ b/internal/cli/atlas/deployments/list.go
@@ -179,6 +179,7 @@ func ListBuilder() *cobra.Command {
 		Short:   "Return all deployments.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
+		GroupID: "all",
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},

--- a/internal/cli/atlas/deployments/search/indexes/create.go
+++ b/internal/cli/atlas/deployments/search/indexes/create.go
@@ -197,9 +197,10 @@ func CreateBuilder() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "create [indexName]",
-		Short: "Create a search index for the specified deployment.",
-		Args:  require.MaximumNArgs(1),
+		Use:     "create [indexName]",
+		Short:   "Create a search index for the specified deployment.",
+		Args:    require.MaximumNArgs(1),
+		GroupID: "local",
 		Annotations: map[string]string{
 			"indexNameDesc": "Name of the index.",
 		},

--- a/internal/cli/atlas/deployments/search/indexes/delete.go
+++ b/internal/cli/atlas/deployments/search/indexes/delete.go
@@ -121,6 +121,7 @@ func DeleteBuilder() *cobra.Command {
 		Aliases: []string{"rm"},
 		Short:   "Delete the specified search index from the specified cluster.",
 		Args:    require.MaximumNArgs(1),
+		GroupID: "all",
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",
 			"output":      opts.SuccessMessage(),

--- a/internal/cli/atlas/deployments/search/indexes/describe.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe.go
@@ -119,9 +119,10 @@ func (opts *DescribeOpts) validateAndPrompt(ctx context.Context) error {
 func DescribeBuilder() *cobra.Command {
 	opts := &DescribeOpts{}
 	cmd := &cobra.Command{
-		Use:   "describe [indexId]",
-		Short: "Describe a search index for the specified deployment.",
-		Args:  require.MaximumNArgs(1),
+		Use:     "describe [indexId]",
+		Short:   "Describe a search index for the specified deployment.",
+		Args:    require.MaximumNArgs(1),
+		GroupID: "all",
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",
 			"output":      describeTemplate,

--- a/internal/cli/atlas/deployments/search/indexes/indexes.go
+++ b/internal/cli/atlas/deployments/search/indexes/indexes.go
@@ -27,6 +27,9 @@ func Builder() *cobra.Command {
 		Aliases: cli.GenerateAliases(use),
 	}
 
+	cmd.AddGroup(&cobra.Group{ID: "all", Title: "Cloud and local deployments commands:"})
+	cmd.AddGroup(&cobra.Group{ID: "local", Title: "Local deployments commands:"})
+
 	cmd.AddCommand(
 		CreateBuilder(),
 		DescribeBuilder(),

--- a/internal/cli/atlas/deployments/search/indexes/list.go
+++ b/internal/cli/atlas/deployments/search/indexes/list.go
@@ -127,6 +127,7 @@ func ListBuilder() *cobra.Command {
 		Short:   "List all Atlas Search indexes for a deployment.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
+		GroupID: "all",
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},

--- a/internal/cli/atlas/deployments/search/search.go
+++ b/internal/cli/atlas/deployments/search/search.go
@@ -22,8 +22,9 @@ import (
 func Builder() *cobra.Command {
 	const use = "search"
 	cmd := &cobra.Command{
-		Use:   use,
-		Short: "Manage search for Atlas and local deployments.",
+		Use:     use,
+		Short:   "Manage search for Atlas and local deployments.",
+		GroupID: "all",
 	}
 
 	cmd.AddCommand(indexes.Builder())

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -795,9 +795,10 @@ func SetupBuilder() *cobra.Command {
 		atlasSetup: &setup.Opts{},
 	}
 	cmd := &cobra.Command{
-		Use:   "setup [deploymentName]",
-		Short: "Create a local deployment.",
-		Args:  require.MaximumNArgs(1),
+		Use:     "setup [deploymentName]",
+		Short:   "Create a local deployment.",
+		Args:    require.MaximumNArgs(1),
+		GroupID: "all",
 		Annotations: map[string]string{
 			"deploymentNameDesc": "Name of the deployment that you want to set up.",
 		},


### PR DESCRIPTION
## Proposed changes
group deployments commands:
<img width="651" alt="image" src="https://github.com/mongodb/mongodb-atlas-cli/assets/2392468/573e639c-8752-4d95-b5cc-4f1d2566a2fd">

_Jira ticket:_ CLOUDP-201089
