### PR TITLE
feat: remove references to atlas client from ops manager commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	go.mongodb.org/atlas v0.35.0
 	go.mongodb.org/atlas-sdk/v20231001002 v20231001002.0.0
 	go.mongodb.org/mongo-driver v1.12.1
-	go.mongodb.org/ops-manager v0.55.2
+	go.mongodb.org/ops-manager v0.55.3
 	golang.org/x/crypto v0.14.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -558,8 +558,8 @@ go.mongodb.org/atlas-sdk/v20231001002 v20231001002.0.0 h1:h1X2CGKyN1UFvNs69vp7xp
 go.mongodb.org/atlas-sdk/v20231001002 v20231001002.0.0/go.mod h1:4TAUPaWPFNSbi8c1hbQLr1wAdkmqi48O7zvyXjBM+a8=
 go.mongodb.org/mongo-driver v1.12.1 h1:nLkghSU8fQNaK7oUmDhQFsnrtcoNy7Z6LVFKsEecqgE=
 go.mongodb.org/mongo-driver v1.12.1/go.mod h1:/rGBTebI3XYboVmgz+Wv3Bcbl3aD0QF9zl6kDDw18rQ=
-go.mongodb.org/ops-manager v0.55.2 h1:J1qT0pX7sH8hdcPUZLgLgWbL6HWZqX6C98oWhoocRQI=
-go.mongodb.org/ops-manager v0.55.2/go.mod h1:3KAtjSrHt4KB0mWLDRDlQpiyZypB+4EX9XXjx3gN5PA=
+go.mongodb.org/ops-manager v0.55.3 h1:ZckNLra9XfvUxWgRfdCVOr7QkeCPi7S4VNbcK5di/2A=
+go.mongodb.org/ops-manager v0.55.3/go.mod h1:3KAtjSrHt4KB0mWLDRDlQpiyZypB+4EX9XXjx3gN5PA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/cli/opsmanager/backup/checkpoints_list_test.go
+++ b/internal/cli/opsmanager/backup/checkpoints_list_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestCheckpointsList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockCheckpointsLister(ctrl)
 
-	expected := &mongodbatlas.Checkpoints{}
+	expected := &opsmngr.Checkpoints{}
 	clusterID := "5ec2ac941271767f21cbaefd"
 
 	listOpts := &CheckpointsListOpts{

--- a/internal/cli/opsmanager/backup/restores_list_test.go
+++ b/internal/cli/opsmanager/backup/restores_list_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestRestoresListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockContinuousJobLister(ctrl)
 
-	expected := &mongodbatlas.ContinuousJobs{}
+	expected := &opsmngr.ContinuousJobs{}
 	clusterID := "5ec2ac941271767f21cbaeff"
 
 	listOpts := &RestoresListOpts{

--- a/internal/cli/opsmanager/backup/restores_start.go
+++ b/internal/cli/opsmanager/backup/restores_start.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const (
@@ -72,8 +72,8 @@ func (opts *RestoresStartOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *RestoresStartOpts) newContinuousJobRequest() *atlas.ContinuousJobRequest {
-	request := &atlas.ContinuousJobRequest{SnapshotID: opts.snapshotID}
+func (opts *RestoresStartOpts) newContinuousJobRequest() *opsmngr.ContinuousJobRequest {
+	request := &opsmngr.ContinuousJobRequest{SnapshotID: opts.snapshotID}
 	request.Delivery.MethodName = opts.method
 
 	if opts.isAutomatedRestore() {

--- a/internal/cli/opsmanager/backup/restores_start_test.go
+++ b/internal/cli/opsmanager/backup/restores_start_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestRestoresStart_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockContinuousJobCreator(ctrl)
 
-	expected := &mongodbatlas.ContinuousJobs{}
+	expected := &opsmngr.ContinuousJobs{}
 
 	t.Run(automatedRestore, func(t *testing.T) {
 		listOpts := &RestoresStartOpts{

--- a/internal/cli/opsmanager/backup/snapshots/list_test.go
+++ b/internal/cli/opsmanager/backup/snapshots/list_test.go
@@ -23,14 +23,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockContinuousSnapshotsLister(ctrl)
 
-	expected := &mongodbatlas.ContinuousSnapshots{}
+	expected := &opsmngr.ContinuousSnapshots{}
 
 	clusterID := "5ec2ac941271767f21cbaefe"
 

--- a/internal/cli/opsmanager/clusters/indexes_create.go
+++ b/internal/cli/opsmanager/clusters/indexes_create.go
@@ -104,8 +104,8 @@ func (opts *IndexesCreateOpts) newIndex() (*opsmngr.IndexConfig, error) {
 	return i, nil
 }
 
-func (opts *IndexesCreateOpts) newIndexOptions() *atlas.IndexOptions {
-	return &atlas.IndexOptions{
+func (opts *IndexesCreateOpts) newIndexOptions() *opsmngr.IndexOptions {
+	return &opsmngr.IndexOptions{
 		Sparse: opts.sparse,
 		Name:   opts.name,
 	}

--- a/internal/cli/opsmanager/livemigrations/link/create.go
+++ b/internal/cli/opsmanager/livemigrations/link/create.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 var createTemplate = "Organization link successfully created.\n"
@@ -54,8 +54,8 @@ func (opts *CreateOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *CreateOpts) newCreateLinkRequest() *mongodbatlas.LinkToken {
-	return &mongodbatlas.LinkToken{
+func (opts *CreateOpts) newCreateLinkRequest() *opsmngr.LinkToken {
+	return &opsmngr.LinkToken{
 		LinkToken: opts.linkToken,
 	}
 }

--- a/internal/cli/opsmanager/livemigrations/link/create_test.go
+++ b/internal/cli/opsmanager/livemigrations/link/create_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -39,7 +38,7 @@ func TestLinkCreateOpts_Run(t *testing.T) {
 	}
 
 	mockStore.
-		EXPECT().ConnectOrganizations(createOpts.OrgID, &mongodbatlas.LinkToken{LinkToken: "test"}).Return(&opsmngr.ConnectionStatus{}, nil).
+		EXPECT().ConnectOrganizations(createOpts.OrgID, &opsmngr.LinkToken{LinkToken: "test"}).Return(&opsmngr.ConnectionStatus{}, nil).
 		Times(1)
 
 	if err := createOpts.Run(); err != nil {

--- a/internal/cli/opsmanager/metrics/databases_describe_test.go
+++ b/internal/cli/opsmanager/metrics/databases_describe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDatabasesDescribeOpts_Run(t *testing.T) {
@@ -36,9 +36,9 @@ func TestDatabasesDescribeOpts_Run(t *testing.T) {
 	}
 
 	opts := listOpts.NewProcessMetricsListOptions()
-	expected := &mongodbatlas.ProcessDatabaseMeasurements{
-		ProcessMeasurements: &mongodbatlas.ProcessMeasurements{
-			Measurements: []*mongodbatlas.Measurements{},
+	expected := &opsmngr.ProcessDatabaseMeasurements{
+		ProcessMeasurements: &opsmngr.ProcessMeasurements{
+			Measurements: []*opsmngr.Measurements{},
 		},
 	}
 	mockStore.

--- a/internal/cli/opsmanager/metrics/databases_list_test.go
+++ b/internal/cli/opsmanager/metrics/databases_list_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDatabasesListsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostDatabaseLister(ctrl)
 
-	expected := &mongodbatlas.ProcessDatabasesResponse{}
+	expected := &opsmngr.ProcessDatabasesResponse{}
 
 	listOpts := &DatabasesListsOpts{
 		hostID: "1",

--- a/internal/cli/opsmanager/metrics/disks_describe_test.go
+++ b/internal/cli/opsmanager/metrics/disks_describe_test.go
@@ -21,16 +21,16 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDisksDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostDiskMeasurementsLister(ctrl)
 
-	expected := &mongodbatlas.ProcessDiskMeasurements{
-		ProcessMeasurements: &mongodbatlas.ProcessMeasurements{
-			Measurements: []*mongodbatlas.Measurements{},
+	expected := &opsmngr.ProcessDiskMeasurements{
+		ProcessMeasurements: &opsmngr.ProcessMeasurements{
+			Measurements: []*opsmngr.Measurements{},
 		},
 	}
 

--- a/internal/cli/opsmanager/metrics/disks_list_test.go
+++ b/internal/cli/opsmanager/metrics/disks_list_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDisksListsOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostDisksLister(ctrl)
 
-	expected := &mongodbatlas.ProcessDisksResponse{}
+	expected := &opsmngr.ProcessDisksResponse{}
 
 	listOpts := &DisksListsOpts{
 		hostID: "1",

--- a/internal/cli/opsmanager/metrics/process_test.go
+++ b/internal/cli/opsmanager/metrics/process_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const oneMinute = "PT1M"
@@ -30,7 +30,7 @@ func TestProcess_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockHostMeasurementLister(ctrl)
 
-	expected := &mongodbatlas.ProcessMeasurements{}
+	expected := &opsmngr.ProcessMeasurements{}
 
 	listOpts := &ProcessOpts{
 		hostID: "hard-00-00.mongodb.net",


### PR DESCRIPTION
Another pass at removing some old references to the old SDK