### PR TITLE
task: automatically update atlas sdk go

### DIFF
--- a/.github/workflows/autoupdate-sdk.yaml
+++ b/.github/workflows/autoupdate-sdk.yaml
@@ -1,11 +1,8 @@
 name: Update SDK
 on:
  schedule:
-   - cron: 30 8 * * MON
+   - cron: 30 8 * * TUE
  workflow_dispatch:
- push:
-    branches:
-      - sdk-update-bot
   
 jobs:
   update-sdk:

--- a/.github/workflows/autoupdate-sdk.yaml
+++ b/.github/workflows/autoupdate-sdk.yaml
@@ -3,6 +3,9 @@ on:
  schedule:
    - cron: 30 8 * * MON
  workflow_dispatch:
+ push:
+    branches:
+      - sdk-update-bot
   
 jobs:
   generate-client:

--- a/.github/workflows/autoupdate-sdk.yaml
+++ b/.github/workflows/autoupdate-sdk.yaml
@@ -8,7 +8,7 @@ on:
       - sdk-update-bot
   
 jobs:
-  generate-client:
+  update-sdk:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,7 +17,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: update
-        run: make update-atlas-sdk
+        run: 	| 
+          go install github.com/icholy/gomajor@latest 
+          make update-atlas-sdk
       - name: Verify Changed files
         uses: tj-actions/verify-changed-files@78dc414e915e0664bcf0d2b42465a86cd47bcc3c
         id: verify-changed-files
@@ -26,8 +28,7 @@ jobs:
              ./internal/**/*
       - uses: peter-evans/create-pull-request@v5
         if: steps.verify-changed-files.outputs.files_changed == 'true'
-        env:
-           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_GITHUB_TOKEN }}
+
         with:
           title: "APIBot: SDK update"
           commit-message: "fix: update go SDK"

--- a/.github/workflows/autoupdate-sdk.yaml
+++ b/.github/workflows/autoupdate-sdk.yaml
@@ -27,7 +27,7 @@ jobs:
         if: steps.verify-changed-files.outputs.files_changed == 'true'
 
         with:
-          title: "APIBot: SDK update"
+          title: "APIBot: Atlas GO SDK update"
           commit-message: "build(deps): bump go.mongodb.org/atlas-sdk"
           delete-branch: true
           branch: atlas-sdk-update

--- a/.github/workflows/autoupdate-sdk.yaml
+++ b/.github/workflows/autoupdate-sdk.yaml
@@ -1,0 +1,34 @@
+name: Update SDK
+on:
+ schedule:
+   - cron: 30 8 * * MON
+ workflow_dispatch:
+  
+jobs:
+  generate-client:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: update
+        run: make update-atlas-sdk
+      - name: Verify Changed files
+        uses: tj-actions/verify-changed-files@78dc414e915e0664bcf0d2b42465a86cd47bcc3c
+        id: verify-changed-files
+        with:
+          files: |
+             ./internal/**/*
+      - uses: peter-evans/create-pull-request@v5
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        env:
+           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_GITHUB_TOKEN }}
+        with:
+          title: "APIBot: SDK update"
+          commit-message: "fix: update go SDK"
+          delete-branch: true
+          branch: sdk-update
+          body: |
+            Automatic update for MongoDB Atlas Go Client SDK

--- a/.github/workflows/autoupdate-sdk.yaml
+++ b/.github/workflows/autoupdate-sdk.yaml
@@ -28,8 +28,8 @@ jobs:
 
         with:
           title: "APIBot: SDK update"
-          commit-message: "fix: update go SDK"
+          commit-message: "build(deps): bump go.mongodb.org/atlas-sdk"
           delete-branch: true
-          branch: sdk-update
+          branch: atlas-sdk-update
           body: |
             Automatic update for MongoDB Atlas Go Client SDK

--- a/Makefile
+++ b/Makefile
@@ -193,11 +193,7 @@ check-library-owners: ## Check that all the dependencies in go.mod has a owner i
 
 .PHONY: update-atlas-sdk
 update-atlas-sdk: ## Update the atlas-sdk dependency
-	$(eval LATEST_SDK_RELEASE := $(shell curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name' | cut -d '.' -f 1 ))
-	@echo "==> Updating SDK to latest major version $(LATEST_SDK_RELEASE)"
-	gomajor get go.mongodb.org/atlas-sdk/$(LATEST_SDK_RELEASE)@latest
-	go mod tidy
-	 @echo "==> Done, remember to update build/ci/library_owners.json"
+	./scripts/update-sdk.sh
 
 .PHONY: help
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -193,11 +193,11 @@ check-library-owners: ## Check that all the dependencies in go.mod has a owner i
 
 .PHONY: update-atlas-sdk
 update-atlas-sdk: ## Update the atlas-sdk dependency
-	@echo "==> Updating SDK to latest major version"
-	LATEST_SDK_RELEASE=$(shell curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name')
-	gomajor get go.mongodb.org/atlas-sdk/ $(shell LATEST_SDK_RELEASE)@latest
+	$(eval LATEST_SDK_RELEASE := $(shell curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name' | cut -d '.' -f 1 ))
+	@echo "==> Updating SDK to latest major version $(LATEST_SDK_RELEASE)"
+	gomajor get go.mongodb.org/atlas-sdk/$(LATEST_SDK_RELEASE)@latest
 	go mod tidy
-	@echo "==> Done, remember to update build/ci/library_owners.json"
+	 @echo "==> Done, remember to update build/ci/library_owners.json"
 
 .PHONY: help
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ check-library-owners: ## Check that all the dependencies in go.mod has a owner i
 .PHONY: update-atlas-sdk
 update-atlas-sdk: ## Update the atlas-sdk dependency
 	@echo "==> Updating SDK to latest major version"
-	gomajor get go.mongodb.org/atlas-sdk/v20230201001@latest
+	LATEST_SDK_RELEASE=$(shell curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name')
+	gomajor get go.mongodb.org/atlas-sdk/ $(shell LATEST_SDK_RELEASE)@latest
 	go mod tidy
 	@echo "==> Done, remember to update build/ci/library_owners.json"
 

--- a/scripts/update-sdk.sh
+++ b/scripts/update-sdk.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2020 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
 
 LATEST_SDK_RELEASE=$(curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name' | cut -d '.' -f 1)

--- a/scripts/update-sdk.sh
+++ b/scripts/update-sdk.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LATEST_SDK_RELEASE=$(curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name' | cut -d '.' -f 1)
+echo  "==> Updating SDK to latest major version $LATEST_SDK_RELEASE"
+gomajor get "go.mongodb.org/atlas-sdk/$LATEST_SDK_RELEASE@latest"
+go mod tidy
+echo "Done, remember to update build/ci/library_owners.json"

--- a/scripts/update-sdk.sh
+++ b/scripts/update-sdk.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 MongoDB Inc
+# Copyright 2023 MongoDB Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
 ## Proposed changes

I have noticed that we are behind with sdk updates for the CLI.
This PR introduces a job that will run once a week and automatically reduce boilerplate work.

I also fixed a bug in the Golang proxy that improperly handles such large major versions :)

## Verification

https://github.com/mongodb/mongodb-atlas-cli/pull/2394


 
 