### PR TITLE
CLOUDP-205691: update evergreen version

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -19,8 +19,8 @@ pre_error_fails_task: true
 
 variables:
   - &go_linux_version
-      go_root: "/opt/golang/go1.21.3"
-      go_bin: "/opt/golang/go1.21.3/bin"
+      go_root: "/opt/golang/go1.21"
+      go_bin: "/opt/golang/go1.21/bin"
       go_base_path: ""
   - &go_env
       XDG_CONFIG_HOME: ${go_base_path}${workdir}

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -1,7 +1,7 @@
 variables:
   - &go_linux_version
-      go_root: "/opt/golang/go1.21.3"
-      go_bin: "/opt/golang/go1.21.3/bin"
+      go_root: "/opt/golang/go1.21"
+      go_bin: "/opt/golang/go1.21/bin"
       go_base_path: ""
   - &go_windows_version
       go_root: "c:\\golang\\go1.19"

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -4,8 +4,8 @@ variables:
       go_bin: "/opt/golang/go1.21/bin"
       go_base_path: ""
   - &go_windows_version
-      go_root: "c:\\golang\\go1.19"
-      go_bin: "c:\\golang\\go1.19/bin"
+      go_root: "c:\\golang\\go1.21"
+      go_bin: "c:\\golang\\go1.21/bin"
       go_base_path: "c:"
   - &go_env
       XDG_CONFIG_HOME: ${go_base_path}${workdir}


### PR DESCRIPTION
Change the version on evergreen to remove the patch. This will remove need for us to do numerous code bumps.