### PR TITLE
CLOUDP-201369: Allowing config to be opened even if parsing not possible

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -55,7 +55,7 @@ To learn more, see our documentation: https://www.mongodb.com/docs/atlas/cli/sta
 // loadConfig reads in config file and ENV variables if set.
 func loadConfig() error {
 	if err := config.LoadAtlasCLIConfig(); err != nil {
-		return fmt.Errorf("error loading config: %w", err)
+		return fmt.Errorf("error loading config: %w. Please run `atlas config init` to reconfigure your profile", err)
 	}
 
 	return nil
@@ -166,7 +166,7 @@ func trackInitError(e error) {
 			Err: e,
 		})
 	}
-	log.Fatal(e)
+	log.Print(e)
 }
 
 func initTrack() {


### PR DESCRIPTION
Issue: CLOUDP-201369

Resolving issue that prevents a user opening their config when there is a formattign error, due to an error being considered fatal. Instead, updating to 
give the user steps to resolve.

Before:
```
atlas config list
2023/10/26 18:43:58 error loading config: While parsing config: toml: expected character =
```

After: 
```
./bin/atlas config list
2023/10/26 18:43:36 error loading config: While parsing config: toml: expected character =. Please run `atlas config init` to reconfigure your profile
PROFILE NAME
```

Resetting a broken config:
```
./bin/atlas config list
2023/10/27 09:26:32 error loading config: While parsing config: toml: expected character =. Please run `atlas config init` to reconfigure your profile
PROFILE NAME
➜  mongodb-atlas-cli git:(CLOUDP-201369) ./bin/atlas config init
2023/10/27 09:26:37 error loading config: While parsing config: toml: expected character =. Please run `atlas config init` to reconfigure your profile
You are configuring a profile for atlas.

All values are optional and you can use environment variables (MONGODB_ATLAS_*) instead.

Enter [?] on any option to get help.

? Public API Key: x
? Private API Key: [? for help] *
There was an error fetching your organizations: https://cloud.mongodb.com/api/atlas/v2/orgs GET: HTTP 401 Unauthorized (Error code: "") Detail: You are not authorized for this resource. Reason: Unauthorized. Params: []
? Do you want to enter the Organization ID manually? No
Skipping default organization setting
There was an error fetching your projects: You are not authorized for this resource.
? Do you want to enter the Project ID manually? No
Skipping default project setting
? Default Output Format: plaintext

Your profile is now configured.
You can use [atlas config set] to change these settings at a later time.
➜  mongodb-atlas-cli git:(CLOUDP-201369) ./bin/atlas config list
PROFILE NAME
default
```