### PR TITLE
task: enable testifylint

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: v1.54.2
+          version: v1.55.0
   unit-tests:
     env:
       COVERAGE: coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,7 @@ linters:
     - staticcheck # (megacheck) It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
     - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
     - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17 [fast: false, auto-fix: false]
+    - testifylint # Checks usage of github.com/stretchr/testify. [fast: false, auto-fix: false]
     - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code [fast: false, auto-fix: false]
     - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
-GOLANGCI_VERSION=v1.54.2
+GOLANGCI_VERSION=v1.55.0
 COVERAGE=coverage.out
 
 MCLI_SOURCE_FILES?=./cmd/mongocli

--- a/internal/cli/atlas/alerts/acknowledge_test.go
+++ b/internal/cli/atlas/alerts/acknowledge_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -99,7 +99,7 @@ func TestAcknowledgeOpts_Run(t *testing.T) {
 					AcknowledgeAlert(params).
 					Return(nil, errors.New("fake")).
 					Times(1)
-				assert.Error(t, opts.Run())
+				require.Error(t, opts.Run())
 			} else {
 				expected := &admin.AlertViewForNdsGroup{}
 				mockStore.
@@ -107,7 +107,7 @@ func TestAcknowledgeOpts_Run(t *testing.T) {
 					AcknowledgeAlert(params).
 					Return(expected, nil).
 					Times(1)
-				assert.NoError(t, opts.Run())
+				require.NoError(t, opts.Run())
 			}
 		})
 	}

--- a/internal/cli/atlas/alerts/describe_test.go
+++ b/internal/cli/atlas/alerts/describe_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -101,14 +102,14 @@ func TestDescribeOpts_Run(t *testing.T) {
 					Alert(params).
 					Return(nil, errors.New("fake")).
 					Times(1)
-				assert.Error(t, cmd.Run())
+				require.Error(t, cmd.Run())
 			} else {
 				mockStore.
 					EXPECT().
 					Alert(params).
 					Return(expected, nil).
 					Times(1)
-				assert.NoError(t, cmd.Run())
+				require.NoError(t, cmd.Run())
 				assert.Equal(t, `ID     TYPE         METRIC   STATUS
 test   NO_PRIMARY   test     test
 `, buf.String())

--- a/internal/cli/atlas/alerts/settings/disable_test.go
+++ b/internal/cli/atlas/alerts/settings/disable_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -57,5 +57,5 @@ func TestDisableOpts_Run(t *testing.T) {
 		DisableAlertConfiguration(opts.ProjectID, opts.alertID).
 		Return(expected, nil).
 		Times(1)
-	assert.NoError(t, opts.Run())
+	require.NoError(t, opts.Run())
 }

--- a/internal/cli/atlas/alerts/settings/enable_test.go
+++ b/internal/cli/atlas/alerts/settings/enable_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -57,5 +57,5 @@ func TestEnableOpts_Run(t *testing.T) {
 		EnableAlertConfiguration(opts.ProjectID, opts.alertID).
 		Return(expected, nil).
 		Times(1)
-	assert.NoError(t, opts.Run())
+	require.NoError(t, opts.Run())
 }

--- a/internal/cli/atlas/backup/compliancepolicy/enable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/enable_test.go
@@ -22,6 +22,7 @@ import (
 	mocks "github.com/mongodb/mongodb-atlas-cli/internal/mocks/atlas"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -104,5 +105,5 @@ func TestEnableOpts_Run_invalidEmail(t *testing.T) {
 		authorizedEmail: invalidEmail,
 	}
 
-	assert.Error(t, opts.Run())
+	require.Error(t, opts.Run())
 }

--- a/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/enable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/enable_test.go
@@ -173,9 +173,9 @@ func TestRestoreWindowDaysValidator(t *testing.T) {
 		}
 
 		if testOptions.wantErr {
-			assert.Error(t, opts.validateRestoreWindowDays())
+			require.Error(t, opts.validateRestoreWindowDays())
 		} else {
-			assert.NoError(t, opts.validateRestoreWindowDays())
+			require.NoError(t, opts.validateRestoreWindowDays())
 		}
 	}
 }

--- a/internal/cli/atlas/backup/schedule/update_test.go
+++ b/internal/cli/atlas/backup/schedule/update_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -64,7 +65,7 @@ func TestUpdateOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run(cmd)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUpdateOpts_RunWithFile(t *testing.T) {
@@ -88,7 +89,7 @@ func TestUpdateOpts_RunWithFile(t *testing.T) {
 }`
 
 	fileName := "test.json"
-	assert.NoError(t, afero.WriteFile(fs, fileName, []byte(fileContents), 0600))
+	require.NoError(t, afero.WriteFile(fs, fileName, []byte(fileContents), 0600))
 
 	opts := &UpdateOpts{
 		store:       mockStore,
@@ -107,7 +108,7 @@ func TestUpdateOpts_RunWithFile(t *testing.T) {
 		Times(1)
 
 	err := opts.Run(cmd)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUpdateBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/advancedsettings/describe_test.go
+++ b/internal/cli/atlas/clusters/advancedsettings/describe_test.go
@@ -23,16 +23,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterConfigurationOptionsDescriber(ctrl)
-
 	expected := &atlasv2.ClusterDescriptionProcessArgs{}
-
 	describeOpts := &DescribeOpts{
 		name:  "test",
 		store: mockStore,
@@ -45,7 +43,7 @@ func TestDescribe_Run(t *testing.T) {
 		Times(1)
 
 	err := describeOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/connectionstring/describe_test.go
+++ b/internal/cli/atlas/clusters/connectionstring/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -45,7 +45,7 @@ func TestDescribe_Run(t *testing.T) {
 		Times(1)
 
 	err := describeOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/clusters/region_tier_autocomplete.go
+++ b/internal/cli/atlas/clusters/region_tier_autocomplete.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const storeErrMsg = "store error: "
+
 type autoCompleteOpts struct {
 	cli.GlobalOpts
 	providers []string
@@ -46,13 +48,13 @@ func (opts *autoCompleteOpts) autocompleteTier() cli.AutoFunc {
 			return nil, cobra.ShellCompDirectiveError
 		}
 		if err := opts.initStore(cmd.Context()); err != nil {
-			cobra.CompErrorln("store error: " + err.Error())
+			cobra.CompErrorln(storeErrMsg + err.Error())
 			return nil, cobra.ShellCompDirectiveError
 		}
 
 		suggestions, err := opts.tierSuggestions(toComplete)
 		if err != nil {
-			cobra.CompErrorln("error fetching: " + err.Error())
+			cobra.CompErrorln("error fetching tier: " + err.Error())
 			return nil, cobra.ShellCompDirectiveError
 		}
 		return suggestions, cobra.ShellCompDirectiveDefault
@@ -94,12 +96,12 @@ func (opts *autoCompleteOpts) autocompleteRegion() cli.AutoFunc {
 			return nil, cobra.ShellCompDirectiveError
 		}
 		if err := opts.initStore(cmd.Context()); err != nil {
-			cobra.CompErrorln("store error: " + err.Error())
+			cobra.CompErrorln(storeErrMsg + err.Error())
 			return nil, cobra.ShellCompDirectiveError
 		}
 		suggestions, err := opts.regionSuggestions(toComplete)
 		if err != nil {
-			cobra.CompErrorln("error fetching: " + err.Error())
+			cobra.CompErrorln("error fetching regions: " + err.Error())
 			return nil, cobra.ShellCompDirectiveError
 		}
 		return suggestions, cobra.ShellCompDirectiveDefault

--- a/internal/cli/atlas/deployments/delete_test.go
+++ b/internal/cli/atlas/deployments/delete_test.go
@@ -102,11 +102,12 @@ func TestDelete_Run_Local(t *testing.T) {
 		Return(nil, nil).
 		Times(1)
 
+	const mongodLocalData = "mongod-local-data-"
 	deploymentsTest.
 		MockPodman.
 		EXPECT().
 		RemoveVolumes(ctx,
-			"mongod-local-data-"+opts.DeploymentName,
+			mongodLocalData+opts.DeploymentName,
 			"mongot-local-data-"+opts.DeploymentName,
 			"mongot-local-metrics-"+opts.DeploymentName,
 		).
@@ -137,7 +138,7 @@ func TestDelete_Run_Local(t *testing.T) {
 				},
 				Mounts: []define.InspectMount{
 					{
-						Name: "mongod-local-data-" + opts.DeploymentName,
+						Name: mongodLocalData + opts.DeploymentName,
 					},
 				},
 			},

--- a/internal/cli/atlas/deployments/options/deployment_opts_select.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts_select.go
@@ -101,11 +101,11 @@ func (opts *DeploymentOpts) Select(deployments []Deployment) (Deployment, error)
 	}
 
 	if len(deployments) == 1 {
-		opts.DeploymentName = deployments[0].Name //nolint:gosec
-		opts.DeploymentType = deployments[0].Type //nolint:gosec
+		opts.DeploymentName = deployments[0].Name
+		opts.DeploymentType = deployments[0].Type
 
 		telemetry.AppendOption(telemetry.WithDeploymentType(opts.DeploymentType))
-		return deployments[0], nil //nolint:gosec
+		return deployments[0], nil
 	}
 
 	displayNames := make([]string, 0, len(deployments))

--- a/internal/cli/atlas/deployments/pause_test.go
+++ b/internal/cli/atlas/deployments/pause_test.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	deploymentName = "localTest2"
-	projectID      = "64f670f0bf789926667dad1a" //nolint:gosec
+	projectID      = "64f670f0bf789926667dad1a"
 )
 
 func TestPause_RunLocal(t *testing.T) {

--- a/internal/cli/atlas/deployments/search/indexes/create_test.go
+++ b/internal/cli/atlas/deployments/search/indexes/create_test.go
@@ -35,7 +35,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
-var indexID = "6509bc5080b2f007e6a2a0ce" //nolint:gosec
+var indexID = "6509bc5080b2f007e6a2a0ce"
 
 const (
 	expectedIndexName       = "idx1"

--- a/internal/cli/atlas/logs/download_test.go
+++ b/internal/cli/atlas/logs/download_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogsDownloadOpts_Run(t *testing.T) {
@@ -52,10 +53,7 @@ func TestLogsDownloadOpts_Run(t *testing.T) {
 			DownloadLog(gomock.Any(), opts.newHostLogsParams()).
 			Return(nil).
 			Times(1)
-
-		if err := opts.Run(); err != nil {
-			t.Fatalf("Run() unexpected error downloading %v logs: %v", validLogToDownload, err)
-		}
+		require.NoError(t, opts.Run())
 	}
 }
 
@@ -105,9 +103,8 @@ func TestDownloadOpts_initDefaultOut(t *testing.T) {
 				name: logName,
 			}
 			opts.Out = out
-			a := assert.New(t)
-			a.NoError(opts.initDefaultOut())
-			a.Equal(opts.Out, want)
+			require.NoError(t, opts.initDefaultOut())
+			assert.Equal(t, want, opts.Out)
 		})
 	}
 }

--- a/internal/cli/atlas/maintenance/clear.go
+++ b/internal/cli/atlas/maintenance/clear.go
@@ -28,6 +28,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const longDesc = `To learn more about maintenance windows, see https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/.
+
+`
+
 type ClearOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
@@ -68,11 +72,9 @@ func (opts *ClearOpts) Prompt() error {
 func ClearBuilder() *cobra.Command {
 	opts := &ClearOpts{}
 	cmd := &cobra.Command{
-		Use:   "clear",
-		Short: "Clear the current maintenance window setting for your project.",
-		Long: `To learn more about maintenance windows, see https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Use:     "clear",
+		Short:   "Clear the current maintenance window setting for your project.",
+		Long:    longDesc + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"rm", "delete"},
 		Annotations: map[string]string{
 			"output": clearTemplate,

--- a/internal/cli/atlas/maintenance/defer.go
+++ b/internal/cli/atlas/maintenance/defer.go
@@ -56,9 +56,7 @@ func DeferBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "defer",
 		Short: "Defer scheduled maintenance for your project for one week.",
-		Long: `To learn more about maintenance windows, see https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Long:  longDesc + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"output": deferTemplate,
 		},

--- a/internal/cli/atlas/maintenance/describe.go
+++ b/internal/cli/atlas/maintenance/describe.go
@@ -56,12 +56,10 @@ func (opts *DescribeOpts) Run() error {
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:     "describe",
-		Aliases: []string{"get"},
-		Short:   "Return the maintenance window details for your project.",
-		Long: `To learn more about maintenance windows, see https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
+		Use:         "describe",
+		Aliases:     []string{"get"},
+		Short:       "Return the maintenance window details for your project.",
+		Long:        longDesc + fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the maintenance window for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s maintenanceWindows describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/maintenance/describe_test.go
+++ b/internal/cli/atlas/maintenance/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/maintenance/update.go
+++ b/internal/cli/atlas/maintenance/update.go
@@ -68,9 +68,7 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Modify the maintenance window for your project.",
-		Long: `To learn more about maintenance windows, see https://www.mongodb.com/docs/atlas/tutorial/cluster-maintenance-window/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Long:  longDesc + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"output": updateTemplate,
 		},

--- a/internal/cli/atlas/networking/containers/delete_test.go
+++ b/internal/cli/atlas/networking/containers/delete_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -44,5 +44,5 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/internal/cli/atlas/networking/peering/create/aws.go
+++ b/internal/cli/atlas/networking/peering/create/aws.go
@@ -111,7 +111,7 @@ func (opts *AWSOpts) newPeer(containerID string) *atlasv2.BaseNetworkPeeringConn
 	}
 }
 
-// mongocli atlas networking peering create aws
+// AwsBuilder mongocli atlas networking peering create aws
 // --accepterRegionName accepterRegionName: Specifies the region where the peer VPC resides.
 // --awsAccountId awsAccountId: Account ID of the owner of the peer VPC.
 // --containerId containerId: Unique identifier of the Atlas VPC container for the region.
@@ -126,11 +126,7 @@ func AwsBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "aws",
 		Short: "Create a network peering connection between the Atlas VPC and your AWS VPC.",
-		Long: `The network peering create command checks if a VPC exists in the region you specify for your Atlas project. If one exists, this command creates the peering connection between that VPC and your VPC. If an Atlas VPC doesn't exist, this command creates one and creates a connection between it and your VPC.
-		
-To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Long:  longDesc + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},

--- a/internal/cli/atlas/networking/peering/create/create.go
+++ b/internal/cli/atlas/networking/peering/create/create.go
@@ -18,6 +18,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const longDesc = `The network peering create command checks if a VPC exists in the region you specify for your Atlas project. If one exists, this command creates the peering connection between that VPC and your VPC. If an Atlas VPC doesn't exist, this command creates one and creates a connection between it and your VPC.
+		
+To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
+
+`
+
 func Builder() *cobra.Command {
 	const use = "create"
 	cmd := &cobra.Command{

--- a/internal/cli/atlas/networking/peering/create/gcp.go
+++ b/internal/cli/atlas/networking/peering/create/gcp.go
@@ -111,11 +111,7 @@ func GCPBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gcp",
 		Short: "Create a network peering connection between the Atlas VPC and your Google Cloud VPC.",
-		Long: `The network peering create command checks if a VPC exists in the region you specify for your Atlas project. If one exists, this command creates the peering connection between that VPC and your VPC. If an Atlas VPC doesn't exist, this command creates one and creates a connection between it and your VPC.
-		
-To learn more about network peering connections, see https://www.mongodb.com/docs/atlas/security-vpc-peering/.
-
-` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Long:  longDesc + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},

--- a/internal/cli/atlas/networking/peering/delete_test.go
+++ b/internal/cli/atlas/networking/peering/delete_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -44,5 +44,5 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/internal/cli/atlas/organizations/apikeys/delete.go
+++ b/internal/cli/atlas/organizations/apikeys/delete.go
@@ -57,7 +57,7 @@ func DeleteBuilder() *cobra.Command {
 		Short:   "Remove the specified API key for your organization.",
 		Long: fmt.Sprintf(`To view possible values for the ID argument, run %s organizations apiKeys list.
 
-`+fmt.Sprintf(usage.RequiredRole, "Organization User Admin"), cli.ExampleAtlasEntryPoint()),
+%s`, cli.ExampleAtlasEntryPoint(), fmt.Sprintf(usage.RequiredRole, "Organization User Admin")),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the organization's API key.",

--- a/internal/cli/atlas/organizations/apikeys/describe.go
+++ b/internal/cli/atlas/organizations/apikeys/describe.go
@@ -65,7 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Short:   "Return the details for the specified API key for your organization.",
 		Long: fmt.Sprintf(`To view possible values for the ID argument, run %s organizations apiKeys list.
 
-`+fmt.Sprintf(usage.RequiredRole, "Organization Member"), cli.ExampleAtlasEntryPoint()),
+%s`, cli.ExampleAtlasEntryPoint(), fmt.Sprintf(usage.RequiredRole, "Organization Member")),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies your API key.",
 			"output": describeTemplate,

--- a/internal/cli/atlas/organizations/apikeys/update.go
+++ b/internal/cli/atlas/organizations/apikeys/update.go
@@ -75,7 +75,7 @@ func UpdateBuilder() *cobra.Command {
 		
 To view possible values for the apiKeyId argument, run %s organizations apiKeys list.
 
-`+fmt.Sprintf(usage.RequiredRole, "Organization User Admin"), cli.ExampleAtlasEntryPoint()),
+%s`, cli.ExampleAtlasEntryPoint(), fmt.Sprintf(usage.RequiredRole, "Organization User Admin")),
 		Annotations: map[string]string{
 			"apiKeyIdDesc": "Unique 24-digit string that identifies your API key.",
 			"output":       updateTemplate,

--- a/internal/cli/atlas/privateendpoints/aws/create_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -45,7 +45,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -46,7 +46,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/aws/list_test.go
+++ b/internal/cli/atlas/privateendpoints/aws/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestList_Run(t *testing.T) {
 		Times(1)
 
 	err := listOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/create_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -45,7 +45,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -46,7 +46,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/azure/list_test.go
+++ b/internal/cli/atlas/privateendpoints/azure/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestList_Run(t *testing.T) {
 		Times(1)
 
 	err := listOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/create_test.go
+++ b/internal/cli/atlas/privateendpoints/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -45,7 +45,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/create_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -43,7 +43,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestDescribe_Run(t *testing.T) {
 		Times(1)
 
 	err := describeOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/datalake/aws/list_test.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestList_Run(t *testing.T) {
 		Times(1)
 
 	err := listOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -44,7 +44,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/create_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -45,7 +45,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -46,7 +46,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/gcp/list_test.go
+++ b/internal/cli/atlas/privateendpoints/gcp/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestList_Run(t *testing.T) {
 		Times(1)
 
 	err := listOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/interfaces/create_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -45,7 +45,7 @@ func TestCreate_Run(t *testing.T) {
 		Times(1)
 
 	err := createOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/interfaces/delete_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/delete_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -46,7 +46,7 @@ func TestDelete_Run(t *testing.T) {
 		Times(1)
 
 	err := deleteOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDeleteBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/interfaces/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -46,7 +46,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/list_test.go
+++ b/internal/cli/atlas/privateendpoints/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -44,7 +44,7 @@ func TestList_Run(t *testing.T) {
 		Times(1)
 
 	err := listOpts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe_test.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/projects/settings/describe_test.go
+++ b/internal/cli/atlas/projects/settings/describe_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -44,7 +44,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDescribeBuilder(t *testing.T) {

--- a/internal/cli/atlas/projects/settings/update_test.go
+++ b/internal/cli/atlas/projects/settings/update_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -56,7 +57,7 @@ func TestUpdateOpts_Run(t *testing.T) {
 		Times(1)
 
 	err := opts.Run()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUpdateBuilder(t *testing.T) {

--- a/internal/cli/atlas/search/update_test.go
+++ b/internal/cli/atlas/search/update_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -40,16 +40,14 @@ func TestUpdateOpts_Run(t *testing.T) {
 		expected := &atlasv2.ClusterSearchIndex{}
 
 		request, err := updateOpts.NewSearchIndex()
-		if err != nil {
-			t.Fatalf("newSearchIndex() unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		mockStore.
 			EXPECT().
 			UpdateSearchIndexes(updateOpts.ConfigProjectID(), updateOpts.clusterName, updateOpts.id, request).
 			Return(expected, nil).
 			Times(1)
 
-		assert.NoError(t, updateOpts.Run())
+		require.NoError(t, updateOpts.Run())
 	})
 
 	t.Run("file run", func(t *testing.T) {
@@ -68,15 +66,13 @@ func TestUpdateOpts_Run(t *testing.T) {
 		expected := &atlasv2.ClusterSearchIndex{}
 
 		request, err := updateOpts.NewSearchIndex()
-		if err != nil {
-			t.Fatalf("newSearchIndex() unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		mockStore.
 			EXPECT().
 			UpdateSearchIndexes(updateOpts.ConfigProjectID(), updateOpts.clusterName, updateOpts.id, request).
 			Return(expected, nil).
 			Times(1)
 
-		assert.NoError(t, updateOpts.Run())
+		require.NoError(t, updateOpts.Run())
 	})
 }

--- a/internal/cli/atlas/serverless/backup/restores/describe_test.go
+++ b/internal/cli/atlas/serverless/backup/restores/describe_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -63,7 +64,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Return(expected, nil).
 		Times(1)
 
-	assert.NoError(t, describeOpts.Run())
+	require.NoError(t, describeOpts.Run())
 
 	assert.Equal(t, `ID     SNAPSHOT   CLUSTER       TYPE        EXPIRES AT                      URLs
 test   test2      ClusterTest   test type   2023-01-01 00:00:00 +0000 UTC   test url

--- a/internal/cli/atlas/setup/confirm_cluster_setup.go
+++ b/internal/cli/atlas/setup/confirm_cluster_setup.go
@@ -52,13 +52,14 @@ Cluster Disk Size (GiB):		%.1f`, opts.Tier, diskSize)
 	fmt.Printf(`
 [Confirm cluster settings]
 Cluster Name:				%s%s
-Cloud Provider and Region:		%s
+Cloud Provider and Region:		%s - %s
 Database User Username:			%s%s
 Allow connections from (IP Address):	%s
 `,
 		opts.ClusterName,
 		clusterTier,
-		opts.Provider+" - "+opts.Region,
+		opts.Provider,
+		opts.Region,
 		opts.DBUsername,
 		loadSampleData,
 		strings.Join(opts.IPAddresses, ", "),

--- a/internal/cli/atlas/setup/confirm_default_setup.go
+++ b/internal/cli/atlas/setup/confirm_default_setup.go
@@ -44,13 +44,14 @@ Cluster Disk Size (GiB):		%.1f`, opts.Tier, diskSize)
 	fmt.Printf(`
 [Default Settings]
 Cluster Name:				%s%s
-Cloud Provider and Region:		%s
+Cloud Provider and Region:		%s - %s
 Database User Username:			%s%s
 Allow connections from (IP Address):	%s
 `,
 		values.ClusterName,
 		clusterTier,
-		values.Provider+" - "+values.Region,
+		values.Provider,
+		values.Region,
 		values.DBUsername,
 		loadSampleData,
 		strings.Join(values.IPAddresses, ", "),

--- a/internal/cli/atlas/streams/connection/create_test.go
+++ b/internal/cli/atlas/streams/connection/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -52,7 +52,7 @@ func TestCreate_Run(t *testing.T) {
 `
 
 	fileName := "test-connection.json"
-	assert.NoError(t, afero.WriteFile(fs, fileName, []byte(fileContents), 0600))
+	require.NoError(t, afero.WriteFile(fs, fileName, []byte(fileContents), 0600))
 
 	buf := new(bytes.Buffer)
 	createOpts := &CreateOpts{

--- a/internal/cli/atlas/streams/connection/update_test.go
+++ b/internal/cli/atlas/streams/connection/update_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -52,7 +52,7 @@ func TestUpdate_Run(t *testing.T) {
 `
 
 	fileName := "connection.json"
-	assert.NoError(t, afero.WriteFile(fs, fileName, []byte(fileContents), 0600))
+	require.NoError(t, afero.WriteFile(fs, fileName, []byte(fileContents), 0600))
 
 	buf := new(bytes.Buffer)
 	updateOpts := &UpdateOpts{

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -200,7 +200,7 @@ func Test_shouldRetryAuthenticate(t *testing.T) {
 		name      string
 		args      args
 		wantRetry bool
-		wantErr   assert.ErrorAssertionFunc
+		wantErr   require.ErrorAssertionFunc
 	}{
 		{
 			name: "timed out error",
@@ -209,7 +209,7 @@ func Test_shouldRetryAuthenticate(t *testing.T) {
 				p:   &confirmMock{},
 			},
 			wantRetry: true,
-			wantErr:   assert.NoError,
+			wantErr:   require.NoError,
 		},
 		{
 			name: "random error",
@@ -218,15 +218,13 @@ func Test_shouldRetryAuthenticate(t *testing.T) {
 				p:   &confirmMock{},
 			},
 			wantRetry: false,
-			wantErr:   assert.NoError,
+			wantErr:   require.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotRetry, err := shouldRetryAuthenticate(tt.args.err, tt.args.p)
-			if !tt.wantErr(t, err, fmt.Sprintf("shouldRetryAuthenticate(%v, %v)", tt.args.err, tt.args.p)) {
-				return
-			}
+			tt.wantErr(t, err, fmt.Sprintf("shouldRetryAuthenticate(%v, %v)", tt.args.err, tt.args.p))
 			assert.Equalf(t, tt.wantRetry, gotRetry, "shouldRetryAuthenticate(%v, %v)", tt.args.err, tt.args.p)
 		})
 	}

--- a/internal/cli/default_setter_opts_test.go
+++ b/internal/cli/default_setter_opts_test.go
@@ -69,7 +69,7 @@ func TestDefaultOpts_DefaultQuestions(t *testing.T) {
 			opts := &DefaultSetterOpts{
 				Service: tt.fields.Service,
 			}
-			assert.Equalf(t, tt.want, len(opts.DefaultQuestions()), "DefaultQuestions()")
+			assert.Len(t, opts.DefaultQuestions(), tt.want)
 		})
 	}
 }

--- a/internal/cli/figautocomplete/fig_autocomplete_test.go
+++ b/internal/cli/figautocomplete/fig_autocomplete_test.go
@@ -25,7 +25,7 @@ import (
 func TestBuilder(t *testing.T) {
 	got := Builder()
 	a := assert.New(t)
-	a.Equal(got.Use, "fig-autocomplete")
-	a.Len(got.Commands(), 0)
+	a.Equal("fig-autocomplete", got.Use)
+	a.Empty(got.Commands())
 	a.True(got.HasAvailableFlags())
 }

--- a/internal/cli/global_opts_test.go
+++ b/internal/cli/global_opts_test.go
@@ -136,7 +136,7 @@ func TestGenerateAliases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := GenerateAliases(args.use, args.extra...)
-			assert.Equal(t, got, want)
+			assert.Equal(t, want, got)
 		})
 	}
 }

--- a/internal/cli/iam/organizations/apikeys/delete.go
+++ b/internal/cli/iam/organizations/apikeys/delete.go
@@ -57,7 +57,7 @@ func DeleteBuilder() *cobra.Command {
 		Short:   "Remove the specified API key for your organization.",
 		Long: fmt.Sprintf(`To view possible values for the ID argument, run %s organizations apiKeys list.
 
-`+fmt.Sprintf(usage.RequiredRole, "Organization User Admin"), cli.ExampleAtlasEntryPoint()),
+%s`, cli.ExampleAtlasEntryPoint(), fmt.Sprintf(usage.RequiredRole, "Organization User Admin")),
 		Args: require.ExactArgs(1),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies the organization's API key.",

--- a/internal/cli/iam/organizations/apikeys/describe.go
+++ b/internal/cli/iam/organizations/apikeys/describe.go
@@ -65,7 +65,7 @@ func DescribeBuilder() *cobra.Command {
 		Short:   "Return the details for the specified API key for your organization.",
 		Long: fmt.Sprintf(`To view possible values for the ID argument, run %s organizations apiKeys list.
 
-`+fmt.Sprintf(usage.RequiredRole, "Organization Member"), cli.ExampleAtlasEntryPoint()),
+%s`, cli.ExampleAtlasEntryPoint(), fmt.Sprintf(usage.RequiredRole, "Organization Member")),
 		Annotations: map[string]string{
 			"IDDesc": "Unique 24-digit string that identifies your API key.",
 			"output": describeTemplate,

--- a/internal/cli/mongocli/alerts/acknowledge_test.go
+++ b/internal/cli/mongocli/alerts/acknowledge_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -93,7 +93,7 @@ func TestAcknowledgeOpts_Run(t *testing.T) {
 					AcknowledgeAlert(opts.ProjectID, opts.alertID, ackReq).
 					Return(nil, errors.New("fake")).
 					Times(1)
-				assert.Error(t, opts.Run())
+				require.Error(t, opts.Run())
 			} else {
 				expected := &mongodbatlas.Alert{}
 				mockStore.
@@ -101,7 +101,7 @@ func TestAcknowledgeOpts_Run(t *testing.T) {
 					AcknowledgeAlert(opts.ProjectID, opts.alertID, ackReq).
 					Return(expected, nil).
 					Times(1)
-				assert.NoError(t, opts.Run())
+				require.NoError(t, opts.Run())
 			}
 		})
 	}

--- a/internal/cli/mongocli/alerts/describe_test.go
+++ b/internal/cli/mongocli/alerts/describe_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -95,14 +96,14 @@ func TestDescribeOpts_Run(t *testing.T) {
 					Alert(cmd.ProjectID, cmd.alertID).
 					Return(nil, errors.New("fake")).
 					Times(1)
-				assert.Error(t, cmd.Run())
+				require.Error(t, cmd.Run())
 			} else {
 				mockStore.
 					EXPECT().
 					Alert(cmd.ProjectID, cmd.alertID).
 					Return(expected, nil).
 					Times(1)
-				assert.NoError(t, cmd.Run())
+				require.NoError(t, cmd.Run())
 				assert.Equal(t, `ID     TYPE   METRIC   STATUS
 test   test   test     test
 `, buf.String())

--- a/internal/cli/mongocli/alerts/settings/disable_test.go
+++ b/internal/cli/mongocli/alerts/settings/disable_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -57,5 +57,5 @@ func TestDisableOpts_Run(t *testing.T) {
 		DisableAlertConfiguration(opts.ProjectID, opts.alertID).
 		Return(expected, nil).
 		Times(1)
-	assert.NoError(t, opts.Run())
+	require.NoError(t, opts.Run())
 }

--- a/internal/cli/mongocli/alerts/settings/enable_test.go
+++ b/internal/cli/mongocli/alerts/settings/enable_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -57,5 +57,5 @@ func TestEnableOpts_Run(t *testing.T) {
 		EnableAlertConfiguration(opts.ProjectID, opts.alertID).
 		Return(expected, nil).
 		Times(1)
-	assert.NoError(t, opts.Run())
+	require.NoError(t, opts.Run())
 }

--- a/internal/cli/mongocli/serverless/backup/restores/describe_test.go
+++ b/internal/cli/mongocli/serverless/backup/restores/describe_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -63,7 +64,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 		Return(expected, nil).
 		Times(1)
 
-	assert.NoError(t, describeOpts.Run())
+	require.NoError(t, describeOpts.Run())
 
 	assert.Equal(t, `ID     SNAPSHOT   CLUSTER       TYPE        EXPIRES AT                      URLs
 test   test2      ClusterTest   test type   2023-01-01 00:00:00 +0000 UTC   test url

--- a/internal/cli/opsmanager/agents/apikeys/create_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/create_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -41,5 +41,5 @@ func TestCreate_Run(t *testing.T) {
 		Return(expected, nil).
 		Times(1)
 
-	assert.NoError(t, createOpts.Run())
+	require.NoError(t, createOpts.Run())
 }

--- a/internal/cli/opsmanager/agents/apikeys/delete_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/delete_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelete_Run(t *testing.T) {
@@ -42,5 +42,5 @@ func TestDelete_Run(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	assert.NoError(t, deleteOpts.Run())
+	require.NoError(t, deleteOpts.Run())
 }

--- a/internal/cli/opsmanager/agents/apikeys/list_test.go
+++ b/internal/cli/opsmanager/agents/apikeys/list_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -45,5 +45,5 @@ func TestAgentsList_Run(t *testing.T) {
 
 	config.SetService(config.OpsManagerService)
 
-	assert.NoError(t, listOpts.Run())
+	require.NoError(t, listOpts.Run())
 }

--- a/internal/cli/opsmanager/agents/list_test.go
+++ b/internal/cli/opsmanager/agents/list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -48,7 +48,7 @@ func TestAgentsList_Run(t *testing.T) {
 
 	config.SetService(config.OpsManagerService)
 
-	assert.NoError(t, listOpts.Run())
+	require.NoError(t, listOpts.Run())
 }
 
 func TestListBuilder(t *testing.T) {

--- a/internal/cli/opsmanager/backup/checkpoints_list_test.go
+++ b/internal/cli/opsmanager/backup/checkpoints_list_test.go
@@ -29,7 +29,7 @@ func TestCheckpointsList_Run(t *testing.T) {
 	mockStore := mocks.NewMockCheckpointsLister(ctrl)
 
 	expected := &mongodbatlas.Checkpoints{}
-	clusterID := "5ec2ac941271767f21cbaefd" //nolint:gosec
+	clusterID := "5ec2ac941271767f21cbaefd"
 
 	listOpts := &CheckpointsListOpts{
 		store:     mockStore,

--- a/internal/cli/opsmanager/backup/restores_list_test.go
+++ b/internal/cli/opsmanager/backup/restores_list_test.go
@@ -29,7 +29,7 @@ func TestRestoresListOpts_Run(t *testing.T) {
 	mockStore := mocks.NewMockContinuousJobLister(ctrl)
 
 	expected := &mongodbatlas.ContinuousJobs{}
-	clusterID := "5ec2ac941271767f21cbaeff" //nolint:gosec
+	clusterID := "5ec2ac941271767f21cbaeff"
 
 	listOpts := &RestoresListOpts{
 		store:     mockStore,

--- a/internal/cli/opsmanager/backup/snapshots/list_test.go
+++ b/internal/cli/opsmanager/backup/snapshots/list_test.go
@@ -31,7 +31,7 @@ func TestList_Run(t *testing.T) {
 	mockStore := mocks.NewMockContinuousSnapshotsLister(ctrl)
 
 	expected := &mongodbatlas.ContinuousSnapshots{}
-	//nolint:gosec
+
 	clusterID := "5ec2ac941271767f21cbaefe"
 
 	listOpts := &ListOpts{

--- a/internal/config/profile_integration_test.go
+++ b/internal/config/profile_integration_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -90,10 +91,11 @@ func profileWithFullDescription() *Profile {
 
 func TestProfile_Get_FullProfile(t *testing.T) {
 	profile := profileWithFullDescription()
-	a := assert.New(t)
-	a.NoError(profile.LoadMongoCLIConfig(false))
+
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
 
 	desc := profile.Map()
+	a := assert.New(t)
 	a.Equal("default", profile.Name())
 	a.Len(desc, 9)
 	a.Equal("cloud", profile.Service())
@@ -106,9 +108,9 @@ func TestProfile_Get_FullProfile(t *testing.T) {
 
 func TestProfile_Get_Default(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
-	a := assert.New(t)
-	a.NoError(profile.LoadMongoCLIConfig(false))
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
 	desc := profile.Map()
+	a := assert.New(t)
 	a.Equal(DefaultProfile, profile.Name())
 	a.Len(desc, 4)
 }
@@ -117,12 +119,11 @@ func TestProfile_Get_NonDefault(t *testing.T) {
 	profile := profileWithOneNonDefaultUser()
 	profile.SetName(atlas)
 
-	a := assert.New(t)
-
-	a.NoError(profile.LoadMongoCLIConfig(false))
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
 
 	desc := profile.Map()
 
+	a := assert.New(t)
 	a.Equal(atlas, profile.Name(), "expected atlas Profile to be described")
 	a.Len(desc, 3)
 	a.Equal("5cac6a2179358edabd12b572", profile.OrgID(), "project id should match")
@@ -131,65 +132,55 @@ func TestProfile_Get_NonDefault(t *testing.T) {
 
 func TestProfile_Delete_NonDefault(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
-
-	a := assert.New(t)
-
-	a.NoError(profile.LoadMongoCLIConfig(false))
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
 
 	profile.SetName(atlas)
 
-	if a.NoError(profile.Delete()) {
-		a.NoError(profile.LoadMongoCLIConfig(false))
-		desc := profile.Map()
-		a.Len(desc, 0, "Profile should have no properties")
-	}
+	require.NoError(t, profile.Delete())
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
+	desc := profile.Map()
+	assert.Empty(t, desc, "Profile should have no properties")
 }
 
 func TestProfile_Rename(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
 	profile.SetName(DefaultProfile)
 
-	a := assert.New(t)
-	a.NoError(profile.LoadMongoCLIConfig(false))
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
 	defaultDescription := profile.Map()
-	if a.NoError(profile.Rename(newProfileName)) {
-		a.NoError(profile.LoadMongoCLIConfig(false))
-		profile.SetName(DefaultProfile)
-		a.Empty(profile.Map())
-		profile.SetName(newProfileName)
-		descriptionAfterRename := profile.Map()
-		// after renaming, one Profile should exist
-		a.Equal(defaultDescription, descriptionAfterRename, "descriptions should be equal after renaming")
-	}
+	require.NoError(t, profile.Rename(newProfileName))
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
+	profile.SetName(DefaultProfile)
+	a := assert.New(t)
+	a.Empty(profile.Map())
+	profile.SetName(newProfileName)
+	descriptionAfterRename := profile.Map()
+	// after renaming, one Profile should exist
+	a.Equal(defaultDescription, descriptionAfterRename, "descriptions should be equal after renaming")
 }
 
 func TestProfile_Rename_OverwriteExisting(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
 	profile.SetName(DefaultProfile)
 
-	a := assert.New(t)
-	a.NoError(profile.LoadMongoCLIConfig(false))
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
 	defaultDescription := profile.Map()
 
-	if a.NoError(profile.Rename(atlas)) {
-		a.NoError(profile.LoadMongoCLIConfig(false))
-		profile.SetName(atlas)
-
-		descriptionAfterRename := profile.Map()
-
-		// after renaming, one Profile should exist
-		a.Equal(defaultDescription, descriptionAfterRename, "descriptions should be equal after renaming")
-	}
+	require.NoError(t, profile.Rename(atlas))
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
+	profile.SetName(atlas)
+	descriptionAfterRename := profile.Map()
+	// after renaming, one Profile should exist
+	assert.Equal(t, defaultDescription, descriptionAfterRename, "descriptions should be equal after renaming")
 }
 
 func TestProfile_Set(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
-	a := assert.New(t)
-	a.NoError(profile.LoadMongoCLIConfig(false))
+	require.NoError(t, profile.LoadMongoCLIConfig(false))
 
 	profile.SetName(DefaultProfile)
 
 	profile.Set(projectID, "newProjectId")
 
-	a.Equal("newProjectId", profile.ProjectID(), "project id should be set to new value")
+	assert.Equal(t, "newProjectId", profile.ProjectID(), "project id should be set to new value")
 }

--- a/internal/convert/process_config_test.go
+++ b/internal/convert/process_config_test.go
@@ -220,7 +220,7 @@ func Test_newConfigRSProcess(t *testing.T) {
 		Version:     "4.4.1-ent",
 	}
 	got := newConfigRSProcess(p, "myReplicaSet")
-	assert.Equal(t, got, want)
+	assert.Equal(t, want, got)
 }
 
 func Test_newConfigRSProcess_audit(t *testing.T) {
@@ -302,7 +302,7 @@ func Test_newConfigRSProcess_audit(t *testing.T) {
 		Version:     "4.4.1-ent",
 	}
 	got := newConfigRSProcess(p, "myReplicaSet")
-	assert.Equal(t, got, want)
+	assert.Equal(t, want, got)
 }
 
 func Test_newReplicaSetProcess(t *testing.T) {
@@ -391,7 +391,7 @@ func Test_newReplicaSetProcess(t *testing.T) {
 		Version:     "4.4.1-ent",
 	}
 	got := newReplicaSetProcess(p, "myReplicaSet")
-	assert.Equal(t, got, want)
+	assert.Equal(t, want, got)
 }
 
 func Test_newMongosProcessConfig(t *testing.T) {
@@ -448,5 +448,5 @@ func Test_newMongosProcessConfig(t *testing.T) {
 		},
 	}
 	got := newMongosProcessConfig(p)
-	assert.Equal(t, got, want)
+	assert.Equal(t, want, got)
 }

--- a/internal/decryption/pem/pem_test.go
+++ b/internal/decryption/pem/pem_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const dummyCA = `-----BEGIN CERTIFICATE-----
@@ -223,7 +224,7 @@ func TestValidateBlocks(t *testing.T) {
 
 		isEncrypted, err := pem.ValidateBlocks("pemfile")
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, isEncrypted)
 	})
 
@@ -234,7 +235,7 @@ func TestValidateBlocks(t *testing.T) {
 
 		isEncrypted, err := pem.ValidateBlocks("pemfile")
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, isEncrypted)
 	})
 
@@ -245,7 +246,7 @@ func TestValidateBlocks(t *testing.T) {
 
 		isEncrypted, err := pem.ValidateBlocks("pemfile")
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, isEncrypted)
 	})
 
@@ -257,7 +258,7 @@ func TestValidateBlocks(t *testing.T) {
 
 		isEncrypted, err := pem.ValidateBlocks("pemfile")
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.False(t, isEncrypted)
 	})
 
@@ -269,7 +270,7 @@ func TestValidateBlocks(t *testing.T) {
 
 		isEncrypted, err := pem.ValidateBlocks("pemfile")
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.False(t, isEncrypted)
 	})
 }
@@ -282,7 +283,7 @@ func TestDecode(t *testing.T) {
 
 		cert, privateKey, err := pem.Decode("pemfile", "")
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Contains(t, string(cert), CertificateBlock)
 		assert.Contains(t, string(privateKey), RSAPrivateKeyBlock)
 	})
@@ -294,7 +295,7 @@ func TestDecode(t *testing.T) {
 
 		cert, privateKey, err := pem.Decode("pemfile", "wrong pwd")
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, cert)
 		assert.Nil(t, privateKey)
 	})
@@ -306,7 +307,7 @@ func TestDecode(t *testing.T) {
 
 		cert, privateKey, err := pem.Decode("pemfile", dummyPwd)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Contains(t, string(cert), CertificateBlock)
 		assert.Contains(t, string(privateKey), RSAPrivateKeyBlock)
 	})

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -37,32 +36,32 @@ func TestLoad(t *testing.T) {
 	t.Run("load file does not exists", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		err := Load(appFS, xmlFileName, nil)
-		assert.ErrorIs(t, err, ErrFileNotFound)
+		require.ErrorIs(t, err, ErrFileNotFound)
 	})
 	t.Run("load file with no ext", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		_ = afero.WriteFile(appFS, noExtFileName, []byte(""), 0600)
 		err := Load(appFS, noExtFileName, nil)
-		assert.ErrorIs(t, err, ErrMissingFileType)
+		require.ErrorIs(t, err, ErrMissingFileType)
 	})
 	t.Run("load file with invalid ext", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		require.NoError(t, afero.WriteFile(appFS, txtFileName, []byte(""), 0600))
 		err := Load(appFS, txtFileName, nil)
-		assert.ErrorIs(t, err, ErrUnsupportedFileType)
+		require.ErrorIs(t, err, ErrUnsupportedFileType)
 	})
 	t.Run("load valid json file", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		_ = afero.WriteFile(appFS, jsonFileName, []byte("{}"), 0600)
 		out := new(map[string]interface{})
-		assert.NoError(t, Load(appFS, jsonFileName, out))
+		require.NoError(t, Load(appFS, jsonFileName, out))
 	})
 	t.Run("load valid yaml file", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		_ = afero.WriteFile(appFS, yamlFileName, []byte(""), 0600)
 		out := new(map[string]interface{})
 		err := Load(appFS, yamlFileName, out)
-		assert.NoError(t, err, ErrMissingFileType)
+		require.NotErrorIs(t, err, ErrMissingFileType)
 	})
 }
 
@@ -71,12 +70,12 @@ func TestSave(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		filename := "test"
 		err := Save(appFS, filename, nil)
-		assert.ErrorIs(t, err, ErrMissingFileType)
+		require.ErrorIs(t, err, ErrMissingFileType)
 	})
 	t.Run("save file with wrong ext", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
 		err := Save(appFS, txtFileName, nil)
-		assert.ErrorIs(t, err, ErrUnsupportedFileType)
+		require.ErrorIs(t, err, ErrUnsupportedFileType)
 	})
 	t.Run("save valid yaml file", func(t *testing.T) {
 		appFS := afero.NewMemMapFs()
@@ -90,6 +89,6 @@ func TestSave(t *testing.T) {
 		}
 
 		yamlData, _ := yaml.Marshal(&tYaml)
-		assert.NoError(t, Save(appFS, yamlFileName, yamlData))
+		require.NoError(t, Save(appFS, yamlFileName, yamlData))
 	})
 }

--- a/internal/kubernetes/operator/features/crds_test.go
+++ b/internal/kubernetes/operator/features/crds_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -268,38 +269,38 @@ func Test_pathExists(t *testing.T) {
 func Test_CRDCompatibleVersion(t *testing.T) {
 	t.Run("should return error when operator version is invalid", func(t *testing.T) {
 		_, err := CRDCompatibleVersion("abc")
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("should return operator major version when it is less than supported CRD version", func(t *testing.T) {
 		crdVersion, err := semver.NewVersion(LatestOperatorMajorVersion)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		operatorVersion := semver.New(crdVersion.Major(), crdVersion.Minor()-1, 2, "", "")
 
 		expected := fmt.Sprintf("%d.%d.0", operatorVersion.Major(), operatorVersion.Minor())
 		compatibleVersion, err := CRDCompatibleVersion(operatorVersion.String())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expected, compatibleVersion)
 	})
 
 	t.Run("should return operator major version when it is equal than supported CRD version", func(t *testing.T) {
 		crdVersion, err := semver.NewVersion(LatestOperatorMajorVersion)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		operatorVersion := semver.New(crdVersion.Major(), crdVersion.Minor(), crdVersion.Patch(), "", "")
 
 		expected := fmt.Sprintf("%d.%d.0", operatorVersion.Major(), operatorVersion.Minor())
 		compatibleVersion, err := CRDCompatibleVersion(operatorVersion.String())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expected, compatibleVersion)
 	})
 
 	t.Run("should return CRD major version when it is less than operator version", func(t *testing.T) {
 		crdVersion, err := semver.NewVersion(LatestOperatorMajorVersion)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		operatorVersion := semver.New(crdVersion.Major(), crdVersion.Minor()+1, 0, "", "")
 
 		compatibleVersion, err := CRDCompatibleVersion(operatorVersion.String())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, LatestOperatorMajorVersion, compatibleVersion)
 	})
 }

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -75,8 +75,8 @@ func TestWithProfile(t *testing.T) {
 		e := newEvent(withProfile(&configMock{name: profile}))
 
 		a := assert.New(t)
-		a.NotEqual(e.Properties["profile"], config.DefaultProfile)
-		a.NotEqual(e.Properties["profile"], profile) // should be a base64
+		a.NotEqual(config.DefaultProfile, e.Properties["profile"])
+		a.NotEqual(profile, e.Properties["profile"]) // should be a base64
 	})
 }
 
@@ -110,7 +110,7 @@ func TestWithFlags(t *testing.T) {
 	_ = cmd.ExecuteContext(NewContext())
 
 	e := newEvent(withFlags(cmd))
-	assert.Equal(t, e.Properties["flags"], []string{"test"})
+	assert.Equal(t, []string{"test"}, e.Properties["flags"])
 }
 
 func TestWithVersion(t *testing.T) {
@@ -122,8 +122,8 @@ func TestWithVersion(t *testing.T) {
 	e := newEvent(withVersion())
 
 	a := assert.New(t)
-	a.Equal(e.Properties["version"], "vTest")
-	a.Equal(e.Properties["git_commit"], "sha-test")
+	a.Equal("vTest", e.Properties["version"])
+	a.Equal("sha-test", e.Properties["git_commit"])
 }
 
 func TestWithOS(t *testing.T) {
@@ -132,8 +132,8 @@ func TestWithOS(t *testing.T) {
 	e := newEvent(withOS())
 
 	a := assert.New(t)
-	a.Equal(e.Properties["os"], runtime.GOOS)
-	a.Equal(e.Properties["arch"], runtime.GOARCH)
+	a.Equal(runtime.GOOS, e.Properties["os"])
+	a.Equal(runtime.GOARCH, e.Properties["arch"])
 }
 
 func TestWithUserAgent(t *testing.T) {
@@ -152,11 +152,11 @@ func TestWithAuthMethod(t *testing.T) {
 			privateKey: "test-private",
 		}
 		e := newEvent(withAuthMethod(c))
-		assert.Equal(t, e.Properties["auth_method"], "api_key")
+		assert.Equal(t, "api_key", e.Properties["auth_method"])
 	})
 	t.Run("Oauth", func(t *testing.T) {
 		e := newEvent(withAuthMethod(&configMock{}))
-		assert.Equal(t, e.Properties["auth_method"], "oauth")
+		assert.Equal(t, "oauth", e.Properties["auth_method"])
 	})
 }
 
@@ -325,28 +325,28 @@ func TestWithChoice(t *testing.T) {
 func TestWithDefault(t *testing.T) {
 	config.ToolName = config.AtlasCLI
 	e := newEvent(withDefault(true))
-	assert.Equal(t, true, e.Properties["default"])
+	assert.Contains(t, e.Properties, "default")
 }
 
 func TestWithEmpty(t *testing.T) {
 	config.ToolName = config.AtlasCLI
 
 	e := newEvent(withEmpty(true))
-	assert.Equal(t, true, e.Properties["empty"])
+	assert.Contains(t, e.Properties, "empty")
 }
 
 func TestWithAnonymousID(t *testing.T) {
 	config.ToolName = config.AtlasCLI
 
 	e := newEvent(withAnonymousID())
-	assert.NotEmpty(t, e.Properties["device_id"])
+	assert.Contains(t, e.Properties, "device_id")
 }
 
 func TestWithDeploymentType(t *testing.T) {
 	config.ToolName = config.AtlasCLI
 
 	e := newEvent(WithDeploymentType("test"))
-	assert.Equal(t, e.Properties["deployment_type"], "test")
+	assert.Equal(t, "test", e.Properties["deployment_type"])
 }
 
 func TestWithSignal(t *testing.T) {
@@ -391,9 +391,7 @@ func TestWithHelpCommand_NotFound(t *testing.T) {
 	args := []string{"test2"}
 
 	e := newEvent(withHelpCommand(helpCmd, args))
-
-	_, ok := e.Properties["help_command"]
-	assert.False(t, ok)
+	assert.NotContains(t, e.Properties, "help_command")
 }
 
 type configMock struct {

--- a/internal/telemetry/read_answer_test.go
+++ b/internal/telemetry/read_answer_test.go
@@ -18,11 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadAnswer(t *testing.T) {
-	a := assert.New(t)
-
 	testCases := []struct {
 		input    interface{}
 		name     string
@@ -117,15 +116,19 @@ func TestReadAnswer(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		answer, err := readAnswer(testCase.input, testCase.name)
-		a.NoError(err)
-		a.Equal(testCase.expected, answer)
+		input := testCase.input
+		name := testCase.name
+		expected := testCase.expected
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			answer, err := readAnswer(input, name)
+			require.NoError(t, err)
+			assert.Equal(t, expected, answer)
+		})
 	}
 }
 
 func TestReadAnswerNotFound(t *testing.T) {
-	a := assert.New(t)
-
 	testCases := []struct {
 		input interface{}
 		name  string
@@ -166,14 +169,17 @@ func TestReadAnswerNotFound(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		_, err := readAnswer(testCase.input, testCase.name)
-		a.ErrorIs(err, ErrFieldNotFound)
+		input := testCase.input
+		name := testCase.name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := readAnswer(input, name)
+			require.ErrorIs(t, err, ErrFieldNotFound)
+		})
 	}
 }
 
 func TestReadAnswerNotStructOrMap(t *testing.T) {
-	a := assert.New(t)
-
 	test := "value"
 
 	testCases := []struct {
@@ -195,7 +201,12 @@ func TestReadAnswerNotStructOrMap(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		_, err := readAnswer(testCase.input, testCase.name)
-		a.ErrorIs(err, ErrNotMapOrStruct)
+		input := testCase.input
+		name := testCase.name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := readAnswer(input, name)
+			require.ErrorIs(t, err, ErrNotMapOrStruct)
+		})
 	}
 }

--- a/internal/test/fixture/automation_configs.go
+++ b/internal/test/fixture/automation_configs.go
@@ -191,6 +191,7 @@ func AutomationConfigWithMonitoring() *opsmngr.AutomationConfig {
 
 func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.AutomationConfig {
 	fipsMode := true
+	procName := name + "_0"
 	return &opsmngr.AutomationConfig{
 		Processes: []*opsmngr.Process{
 			{
@@ -233,7 +234,7 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 					},
 				},
 				AuthSchemaVersion:           defaultAuthSchemaVersion,
-				Name:                        name + "_0",
+				Name:                        procName,
 				Disabled:                    disabled,
 				FeatureCompatibilityVersion: "4.2",
 				Hostname:                    "host0",
@@ -254,7 +255,7 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 						ArbiterOnly:        false,
 						BuildIndexes:       true,
 						Hidden:             false,
-						Host:               name + "_0",
+						Host:               procName,
 						Priority:           1,
 						SlaveDelay:         pointer.Get[float64](1),
 						SecondaryDelaySecs: pointer.Get[float64](1),
@@ -267,6 +268,8 @@ func AutomationConfigWithOneReplicaSet(name string, disabled bool) *opsmngr.Auto
 }
 
 func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.AutomationConfig {
+	configName := name + "_configRS_1"
+	shardName := name + "_myShard_0_0"
 	return &opsmngr.AutomationConfig{
 		Auth: opsmngr.Auth{
 			DeploymentAuthMechanisms: []string{},
@@ -291,7 +294,7 @@ func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
 				AuthSchemaVersion:           defaultAuthSchemaVersion,
-				Name:                        name + "_myShard_0_0",
+				Name:                        shardName,
 				Disabled:                    disabled,
 				FeatureCompatibilityVersion: "4.2",
 				Hostname:                    "example",
@@ -319,7 +322,7 @@ func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 					TimeThresholdHrs: defaultTimeThresholdHrs,
 				},
 				AuthSchemaVersion:           defaultAuthSchemaVersion,
-				Name:                        name + "_configRS_1",
+				Name:                        configName,
 				Disabled:                    disabled,
 				FeatureCompatibilityVersion: "4.2",
 				Hostname:                    "example",
@@ -360,7 +363,7 @@ func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 						ArbiterOnly:        false,
 						BuildIndexes:       true,
 						Hidden:             false,
-						Host:               name + "_myShard_0_0",
+						Host:               shardName,
 						Priority:           1,
 						SlaveDelay:         pointer.Get[float64](1),
 						SecondaryDelaySecs: pointer.Get[float64](1),
@@ -377,7 +380,7 @@ func AutomationConfigWithOneShardedCluster(name string, disabled bool) *opsmngr.
 						ArbiterOnly:        false,
 						BuildIndexes:       true,
 						Hidden:             false,
-						Host:               name + "_configRS_1",
+						Host:               configName,
 						Priority:           1,
 						SlaveDelay:         pointer.Get[float64](1),
 						SecondaryDelaySecs: pointer.Get[float64](1),

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -193,10 +193,10 @@ dbName and collection are required only for built-in roles.`
 	SSEEnabled                                = "Flag indicating whether this Amazon S3 blockstore enables server-side encryption."
 	PathStyleAccessEnabled                    = "Flag indicating the style of this endpoint."
 	APIKeyDescription                         = "Description of the API key."
-	AtlasAPIKeyDescription                    = APIKeyDescription + " Required when creating organizations authenticated with API Keys."
+	AtlasAPIKeyDescription                    = APIKeyDescription + requiredForAtlas
 	APIKeyRoles                               = "Role or roles that you want to assign to the API key. To assign more than one role, specify each role with a separate role flag or specify all of the roles as a comma-separated list using one role flag. To learn which values the CLI accepts, see the Items Enum for roles in the Atlas API spec: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/createApiKey/."        //nolint:gosec // This is just a message not a credential
 	ProjectAPIKeyRoles                        = "Role or roles that you want to assign to the API key. To assign more than one role, specify each role with a separate role flag or specify all of the roles as a comma-separated list using one role flag. To learn which values the CLI accepts, see the Items Enum for roles in the Atlas API spec: https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Programmatic-API-Keys/operation/createProjectApiKey/." //nolint:gosec // This is just a message not a credential
-	AtlasAPIKeyRoles                          = APIKeyRoles + " Required when creating organizations authenticated with API Keys."
+	AtlasAPIKeyRoles                          = APIKeyRoles + requiredForAtlas
 	GlobalAPIKeyRoles                         = "Role or roles that you want to assign to the API key. To assign more than one role, you can specify each role with a separate role flag or specify all of the roles as a comma-separated list using one role flag. Valid values are GLOBAL_AUTOMATION_ADMIN, GLOBAL_BACKUP_ADMIN GLOBAL_MONITORING_ADMIN, GLOBAL_OWNER, GLOBAL_READ_ONLY,GLOBAL_USER_ADMIN." //nolint:gosec // This is just a message not a credential
 	NotificationRegion                        = "Region that indicates which API URL to use."
 	NotificationDelayMin                      = "Number of minutes to wait after an alert condition is detected before sending out the first notification."
@@ -467,4 +467,5 @@ dbName and collection are required only for built-in roles.`
 	DeploymentName                            = "Name of the deployment."
 	LogName                                   = "Name of the log file (e.g. mongodb.gz|mongos.gz|mongosqld.gz|mongodb-audit-log.gz|mongos-audit-log.gz)."
 	LogHostName                               = "Name of the host that stores the log files that you want to download."
+	requiredForAtlas                          = " Required when creating organizations authenticated with API Keys."
 )

--- a/test/e2e/atlas/access_roles_test.go
+++ b/test/e2e/atlas/access_roles_test.go
@@ -47,14 +47,11 @@ func TestAccessRoles(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var iamRole atlasv2.CloudProviderAccessRole
-		if err := json.Unmarshal(resp, &iamRole); a.NoError(err) {
-			a.Equal(aws, iamRole.ProviderName)
-		}
+		require.NoError(t, json.Unmarshal(resp, &iamRole))
+		assert.Equal(t, aws, iamRole.ProviderName)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -67,13 +64,9 @@ func TestAccessRoles(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
-
+		require.NoError(t, err, string(resp))
 		var roles atlasv2.CloudProviderAccessRoles
-		if err := json.Unmarshal(resp, &roles); a.NoError(err) {
-			a.Len(roles.AwsIamRoles, 1)
-		}
+		require.NoError(t, json.Unmarshal(resp, &roles))
+		assert.Len(t, roles.AwsIamRoles, 1)
 	})
 }

--- a/test/e2e/atlas/alert_settings_test.go
+++ b/test/e2e/atlas/alert_settings_test.go
@@ -55,19 +55,17 @@ func TestAlertConfig(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+		var alert admin.GroupAlertsConfig
+		require.NoError(t, json.Unmarshal(resp, &alert))
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var alert admin.GroupAlertsConfig
-			if err := json.Unmarshal(resp, &alert); a.NoError(err) {
-				a.Equal(eventTypeName, alert.GetEventTypeName())
-				a.NotEmpty(alert.Notifications)
-				a.Equal(delayMin, alert.Notifications[0].GetDelayMin())
-				a.Equal(group, alert.Notifications[0].GetTypeName())
-				a.Equal(intervalMin, alert.Notifications[0].GetIntervalMin())
-				a.False(alert.Notifications[0].GetSmsEnabled())
-				alertID = alert.GetId()
-			}
-		}
+		a.Equal(eventTypeName, alert.GetEventTypeName())
+		a.NotEmpty(alert.Notifications)
+		a.Equal(delayMin, alert.Notifications[0].GetDelayMin())
+		a.Equal(group, alert.Notifications[0].GetTypeName())
+		a.Equal(intervalMin, alert.Notifications[0].GetIntervalMin())
+		a.False(alert.Notifications[0].GetSmsEnabled())
+		alertID = alert.GetId()
 	})
 	if alertID == "" {
 		assert.FailNow(t, "Failed to create alert setting")
@@ -81,12 +79,10 @@ func TestAlertConfig(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
-		a := assert.New(t)
+		require.NoError(t, err, string(resp))
 		var config admin.PaginatedAlertConfig
-		if err := json.Unmarshal(resp, &config); a.NoError(err) {
-			a.NotEmpty(config.Results)
-		}
+		require.NoError(t, json.Unmarshal(resp, &config))
+		assert.NotEmpty(t, config.Results)
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
@@ -98,12 +94,10 @@ func TestAlertConfig(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
-		a := assert.New(t)
+		require.NoError(t, err, string(resp))
 		var config []admin.GroupAlertsConfig
-		if err := json.Unmarshal(resp, &config); a.NoError(err) {
-			a.NotEmpty(config)
-		}
+		require.NoError(t, json.Unmarshal(resp, &config))
+		assert.NotEmpty(t, config)
 	})
 
 	t.Run("Update", func(t *testing.T) {
@@ -127,15 +121,13 @@ func TestAlertConfig(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var alert admin.GroupAlertsConfig
-			if err := json.Unmarshal(resp, &alert); a.NoError(err) {
-				a.False(alert.GetEnabled())
-				a.NotEmpty(alert.Notifications)
-				a.True(alert.Notifications[0].GetSmsEnabled())
-				a.True(alert.Notifications[0].GetEmailEnabled())
-			}
-		}
+		require.NoError(t, err, string(resp))
+		var alert admin.GroupAlertsConfig
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		a.False(alert.GetEnabled())
+		a.NotEmpty(alert.Notifications)
+		a.True(alert.Notifications[0].GetSmsEnabled())
+		a.True(alert.Notifications[0].GetEmailEnabled())
 	})
 
 	t.Run("Update Setting using file input", func(t *testing.T) {
@@ -171,15 +163,13 @@ func TestAlertConfig(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var alert admin.GroupAlertsConfig
-			if err := json.Unmarshal(resp, &alert); a.NoError(err) {
-				a.False(alert.GetEnabled())
-				a.NotEmpty(alert.Notifications)
-				a.True(alert.Notifications[0].GetSmsEnabled())
-				a.True(alert.Notifications[0].GetEmailEnabled())
-			}
-		}
+		require.NoError(t, err, string(resp))
+		var alert admin.GroupAlertsConfig
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		a.False(alert.GetEnabled())
+		a.NotEmpty(alert.Notifications)
+		a.True(alert.Notifications[0].GetSmsEnabled())
+		a.True(alert.Notifications[0].GetEmailEnabled())
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/test/e2e/atlas/alerts_test.go
+++ b/test/e2e/atlas/alerts_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -50,14 +51,11 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var alerts atlasv2.PaginatedAlert
-			err := json.Unmarshal(resp, &alerts)
-			a.NoError(err)
-			a.NotEmpty(alerts.Results)
-			alertID = *alerts.Results[0].Id
-		}
+		require.NoError(t, err, string(resp))
+		var alerts atlasv2.PaginatedAlert
+		require.NoError(t, json.Unmarshal(resp, &alerts))
+		assert.NotEmpty(t, alerts.Results)
+		alertID = *alerts.Results[0].Id
 	})
 
 	t.Run("List with status OPEN", func(t *testing.T) {
@@ -71,7 +69,7 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List with no status", func(t *testing.T) {
@@ -83,7 +81,7 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -97,13 +95,11 @@ func TestAlerts(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var alert atlasv2.AlertViewForNdsGroup
-			err := json.Unmarshal(resp, &alert)
-			a.NoError(err)
-			a.Equal(alertID, *alert.Id)
-			a.Equal(closed, *alert.Status)
-		}
+		require.NoError(t, err, string(resp))
+		var alert atlasv2.AlertViewForNdsGroup
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		a.Equal(alertID, *alert.Id)
+		a.Equal(closed, *alert.Status)
 	})
 
 	t.Run("Acknowledge", func(t *testing.T) {
@@ -117,13 +113,10 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var alert atlasv2.AlertViewForNdsGroup
-			err := json.Unmarshal(resp, &alert)
-			a.NoError(err)
-			a.Equal(alertID, *alert.Id)
-		}
+		require.NoError(t, err, string(resp))
+		var alert atlasv2.AlertViewForNdsGroup
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		assert.Equal(t, alertID, *alert.Id)
 	})
 
 	t.Run("Acknowledge Forever", func(t *testing.T) {
@@ -136,13 +129,10 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var alert atlasv2.AlertViewForNdsGroup
-			err := json.Unmarshal(resp, &alert)
-			a.NoError(err)
-			a.Equal(alertID, *alert.Id)
-		}
+		require.NoError(t, err, string(resp))
+		var alert atlasv2.AlertViewForNdsGroup
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		assert.Equal(t, alertID, *alert.Id)
 	})
 
 	t.Run("UnAcknowledge", func(t *testing.T) {
@@ -155,11 +145,9 @@ func TestAlerts(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var alert atlasv2.AlertViewForNdsGroup
-			err := json.Unmarshal(resp, &alert)
-			a.NoError(err)
-			a.Equal(alertID, *alert.Id)
-		}
+		require.NoError(t, err, string(resp))
+		var alert atlasv2.AlertViewForNdsGroup
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		a.Equal(alertID, *alert.Id)
 	})
 }

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -287,7 +287,7 @@ func deleteOrgTeams(t *testing.T, cliPath string) {
 	var teams atlasv2.PaginatedTeam
 	require.NoError(t, json.Unmarshal(resp, &teams), string(resp))
 	for _, team := range teams.Results {
-		assert.NoError(t, deleteTeam(team.GetId()))
+		assert.NoError(t, deleteTeam(team.GetId())) //nolint: testifylint // try to delete all
 	}
 }
 

--- a/test/e2e/atlas/backup_compliancepolicy_enable_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_enable_test.go
@@ -53,5 +53,5 @@ func TestBackupCompliancePolicyEnable(t *testing.T) {
 	var result atlasv2.DataProtectionSettings
 	r.NoError(json.Unmarshal(resp, &result), string(resp))
 
-	assert.Equal(t, result.GetAuthorizedEmail(), authorizedEmail)
+	assert.Equal(t, authorizedEmail, result.GetAuthorizedEmail())
 }

--- a/test/e2e/atlas/backup_compliancepolicy_setup_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_setup_test.go
@@ -73,5 +73,5 @@ func TestBackupCompliancePolicySetup(t *testing.T) {
 
 	a := assert.New(t)
 	a.Len(result.GetScheduledPolicyItems(), 1)
-	a.Equal(result.GetAuthorizedEmail(), authorizedEmail)
+	a.Equal(authorizedEmail, result.GetAuthorizedEmail())
 }

--- a/test/e2e/atlas/backup_export_buckets_test.go
+++ b/test/e2e/atlas/backup_export_buckets_test.go
@@ -58,9 +58,8 @@ func TestExportBuckets(t *testing.T) {
 
 		a := assert.New(t)
 		var exportBucket atlasv2.DiskBackupSnapshotAWSExportBucket
-		if err = json.Unmarshal(resp, &exportBucket); a.NoError(err) {
-			a.Equal(bucketName, exportBucket.GetBucketName())
-		}
+		r.NoError(json.Unmarshal(resp, &exportBucket))
+		a.Equal(bucketName, exportBucket.GetBucketName())
 		bucketID = exportBucket.GetId()
 	})
 
@@ -73,14 +72,10 @@ func TestExportBuckets(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
 		r.NoError(err, string(resp))
-
-		var r atlasv2.PaginatedBackupSnapshotExportBucket
-		a := assert.New(t)
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		var buckets atlasv2.PaginatedBackupSnapshotExportBucket
+		r.NoError(json.Unmarshal(resp, &buckets))
+		assert.NotEmpty(t, buckets)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -94,14 +89,10 @@ func TestExportBuckets(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
 		r.NoError(err, string(resp))
-
-		a := assert.New(t)
 		var exportBucket atlasv2.DiskBackupSnapshotAWSExportBucket
-		if err = json.Unmarshal(resp, &exportBucket); a.NoError(err) {
-			a.Equal(bucketName, exportBucket.GetBucketName())
-		}
+		r.NoError(json.Unmarshal(resp, &exportBucket))
+		assert.Equal(t, bucketName, exportBucket.GetBucketName())
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/test/e2e/atlas/backup_export_jobs_test.go
+++ b/test/e2e/atlas/backup_export_jobs_test.go
@@ -94,14 +94,10 @@ func TestExportJobs(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
 		r.NoError(err, string(resp))
-
-		a := assert.New(t)
 		var exportBucket atlasv2.DiskBackupSnapshotAWSExportBucket
-		if err = json.Unmarshal(resp, &exportBucket); a.NoError(err) {
-			a.Equal(bucketName, exportBucket.GetBucketName())
-		}
+		r.NoError(json.Unmarshal(resp, &exportBucket))
+		assert.Equal(t, bucketName, exportBucket.GetBucketName())
 		bucketID = exportBucket.GetId()
 	})
 
@@ -121,9 +117,8 @@ func TestExportJobs(t *testing.T) {
 
 		a := assert.New(t)
 		var snapshot atlasv2.DiskBackupSnapshot
-		if err = json.Unmarshal(resp, &snapshot); a.NoError(err) {
-			a.Equal("test-snapshot", snapshot.GetDescription())
-		}
+		r.NoError(json.Unmarshal(resp, &snapshot))
+		a.Equal("test-snapshot", snapshot.GetDescription())
 		snapshotID = snapshot.GetId()
 	})
 
@@ -157,14 +152,11 @@ func TestExportJobs(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		r.NoError(err, string(resp))
-
 		a := assert.New(t)
 		var job atlasv2.DiskBackupExportJob
-		if err = json.Unmarshal(resp, &job); a.NoError(err) {
-			a.Equal(job.GetExportBucketId(), bucketID)
-
-			exportJobID = job.GetId()
-		}
+		r.NoError(json.Unmarshal(resp, &job))
+		a.Equal(job.GetExportBucketId(), bucketID)
+		exportJobID = job.GetId()
 	})
 
 	t.Run("Watch create job", func(t *testing.T) {
@@ -199,9 +191,8 @@ func TestExportJobs(t *testing.T) {
 
 		a := assert.New(t)
 		var job atlasv2.DiskBackupExportJob
-		if err = json.Unmarshal(resp, &job); a.NoError(err) {
-			a.Equal(job.GetExportBucketId(), bucketID)
-		}
+		r.NoError(json.Unmarshal(resp, &job))
+		a.Equal(job.GetExportBucketId(), bucketID)
 	})
 
 	t.Run("List jobs", func(t *testing.T) {
@@ -216,11 +207,10 @@ func TestExportJobs(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		r.NoError(err, string(resp))
 
-		var r atlasv2.PaginatedApiAtlasDiskBackupExportJob
+		var jobs atlasv2.PaginatedApiAtlasDiskBackupExportJob
 		a := assert.New(t)
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		r.NoError(json.Unmarshal(resp, &jobs))
+		a.NotEmpty(jobs)
 	})
 
 	t.Run("Delete snapshot", func(t *testing.T) {

--- a/test/e2e/atlas/backup_restores_test.go
+++ b/test/e2e/atlas/backup_restores_test.go
@@ -61,9 +61,8 @@ func TestRestores(t *testing.T) {
 
 		a := assert.New(t)
 		var snapshot atlasv2.DiskBackupSnapshot
-		if err = json.Unmarshal(resp, &snapshot); a.NoError(err) {
-			a.Equal("test-snapshot", snapshot.GetDescription())
-		}
+		require.NoError(t, json.Unmarshal(resp, &snapshot))
+		a.Equal("test-snapshot", snapshot.GetDescription())
 		snapshotID = snapshot.GetId()
 	})
 
@@ -103,11 +102,9 @@ func TestRestores(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		r.NoError(err, string(resp))
-		a := assert.New(t)
 		var result atlasv2.DiskBackupSnapshotRestoreJob
-		if err = json.Unmarshal(resp, &result); a.NoError(err) {
-			restoreJobID = result.GetId()
-		}
+		require.NoError(t, json.Unmarshal(resp, &result))
+		restoreJobID = result.GetId()
 	})
 
 	t.Run("Restores Watch", func(t *testing.T) {
@@ -143,9 +140,8 @@ func TestRestores(t *testing.T) {
 
 		a := assert.New(t)
 		var result atlasv2.PaginatedCloudBackupRestoreJob
-		if err = json.Unmarshal(resp, &result); a.NoError(err, string(resp)) {
-			a.NotEmpty(result)
-		}
+		require.NoError(t, json.Unmarshal(resp, &result), string(resp))
+		a.NotEmpty(result)
 	})
 
 	t.Run("Restores Describe", func(t *testing.T) {
@@ -166,9 +162,8 @@ func TestRestores(t *testing.T) {
 
 		a := assert.New(t)
 		var result atlasv2.DiskBackupSnapshotRestoreJob
-		if err = json.Unmarshal(resp, &result); a.NoError(err, string(resp)) {
-			a.NotEmpty(result)
-		}
+		require.NoError(t, json.Unmarshal(resp, &result), string(resp))
+		a.NotEmpty(result)
 	})
 
 	t.Run("Delete snapshot", func(t *testing.T) {

--- a/test/e2e/atlas/backup_snapshot_test.go
+++ b/test/e2e/atlas/backup_snapshot_test.go
@@ -89,9 +89,8 @@ func TestSnapshots(t *testing.T) {
 
 		a := assert.New(t)
 		var snapshot atlasv2.DiskBackupSnapshot
-		if err = json.Unmarshal(resp, &snapshot); a.NoError(err) {
-			a.Equal("test-snapshot", snapshot.GetDescription())
-		}
+		require.NoError(t, json.Unmarshal(resp, &snapshot))
+		a.Equal("test-snapshot", snapshot.GetDescription())
 		snapshotID = snapshot.GetId()
 	})
 
@@ -120,11 +119,10 @@ func TestSnapshots(t *testing.T) {
 
 		r.NoError(err, string(resp))
 
-		var r atlasv2.PaginatedCloudBackupReplicaSet
+		var backups atlasv2.PaginatedCloudBackupReplicaSet
 		a := assert.New(t)
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		r.NoError(json.Unmarshal(resp, &backups))
+		a.NotEmpty(backups)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -143,9 +141,8 @@ func TestSnapshots(t *testing.T) {
 
 		a := assert.New(t)
 		var result atlasv2.DiskBackupReplicaSet
-		if err = json.Unmarshal(resp, &result); a.NoError(err) {
-			a.Equal(snapshotID, result.GetId())
-		}
+		r.NoError(json.Unmarshal(resp, &result))
+		a.Equal(snapshotID, result.GetId())
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/test/e2e/atlas/custom_dns_test.go
+++ b/test/e2e/atlas/custom_dns_test.go
@@ -46,12 +46,11 @@ func TestCustomDNS(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var dns atlasv2.AWSCustomDNSEnabled
-		if err := json.Unmarshal(resp, &dns); a.NoError(err) {
-			a.True(dns.Enabled)
-		}
+		require.NoError(t, json.Unmarshal(resp, &dns))
+		a.True(dns.Enabled)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -66,12 +65,11 @@ func TestCustomDNS(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var dns atlasv2.AWSCustomDNSEnabled
-		if err := json.Unmarshal(resp, &dns); a.NoError(err) {
-			a.True(dns.Enabled)
-		}
+		require.NoError(t, json.Unmarshal(resp, &dns))
+		a.True(dns.Enabled)
 	})
 
 	t.Run("Disable", func(t *testing.T) {
@@ -86,11 +84,9 @@ func TestCustomDNS(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
-
+		require.NoError(t, err, string(resp))
 		var dns atlasv2.AWSCustomDNSEnabled
-		if err := json.Unmarshal(resp, &dns); a.NoError(err) {
-			a.False(dns.Enabled)
-		}
+		require.NoError(t, json.Unmarshal(resp, &dns))
+		a.False(dns.Enabled)
 	})
 }

--- a/test/e2e/atlas/data_federation_db_test.go
+++ b/test/e2e/atlas/data_federation_db_test.go
@@ -63,9 +63,8 @@ func TestDataFederation(t *testing.T) {
 
 		a := assert.New(t)
 		var dataLake atlas.DataLake
-		if err = json.Unmarshal(resp, &dataLake); a.NoError(err) {
-			a.Equal(dataFederationName, dataLake.Name)
-		}
+		require.NoError(t, json.Unmarshal(resp, &dataLake))
+		a.Equal(dataFederationName, dataLake.Name)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -81,9 +80,8 @@ func TestDataFederation(t *testing.T) {
 
 		a := assert.New(t)
 		var dataLake atlas.DataLake
-		if err = json.Unmarshal(resp, &dataLake); a.NoError(err) {
-			a.Equal(dataFederationName, dataLake.Name)
-		}
+		require.NoError(t, json.Unmarshal(resp, &dataLake))
+		a.Equal(dataFederationName, dataLake.Name)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -97,9 +95,8 @@ func TestDataFederation(t *testing.T) {
 
 		var r []atlas.DataLake
 		a := assert.New(t)
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		a.NotEmpty(r)
 	})
 
 	t.Run("Update", func(t *testing.T) {
@@ -117,9 +114,8 @@ func TestDataFederation(t *testing.T) {
 
 		var dataLake atlas.DataLake
 		a := assert.New(t)
-		if err = json.Unmarshal(resp, &dataLake); a.NoError(err) {
-			a.Equal(updateRegion, dataLake.DataProcessRegion.Region)
-		}
+		require.NoError(t, json.Unmarshal(resp, &dataLake))
+		a.Equal(updateRegion, dataLake.DataProcessRegion.Region)
 	})
 
 	t.Run("Log", func(t *testing.T) {

--- a/test/e2e/atlas/data_federation_private_endpoint_test.go
+++ b/test/e2e/atlas/data_federation_private_endpoint_test.go
@@ -53,13 +53,12 @@ func TestDataFederationPrivateEndpointsAWS(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		a := assert.New(t)
-		if resp, err := cmd.CombinedOutput(); a.NoError(err, string(resp)) {
-			var r atlasv2.PaginatedPrivateNetworkEndpointIdEntry
-			if err = json.Unmarshal(resp, &r); a.NoError(err) {
-				a.NotEmpty(r.Results)
-				a.Equal(r.Results[0].GetEndpointId(), vpcID)
-			}
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+		var r atlasv2.PaginatedPrivateNetworkEndpointIdEntry
+		require.NoError(t, json.Unmarshal(resp, &r))
+		a.NotEmpty(r.Results)
+		a.Equal(r.Results[0].GetEndpointId(), vpcID)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -76,9 +75,8 @@ func TestDataFederationPrivateEndpointsAWS(t *testing.T) {
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var r atlasv2.PrivateNetworkEndpointIdEntry
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.Equal(vpcID, r.GetEndpointId())
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		a.Equal(vpcID, r.GetEndpointId())
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -93,11 +91,10 @@ func TestDataFederationPrivateEndpointsAWS(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var r atlasv2.PaginatedPrivateNetworkEndpointIdEntry
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		a.NotEmpty(r)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -113,7 +110,7 @@ func TestDataFederationPrivateEndpointsAWS(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("'%s' deleted\n", vpcID)
 		a.Equal(expected, string(resp))
 	})

--- a/test/e2e/atlas/data_federation_query_limit_test.go
+++ b/test/e2e/atlas/data_federation_query_limit_test.go
@@ -61,9 +61,8 @@ func TestDataFederationQueryLimit(t *testing.T) {
 
 		a := assert.New(t)
 		var dataLake atlas.DataLake
-		if err = json.Unmarshal(resp, &dataLake); a.NoError(err) {
-			a.Equal(dataFederationName, dataLake.Name)
-		}
+		require.NoError(t, json.Unmarshal(resp, &dataLake))
+		a.Equal(dataFederationName, dataLake.Name)
 	})
 
 	t.Run("Create", func(t *testing.T) {
@@ -82,12 +81,11 @@ func TestDataFederationQueryLimit(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		a := assert.New(t)
-		if resp, err := cmd.CombinedOutput(); a.NoError(err, string(resp)) {
-			var r atlasv2.DataFederationTenantQueryLimit
-			if err = json.Unmarshal(resp, &r); a.NoError(err) {
-				a.Equal(dataFederationName, *r.TenantName)
-			}
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+		var r atlasv2.DataFederationTenantQueryLimit
+		require.NoError(t, json.Unmarshal(resp, &r))
+		a.Equal(dataFederationName, *r.TenantName)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -104,9 +102,8 @@ func TestDataFederationQueryLimit(t *testing.T) {
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var r atlasv2.DataFederationTenantQueryLimit
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.Equal(limitName, r.Name)
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		a.Equal(limitName, r.Name)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -121,11 +118,10 @@ func TestDataFederationQueryLimit(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var r []atlasv2.DataFederationTenantQueryLimit
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		a.NotEmpty(r)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -141,7 +137,7 @@ func TestDataFederationQueryLimit(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("'%s' deleted\n", limitName)
 		a.Equal(expected, string(resp))
 	})

--- a/test/e2e/atlas/data_lake_pipelines_test.go
+++ b/test/e2e/atlas/data_lake_pipelines_test.go
@@ -125,10 +125,9 @@ func TestDataLakePipelines(t *testing.T) {
 
 		a := assert.New(t)
 		var pipeline *atlasv2.DataLakeIngestionPipeline
-		if err = json.Unmarshal(resp, &pipeline); a.NoError(err) {
-			pipelineID = *pipeline.Id
-			a.Equal(pipelineName, *pipeline.Name)
-		}
+		req.NoError(json.Unmarshal(resp, &pipeline))
+		pipelineID = *pipeline.Id
+		a.Equal(pipelineName, *pipeline.Name)
 	})
 
 	t.Run("Watch", func(t *testing.T) {
@@ -154,9 +153,8 @@ func TestDataLakePipelines(t *testing.T) {
 
 		a := assert.New(t)
 		var pipeline atlasv2.DataLakeIngestionPipeline
-		if err = json.Unmarshal(resp, &pipeline); a.NoError(err) {
-			a.Equal(pipelineName, *pipeline.Name)
-		}
+		req.NoError(json.Unmarshal(resp, &pipeline))
+		a.Equal(pipelineName, *pipeline.Name)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -171,9 +169,8 @@ func TestDataLakePipelines(t *testing.T) {
 
 		var r []atlasv2.DataLakeIngestionPipeline
 		a := assert.New(t)
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		req.NoError(json.Unmarshal(resp, &r))
+		a.NotEmpty(r)
 	})
 
 	t.Run("Update", func(t *testing.T) {
@@ -192,9 +189,8 @@ func TestDataLakePipelines(t *testing.T) {
 
 		a := assert.New(t)
 		var pipeline *atlasv2.DataLakeIngestionPipeline
-		if err = json.Unmarshal(resp, &pipeline); a.NoError(err) {
-			a.Equal(pipelineName, *pipeline.Name)
-		}
+		req.NoError(json.Unmarshal(resp, &pipeline))
+		a.Equal(pipelineName, *pipeline.Name)
 	})
 
 	t.Run("Trigger", func(t *testing.T) {
@@ -211,10 +207,9 @@ func TestDataLakePipelines(t *testing.T) {
 
 		a := assert.New(t)
 		var run *atlasv2.IngestionPipelineRun
-		if err = json.Unmarshal(resp, &run); a.NoError(err) {
-			pipelineRunID = *run.Id
-			a.Equal(pipelineID, *run.PipelineId)
-		}
+		req.NoError(json.Unmarshal(resp, &run))
+		pipelineRunID = *run.Id
+		a.Equal(pipelineID, *run.PipelineId)
 	})
 
 	t.Run("Pause", func(t *testing.T) {
@@ -230,9 +225,8 @@ func TestDataLakePipelines(t *testing.T) {
 
 		a := assert.New(t)
 		var pipeline *atlasv2.DataLakeIngestionPipeline
-		if err = json.Unmarshal(resp, &pipeline); a.NoError(err) {
-			a.Equal(pipelineName, *pipeline.Name)
-		}
+		req.NoError(json.Unmarshal(resp, &pipeline))
+		a.Equal(pipelineName, *pipeline.Name)
 	})
 
 	t.Run("Start", func(t *testing.T) {
@@ -248,9 +242,8 @@ func TestDataLakePipelines(t *testing.T) {
 
 		a := assert.New(t)
 		var pipeline *atlasv2.DataLakeIngestionPipeline
-		if err = json.Unmarshal(resp, &pipeline); a.NoError(err) {
-			a.Equal(pipelineName, *pipeline.Name)
-		}
+		req.NoError(json.Unmarshal(resp, &pipeline))
+		a.Equal(pipelineName, *pipeline.Name)
 	})
 
 	t.Run("Runs List", func(t *testing.T) {
@@ -267,9 +260,8 @@ func TestDataLakePipelines(t *testing.T) {
 
 		var r *atlasv2.PaginatedPipelineRun
 		a := assert.New(t)
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		req.NoError(json.Unmarshal(resp, &r))
+		a.NotEmpty(r)
 	})
 
 	t.Run("Runs Describe", func(t *testing.T) {
@@ -286,10 +278,9 @@ func TestDataLakePipelines(t *testing.T) {
 
 		a := assert.New(t)
 		var run *atlasv2.IngestionPipelineRun
-		if err = json.Unmarshal(resp, &run); a.NoError(err) {
-			pipelineRunID = *run.Id
-			a.Equal(pipelineID, *run.PipelineId)
-		}
+		req.NoError(json.Unmarshal(resp, &run))
+		pipelineRunID = *run.Id
+		a.Equal(pipelineID, *run.PipelineId)
 	})
 
 	t.Run("Runs Watch", func(t *testing.T) {
@@ -333,9 +324,8 @@ func TestDataLakePipelines(t *testing.T) {
 
 		var r []atlasv2.DiskBackupApiPolicyItem
 		a := assert.New(t)
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		req.NoError(json.Unmarshal(resp, &r))
+		a.NotEmpty(r)
 	})
 
 	t.Run("AvailableSnapshots List", func(t *testing.T) {
@@ -352,9 +342,8 @@ func TestDataLakePipelines(t *testing.T) {
 
 		var r *atlasv2.PaginatedBackupSnapshot
 		a := assert.New(t)
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		req.NoError(json.Unmarshal(resp, &r))
+		a.NotEmpty(r)
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/test/e2e/atlas/dbusers_test.go
+++ b/test/e2e/atlas/dbusers_test.go
@@ -193,10 +193,10 @@ func testCreateUserCmd(t *testing.T, cmd *exec.Cmd, username string) {
 	a := assert.New(t)
 	a.Equal(username, user.Username)
 	if a.Len(user.Scopes, 2) {
-		a.Equal(user.Scopes[0].Name, clusterName0)
-		a.Equal(user.Scopes[0].Type, clusterType)
-		a.Equal(user.Scopes[1].Name, clusterName1)
-		a.Equal(user.Scopes[1].Type, clusterType)
+		a.Equal(clusterName0, user.Scopes[0].Name)
+		a.Equal(clusterType, user.Scopes[0].Type)
+		a.Equal(clusterName1, user.Scopes[1].Name)
+		a.Equal(clusterType, user.Scopes[1].Type)
 	}
 }
 
@@ -237,8 +237,8 @@ func testUpdateUserCmd(t *testing.T, cmd *exec.Cmd, username string) {
 	}
 
 	a.Len(user.Scopes, 1)
-	a.Equal(user.Scopes[0].Name, clusterName0)
-	a.Equal(user.Scopes[0].Type, clusterType)
+	a.Equal(clusterName0, user.Scopes[0].Name)
+	a.Equal(clusterType, user.Scopes[0].Type)
 }
 
 func testDeleteUser(t *testing.T, cliPath, dbusersEntity, username string) {

--- a/test/e2e/atlas/deployments_local_test.go
+++ b/test/e2e/atlas/deployments_local_test.go
@@ -260,7 +260,7 @@ func TestDeploymentsLocal(t *testing.T) {
 		var results []bson.M
 		err = c.All(ctx, &results)
 		req.NoError(err)
-		req.Equal(1, len(results))
+		req.Len(results, 1)
 	})
 
 	t.Run("Delete Index", func(t *testing.T) {

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -609,7 +609,7 @@ func deleteClustersForProject(t *testing.T, cliPath, projectID string) {
 		if cluster.StateName == "DELETING" {
 			continue
 		}
-		assert.NoError(t, deleteClusterForProject(projectID, cluster.Name))
+		assert.NoError(t, deleteClusterForProject(projectID, cluster.Name)) //nolint: testifylint // we want to check all instead of failing early
 	}
 }
 
@@ -627,7 +627,7 @@ func deleteDatapipelinesForProject(t *testing.T, cliPath, projectID string) {
 	var pipelines []atlasv2.DataLakeIngestionPipeline
 	require.NoError(t, json.Unmarshal(resp, &pipelines))
 	for _, p := range pipelines {
-		assert.NoError(t, deleteDatalakeForProject(cliPath, projectID, p.GetName()))
+		assert.NoError(t, deleteDatalakeForProject(cliPath, projectID, p.GetName())) //nolint: testifylint // we want to check all instead of failing early
 	}
 }
 
@@ -663,7 +663,7 @@ func deleteAllNetworkPeers(t *testing.T, cliPath, projectID, provider string) {
 		)
 		cmd.Env = os.Environ()
 		resp, err = cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		assert.NoError(t, err, string(resp)) //nolint: testifylint // we want to check all instead of failing early
 	}
 }
 
@@ -726,7 +726,7 @@ func deletePrivateEndpoint(t *testing.T, cliPath, projectID, provider, endpointI
 	)
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
-	assert.NoError(t, err, string(resp))
+	require.NoError(t, err, string(resp))
 }
 
 func deleteTeam(teamID string) error {
@@ -840,7 +840,7 @@ func ensureCluster(t *testing.T, cluster *atlasv2.AdvancedClusterDescription, cl
 	a := assert.New(t)
 	a.Equal(clusterName, cluster.GetName())
 	a.Equal(version, cluster.GetMongoDBMajorVersion())
-	a.Equal(diskSizeGB, cluster.GetDiskSizeGB())
+	a.InDelta(diskSizeGB, cluster.GetDiskSizeGB(), 0.01)
 	a.Equal(terminationProtection, cluster.GetTerminationProtectionEnabled())
 }
 
@@ -852,7 +852,7 @@ func ensureSharedCluster(t *testing.T, cluster *mongodbatlas.Cluster, clusterNam
 	if cluster.ProviderSettings != nil {
 		a.Equal(tier, cluster.ProviderSettings.InstanceSizeName)
 	}
-	a.Equal(diskSizeGB, *cluster.DiskSizeGB)
+	a.InDelta(diskSizeGB, *cluster.DiskSizeGB, 0.01)
 	a.Equal(terminationProtection, *cluster.TerminationProtectionEnabled)
 }
 

--- a/test/e2e/atlas/integrations_test.go
+++ b/test/e2e/atlas/integrations_test.go
@@ -59,12 +59,11 @@ func TestIntegrations(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var thirdPartyIntegrations atlasv2.PaginatedIntegration
-		if err := json.Unmarshal(resp, &thirdPartyIntegrations); a.NoError(err) {
-			a.True(integrationExists(datadogEntity, thirdPartyIntegrations))
-		}
+		require.NoError(t, json.Unmarshal(resp, &thirdPartyIntegrations))
+		a.True(integrationExists(datadogEntity, thirdPartyIntegrations))
 	})
 
 	t.Run("Create OPSGENIE", func(t *testing.T) {
@@ -84,12 +83,11 @@ func TestIntegrations(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var thirdPartyIntegrations atlasv2.PaginatedIntegration
-		if err := json.Unmarshal(resp, &thirdPartyIntegrations); a.NoError(err) {
-			a.True(integrationExists(opsGenieEntity, thirdPartyIntegrations))
-		}
+		require.NoError(t, json.Unmarshal(resp, &thirdPartyIntegrations))
+		a.True(integrationExists(opsGenieEntity, thirdPartyIntegrations))
 	})
 
 	t.Run("Create PAGER_DUTY", func(t *testing.T) {
@@ -109,12 +107,11 @@ func TestIntegrations(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var thirdPartyIntegrations atlasv2.PaginatedIntegration
-		if err := json.Unmarshal(resp, &thirdPartyIntegrations); a.NoError(err) {
-			a.True(integrationExists(pagerDutyEntity, thirdPartyIntegrations))
-		}
+		require.NoError(t, json.Unmarshal(resp, &thirdPartyIntegrations))
+		a.True(integrationExists(pagerDutyEntity, thirdPartyIntegrations))
 	})
 
 	t.Run("Create VICTOR_OPS", func(t *testing.T) {
@@ -136,12 +133,11 @@ func TestIntegrations(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var thirdPartyIntegrations atlasv2.PaginatedIntegration
-		if err := json.Unmarshal(resp, &thirdPartyIntegrations); a.NoError(err) {
-			a.True(integrationExists(victorOpsEntity, thirdPartyIntegrations))
-		}
+		require.NoError(t, json.Unmarshal(resp, &thirdPartyIntegrations))
+		a.True(integrationExists(victorOpsEntity, thirdPartyIntegrations))
 	})
 
 	t.Run("Create WEBHOOK", func(t *testing.T) {
@@ -160,12 +156,11 @@ func TestIntegrations(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var thirdPartyIntegrations atlasv2.PaginatedIntegration
-		if err := json.Unmarshal(resp, &thirdPartyIntegrations); a.NoError(err) {
-			a.True(integrationExists(webhookEntity, thirdPartyIntegrations))
-		}
+		require.NoError(t, json.Unmarshal(resp, &thirdPartyIntegrations))
+		a.True(integrationExists(webhookEntity, thirdPartyIntegrations))
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -179,11 +174,10 @@ func TestIntegrations(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var thirdPartyIntegrations atlasv2.PaginatedIntegration
-		if err := json.Unmarshal(resp, &thirdPartyIntegrations); a.NoError(err) {
-			a.NotEmpty(thirdPartyIntegrations.Results)
-		}
+		require.NoError(t, json.Unmarshal(resp, &thirdPartyIntegrations))
+		a.NotEmpty(thirdPartyIntegrations.Results)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -198,11 +192,10 @@ func TestIntegrations(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var thirdPartyIntegration atlasv2.ThridPartyIntegration
-		if err := json.Unmarshal(resp, &thirdPartyIntegration); a.NoError(err) {
-			a.Equal(webhookEntity, thirdPartyIntegration.GetType())
-		}
+		require.NoError(t, json.Unmarshal(resp, &thirdPartyIntegration))
+		a.Equal(webhookEntity, thirdPartyIntegration.GetType())
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -217,8 +210,7 @@ func TestIntegrations(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
-
+		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Integration '%s' deleted\n", webhookEntity)
 		a.Equal(expected, string(resp))
 	})

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -152,14 +152,13 @@ func TestEmptyProject(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -216,13 +215,13 @@ func TestProjectWithNonDefaultSettings(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
-			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NoError(t, err)
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -291,13 +290,13 @@ func TestProjectWithNonDefaultAlertConf(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
-			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NoError(t, err)
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -348,13 +347,13 @@ func TestProjectWithAccessList(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -401,13 +400,13 @@ func TestProjectWithAccessRole(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
-			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NoError(t, err)
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -467,13 +466,13 @@ func TestProjectWithCustomRole(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -527,13 +526,13 @@ func TestProjectWithIntegration(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -587,13 +586,13 @@ func TestProjectWithMaintenanceWindow(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -656,13 +655,13 @@ func TestProjectWithNetworkPeering(t *testing.T) {
 
 		resp, err = cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -690,7 +689,8 @@ func TestProjectWithPrivateEndpoint_Azure(t *testing.T) {
 			privateEndpointsEntity,
 			azureEntity,
 			"create",
-			"--region="+region,
+			"--region",
+			region,
 			"--projectId",
 			generator.projectID,
 			"-o=json")
@@ -728,13 +728,13 @@ func TestProjectWithPrivateEndpoint_Azure(t *testing.T) {
 
 		resp, err = cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -794,13 +794,13 @@ func TestProjectAndTeams(t *testing.T) {
 
 		resp, err = cmd.CombinedOutput()
 		t.Log(string(resp))
-		assertions.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
@@ -1227,9 +1227,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Generate valid resources of ONE project and ONE cluster", func(t *testing.T) {
@@ -1248,9 +1246,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
@@ -1261,10 +1257,8 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 
 		t.Run("Project present with valid name", func(t *testing.T) {
 			p, found := findAtlasProject(objects)
-			if !found {
-				t.Fatal("AtlasProject is not found in results")
-			}
-			assert.Equal(t, p.Namespace, targetNamespace)
+			require.True(t, found, "AtlasProject is not found in results")
+			assert.Equal(t, targetNamespace, p.Namespace)
 		})
 
 		t.Run("Deployment present with valid data", func(t *testing.T) {
@@ -1281,31 +1275,25 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 			if !found {
 				t.Fatal("AtlasDeployment is not found in results")
 			}
-			a.Equal(expectedDeployment, deployment)
+			assert.Equal(t, expectedDeployment, deployment)
 		})
 
 		t.Run("Connection Secret present with non-empty credentials", func(t *testing.T) {
 			secret, found := findSecret(objects)
-			if !found {
-				t.Fatal("Secret is not found in results")
-			}
-			assert.Equal(t, secret.Namespace, targetNamespace)
+			require.True(t, found, "Secret is not found in results")
+			assert.Equal(t, targetNamespace, secret.Namespace)
 		})
 
 		t.Run("Backup Schedule present with valid data", func(t *testing.T) {
 			schedule, found := atlasBackupSchedule(objects)
-			if !found {
-				t.Fatal("AtlasBackupSchedule is not found in results")
-			}
+			require.True(t, found, "AtlasBackupSchedule is not found in results")
 			assert.Equal(t, expectedBackupSchedule, schedule)
 		})
 
 		t.Run("Backup policy present with valid data", func(t *testing.T) {
 			policy, found := atlasBackupPolicy(objects)
-			if !found {
-				t.Fatal("AtlasBackupSchedule is not found in results")
-			}
-			a.Equal(expectedBackupPolicy, policy)
+			require.True(t, found, "AtlasBackupPolicy is not found in results")
+			assert.Equal(t, expectedBackupPolicy, policy)
 		})
 	})
 
@@ -1325,15 +1313,13 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		t.Run("Project present with valid name", func(t *testing.T) {
@@ -1379,7 +1365,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 		t.Run("Output can be decoded", func(t *testing.T) {
 			objects, err = getK8SEntities(resp)
 			require.NoError(t, err, "should not fail on decode")
-			require.True(t, len(objects) > 0, "result should not be empty. got", len(objects))
+			require.NotEmpty(t, objects)
 		})
 
 		t.Run("Project present with valid name", func(t *testing.T) {
@@ -1400,7 +1386,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 			if !found {
 				t.Fatal("Secret is not found in results")
 			}
-			assert.Equal(t, secret.Namespace, targetNamespace)
+			assert.Equal(t, targetNamespace, secret.Namespace)
 		})
 	})
 }
@@ -1457,7 +1443,7 @@ func TestKubernetesConfigGenerateSharedCluster(t *testing.T) {
 			if !found {
 				t.Fatal("AtlasProject is not found in results")
 			}
-			assert.Equal(t, p.Namespace, targetNamespace)
+			assert.Equal(t, targetNamespace, p.Namespace)
 		})
 
 		t.Run("Deployment present with valid data", func(t *testing.T) {
@@ -1584,8 +1570,7 @@ func TestKubernetesConfigGenerate_DataFederation(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
 
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
@@ -1614,7 +1599,7 @@ func TestKubernetesConfigGenerate_DataFederation(t *testing.T) {
 			if !found {
 				t.Fatal("AtlasDataFederation is not found in results")
 			}
-			a.Equal(expectedDataFederation, datafederation)
+			assert.Equal(t, expectedDataFederation, datafederation)
 		})
 	})
 
@@ -1633,9 +1618,7 @@ func TestKubernetesConfigGenerate_DataFederation(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {
@@ -1670,9 +1653,7 @@ func TestKubernetesConfigGenerate_DataFederation(t *testing.T) {
 
 		resp, err := cmd.CombinedOutput()
 		t.Log(string(resp))
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
 		t.Run("Output can be decoded", func(t *testing.T) {

--- a/test/e2e/atlas/ldap_test.go
+++ b/test/e2e/atlas/ldap_test.go
@@ -98,9 +98,8 @@ func TestLDAPWithFlags(t *testing.T) {
 
 		a := assert.New(t)
 		var configuration atlasv2.LDAPVerifyConnectivityJobRequest
-		if err := json.Unmarshal(resp, &configuration); a.NoError(err) {
-			a.Equal(requestID, *configuration.RequestId)
-		}
+		require.NoError(t, json.Unmarshal(resp, &configuration))
+		a.Equal(requestID, *configuration.RequestId)
 	})
 
 	t.Run("Save", func(t *testing.T) {
@@ -142,9 +141,8 @@ func TestLDAPWithFlags(t *testing.T) {
 
 		a := assert.New(t)
 		var configuration atlasv2.UserSecurity
-		if err := json.Unmarshal(resp, &configuration); a.NoError(err) {
-			a.Equal(ldapHostname, *configuration.Ldap.Hostname)
-		}
+		require.NoError(t, json.Unmarshal(resp, &configuration))
+		a.Equal(ldapHostname, *configuration.Ldap.Hostname)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -239,12 +237,9 @@ func testLDAPVerifyCmd(t *testing.T, cmd *exec.Cmd) string {
 
 	a := assert.New(t)
 	var configuration atlasv2.LDAPVerifyConnectivityJobRequest
-	if err := json.Unmarshal(resp, &configuration); a.NoError(err) {
-		a.Equal(pending, *configuration.Status)
-		return *configuration.RequestId
-	}
-
-	return ""
+	require.NoError(t, json.Unmarshal(resp, &configuration))
+	a.Equal(pending, *configuration.Status)
+	return *configuration.RequestId
 }
 
 func testLDAPSaveCmd(t *testing.T, cmd *exec.Cmd) {
@@ -256,7 +251,6 @@ func testLDAPSaveCmd(t *testing.T, cmd *exec.Cmd) {
 
 	a := assert.New(t)
 	var configuration atlasv2.UserSecurity
-	if err := json.Unmarshal(resp, &configuration); a.NoError(err) {
-		a.Equal(ldapHostname, *configuration.Ldap.Hostname)
-	}
+	require.NoError(t, json.Unmarshal(resp, &configuration))
+	a.Equal(ldapHostname, *configuration.Ldap.Hostname)
 }

--- a/test/e2e/atlas/maintenance_test.go
+++ b/test/e2e/atlas/maintenance_test.go
@@ -48,10 +48,9 @@ func TestMaintenanceWindows(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := "Maintenance window updated.\n"
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := "Maintenance window updated.\n"
+		a.Equal(expected, string(resp))
 	})
 
 	t.Run("describe", func(t *testing.T) {
@@ -66,13 +65,12 @@ func TestMaintenanceWindows(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var maintenanceWindow atlasv2.GroupMaintenanceWindow
-		if err := json.Unmarshal(resp, &maintenanceWindow); a.NoError(err) {
-			a.Equal(1, maintenanceWindow.DayOfWeek)
-			a.Equal(1, maintenanceWindow.HourOfDay)
-		}
+		require.NoError(t, json.Unmarshal(resp, &maintenanceWindow))
+		a.Equal(1, maintenanceWindow.DayOfWeek)
+		a.Equal(1, maintenanceWindow.HourOfDay)
 	})
 
 	t.Run("clear", func(t *testing.T) {
@@ -86,9 +84,8 @@ func TestMaintenanceWindows(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := "Maintenance window removed.\n"
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := "Maintenance window removed.\n"
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/atlas/online_archives_test.go
+++ b/test/e2e/atlas/online_archives_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -89,11 +90,9 @@ func deleteOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveI
 
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-	}
+	require.NoError(t, err, string(resp))
 	expected := fmt.Sprintf("Archive '%s' deleted\n", archiveID)
-	assert.Equal(t, string(resp), expected)
+	assert.Equal(t, expected, string(resp))
 }
 
 func watchOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID string) {
@@ -123,7 +122,7 @@ func startOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveID
 
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
-	// online archive never reaches goal state as the db and collection must exists
+	// online archive never reaches goal state as the db and collection must exist
 	const expectedError = "ONLINE_ARCHIVE_CANNOT_MODIFY_FIELD"
 	if err != nil && !strings.Contains(string(resp), expectedError) {
 		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))

--- a/test/e2e/atlas/performance_advisor_test.go
+++ b/test/e2e/atlas/performance_advisor_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +46,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List slow query logs", func(t *testing.T) {
@@ -62,7 +61,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List suggested indexes", func(t *testing.T) {
@@ -77,8 +76,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Enable Managed Slow Operation Threshold", func(t *testing.T) {
@@ -91,7 +89,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Disable Managed Slow Operation Threshold", func(t *testing.T) {
@@ -104,6 +102,6 @@ func TestPerformanceAdvisor(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/atlas/private_endpoint_test.go
+++ b/test/e2e/atlas/private_endpoint_test.go
@@ -56,19 +56,17 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 			privateEndpointsEntity,
 			awsEntity,
 			"create",
-			"--region="+region,
+			"--region",
+			region,
 			"--projectId",
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-
-		a := assert.New(t)
-		if resp, err := cmd.CombinedOutput(); a.NoError(err, string(resp)) {
-			var r atlasv2.EndpointService
-			if err = json.Unmarshal(resp, &r); a.NoError(err) {
-				id = r.GetId()
-			}
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+		var r atlasv2.EndpointService
+		require.NoError(t, json.Unmarshal(resp, &r))
+		id = r.GetId()
 	})
 	require.NotEmpty(t, id)
 
@@ -83,7 +81,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -98,11 +96,9 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		a := assert.New(t)
 		var r atlasv2.EndpointService
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.Equal(id, r.GetId())
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		assert.Equal(t, id, r.GetId())
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -115,13 +111,10 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var r []atlasv2.EndpointService
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		assert.NotEmpty(t, r)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -136,10 +129,9 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Private endpoint '%s' deleted\n", id)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 
 	t.Run("Watch", func(t *testing.T) {
@@ -153,10 +145,9 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
 		// We expect a 404 error once the private endpoint has been completely deleted
-		a.Error(err)
-		a.Contains(string(resp), "404")
+		require.Error(t, err, string(resp))
+		assert.Contains(t, string(resp), "404")
 	})
 }
 
@@ -185,19 +176,18 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			privateEndpointsEntity,
 			azureEntity,
 			"create",
-			"--region="+region,
+			"--region",
+			region,
 			"--projectId",
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
 
-		a := assert.New(t)
-		if resp, err := cmd.CombinedOutput(); a.NoError(err, string(resp)) {
-			var r atlasv2.EndpointService
-			if err = json.Unmarshal(resp, &r); a.NoError(err) {
-				id = r.GetId()
-			}
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+		var r atlasv2.EndpointService
+		require.NoError(t, json.Unmarshal(resp, &r))
+		id = r.GetId()
 	})
 	if id == "" {
 		assert.FailNow(t, "Failed to create private endpoint")
@@ -212,10 +202,8 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-
 		_, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -229,12 +217,10 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var r atlasv2.EndpointService
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.Equal(id, r.GetId())
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		assert.Equal(t, id, r.GetId())
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -247,13 +233,10 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var r []atlasv2.EndpointService
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		assert.NotEmpty(t, r)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -268,10 +251,9 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Private endpoint '%s' deleted\n", id)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 
 	t.Run("Watch", func(t *testing.T) {
@@ -283,12 +265,10 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
 		// We expect a 404 error once the private endpoint has been completely deleted
-		a.Error(err)
-		a.Contains(string(resp), "404")
+		require.Error(t, err)
+		assert.Contains(t, string(resp), "404")
 	})
 }
 
@@ -330,15 +310,12 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-
-		a := assert.New(t)
-		if resp, err := cmd.CombinedOutput(); a.NoError(err, string(resp)) {
-			var r atlasv2.EndpointService
-			if err = json.Unmarshal(resp, &r); a.NoError(err) {
-				id = r.GetId()
-				a.NotEmpty(id)
-			}
-		}
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+		var r atlasv2.EndpointService
+		require.NoError(t, json.Unmarshal(resp, &r))
+		id = r.GetId()
+		assert.NotEmpty(t, id)
 	})
 
 	t.Run("Watch", func(t *testing.T) {
@@ -352,8 +329,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		_, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err)
+		require.NoError(t, err)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -367,12 +343,10 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var r atlasv2.EndpointService
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.Equal(id, r.GetId())
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		assert.Equal(t, id, r.GetId())
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -385,13 +359,10 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var r []atlasv2.EndpointService
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.NotEmpty(r)
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		assert.NotEmpty(t, r)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -406,10 +377,9 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Private endpoint '%s' deleted\n", id)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 
 	t.Run("Watch", func(t *testing.T) {
@@ -423,10 +393,9 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
 		// We expect a 404 error once the private endpoint has been completely deleted
-		a.Error(err)
-		a.Contains(string(resp), "404")
+		require.Error(t, err)
+		assert.Contains(t, string(resp), "404")
 	})
 }
 
@@ -447,9 +416,8 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
-		a.Equal("Regionalized private endpoint setting enabled.\n", string(resp))
+		require.NoError(t, err, string(resp))
+		assert.Equal(t, "Regionalized private endpoint setting enabled.\n", string(resp))
 	})
 
 	t.Run("Disable regionalized private endpoint setting", func(t *testing.T) {
@@ -462,9 +430,8 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
-		a.Equal("Regionalized private endpoint setting disabled.\n", string(resp))
+		require.NoError(t, err, string(resp))
+		assert.Equal(t, "Regionalized private endpoint setting disabled.\n", string(resp))
 	})
 
 	t.Run("Get regionalized private endpoint setting", func(t *testing.T) {
@@ -478,11 +445,9 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var r atlasv2.ProjectSettingItem
-		if err = json.Unmarshal(resp, &r); a.NoError(err) {
-			a.False(r.GetEnabled())
-		}
+		require.NoError(t, json.Unmarshal(resp, &r))
+		assert.False(t, r.GetEnabled())
 	})
 }

--- a/test/e2e/atlas/processes_test.go
+++ b/test/e2e/atlas/processes_test.go
@@ -45,14 +45,9 @@ func TestProcesses(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
-		if err := json.Unmarshal(resp, &processes); assert.NoError(t, err) {
-			require.NotEmpty(t, processes.Results)
-		}
+		require.NoError(t, err, string(resp))
+		require.NoError(t, json.Unmarshal(resp, &processes))
+		require.NotEmpty(t, processes.Results)
 	})
 
 	t.Run("list compact", func(t *testing.T) {
@@ -65,15 +60,10 @@ func TestProcesses(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 		var hostViewsCompact []atlasv2.ApiHostViewAtlas
-
-		if err := json.Unmarshal(resp, &hostViewsCompact); assert.NoError(t, err) {
-			require.NotEmpty(t, hostViewsCompact)
-		}
+		require.NoError(t, json.Unmarshal(resp, &hostViewsCompact))
+		require.NotEmpty(t, hostViewsCompact)
 	})
 
 	t.Run("describe", func(t *testing.T) {
@@ -86,14 +76,9 @@ func TestProcesses(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
-		var process *atlasv2.ApiHostViewAtlas
-		if err := json.Unmarshal(resp, &process); assert.NoError(t, err) {
-			assert.Equal(t, *process.Id, *processes.Results[0].Id)
-		}
+		require.NoError(t, err, string(resp))
+		var p *atlasv2.ApiHostViewAtlas
+		require.NoError(t, json.Unmarshal(resp, &p))
+		assert.Equal(t, *p.Id, *processes.Results[0].Id)
 	})
 }

--- a/test/e2e/atlas/project_settings_test.go
+++ b/test/e2e/atlas/project_settings_test.go
@@ -81,10 +81,10 @@ func TestProjectSettings(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		a := assert.New(t)
-		a.Equal(false, *settings.IsCollectDatabaseSpecificsStatisticsEnabled)
-		a.Equal(true, *settings.IsSchemaAdvisorEnabled)
-		a.Equal(true, *settings.IsPerformanceAdvisorEnabled)
-		a.Equal(true, *settings.IsRealtimePerformancePanelEnabled)
-		a.Equal(true, *settings.IsDataExplorerEnabled)
+		a.False(*settings.IsCollectDatabaseSpecificsStatisticsEnabled)
+		a.True(*settings.IsSchemaAdvisorEnabled)
+		a.True(*settings.IsPerformanceAdvisorEnabled)
+		a.True(*settings.IsRealtimePerformancePanelEnabled)
+		a.True(*settings.IsDataExplorerEnabled)
 	})
 }

--- a/test/e2e/atlas/search_test.go
+++ b/test/e2e/atlas/search_test.go
@@ -52,21 +52,16 @@ func TestSearch(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		err := cmd.Run()
-		r.NoError(err)
+		require.NoError(t, cmd.Run())
 	})
 
 	t.Run("Create via file", func(t *testing.T) {
 		fileName := fmt.Sprintf("create_index_search_test-%v.json", n)
 
 		file, err := os.Create(fileName)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		defer func() {
-			if e := os.Remove(fileName); e != nil {
-				t.Errorf("error deleting file '%v': %v", fileName, e)
-			}
+			require.NoError(t, os.Remove(fileName))
 		}()
 
 		tpl := template.Must(template.New("").Parse(`
@@ -78,13 +73,10 @@ func TestSearch(t *testing.T) {
 		"dynamic": true
 	}
 }`))
-		err = tpl.Execute(file, map[string]string{
+		require.NoError(t, tpl.Execute(file, map[string]string{
 			"collectionName": collectionName,
 			"indexName":      indexName,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		}))
 
 		cmd := exec.Command(cliPath,
 			clustersEntity,
@@ -99,15 +91,11 @@ func TestSearch(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
-		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
-			assert.Equal(t, index.GetName(), indexName)
-			indexID = index.GetIndexID()
-		}
+		require.NoError(t, json.Unmarshal(resp, &index))
+		assert.Equal(t, index.GetName(), indexName)
+		indexID = index.GetIndexID()
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -122,15 +110,10 @@ func TestSearch(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
+		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
-		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
-			assert.Equal(t, indexID, index.GetIndexID())
-		}
+		require.NoError(t, json.Unmarshal(resp, &index))
+		assert.Equal(t, indexID, index.GetIndexID())
 	})
 
 	t.Run("Update via file", func(t *testing.T) {
@@ -138,9 +121,7 @@ func TestSearch(t *testing.T) {
 		fileName := fmt.Sprintf("update_index_search_test-%v.json", n)
 
 		file, err := os.Create(fileName)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, err)
 		defer func() {
 			if e := os.Remove(fileName); e != nil {
 				t.Errorf("error deleting file '%v': %v", fileName, e)
@@ -157,14 +138,11 @@ func TestSearch(t *testing.T) {
 		"dynamic": true
 	}
 }`))
-		err = tpl.Execute(file, map[string]string{
+		require.NoError(t, tpl.Execute(file, map[string]string{
 			"collectionName": collectionName,
 			"indexName":      indexName,
 			"analyzer":       analyzer,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		}))
 
 		cmd := exec.Command(cliPath,
 			clustersEntity,
@@ -180,16 +158,12 @@ func TestSearch(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
-		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
-			a := assert.New(t)
-			a.Equal(indexID, index.GetIndexID())
-			a.Equal(analyzer, index.GetAnalyzer())
-		}
+		require.NoError(t, json.Unmarshal(resp, &index))
+		a := assert.New(t)
+		a.Equal(indexID, index.GetIndexID())
+		a.Equal(analyzer, index.GetAnalyzer())
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -204,13 +178,9 @@ func TestSearch(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
-
+		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Index '%s' deleted\n", indexID)
-		assert.Equal(t, string(resp), expected)
+		assert.Equal(t, expected, string(resp))
 	})
 
 	t.Run("Create combinedMapping", func(t *testing.T) {
@@ -256,12 +226,9 @@ func TestSearch(t *testing.T) {
     }
   }
 }`))
-		err = tpl.Execute(file, map[string]string{
+		require.NoError(t, tpl.Execute(file, map[string]string{
 			"indexName": indexName,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		}))
 
 		cmd := exec.Command(cliPath,
 			clustersEntity,
@@ -276,14 +243,10 @@ func TestSearch(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
-		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
-			assert.Equal(t, index.Name, indexName)
-		}
+		require.NoError(t, json.Unmarshal(resp, &index))
+		assert.Equal(t, indexName, index.Name)
 	})
 
 	t.Run("Create staticMapping", func(t *testing.T) {
@@ -368,12 +331,9 @@ func TestSearch(t *testing.T) {
       }
    ]
 }`))
-		err = tpl.Execute(file, map[string]string{
+		require.NoError(t, tpl.Execute(file, map[string]string{
 			"indexName": indexName,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		}))
 
 		cmd := exec.Command(cliPath,
 			clustersEntity,
@@ -388,14 +348,10 @@ func TestSearch(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
-		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
-			assert.Equal(t, index.Name, indexName)
-		}
+		require.NoError(t, json.Unmarshal(resp, &index))
+		assert.Equal(t, indexName, index.Name)
 	})
 
 	t.Run("Create array mapping", func(t *testing.T) {
@@ -433,12 +389,9 @@ func TestSearch(t *testing.T) {
     }
   }
 }`))
-		err = tpl.Execute(file, map[string]string{
+		require.NoError(t, tpl.Execute(file, map[string]string{
 			"indexName": indexName,
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		}))
 
 		cmd := exec.Command(cliPath,
 			clustersEntity,
@@ -453,14 +406,10 @@ func TestSearch(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
-		if err := json.Unmarshal(resp, &index); assert.NoError(t, err) {
-			assert.Equal(t, index.Name, indexName)
-		}
+		require.NoError(t, json.Unmarshal(resp, &index))
+		assert.Equal(t, indexName, index.Name)
 	})
 
 	t.Run("list", func(t *testing.T) {
@@ -477,14 +426,10 @@ func TestSearch(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 
 		var indexes []atlasv2.ClusterSearchIndex
-		if err := json.Unmarshal(resp, &indexes); assert.NoError(t, err) {
-			assert.NotEmpty(t, indexes)
-		}
+		require.NoError(t, json.Unmarshal(resp, &indexes))
+		assert.NotEmpty(t, indexes)
 	})
 }

--- a/test/e2e/atlas/streams_test.go
+++ b/test/e2e/atlas/streams_test.go
@@ -113,8 +113,8 @@ func TestStreams(t *testing.T) {
 
 		a.Len(instances.Results, 1)
 		a.Equal(*instances.Results[0].Name, instanceName)
-		a.Equal(instances.Results[0].DataProcessRegion.CloudProvider, "AWS")
-		a.Equal(instances.Results[0].DataProcessRegion.Region, "VIRGINIA_USA")
+		a.Equal("AWS", instances.Results[0].DataProcessRegion.CloudProvider)
+		a.Equal("VIRGINIA_USA", instances.Results[0].DataProcessRegion.Region)
 	})
 
 	t.Run("Describing a streams instance", func(t *testing.T) {
@@ -135,9 +135,9 @@ func TestStreams(t *testing.T) {
 		var instance atlasv2.StreamsTenant
 		req.NoError(json.Unmarshal(resp, &instance))
 
-		a.Equal(*instance.Name, instanceName)
-		a.Equal(instance.DataProcessRegion.CloudProvider, "AWS")
-		a.Equal(instance.DataProcessRegion.Region, "VIRGINIA_USA")
+		a.Equal(instanceName, *instance.Name)
+		a.Equal("AWS", instance.DataProcessRegion.CloudProvider)
+		a.Equal("VIRGINIA_USA", instance.DataProcessRegion.Region)
 	})
 
 	t.Run("Updating a streams instance", func(t *testing.T) {
@@ -164,8 +164,8 @@ func TestStreams(t *testing.T) {
 		req.NoError(json.Unmarshal(resp, &instance))
 
 		a.Equal(*instance.Name, instanceName)
-		a.Equal(instance.DataProcessRegion.CloudProvider, "AWS")
-		a.Equal(instance.DataProcessRegion.Region, "VIRGINIA_USA")
+		a.Equal("AWS", instance.DataProcessRegion.CloudProvider)
+		a.Equal("VIRGINIA_USA", instance.DataProcessRegion.Region)
 	})
 
 	// Connections
@@ -214,9 +214,9 @@ func TestStreams(t *testing.T) {
 		var connection atlasv2.StreamsConnection
 		req.NoError(json.Unmarshal(resp, &connection))
 
-		a.Equal(*connection.Name, connectionName)
-		a.Equal(*connection.Type, "Kafka")
-		a.Equal(*connection.BootstrapServers, "example.com:8080,fraud.example.com:8000")
+		a.Equal(connectionName, *connection.Name)
+		a.Equal("Kafka", *connection.Type)
+		a.Equal("example.com:8080,fraud.example.com:8000", *connection.BootstrapServers)
 	})
 
 	t.Run("Listing streams connections", func(t *testing.T) {
@@ -240,9 +240,9 @@ func TestStreams(t *testing.T) {
 
 		connections := response.Results
 		a.Len(connections, 1)
-		a.Equal(*connections[0].Name, connectionName)
-		a.Equal(*connections[0].Type, "Kafka")
-		a.Equal(*connections[0].BootstrapServers, "example.com:8080,fraud.example.com:8000")
+		a.Equal(connectionName, *connections[0].Name)
+		a.Equal("Kafka", *connections[0].Type)
+		a.Equal("example.com:8080,fraud.example.com:8000", *connections[0].BootstrapServers)
 	})
 
 	t.Run("Updating a streams connection", func(t *testing.T) {
@@ -268,7 +268,7 @@ func TestStreams(t *testing.T) {
 		req.NoError(json.Unmarshal(resp, &connection))
 
 		a.Equal(*connection.Name, connectionName)
-		a.Equal(*connection.Security.Protocol, "SSL")
+		a.Equal("SSL", *connection.Security.Protocol)
 	})
 
 	t.Run("Deleting a streams connection", func(t *testing.T) {

--- a/test/e2e/cloud_manager/agent_api_keys_test.go
+++ b/test/e2e/cloud_manager/agent_api_keys_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -50,11 +51,9 @@ func TestAgentAPIKeys(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
 
-		if a.NoError(err, string(resp)) {
-			var keys []*opsmngr.AgentAPIKey
-			err := json.Unmarshal(resp, &keys)
-			a.NoError(err)
-			a.NotEmpty(keys)
-		}
+		require.NoError(t, err, string(resp))
+		var keys []*opsmngr.AgentAPIKey
+		require.NoError(t, json.Unmarshal(resp, &keys))
+		a.NotEmpty(keys)
 	})
 }

--- a/test/e2e/cloud_manager/agents_test.go
+++ b/test/e2e/cloud_manager/agents_test.go
@@ -46,13 +46,11 @@ func TestAgents(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
 
-		if a.NoError(err, string(resp)) {
-			var servers *opsmngr.Agents
-			err := json.Unmarshal(resp, &servers)
-			require.NoError(t, err)
-			a.NotZero(servers.TotalCount)
-			hostname = servers.Results[0].Hostname
-		}
+		require.NoError(t, err, string(resp))
+		var servers *opsmngr.Agents
+		require.NoError(t, json.Unmarshal(resp, &servers))
+		a.NotZero(servers.TotalCount)
+		hostname = servers.Results[0].Hostname
 	})
 
 	t.Run("Version List", func(t *testing.T) {
@@ -68,12 +66,10 @@ func TestAgents(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
 
-		if a.NoError(err, string(resp)) {
-			var agents *opsmngr.AgentVersions
-			err := json.Unmarshal(resp, &agents)
-			require.NoError(t, err)
-			a.NotZero(agents.Count)
-		}
+		require.NoError(t, err, string(resp))
+		var agents *opsmngr.AgentVersions
+		require.NoError(t, json.Unmarshal(resp, &agents))
+		a.NotZero(agents.Count)
 	})
 
 	t.Run("Enable backup", func(t *testing.T) {
@@ -85,7 +81,7 @@ func TestAgents(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 	t.Run("Disable backup", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
@@ -96,7 +92,7 @@ func TestAgents(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Enable monitoring", func(t *testing.T) {
@@ -108,7 +104,7 @@ func TestAgents(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 	t.Run("Disable monitoring", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
@@ -119,6 +115,6 @@ func TestAgents(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/cloud_manager/alerts_test.go
+++ b/test/e2e/cloud_manager/alerts_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -53,15 +54,12 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a.NoError(err)
-
-		if a.NoError(err, string(resp)) {
-			var alerts mongodbatlas.AlertsResponse
-			err := json.Unmarshal(resp, &alerts)
-			a.NoError(err)
-			a.NotEmpty(alerts.Results)
-			alertID = alerts.Results[0].ID
-		}
+		require.NoError(t, err)
+		require.NoError(t, err, string(resp))
+		var alerts mongodbatlas.AlertsResponse
+		require.NoError(t, json.Unmarshal(resp, &alerts))
+		a.NotEmpty(alerts.Results)
+		alertID = alerts.Results[0].ID
 	})
 
 	t.Run("List with status OPEN", func(t *testing.T) {
@@ -76,7 +74,7 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -90,15 +88,11 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a.NoError(err)
-
-		if a.NoError(err, string(resp)) {
-			var alert mongodbatlas.Alert
-			err := json.Unmarshal(resp, &alert)
-			a.NoError(err)
-			a.Equal(alertID, alert.ID)
-			a.Equal(closed, alert.Status)
-		}
+		require.NoError(t, err, string(resp))
+		var alert mongodbatlas.Alert
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		a.Equal(alertID, alert.ID)
+		a.Equal(closed, alert.Status)
 	})
 
 	t.Run("List with no status", func(t *testing.T) {
@@ -111,13 +105,9 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a.NoError(err)
-
-		if a.NoError(err, string(resp)) {
-			var alerts mongodbatlas.AlertsResponse
-			err = json.Unmarshal(resp, &alerts)
-			a.NoError(err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		var alerts mongodbatlas.AlertsResponse
+		require.NoError(t, json.Unmarshal(resp, &alerts), string(resp))
 	})
 
 	t.Run("List with status CLOSED", func(t *testing.T) {
@@ -132,13 +122,9 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a.NoError(err)
-
-		if a.NoError(err, string(resp)) {
-			var alerts mongodbatlas.AlertsResponse
-			err = json.Unmarshal(resp, &alerts)
-			a.NoError(err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		var alerts mongodbatlas.AlertsResponse
+		require.NoError(t, json.Unmarshal(resp, &alerts), string(resp))
 	})
 
 	t.Run("Acknowledge", func(t *testing.T) {
@@ -153,14 +139,10 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a.NoError(err)
-
-		if a.NoError(err, string(resp)) {
-			var alert mongodbatlas.Alert
-			err := json.Unmarshal(resp, &alert)
-			a.NoError(err)
-			a.Equal(alertID, alert.ID)
-		}
+		require.NoError(t, err, string(resp))
+		var alert mongodbatlas.Alert
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		a.Equal(alertID, alert.ID)
 	})
 
 	t.Run("Acknowledge Forever", func(t *testing.T) {
@@ -174,14 +156,10 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a.NoError(err)
-
-		if a.NoError(err, string(resp)) {
-			var alert mongodbatlas.Alert
-			err := json.Unmarshal(resp, &alert)
-			a.NoError(err)
-			a.Equal(alertID, alert.ID)
-		}
+		require.NoError(t, err, string(resp))
+		var alert mongodbatlas.Alert
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		a.Equal(alertID, alert.ID)
 	})
 
 	t.Run("UnAcknowledge", func(t *testing.T) {
@@ -194,14 +172,9 @@ func TestAlerts(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a.NoError(err)
-
-		if a.NoError(err, string(resp)) {
-			var alert mongodbatlas.Alert
-			err := json.Unmarshal(resp, &alert)
-			a.NoError(err)
-			a.Equal(alertID, alert.ID)
-		}
+		require.NoError(t, err, string(resp))
+		var alert mongodbatlas.Alert
+		require.NoError(t, json.Unmarshal(resp, &alert))
+		a.Equal(alertID, alert.ID)
 	})
 }

--- a/test/e2e/cloud_manager/maintenance_test.go
+++ b/test/e2e/cloud_manager/maintenance_test.go
@@ -67,14 +67,13 @@ func TestMaintenanceWindows(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var maintenanceWindow opsmngr.MaintenanceWindow
-		if err := json.Unmarshal(resp, &maintenanceWindow); a.NoError(err) {
-			a.Equal(startDate, maintenanceWindow.StartDate)
-			a.Equal(endDate, maintenanceWindow.EndDate)
-			maintenanceWindowID = maintenanceWindow.ID
-		}
+		require.NoError(t, json.Unmarshal(resp, &maintenanceWindow))
+		a.Equal(startDate, maintenanceWindow.StartDate)
+		a.Equal(endDate, maintenanceWindow.EndDate)
+		maintenanceWindowID = maintenanceWindow.ID
 	})
 
 	t.Run("describe", func(t *testing.T) {
@@ -89,14 +88,11 @@ func TestMaintenanceWindows(t *testing.T) {
 			projectID)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var maintenanceWindow opsmngr.MaintenanceWindow
-		if err := json.Unmarshal(resp, &maintenanceWindow); a.NoError(err) {
-			a.Equal(maintenanceWindowID, maintenanceWindow.ID)
-		}
+		require.NoError(t, json.Unmarshal(resp, &maintenanceWindow))
+		assert.Equal(t, maintenanceWindowID, maintenanceWindow.ID)
 	})
 
 	t.Run("list", func(t *testing.T) {
@@ -112,12 +108,11 @@ func TestMaintenanceWindows(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var maintenanceWindows opsmngr.MaintenanceWindows
-		if err := json.Unmarshal(resp, &maintenanceWindows); a.NoError(err) {
-			a.NotEmpty(maintenanceWindows.Results)
-		}
+		require.NoError(t, json.Unmarshal(resp, &maintenanceWindows))
+		a.NotEmpty(maintenanceWindows.Results)
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -136,12 +131,11 @@ func TestMaintenanceWindows(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var maintenanceWindow opsmngr.MaintenanceWindow
-		if err := json.Unmarshal(resp, &maintenanceWindow); a.NoError(err) {
-			a.Contains(maintenanceWindow.AlertTypeNames, "CLUSTER")
-		}
+		require.NoError(t, json.Unmarshal(resp, &maintenanceWindow))
+		a.Contains(maintenanceWindow.AlertTypeNames, "CLUSTER")
 	})
 
 	t.Run("delete", func(t *testing.T) {
@@ -158,9 +152,8 @@ func TestMaintenanceWindows(t *testing.T) {
 
 		a := assert.New(t)
 
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Maintenance window '%s' deleted\n", maintenanceWindowID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Maintenance window '%s' deleted\n", maintenanceWindowID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_org_api_key_access_list_test.go
+++ b/test/e2e/iam/atlas_org_api_key_access_list_test.go
@@ -58,13 +58,10 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key atlasv2.PaginatedApiUserAccessList
-			if err := json.Unmarshal(resp, &key); a.NoError(err) {
-				a.NotEmpty(key.Results)
-			}
-		}
+		require.NoError(t, err, string(resp))
+		var key atlasv2.PaginatedApiUserAccessList
+		require.NoError(t, json.Unmarshal(resp, &key))
+		assert.NotEmpty(t, key.Results)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -77,13 +74,10 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key atlasv2.PaginatedApiUserAccessList
-			if err := json.Unmarshal(resp, &key); a.NoError(err) {
-				a.NotEmpty(key.Results)
-			}
-		}
+		require.NoError(t, err, string(resp))
+		var key atlasv2.PaginatedApiUserAccessList
+		require.NoError(t, json.Unmarshal(resp, &key))
+		assert.NotEmpty(t, key.Results)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -102,14 +96,11 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key atlasv2.PaginatedApiUserAccessList
-			if err := json.Unmarshal(resp, &key); a.NoError(err) {
-				a.NotEmpty(key.Results)
-				entry = *key.Results[0].IpAddress
-			}
-		}
+		require.NoError(t, err, string(resp))
+		var key atlasv2.PaginatedApiUserAccessList
+		require.NoError(t, json.Unmarshal(resp, &key))
+		assert.NotEmpty(t, key.Results)
+		entry = *key.Results[0].IpAddress
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -130,8 +121,7 @@ func deleteAtlasAccessListEntry(t *testing.T, cliPath, entry, apiKeyID string) {
 		"--force")
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
-	if assert.NoError(t, err, string(resp)) {
-		expected := fmt.Sprintf("Access list entry '%s' deleted\n", entry)
-		assert.Equal(t, string(resp), expected)
-	}
+	require.NoError(t, err, string(resp))
+	expected := fmt.Sprintf("Access list entry '%s' deleted\n", entry)
+	assert.Equal(t, expected, string(resp))
 }

--- a/test/e2e/iam/atlas_org_api_keys_test.go
+++ b/test/e2e/iam/atlas_org_api_keys_test.go
@@ -49,15 +49,11 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key atlasv2.ApiKeyUserDetails
-			if err := json.Unmarshal(resp, &key); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			a.Equal(desc, *key.Desc)
-			ID = *key.Id
-		}
+		require.NoError(t, err, string(resp))
+		var key atlasv2.ApiKeyUserDetails
+		require.NoError(t, json.Unmarshal(resp, &key))
+		assert.Equal(t, desc, *key.Desc)
+		ID = *key.Id
 	})
 	require.NotEmpty(t, ID)
 
@@ -70,11 +66,8 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-
 		var keys atlasv2.PaginatedApiApiUser
-		if err := json.Unmarshal(resp, &keys); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, json.Unmarshal(resp, &keys))
 		assert.NotEmpty(t, keys.Results)
 	})
 
@@ -90,9 +83,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 		require.NoError(t, err, string(resp))
 
 		var keys []atlasv2.ApiKeyUserDetails
-		if err := json.Unmarshal(resp, &keys); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, json.Unmarshal(resp, &keys))
 		assert.NotEmpty(t, keys)
 	})
 
@@ -109,14 +100,10 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key atlasv2.ApiKeyUserDetails
-			if err := json.Unmarshal(resp, &key); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			a.Equal(newDesc, *key.Desc)
-		}
+		require.NoError(t, err, string(resp))
+		var key atlasv2.ApiKeyUserDetails
+		require.NoError(t, json.Unmarshal(resp, &key))
+		assert.Equal(t, newDesc, *key.Desc)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -128,15 +115,10 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key atlasv2.ApiKeyUserDetails
-			if err := json.Unmarshal(resp, &key); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			a.Equal(ID, *key.Id)
-		}
+		require.NoError(t, err, string(resp))
+		var key atlasv2.ApiKeyUserDetails
+		require.NoError(t, json.Unmarshal(resp, &key))
+		assert.Equal(t, ID, *key.Id)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -148,11 +130,8 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
+		assert.Equal(t, expected, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_org_invitations_test.go
+++ b/test/e2e/iam/atlas_org_invitations_test.go
@@ -53,11 +53,9 @@ func TestAtlasOrgInvitations(t *testing.T) {
 		require.NoError(t, err, string(resp))
 
 		var invitation admin.OrganizationInvitation
-		if err := json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailOrg, invitation.GetUsername())
-			require.NotEmpty(t, invitation.GetId())
-		}
-
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailOrg, invitation.GetUsername())
+		require.NotEmpty(t, invitation.GetId())
 		orgInvitationID = invitation.GetId()
 	})
 
@@ -74,9 +72,8 @@ func TestAtlasOrgInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitations []admin.OrganizationInvitation
-		if err = json.Unmarshal(resp, &invitations); a.NoError(err) {
-			a.NotEmpty(invitations)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitations))
+		a.NotEmpty(invitations)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -93,10 +90,9 @@ func TestAtlasOrgInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation admin.OrganizationInvitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(orgInvitationID, invitation.GetId())
-			a.Equal([]string{"ORG_MEMBER"}, invitation.GetRoles())
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(orgInvitationID, invitation.GetId())
+		a.Equal([]string{"ORG_MEMBER"}, invitation.GetRoles())
 	})
 
 	t.Run("Update by email", func(t *testing.T) {
@@ -116,10 +112,9 @@ func TestAtlasOrgInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation admin.OrganizationInvitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailOrg, invitation.GetUsername())
-			a.ElementsMatch([]string{roleNameOrg}, invitation.GetRoles())
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailOrg, invitation.GetUsername())
+		a.ElementsMatch([]string{roleNameOrg}, invitation.GetRoles())
 	})
 
 	t.Run("Update by ID", func(t *testing.T) {
@@ -137,10 +132,9 @@ func TestAtlasOrgInvitations(t *testing.T) {
 
 		a := assert.New(t)
 		var invitation admin.OrganizationInvitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailOrg, invitation.GetUsername())
-			a.ElementsMatch([]string{roleNameOrg}, invitation.GetRoles())
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailOrg, invitation.GetUsername())
+		a.ElementsMatch([]string{roleNameOrg}, invitation.GetRoles())
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -153,9 +147,8 @@ func TestAtlasOrgInvitations(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Invitation '%s' deleted\n", orgInvitationID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Invitation '%s' deleted\n", orgInvitationID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_orgs_test.go
+++ b/test/e2e/iam/atlas_orgs_test.go
@@ -59,7 +59,7 @@ func TestAtlasOrgs(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err2 := cmd.CombinedOutput()
-		assert.NoError(t, err2, string(resp))
+		require.NoError(t, err2, string(resp))
 	})
 
 	var userID string
@@ -73,10 +73,9 @@ func TestAtlasOrgs(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err2 := cmd.CombinedOutput()
-		assert.NoError(t, err2, string(resp))
+		require.NoError(t, err2, string(resp))
 		var users admin.PaginatedApiAppUser
-		err = json.Unmarshal(resp, &users)
-		require.NoError(t, err, string(resp))
+		require.NoError(t, json.Unmarshal(resp, &users), string(resp))
 		assert.NotEmpty(t, users.GetResults())
 		userID = users.Results[0].GetId()
 	})
@@ -104,10 +103,9 @@ func TestAtlasOrgs(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
-		var org admin.CreateOrganizationResponse
-		err = json.Unmarshal(resp, &org)
 		require.NoError(t, err, string(resp))
+		var org admin.CreateOrganizationResponse
+		require.NoError(t, json.Unmarshal(resp, &org), string(resp))
 		orgID = org.Organization.GetId()
 		publicAPIKey = org.ApiKey.GetPublicKey()
 		privateAPIKey = org.ApiKey.GetPrivateKey()
@@ -117,7 +115,7 @@ func TestAtlasOrgs(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		t.Skip("Skipping delete org e2e test, exceeded max number of linked orgs. Will reenable post cleanup")
+		t.Skip("Skipping delete org e2e test, exceeded max number of linked orgs. Will re-enable post cleanup")
 		if os.Getenv("MCLI_SERVICE") == "cloudgov" {
 			t.Skip("not available for gov")
 		}
@@ -131,6 +129,6 @@ func TestAtlasOrgs(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_project_api_keys_test.go
+++ b/test/e2e/iam/atlas_project_api_keys_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -50,19 +51,13 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key atlasv2.ApiKeyUserDetails
-			if err := json.Unmarshal(resp, &key); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			a.Equal(desc, *key.Desc)
-			ID = *key.Id
-		}
+		require.NoError(t, err, string(resp))
+		var key atlasv2.ApiKeyUserDetails
+		require.NoError(t, json.Unmarshal(resp, &key))
+		a.Equal(desc, *key.Desc)
+		ID = *key.Id
 	})
-
-	if ID == "" {
-		assert.FailNow(t, "Failed to create API key")
-	}
+	require.NotEmpty(t, ID)
 
 	defer func() {
 		if e := deleteOrgAPIKey(ID); e != nil {
@@ -80,7 +75,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -131,11 +126,8 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
+		assert.Equal(t, expected, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_project_invitations_test.go
+++ b/test/e2e/iam/atlas_project_invitations_test.go
@@ -64,10 +64,9 @@ func TestAtlasProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation admin.GroupInvitation
-		if err := json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailProject, invitation.GetUsername())
-			require.NotEmpty(t, invitation.GetId())
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailProject, invitation.GetUsername())
+		require.NotEmpty(t, invitation.GetId())
 		invitationID = invitation.GetId()
 	})
 
@@ -86,9 +85,8 @@ func TestAtlasProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitations []admin.GroupInvitation
-		if err = json.Unmarshal(resp, &invitations); a.NoError(err) {
-			a.NotEmpty(invitations)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitations))
+		a.NotEmpty(invitations)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -107,10 +105,9 @@ func TestAtlasProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation admin.GroupInvitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(invitationID, invitation.GetId())
-			a.Equal([]string{"GROUP_READ_ONLY"}, invitation.GetRoles())
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(invitationID, invitation.GetId())
+		a.Equal([]string{"GROUP_READ_ONLY"}, invitation.GetRoles())
 	})
 
 	t.Run("Update by email", func(t *testing.T) {
@@ -134,10 +131,9 @@ func TestAtlasProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation admin.GroupInvitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailProject, invitation.GetUsername())
-			a.ElementsMatch([]string{roleName1, roleName2}, invitation.GetRoles())
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailProject, invitation.GetUsername())
+		a.ElementsMatch([]string{roleName1, roleName2}, invitation.GetRoles())
 	})
 
 	t.Run("Update by ID", func(t *testing.T) {
@@ -160,10 +156,9 @@ func TestAtlasProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation admin.GroupInvitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailProject, invitation.GetUsername())
-			a.ElementsMatch([]string{roleName1, roleName2}, invitation.GetRoles())
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailProject, invitation.GetUsername())
+		a.ElementsMatch([]string{roleName1, roleName2}, invitation.GetRoles())
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -179,9 +174,8 @@ func TestAtlasProjectInvitations(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Invitation '%s' deleted\n", invitationID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Invitation '%s' deleted\n", invitationID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_project_teams_test.go
+++ b/test/e2e/iam/atlas_project_teams_test.go
@@ -65,19 +65,18 @@ func TestAtlasProjectTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var teams atlasv2.PaginatedTeamRole
-		if err := json.Unmarshal(resp, &teams); a.NoError(err) {
-			found := false
-			for _, team := range teams.GetResults() {
-				if team.GetTeamId() == teamID {
-					found = true
-					break
-				}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		found := false
+		for _, team := range teams.GetResults() {
+			if team.GetTeamId() == teamID {
+				found = true
+				break
 			}
-			a.True(found)
 		}
+		a.True(found)
 	})
 
 	t.Run("Update", func(t *testing.T) {
@@ -96,17 +95,16 @@ func TestAtlasProjectTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var roles atlasv2.PaginatedTeamRole
-		if err = json.Unmarshal(resp, &roles); a.NoError(err) {
-			a.Len(roles.Results, 1)
+		require.NoError(t, json.Unmarshal(resp, &roles))
+		a.Len(roles.Results, 1)
 
-			role := roles.Results[0]
-			a.Equal(teamID, role.GetTeamId())
-			a.Len(role.RoleNames, 2)
-			a.ElementsMatch([]string{roleName1, roleName2}, role.RoleNames)
-		}
+		role := roles.Results[0]
+		a.Equal(teamID, role.GetTeamId())
+		a.Len(role.RoleNames, 2)
+		a.ElementsMatch([]string{roleName1, roleName2}, role.RoleNames)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -120,12 +118,11 @@ func TestAtlasProjectTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var teams atlasv2.PaginatedTeamRole
-		if err = json.Unmarshal(resp, &teams); a.NoError(err) {
-			a.NotEmpty(teams.GetResults())
-		}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		a.NotEmpty(teams.GetResults())
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -140,9 +137,8 @@ func TestAtlasProjectTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_projects_test.go
+++ b/test/e2e/iam/atlas_projects_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -51,13 +51,10 @@ func TestAtlasProjects(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var project admin.Group
-		if err = json.Unmarshal(resp, &project); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
+		require.NoError(t, json.Unmarshal(resp, &project))
 		if project.GetName() != projectName {
 			t.Errorf("got=%#v\nwant=%#v\n", project.Name, projectName)
 		}
@@ -72,7 +69,7 @@ func TestAtlasProjects(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -84,7 +81,7 @@ func TestAtlasProjects(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Users", func(t *testing.T) {
@@ -97,7 +94,7 @@ func TestAtlasProjects(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -109,7 +106,7 @@ func TestAtlasProjects(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Project '%s' deleted\n", projectID)
 		if string(resp) != expected {

--- a/test/e2e/iam/atlas_team_users_test.go
+++ b/test/e2e/iam/atlas_team_users_test.go
@@ -64,17 +64,15 @@ func TestAtlasTeamUsers(t *testing.T) {
 		a := assert.New(t)
 
 		var users atlasv2.PaginatedApiAppUser
-		if err := json.Unmarshal(resp, &users); a.NoError(err) {
-			found := false
-			for _, user := range users.Results {
-				if user.Username == username {
-					found = true
-					break
-				}
+		require.NoError(t, json.Unmarshal(resp, &users))
+		found := false
+		for _, user := range users.Results {
+			if user.Username == username {
+				found = true
+				break
 			}
-
-			a.True(found)
 		}
+		a.True(found)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -90,9 +88,8 @@ func TestAtlasTeamUsers(t *testing.T) {
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var teams atlasv2.PaginatedApiAppUser
-		if err := json.Unmarshal(resp, &teams); a.NoError(err) {
-			a.NotEmpty(teams.Results)
-		}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		a.NotEmpty(teams.Results)
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
@@ -109,9 +106,8 @@ func TestAtlasTeamUsers(t *testing.T) {
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var teams []atlasv2.CloudAppUser
-		if err := json.Unmarshal(resp, &teams); a.NoError(err) {
-			a.NotEmpty(teams)
-		}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		a.NotEmpty(teams)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -128,9 +124,8 @@ func TestAtlasTeamUsers(t *testing.T) {
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("User '%s' deleted from the team\n", userID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("User '%s' deleted from the team\n", userID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_teams_test.go
+++ b/test/e2e/iam/atlas_teams_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
@@ -59,13 +60,12 @@ func TestAtlasTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var team atlasv2.Team
-		if err := json.Unmarshal(resp, &team); a.NoError(err) {
-			a.Equal(teamName, team.Name)
-			teamID = *team.Id
-		}
+		require.NoError(t, json.Unmarshal(resp, &team))
+		a.Equal(teamName, team.Name)
+		teamID = *team.Id
 	})
 
 	t.Run("Describe By Id", func(t *testing.T) {
@@ -79,12 +79,11 @@ func TestAtlasTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var team atlasv2.TeamResponse
-		if err := json.Unmarshal(resp, &team); a.NoError(err) {
-			a.Equal(teamID, *team.Id)
-		}
+		require.NoError(t, json.Unmarshal(resp, &team))
+		a.Equal(teamID, *team.Id)
 	})
 
 	t.Run("Describe By Name", func(t *testing.T) {
@@ -98,12 +97,10 @@ func TestAtlasTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
-
+		require.NoError(t, err, string(resp))
 		var team atlasv2.TeamResponse
-		if err := json.Unmarshal(resp, &team); a.NoError(err) {
-			a.Equal(teamName, *team.Name)
-		}
+		require.NoError(t, json.Unmarshal(resp, &team))
+		a.Equal(teamName, *team.Name)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -115,12 +112,11 @@ func TestAtlasTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var teams atlasv2.PaginatedTeam
-		if err := json.Unmarshal(resp, &teams); a.NoError(err) {
-			a.NotEmpty(t, teams.Results)
-		}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		a.NotEmpty(t, teams.Results)
 	})
 
 	t.Run("List Compact", func(t *testing.T) {
@@ -133,12 +129,11 @@ func TestAtlasTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var teams []atlasv2.TeamResponse
-		if err := json.Unmarshal(resp, &teams); a.NoError(err) {
-			a.NotEmpty(t, teams)
-		}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		a.NotEmpty(t, teams)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -150,9 +145,8 @@ func TestAtlasTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_users_test.go
+++ b/test/e2e/iam/atlas_users_test.go
@@ -115,10 +115,9 @@ func TestAtlasUsers(t *testing.T) {
 		require.NoError(t, err, string(resp))
 
 		var user atlasv2.CloudAppUser
-		if err := json.Unmarshal(resp, &user); assert.NoError(t, err) {
-			assert.Equal(t, emailUser, user.GetUsername())
-			assert.NotEmpty(t, user.GetId())
-			assert.Empty(t, user.GetRoles()) // This is returned empty until the invite is accepted
-		}
+		require.NoError(t, json.Unmarshal(resp, &user))
+		assert.Equal(t, emailUser, user.GetUsername())
+		assert.NotEmpty(t, user.GetId())
+		assert.Empty(t, user.GetRoles()) // This is returned empty until the invite is accepted
 	})
 }

--- a/test/e2e/iam/org_api_key_access_list_test.go
+++ b/test/e2e/iam/org_api_key_access_list_test.go
@@ -41,9 +41,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 	})
 
 	n, err := e2e.RandInt(255)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	entry := fmt.Sprintf("192.168.0.%d", n)
 
 	t.Run("Create", func(t *testing.T) {
@@ -59,13 +57,10 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key mongodbatlas.AccessListAPIKeys
-			if err := json.Unmarshal(resp, &key); a.NoError(err) {
-				a.NotEmpty(key.Results)
-			}
-		}
+		require.NoError(t, err, string(resp))
+		var key mongodbatlas.AccessListAPIKeys
+		require.NoError(t, json.Unmarshal(resp, &key))
+		assert.NotEmpty(t, key.Results)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -78,13 +73,10 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key mongodbatlas.AccessListAPIKeys
-			if err := json.Unmarshal(resp, &key); a.NoError(err) {
-				a.NotEmpty(key.Results)
-			}
-		}
+		require.NoError(t, err, string(resp))
+		var key mongodbatlas.AccessListAPIKeys
+		require.NoError(t, json.Unmarshal(resp, &key))
+		assert.NotEmpty(t, key.Results)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -105,13 +97,11 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key mongodbatlas.AccessListAPIKeys
-			if err := json.Unmarshal(resp, &key); a.NoError(err) {
-				a.NotEmpty(key.Results)
-				entry = key.Results[0].IPAddress
-			}
-		}
+		require.NoError(t, err, string(resp))
+		var key mongodbatlas.AccessListAPIKeys
+		require.NoError(t, json.Unmarshal(resp, &key))
+		a.NotEmpty(key.Results)
+		entry = key.Results[0].IPAddress
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -134,8 +124,7 @@ func deleteAccessListEntry(t *testing.T, cliPath, entry, apiKeyID string) {
 		"--force")
 	cmd.Env = os.Environ()
 	resp, err := cmd.CombinedOutput()
-	if assert.NoError(t, err, string(resp)) {
-		expected := fmt.Sprintf("Access list entry '%s' deleted\n", entry)
-		assert.Equal(t, string(resp), expected)
-	}
+	require.NoError(t, err, string(resp))
+	expected := fmt.Sprintf("Access list entry '%s' deleted\n", entry)
+	assert.Equal(t, expected, string(resp))
 }

--- a/test/e2e/iam/org_api_keys_test.go
+++ b/test/e2e/iam/org_api_keys_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -49,14 +50,11 @@ func TestOrgAPIKeys(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key mongodbatlas.APIKey
-			if err := json.Unmarshal(resp, &key); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			a.Equal(desc, key.Desc)
-			ID = key.ID
-		}
+		require.NoError(t, err, string(resp))
+		var key mongodbatlas.APIKey
+		require.NoError(t, json.Unmarshal(resp, &key))
+		a.Equal(desc, key.Desc)
+		ID = key.ID
 	})
 	if ID == "" {
 		assert.FailNow(t, "Failed to create API key")
@@ -96,13 +94,10 @@ func TestOrgAPIKeys(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key mongodbatlas.APIKey
-			if err := json.Unmarshal(resp, &key); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			a.Equal(newDesc, key.Desc)
-		}
+		require.NoError(t, err, string(resp))
+		var key mongodbatlas.APIKey
+		require.NoError(t, json.Unmarshal(resp, &key))
+		a.Equal(newDesc, key.Desc)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -117,13 +112,10 @@ func TestOrgAPIKeys(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key mongodbatlas.APIKey
-			if err := json.Unmarshal(resp, &key); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			a.Equal(ID, key.ID)
-		}
+		require.NoError(t, err, string(resp))
+		var key mongodbatlas.APIKey
+		require.NoError(t, json.Unmarshal(resp, &key))
+		a.Equal(ID, key.ID)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -138,9 +130,8 @@ func TestOrgAPIKeys(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/org_invitations_test.go
+++ b/test/e2e/iam/org_invitations_test.go
@@ -56,11 +56,9 @@ func TestOrgInvitations(t *testing.T) {
 		require.NoError(t, err, string(resp))
 
 		var invitation mongodbatlas.Invitation
-		if err := json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailOrg, invitation.Username)
-			require.NotEmpty(t, invitation.ID)
-		}
-
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailOrg, invitation.Username)
+		require.NotEmpty(t, invitation.ID)
 		orgInvitationID = invitation.ID
 	})
 
@@ -78,9 +76,8 @@ func TestOrgInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitations []mongodbatlas.Invitation
-		if err = json.Unmarshal(resp, &invitations); a.NoError(err) {
-			a.NotEmpty(invitations)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitations))
+		a.NotEmpty(invitations)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -98,9 +95,8 @@ func TestOrgInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation mongodbatlas.Invitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(orgInvitationID, invitation.ID)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(orgInvitationID, invitation.ID)
 	})
 
 	t.Run("Update by email", func(t *testing.T) {
@@ -121,10 +117,9 @@ func TestOrgInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation mongodbatlas.Invitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailOrg, invitation.Username)
-			a.ElementsMatch([]string{roleNameOrg}, invitation.Roles)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailOrg, invitation.Username)
+		a.ElementsMatch([]string{roleNameOrg}, invitation.Roles)
 	})
 
 	t.Run("Update by ID", func(t *testing.T) {
@@ -143,10 +138,9 @@ func TestOrgInvitations(t *testing.T) {
 
 		a := assert.New(t)
 		var invitation mongodbatlas.Invitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailOrg, invitation.Username)
-			a.ElementsMatch([]string{roleNameOrg}, invitation.Roles)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailOrg, invitation.Username)
+		a.ElementsMatch([]string{roleNameOrg}, invitation.Roles)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -160,9 +154,8 @@ func TestOrgInvitations(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Invitation '%s' deleted\n", orgInvitationID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Invitation '%s' deleted\n", orgInvitationID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/orgs_test.go
+++ b/test/e2e/iam/orgs_test.go
@@ -62,7 +62,7 @@ func TestOrgs(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List Org Users", func(t *testing.T) {
@@ -76,6 +76,6 @@ func TestOrgs(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/iam/project_api_keys_test.go
+++ b/test/e2e/iam/project_api_keys_test.go
@@ -25,14 +25,13 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
 func TestProjectAPIKeys(t *testing.T) {
 	cliPath, err := e2e.Bin()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	var ID string
 
@@ -50,14 +49,11 @@ func TestProjectAPIKeys(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			var key mongodbatlas.APIKey
-			if err := json.Unmarshal(resp, &key); err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			a.Equal(desc, key.Desc)
-			ID = key.ID
-		}
+		require.NoError(t, err, string(resp))
+		var key mongodbatlas.APIKey
+		require.NoError(t, json.Unmarshal(resp, &key))
+		a.Equal(desc, key.Desc)
+		ID = key.ID
 	})
 
 	if ID == "" {
@@ -80,7 +76,7 @@ func TestProjectAPIKeys(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -92,14 +88,9 @@ func TestProjectAPIKeys(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
-		}
+		require.NoError(t, err, string(resp))
 		var keys []mongodbatlas.APIKey
-		if err := json.Unmarshal(resp, &keys); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		require.NoError(t, json.Unmarshal(resp, &keys))
 		assert.NotEmpty(t, keys)
 	})
 
@@ -115,9 +106,8 @@ func TestProjectAPIKeys(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/project_invitations_test.go
+++ b/test/e2e/iam/project_invitations_test.go
@@ -64,10 +64,9 @@ func TestProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation mongodbatlas.Invitation
-		if err := json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailProject, invitation.Username)
-			require.NotEmpty(t, invitation.ID)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailProject, invitation.Username)
+		require.NotEmpty(t, invitation.ID)
 		invitationID = invitation.ID
 	})
 
@@ -86,9 +85,8 @@ func TestProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitations []mongodbatlas.Invitation
-		if err = json.Unmarshal(resp, &invitations); a.NoError(err) {
-			a.NotEmpty(invitations)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitations))
+		a.NotEmpty(invitations)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -107,9 +105,8 @@ func TestProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation mongodbatlas.Invitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(invitationID, invitation.ID)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(invitationID, invitation.ID)
 	})
 
 	t.Run("Update by email", func(t *testing.T) {
@@ -133,10 +130,9 @@ func TestProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation mongodbatlas.Invitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailProject, invitation.Username)
-			a.ElementsMatch([]string{roleName1, roleName2}, invitation.Roles)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailProject, invitation.Username)
+		a.ElementsMatch([]string{roleName1, roleName2}, invitation.Roles)
 	})
 
 	t.Run("Update by ID", func(t *testing.T) {
@@ -159,10 +155,9 @@ func TestProjectInvitations(t *testing.T) {
 		a := assert.New(t)
 
 		var invitation mongodbatlas.Invitation
-		if err = json.Unmarshal(resp, &invitation); a.NoError(err) {
-			a.Equal(emailProject, invitation.Username)
-			a.ElementsMatch([]string{roleName1, roleName2}, invitation.Roles)
-		}
+		require.NoError(t, json.Unmarshal(resp, &invitation))
+		a.Equal(emailProject, invitation.Username)
+		a.ElementsMatch([]string{roleName1, roleName2}, invitation.Roles)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -178,9 +173,8 @@ func TestProjectInvitations(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Invitation '%s' deleted\n", invitationID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Invitation '%s' deleted\n", invitationID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/project_teams_test.go
+++ b/test/e2e/iam/project_teams_test.go
@@ -66,19 +66,18 @@ func TestProjectTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var teams mongodbatlas.TeamsAssigned
-		if err := json.Unmarshal(resp, &teams); a.NoError(err) {
-			found := false
-			for _, team := range teams.Results {
-				if team.TeamID == teamID {
-					found = true
-					break
-				}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		found := false
+		for _, team := range teams.Results {
+			if team.TeamID == teamID {
+				found = true
+				break
 			}
-			a.True(found)
 		}
+		a.True(found)
 	})
 
 	t.Run("Update", func(t *testing.T) {
@@ -100,17 +99,16 @@ func TestProjectTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var roles []mongodbatlas.TeamRoles
-		if err = json.Unmarshal(resp, &roles); a.NoError(err) {
-			a.Len(roles, 1)
+		require.NoError(t, json.Unmarshal(resp, &roles))
+		a.Len(roles, 1)
 
-			role := roles[0]
-			a.Equal(teamID, role.TeamID)
-			a.Len(role.RoleNames, 2)
-			a.ElementsMatch([]string{roleName1, roleName2}, role.RoleNames)
-		}
+		role := roles[0]
+		a.Equal(teamID, role.TeamID)
+		a.Len(role.RoleNames, 2)
+		a.ElementsMatch([]string{roleName1, roleName2}, role.RoleNames)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -125,12 +123,11 @@ func TestProjectTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var teams mongodbatlas.TeamsAssigned
-		if err = json.Unmarshal(resp, &teams); a.NoError(err) {
-			a.NotEmpty(teams.Results)
-		}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		a.NotEmpty(teams.Results)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -146,9 +143,8 @@ func TestProjectTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/projects_test.go
+++ b/test/e2e/iam/projects_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -52,7 +52,7 @@ func TestProjects(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var project mongodbatlas.Project
 		if err = json.Unmarshal(resp, &project); err != nil {
@@ -74,7 +74,7 @@ func TestProjects(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestProjects(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Users", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestProjects(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -114,7 +114,7 @@ func TestProjects(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		assert.NoError(t, err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Project '%s' deleted\n", projectID)
 		if string(resp) != expected {

--- a/test/e2e/iam/team_users_test.go
+++ b/test/e2e/iam/team_users_test.go
@@ -65,17 +65,15 @@ func TestTeamUsers(t *testing.T) {
 		a := assert.New(t)
 
 		var users []mongodbatlas.AtlasUser
-		if err := json.Unmarshal(resp, &users); a.NoError(err) {
-			found := false
-			for _, user := range users {
-				if user.Username == username {
-					found = true
-					break
-				}
+		require.NoError(t, json.Unmarshal(resp, &users))
+		found := false
+		for _, user := range users {
+			if user.Username == username {
+				found = true
+				break
 			}
-
-			a.True(found)
 		}
+		a.True(found)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -92,9 +90,8 @@ func TestTeamUsers(t *testing.T) {
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var teams []mongodbatlas.AtlasUser
-		if err := json.Unmarshal(resp, &teams); a.NoError(err) {
-			a.NotEmpty(teams)
-		}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		a.NotEmpty(teams)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -112,9 +109,8 @@ func TestTeamUsers(t *testing.T) {
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("User '%s' deleted from the team\n", userID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("User '%s' deleted from the team\n", userID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/test/e2e/iam/teams_test.go
+++ b/test/e2e/iam/teams_test.go
@@ -55,13 +55,12 @@ func TestTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var team mongodbatlas.Team
-		if err := json.Unmarshal(resp, &team); a.NoError(err) {
-			a.Equal(teamName, team.Name)
-			teamID = team.ID
-		}
+		require.NoError(t, json.Unmarshal(resp, &team))
+		a.Equal(teamName, team.Name)
+		teamID = team.ID
 	})
 	require.NotEmpty(t, teamID)
 
@@ -77,12 +76,11 @@ func TestTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var team mongodbatlas.Team
-		if err := json.Unmarshal(resp, &team); a.NoError(err) {
-			a.Equal(teamID, team.ID)
-		}
+		require.NoError(t, json.Unmarshal(resp, &team))
+		a.Equal(teamID, team.ID)
 	})
 
 	t.Run("Describe By Name", func(t *testing.T) {
@@ -97,12 +95,11 @@ func TestTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var team mongodbatlas.Team
-		if err := json.Unmarshal(resp, &team); a.NoError(err) {
-			a.Equal(teamName, team.Name)
-		}
+		require.NoError(t, json.Unmarshal(resp, &team))
+		a.Equal(teamName, team.Name)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -115,12 +112,11 @@ func TestTeams(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		a := assert.New(t)
-		a.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var teams []mongodbatlas.Team
-		if err := json.Unmarshal(resp, &teams); a.NoError(err) {
-			a.NotEmpty(t, teams)
-		}
+		require.NoError(t, json.Unmarshal(resp, &teams))
+		a.NotEmpty(t, teams)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -133,9 +129,8 @@ func TestTeams(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
-		if a.NoError(err, string(resp)) {
-			expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
-			a.Equal(expected, string(resp))
-		}
+		require.NoError(t, err, string(resp))
+		expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
+		a.Equal(expected, string(resp))
 	})
 }

--- a/tools/cli-generator/generate.go
+++ b/tools/cli-generator/generate.go
@@ -76,12 +76,18 @@ type Command struct {
 	SubCommands    []Command `yaml:"sub_commands,omitempty"`
 }
 
+const (
+	gotmplExt     = ".gotmpl"
+	gotmplTestExt = "_test" + gotmplExt
+	goExt         = ".go"
+)
+
 func (c *Command) TemplateFile() string {
-	return c.Template + ".gotmpl"
+	return c.Template + gotmplExt
 }
 
 func (c *Command) TemplateUnitTestFile() string {
-	return c.Template + "_test.gotmpl"
+	return c.Template + gotmplTestExt
 }
 
 type Store struct {
@@ -95,7 +101,7 @@ type Store struct {
 }
 
 func (s *Store) TemplateFile() string {
-	return s.Template + ".gotmpl"
+	return s.Template + gotmplExt
 }
 
 func (s *Store) InterfaceNames() string {
@@ -148,11 +154,11 @@ func (c *Command) baseFileName(basePath string) string {
 }
 
 func (c *Command) FileName(basePath string) string {
-	return c.baseFileName(basePath) + ".go"
+	return c.baseFileName(basePath) + goExt
 }
 
 func (c *Command) UnitTestFileName(basePath string) string {
-	return c.baseFileName(basePath) + "_test.go"
+	return c.baseFileName(basePath) + gotmplTestExt
 }
 
 func fileExists(f string) bool {
@@ -161,7 +167,7 @@ func fileExists(f string) bool {
 }
 
 func (cli *CLI) generateStore(store *Store) error {
-	storeFile := filepath.Join(cli.basePath, "internal", "store", "atlas", store.BaseFileName+".go")
+	storeFile := filepath.Join(cli.basePath, "internal", "store", "atlas", store.BaseFileName+goExt)
 
 	fileCreated, err := cli.generateFile(storeFile, store.TemplateFile(), store)
 	if err != nil {
@@ -175,12 +181,10 @@ func (cli *CLI) generateStore(store *Store) error {
 
 func (cli *CLI) generateFile(file string, templateFile string, data any) (bool, error) {
 	if !cli.overwrite && fileExists(file) {
-		fmt.Fprintf(os.Stderr, "File %q already present in disk, skipping\n", file)
+		_, _ = fmt.Fprintf(os.Stderr, "File %q already present in disk, skipping\n", file)
 		return false, nil
 	}
-
-	err := os.MkdirAll(filepath.Dir(file), os.ModePerm)
-	if err != nil {
+	if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
Update `golangci-lint`and enable the new `testifylint` so our test are more consistent if we use that lib 

This also fixes a lot of the inconsistencies, the main one the linter is opinionated on `require.Error` over `assert.Error` which we have a bit lax on