### PR TITLE
CLOUDP-202471: add support to track GH Actions telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3-labs
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
-ENV MONGODB_ATLAS_IS_CONTAINERIZED=true
+ENV MONGODB_ATLAS_HOSTNAME=container
 
 COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
 [mongodb-org-x86_64-6.0]

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -69,8 +69,10 @@ const (
 	TelemetryEnabledProperty     = "telemetry_enabled"
 	MongoCLI                     = "mongocli"
 	AtlasCLI                     = "atlascli"
+	HostnameEnv                  = "MONGODB_ATLAS_HOSTNAME"
 	NativeHostName               = "native"
 	ContainerHostName            = "container"
+	ActionsHostName              = "actions"
 )
 
 var (

--- a/internal/oauth/oauth_test.go
+++ b/internal/oauth/oauth_test.go
@@ -1,0 +1,81 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package oauth
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongodb-atlas-cli/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_patchConfigHostname(t *testing.T) {
+	type fields struct {
+		containerizedEnv string
+		hostnameEnv      string
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		expectedHostName string
+	}{
+		{
+			name: "sets native hostname when no hostname env var is set",
+			fields: fields{
+				containerizedEnv: "",
+				hostnameEnv:      "",
+			},
+			expectedHostName: config.NativeHostName,
+		},
+		{
+			name: "sets container hostname when legacy containerized env var is set to true",
+			fields: fields{
+				containerizedEnv: "true",
+				hostnameEnv:      "",
+			},
+			expectedHostName: config.ContainerHostName,
+		},
+		{
+			name: "sets action hostname when valid action hostname env var is set",
+			fields: fields{
+				containerizedEnv: "",
+				hostnameEnv:      config.ActionsHostName,
+			},
+			expectedHostName: config.ActionsHostName,
+		},
+		{
+			name: "does not set hostname when invalid hostname env var is set",
+			fields: fields{
+				containerizedEnv: "",
+				hostnameEnv:      "nonsense",
+			},
+			expectedHostName: config.NativeHostName,
+		},
+	}
+	for _, tt := range tests {
+		fields := tt.fields
+		expectedHostName := tt.expectedHostName
+		t.Run(tt.name, func(t *testing.T) {
+			config.HostName = config.NativeHostName
+			t.Setenv("MONGODB_ATLAS_IS_CONTAINERIZED", fields.containerizedEnv)
+			t.Setenv("MONGODB_ATLAS_HOSTNAME", fields.hostnameEnv)
+			patchConfigHostname()
+
+			assert.Equal(t, expectedHostName, config.HostName)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-202471

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Adding telemetry support to GH Actions (API Telemetry and CLI Telemetry)

Setting hostname via the same mechanism as docker container (env var) 
Small change to how - using new shared env var `MONGODB_ATLAS_HOSTNAME` with explicit hostname allow-list

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
