### PR TITLE
task: move global apis to use only ops manager libs

### DIFF
--- a/internal/cli/iam/globalapikeys/create.go
+++ b/internal/cli/iam/globalapikeys/create.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const createTemplate = `API Key '{{.ID}}' created.
@@ -46,8 +46,8 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-func (opts *CreateOpts) newAPIKeyInput() *atlas.APIKeyInput {
-	return &atlas.APIKeyInput{
+func (opts *CreateOpts) newAPIKeyInput() *opsmngr.APIKeyInput {
+	return &opsmngr.APIKeyInput{
 		Desc:  opts.desc,
 		Roles: opts.roles,
 	}

--- a/internal/cli/iam/globalapikeys/create_test.go
+++ b/internal/cli/iam/globalapikeys/create_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyCreator(ctrl)
 
-	expected := &mongodbatlas.APIKey{
+	expected := &opsmngr.APIKey{
 		ID: "1",
 	}
 

--- a/internal/cli/iam/globalapikeys/describe_test.go
+++ b/internal/cli/iam/globalapikeys/describe_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {
@@ -36,7 +36,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 	mockStore.
 		EXPECT().
 		GlobalAPIKey(opts.id).
-		Return(&mongodbatlas.APIKey{}, nil).
+		Return(&opsmngr.APIKey{}, nil).
 		Times(1)
 
 	if err := opts.Run(); err != nil {

--- a/internal/cli/iam/globalapikeys/list_test.go
+++ b/internal/cli/iam/globalapikeys/list_test.go
@@ -22,14 +22,14 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyLister(ctrl)
 
-	var expected []mongodbatlas.APIKey
+	var expected []opsmngr.APIKey
 
 	opts := &ListOpts{
 		store: mockStore,

--- a/internal/cli/iam/globalapikeys/update.go
+++ b/internal/cli/iam/globalapikeys/update.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 type UpdateOpts struct {
@@ -43,8 +43,8 @@ func (opts *UpdateOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-func (opts *UpdateOpts) newAPIKeyInput() *atlas.APIKeyInput {
-	return &atlas.APIKeyInput{
+func (opts *UpdateOpts) newAPIKeyInput() *opsmngr.APIKeyInput {
+	return &opsmngr.APIKeyInput{
 		Desc:  opts.desc,
 		Roles: opts.roles,
 	}

--- a/internal/cli/iam/globalapikeys/update_test.go
+++ b/internal/cli/iam/globalapikeys/update_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockGlobalAPIKeyUpdater(ctrl)
 
-	expected := &mongodbatlas.APIKey{
+	expected := &opsmngr.APIKey{
 		ID: "1",
 	}
 

--- a/internal/store/blockstores.go
+++ b/internal/store/blockstores.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_backup_blockstores.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store BlockstoresLister,BlockstoresDescriber,BlockstoresCreator,BlockstoresUpdater,BlockstoresDeleter
 
 type BlockstoresLister interface {
-	ListBlockstores(*atlas.ListOptions) (*opsmngr.BackupStores, error)
+	ListBlockstores(*opsmngr.ListOptions) (*opsmngr.BackupStores, error)
 }
 
 type BlockstoresDescriber interface {
@@ -45,7 +44,7 @@ type BlockstoresDeleter interface {
 }
 
 // ListBlockstore encapsulates the logic to manage different cloud providers.
-func (s *Store) ListBlockstores(options *atlas.ListOptions) (*opsmngr.BackupStores, error) {
+func (s *Store) ListBlockstores(options *opsmngr.ListOptions) (*opsmngr.BackupStores, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).BlockstoreConfig.List(s.ctx, options)

--- a/internal/store/feature_control_policies.go
+++ b/internal/store/feature_control_policies.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_feature_control_policy.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store FeatureControlPoliciesLister,FeatureControlPoliciesUpdater
 
 type FeatureControlPoliciesLister interface {
-	FeatureControlPolicies(string, *atlas.ListOptions) (*opsmngr.FeaturePolicy, error)
+	FeatureControlPolicies(string, *opsmngr.ListOptions) (*opsmngr.FeaturePolicy, error)
 }
 
 type FeatureControlPoliciesUpdater interface {
@@ -33,7 +32,7 @@ type FeatureControlPoliciesUpdater interface {
 }
 
 // FeatureControlPolicies encapsulate the logic to manage different cloud providers.
-func (s *Store) FeatureControlPolicies(projectID string, opts *atlas.ListOptions) (*opsmngr.FeaturePolicy, error) {
+func (s *Store) FeatureControlPolicies(projectID string, opts *opsmngr.ListOptions) (*opsmngr.FeaturePolicy, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.(*opsmngr.Client).FeatureControlPolicies.List(s.ctx, projectID, opts)

--- a/internal/store/file_systems.go
+++ b/internal/store/file_systems.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_backup_file_systems.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store FileSystemsLister,FileSystemsDescriber,FileSystemsDeleter,FileSystemsCreator,FileSystemsUpdater
 
 type FileSystemsLister interface {
-	ListFileSystems(*atlas.ListOptions) (*opsmngr.FileSystemStoreConfigurations, error)
+	ListFileSystems(*opsmngr.ListOptions) (*opsmngr.FileSystemStoreConfigurations, error)
 }
 
 type FileSystemsDescriber interface {
@@ -45,7 +44,7 @@ type FileSystemsUpdater interface {
 }
 
 // ListFileSystems encapsulates the logic to manage different cloud providers.
-func (s *Store) ListFileSystems(options *atlas.ListOptions) (*opsmngr.FileSystemStoreConfigurations, error) {
+func (s *Store) ListFileSystems(options *opsmngr.ListOptions) (*opsmngr.FileSystemStoreConfigurations, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).FileSystemStoreConfig.List(s.ctx, options)

--- a/internal/store/global_api_keys.go
+++ b/internal/store/global_api_keys.go
@@ -25,19 +25,19 @@ import (
 //go:generate mockgen -destination=../mocks/mock_global_api_keys.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store GlobalAPIKeyLister,GlobalAPIKeyDescriber,GlobalAPIKeyUpdater,GlobalAPIKeyCreator,GlobalAPIKeyDeleter
 
 type GlobalAPIKeyLister interface {
-	GlobalAPIKeys(*atlas.ListOptions) ([]atlas.APIKey, error)
+	GlobalAPIKeys(*opsmngr.ListOptions) ([]opsmngr.APIKey, error)
 }
 
 type GlobalAPIKeyDescriber interface {
-	GlobalAPIKey(string) (*atlas.APIKey, error)
+	GlobalAPIKey(string) (*opsmngr.APIKey, error)
 }
 
 type GlobalAPIKeyUpdater interface {
-	UpdateGlobalAPIKey(string, *atlas.APIKeyInput) (*atlas.APIKey, error)
+	UpdateGlobalAPIKey(string, *opsmngr.APIKeyInput) (*opsmngr.APIKey, error)
 }
 
 type GlobalAPIKeyCreator interface {
-	CreateGlobalAPIKey(*atlas.APIKeyInput) (*atlas.APIKey, error)
+	CreateGlobalAPIKey(*opsmngr.APIKeyInput) (*opsmngr.APIKey, error)
 }
 
 type GlobalAPIKeyDeleter interface {
@@ -45,7 +45,7 @@ type GlobalAPIKeyDeleter interface {
 }
 
 // GlobalAPIKeys encapsulates the logic to manage different cloud providers.
-func (s *Store) GlobalAPIKeys(opts *atlas.ListOptions) ([]atlas.APIKey, error) {
+func (s *Store) GlobalAPIKeys(opts *opsmngr.ListOptions) ([]opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).GlobalAPIKeys.List(s.ctx, opts)
@@ -56,7 +56,7 @@ func (s *Store) GlobalAPIKeys(opts *atlas.ListOptions) ([]atlas.APIKey, error) {
 }
 
 // GlobalAPIKey encapsulates the logic to manage different cloud providers.
-func (s *Store) GlobalAPIKey(apiKeyID string) (*atlas.APIKey, error) {
+func (s *Store) GlobalAPIKey(apiKeyID string) (*opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).GlobalAPIKeys.Get(s.ctx, apiKeyID)
@@ -67,7 +67,7 @@ func (s *Store) GlobalAPIKey(apiKeyID string) (*atlas.APIKey, error) {
 }
 
 // UpdateGlobalAPIKey encapsulates the logic to manage different cloud providers.
-func (s *Store) UpdateGlobalAPIKey(apiKeyID string, input *atlas.APIKeyInput) (*atlas.APIKey, error) {
+func (s *Store) UpdateGlobalAPIKey(apiKeyID string, input *atlas.APIKeyInput) (*opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).GlobalAPIKeys.Update(s.ctx, apiKeyID, input)
@@ -78,7 +78,7 @@ func (s *Store) UpdateGlobalAPIKey(apiKeyID string, input *atlas.APIKeyInput) (*
 }
 
 // CreateGlobalAPIKey encapsulates the logic to manage different cloud providers.
-func (s *Store) CreateGlobalAPIKey(input *atlas.APIKeyInput) (*atlas.APIKey, error) {
+func (s *Store) CreateGlobalAPIKey(input *opsmngr.APIKeyInput) (*opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).GlobalAPIKeys.Create(s.ctx, input)

--- a/internal/store/oplog.go
+++ b/internal/store/oplog.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_backup_oplogs.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store OplogsLister,OplogsDescriber,OplogsCreator,OplogsUpdater,OplogsDeleter
 
 type OplogsLister interface {
-	ListOplogs(*atlas.ListOptions) (*opsmngr.BackupStores, error)
+	ListOplogs(*opsmngr.ListOptions) (*opsmngr.BackupStores, error)
 }
 
 type OplogsDescriber interface {
@@ -45,7 +44,7 @@ type OplogsDeleter interface {
 }
 
 // ListOplogs encapsulates the logic to manage different cloud providers.
-func (s *Store) ListOplogs(options *atlas.ListOptions) (*opsmngr.BackupStores, error) {
+func (s *Store) ListOplogs(options *opsmngr.ListOptions) (*opsmngr.BackupStores, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).OplogStoreConfig.List(s.ctx, options)

--- a/internal/store/s3_blockstores.go
+++ b/internal/store/s3_blockstores.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_backup_s3_blockstores.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store S3BlockstoresLister,S3BlockstoresDeleter,S3BlockstoresCreator,S3BlockstoresUpdater,S3BlockstoresDescriber
 
 type S3BlockstoresLister interface {
-	ListS3Blockstores(*atlas.ListOptions) (*opsmngr.S3Blockstores, error)
+	ListS3Blockstores(*opsmngr.ListOptions) (*opsmngr.S3Blockstores, error)
 }
 
 type S3BlockstoresDeleter interface {
@@ -45,7 +44,7 @@ type S3BlockstoresDescriber interface {
 }
 
 // ListS3Blockstores encapsulates the logic to manage different cloud providers.
-func (s *Store) ListS3Blockstores(options *atlas.ListOptions) (*opsmngr.S3Blockstores, error) {
+func (s *Store) ListS3Blockstores(options *opsmngr.ListOptions) (*opsmngr.S3Blockstores, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).S3BlockstoreConfig.List(s.ctx, options)

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_backup_sync.go -package=mocks github.com/mongodb/mongodb-atlas-cli/internal/store SyncsLister,SyncsDescriber,SyncsCreator,SyncsUpdater,SyncsDeleter
 
 type SyncsLister interface {
-	ListSyncs(*atlas.ListOptions) (*opsmngr.BackupStores, error)
+	ListSyncs(*opsmngr.ListOptions) (*opsmngr.BackupStores, error)
 }
 
 type SyncsDescriber interface {
@@ -45,7 +44,7 @@ type SyncsDeleter interface {
 }
 
 // ListSyncs encapsulates the logic to manage different cloud providers.
-func (s *Store) ListSyncs(options *atlas.ListOptions) (*opsmngr.BackupStores, error) {
+func (s *Store) ListSyncs(options *opsmngr.ListOptions) (*opsmngr.BackupStores, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.(*opsmngr.Client).SyncStoreConfig.List(s.ctx, options)

--- a/test/e2e/atlas/cleanup_test.go
+++ b/test/e2e/atlas/cleanup_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
 func TestCleanup(t *testing.T) {
@@ -45,17 +45,17 @@ func TestCleanup(t *testing.T) {
 	resp, err := cmd.CombinedOutput()
 	req.NoError(err, string(resp))
 
-	var projects mongodbatlas.Projects
+	var projects admin.PaginatedAtlasGroup
 	err = json.Unmarshal(resp, &projects)
 	req.NoError(err, string(resp))
 	t.Logf("%s\n", resp)
 	for _, project := range projects.Results {
-		projectID := project.ID
+		projectID := project.GetId()
 		if projectID == os.Getenv("MCLI_PROJECT_ID") {
 			t.Log("skipping project", projectID)
 			continue
 		}
-		t.Run(fmt.Sprintf("trying to delete project %s\n", project.ID), func(t *testing.T) {
+		t.Run(fmt.Sprintf("trying to delete project %s\n", project.GetId()), func(t *testing.T) {
 			t.Parallel()
 			deleteAllNetworkPeers(t, cliPath, projectID, "aws")
 			deleteAllNetworkPeers(t, cliPath, projectID, "gcp")

--- a/test/e2e/cloud_manager/alerts_test.go
+++ b/test/e2e/cloud_manager/alerts_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const (
@@ -56,7 +56,7 @@ func TestAlerts(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err)
 		require.NoError(t, err, string(resp))
-		var alerts mongodbatlas.AlertsResponse
+		var alerts opsmngr.AlertsResponse
 		require.NoError(t, json.Unmarshal(resp, &alerts))
 		a.NotEmpty(alerts.Results)
 		alertID = alerts.Results[0].ID
@@ -89,7 +89,7 @@ func TestAlerts(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var alert mongodbatlas.Alert
+		var alert opsmngr.Alert
 		require.NoError(t, json.Unmarshal(resp, &alert))
 		a.Equal(alertID, alert.ID)
 		a.Equal(closed, alert.Status)
@@ -106,7 +106,7 @@ func TestAlerts(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var alerts mongodbatlas.AlertsResponse
+		var alerts opsmngr.AlertsResponse
 		require.NoError(t, json.Unmarshal(resp, &alerts), string(resp))
 	})
 
@@ -123,7 +123,7 @@ func TestAlerts(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var alerts mongodbatlas.AlertsResponse
+		var alerts opsmngr.AlertsResponse
 		require.NoError(t, json.Unmarshal(resp, &alerts), string(resp))
 	})
 
@@ -140,7 +140,7 @@ func TestAlerts(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var alert mongodbatlas.Alert
+		var alert opsmngr.Alert
 		require.NoError(t, json.Unmarshal(resp, &alert))
 		a.Equal(alertID, alert.ID)
 	})
@@ -157,7 +157,7 @@ func TestAlerts(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var alert mongodbatlas.Alert
+		var alert opsmngr.Alert
 		require.NoError(t, json.Unmarshal(resp, &alert))
 		a.Equal(alertID, alert.ID)
 	})
@@ -173,7 +173,7 @@ func TestAlerts(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var alert mongodbatlas.Alert
+		var alert opsmngr.Alert
 		require.NoError(t, json.Unmarshal(resp, &alert))
 		a.Equal(alertID, alert.ID)
 	})

--- a/test/e2e/cloud_manager/events_test.go
+++ b/test/e2e/cloud_manager/events_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestEvents(t *testing.T) {
@@ -48,7 +48,7 @@ func TestEvents(t *testing.T) {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
 
-		var events mongodbatlas.EventResponse
+		var events opsmngr.EventResponse
 		if err := json.Unmarshal(resp, &events); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -71,7 +71,7 @@ func TestEvents(t *testing.T) {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
 
-		var events mongodbatlas.EventResponse
+		var events opsmngr.EventResponse
 		if err := json.Unmarshal(resp, &events); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
Move some ops manager/cloud manager actions to only use the ops manager lib and reduce references to the legacy atlas client