### PR TITLE
CLOUDP-202232: add missing namespaces to suggestedIndexes command

### DIFF
--- a/internal/store/atlas/performance_advisor.go
+++ b/internal/store/atlas/performance_advisor.go
@@ -76,6 +76,9 @@ func (s *Store) PerformanceAdvisorSlowQueries(opts *atlasv2.ListSlowQueriesApiPa
 func (s *Store) PerformanceAdvisorIndexes(opts *atlasv2.ListSuggestedIndexesApiParams) (*atlasv2.PerformanceAdvisorResponse, error) {
 	request := s.clientv2.PerformanceAdvisorApi.
 		ListSuggestedIndexes(s.ctx, opts.GroupId, opts.ProcessId)
+	if opts.Namespaces != nil {
+		request = request.Namespaces(*opts.Namespaces)
+	}
 	if opts.Duration != nil {
 		request = request.Duration(*opts.Duration)
 	}


### PR DESCRIPTION
## Proposed changes

Add missing namespaces checks. Review other performance advisor commands for missing namespaces.

Closes CLOUDP-202232

# Verification

Verified locally. Namespace is sent.
Could not extend e2e tests.
It is hard to verify in e2e due to nature of the command/API
 