### PR TITLE
chore: Fix linter cache

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:


### PR DESCRIPTION
## Proposed changes

Fix linter cache by disabling Go cache as it's duplicated and not needed. It helps to reduce errors logs in linter "prepare environment" step and reduce lint run duration.

same change as in: https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1555

## Checklist
- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [X] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

Example of previous errors:

![Screenshot 2023-10-24 at 14 35 44](https://github.com/mongodb/mongodb-atlas-cli/assets/430982/126fb4ba-0ef3-4980-9fdd-8c748a02e7b6)

