### PR TITLE
CLOUDP-201297: Add json output flag to index commands

### DIFF
--- a/docs/atlascli/command/atlas-deployments-search-indexes-create.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-create.txt
@@ -77,6 +77,10 @@ Options
      - 
      - false
      - help for create
+   * - -o, --output
+     - string
+     - false
+     - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-deployments-search-indexes-delete.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-delete.txt
@@ -63,6 +63,10 @@ Options
      - 
      - false
      - help for delete
+   * - -o, --output
+     - string
+     - false
+     - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-deployments-search-indexes-describe.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-describe.txt
@@ -95,7 +95,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION
-   <IndexID>   <Name>   <Database>   <CollectionName>
+   ID          NAME     DATABASE     COLLECTION         STATUS
+   <IndexID>   <Name>   <Database>   <CollectionName>   <Status>
    
 

--- a/docs/atlascli/command/atlas-deployments-search-indexes-describe.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-describe.txt
@@ -59,6 +59,10 @@ Options
      - 
      - false
      - help for describe
+   * - -o, --output
+     - string
+     - false
+     - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
@@ -51,6 +51,10 @@ Options
      - 
      - false
      - help for list
+   * - -o, --output
+     - string
+     - false
+     - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
    * - --projectId
      - string
      - false

--- a/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
@@ -87,7 +87,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION{{range .>
-   <IndexID>   <Name>   <Database>   <CollectionName>
+   ID          NAME     DATABASE     COLLECTION         STATUS{{range .>
+   <IndexID>   <Name>   <Database>   <CollectionName>   <Status>
    
 

--- a/internal/cli/atlas/deployments/search/indexes/create.go
+++ b/internal/cli/atlas/deployments/search/indexes/create.go
@@ -304,6 +304,7 @@ func CreateBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DBName, flag.Database, "", usage.Database)
 	cmd.Flags().StringVar(&opts.Collection, flag.Collection, "", usage.Collection)
 	cmd.Flags().StringVarP(&opts.Filename, flag.File, flag.FileShort, "", usage.SearchFilename)
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
 	// Local only
 	cmd.Flags().BoolVarP(&opts.EnableWatch, flag.EnableWatch, flag.EnableWatchShort, false, usage.EnableWatch)

--- a/internal/cli/atlas/deployments/search/indexes/delete.go
+++ b/internal/cli/atlas/deployments/search/indexes/delete.go
@@ -37,6 +37,7 @@ const (
 )
 
 type DeleteOpts struct {
+	cli.OutputOpts
 	cli.GlobalOpts
 	*cli.DeleteOpts
 	options.DeploymentOpts
@@ -157,6 +158,7 @@ func DeleteBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DeploymentName, flag.DeploymentName, "", usage.DeploymentName)
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
 	cmd.Flags().StringVar(&opts.DeploymentType, flag.TypeFlag, "", usage.DeploymentType)
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/deployments/search/indexes/describe.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe.go
@@ -158,6 +158,7 @@ func DescribeBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DeploymentType, flag.TypeFlag, "", usage.DeploymentType)
 	cmd.Flags().StringVar(&opts.DeploymentName, flag.DeploymentName, "", usage.DeploymentName)
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
 	return cmd
 }

--- a/internal/cli/atlas/deployments/search/indexes/describe.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe.go
@@ -30,8 +30,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var describeTemplate = `ID	NAME	DATABASE	COLLECTION
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}
+var describeTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}
 `
 
 type DescribeOpts struct {

--- a/internal/cli/atlas/deployments/search/indexes/describe_test.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe_test.go
@@ -46,6 +46,7 @@ func TestDescribe_RunLocal(t *testing.T) {
 		expectedLocalDeployment = "localDeployment1"
 		expectedDB              = "db1"
 		expectedCollection      = "col1"
+		expectedStatus          = "STEADY"
 	)
 
 	buf := new(bytes.Buffer)
@@ -115,6 +116,7 @@ func TestDescribe_RunLocal(t *testing.T) {
 		IndexID:        pointer.GetStringPointerIfNotEmpty("test"),
 		CollectionName: "coll",
 		Database:       "db",
+		Status:         pointer.GetStringPointerIfNotEmpty(expectedStatus),
 	}
 
 	mockMongodbClient.
@@ -127,8 +129,8 @@ func TestDescribe_RunLocal(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	assert.Equal(t, `ID     NAME   DATABASE   COLLECTION
-test   name   db         coll
+	assert.Equal(t, `ID     NAME   DATABASE   COLLECTION   STATUS
+test   name   db         coll         STEADY
 `, buf.String())
 	t.Log(buf.String())
 }

--- a/internal/cli/atlas/deployments/search/indexes/list.go
+++ b/internal/cli/atlas/deployments/search/indexes/list.go
@@ -31,8 +31,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listTemplate = `ID	NAME	DATABASE	COLLECTION{{range .}}
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}{{end}}
+var listTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS{{range .}}
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}{{end}}
 `
 
 type ListOpts struct {

--- a/internal/cli/atlas/deployments/search/indexes/list.go
+++ b/internal/cli/atlas/deployments/search/indexes/list.go
@@ -161,6 +161,7 @@ func ListBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DBName, flag.Database, "", usage.Database)
 	cmd.Flags().StringVar(&opts.Collection, flag.Collection, "", usage.Collection)
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
+	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 
 	return cmd
 }

--- a/internal/cli/atlas/deployments/search/indexes/list_test.go
+++ b/internal/cli/atlas/deployments/search/indexes/list_test.go
@@ -49,6 +49,7 @@ func TestList_RunLocal(t *testing.T) {
 		expectedCollection      = "col1"
 		expectedName            = "test"
 		expectedID              = "1"
+		expectedStatus          = "STEADY"
 	)
 
 	buf := new(bytes.Buffer)
@@ -128,6 +129,7 @@ func TestList_RunLocal(t *testing.T) {
 			IndexID:        pointer.GetStringPointerIfNotEmpty(expectedID),
 			CollectionName: expectedCollection,
 			Database:       expectedDB,
+			Status:         pointer.GetStringPointerIfNotEmpty(expectedStatus),
 		},
 	}
 
@@ -141,9 +143,9 @@ func TestList_RunLocal(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	assert.Equal(t, fmt.Sprintf(`ID    NAME   DATABASE   COLLECTION
-%s     %s   %s        %s
-`, expectedID, expectedName, expectedDB, expectedCollection), buf.String())
+	assert.Equal(t, fmt.Sprintf(`ID    NAME   DATABASE   COLLECTION   STATUS
+%s     %s   %s        %s         %s
+`, expectedID, expectedName, expectedDB, expectedCollection, expectedStatus), buf.String())
 	t.Log(buf.String())
 }
 

--- a/internal/mongodbclient/search_index.go
+++ b/internal/mongodbclient/search_index.go
@@ -49,6 +49,7 @@ type SearchIndexDefinition struct {
 	Analyzers  []admin.ApiAtlasFTSAnalyzers           `bson:"analyzers,omitempty"`
 	Synonyms   []admin.SearchSynonymMappingDefinition `bson:"synonyms,omitempty"`
 	Mappings   *admin.ApiAtlasFTSMappings             `bson:"mappings,omitempty"`
+	Status     *string                                `bson:"status,omitempty"`
 }
 
 func (o *database) CreateSearchIndex(ctx context.Context, collection string, idx *admin.ClusterSearchIndex) (*admin.ClusterSearchIndex, error) {
@@ -110,6 +111,7 @@ func (o *database) SearchIndex(ctx context.Context, id string) (*admin.ClusterSe
 				Name:       results[0].Name,
 				Collection: coll,
 				Database:   o.db.Name(),
+				Status:     results[0].Status,
 			}
 			return newClusterSearchIndex(searchIndexDef), nil
 		}
@@ -189,6 +191,7 @@ func newClusterSearchIndex(index *SearchIndexDefinition) *admin.ClusterSearchInd
 		IndexID:        &index.ID,
 		CollectionName: index.Collection,
 		Database:       index.Database,
+		Status:         index.Status,
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-201297](https://jira.mongodb.org/browse/CLOUDP-201297)
Local
```shell
~/workp/mongocli CLOUDP-201297 *28 !3 ?2 ❯ atlasdev deployments search index describe 652530a4b59e137f714584da
? What type of deployment would you like to work with? local
? Select a deployment local4461
ID                         NAME   DATABASE       COLLECTION        STATUS
652530a4b59e137f714584da   test   sample_mflix   embedded_movies   BUILDING
~/workp/mongocli CLOUDP-201297 *28 !3 ?2 ❯ atlasdev deployments search index describe 652530a4b59e137f714584da --output json
? What type of deployment would you like to work with? local
? Select a deployment local4461
{
  "collectionName": "embedded_movies",
  "database": "sample_mflix",
  "indexID": "652530a4b59e137f714584da",
  "name": "test",
  "status": "BUILDING"
}

~/workp/mongocli CLOUDP-201297 *28 !3 ?2 ❯ atlasdev deployments search index list
? What type of deployment would you like to work with? local
? Select a deployment local4461
? Database sample_mflix
? Collection embedded_movies
ID                         NAME   DATABASE       COLLECTION        STATUS
652530a4b59e137f714584da   test   sample_mflix   embedded_movies   READY
```


Atlas
```shell
~/workp/mongocli CLOUDP-201297 *28 !1 ?1 ❯ atlasdev deployments search index describe 650ad19bc478c342b80927e1  --deploymentName Cluster07293 --type atlas -P default1
ID                         NAME        DATABASE       COLLECTION        STATUS
650ad19bc478c342b80927e1   testIndex   sample_mflix   embedded_movies   STEADY
~/workp/mongocli CLOUDP-201297 *28 !1 ?1 ❯ atlasdev deployments search index describe 650ad19bc478c342b80927e1  --deploymentName Cluster07293 --type atlas -P default1 --output json
{
  "collectionName": "embedded_movies",
  "database": "sample_mflix",
  "indexID": "650ad19bc478c342b80927e1",
  "mappings": {
    "dynamic": true,
    "fields": {
      "plot_embedding": {
        "dimensions": 1536,
        "similarity": "euclidean",
        "type": "knnVector"
      }
    }
  },
  "name": "testIndex",
  "status": "STEADY"
}
```

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
