### PR TITLE
CLOUDP-204057: support for vectorSearch

### DIFF
--- a/docs/atlascli/command/atlas-clusters-search-indexes-describe.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-describe.txt
@@ -93,8 +93,8 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION
-   <IndexID>   <Name>   <Database>   <CollectionName>
+   ID          NAME     DATABASE     COLLECTION         TYPE
+   <IndexID>   <Name>   <Database>   <CollectionName>   <Type>
    
 
 Examples

--- a/docs/atlascli/command/atlas-clusters-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-list.txt
@@ -85,7 +85,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION         TYPE{{range .>
+   ID          NAME     DATABASE     COLLECTION         TYPE
    <IndexID>   <Name>   <Database>   <CollectionName>   <Type>
    
 

--- a/docs/atlascli/command/atlas-clusters-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-clusters-search-indexes-list.txt
@@ -78,6 +78,17 @@ Inherited Options
      - false
      - Name of the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID          NAME     DATABASE     COLLECTION         TYPE{{range .>
+   <IndexID>   <Name>   <Database>   <CollectionName>   <Type>
+   
+
 Examples
 --------
 

--- a/docs/atlascli/command/atlas-deployments-list.txt
+++ b/docs/atlascli/command/atlas-deployments-list.txt
@@ -67,7 +67,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   NAME               TYPE     MDB VER            STATE
-   {{range .><Name>   <Type>   <MongoDBVersion>   <StateName>
+   NAME     TYPE     MDB VER            STATE
+   <Name>   <Type>   <MongoDBVersion>   <StateName>
    
 

--- a/docs/atlascli/command/atlas-deployments-search-indexes-describe.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-describe.txt
@@ -95,7 +95,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION         STATUS
-   <IndexID>   <Name>   <Database>   <CollectionName>   <Status>
+   ID          NAME     DATABASE     COLLECTION         STATUS     TYPE
+   <IndexID>   <Name>   <Database>   <CollectionName>   <Status>   <Type>
    
 

--- a/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
@@ -87,7 +87,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION         STATUS     TYPE{{range .>
+   ID          NAME     DATABASE     COLLECTION         STATUS     TYPE
    <IndexID>   <Name>   <Database>   <CollectionName>   <Status>   <Type>
    
 

--- a/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
@@ -87,7 +87,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION         STATUS{{range .>
-   <IndexID>   <Name>   <Database>   <CollectionName>   <Status>
+   ID          NAME     DATABASE     COLLECTION         STATUS     TYPE{{range .>
+   <IndexID>   <Name>   <Database>   <CollectionName>   <Status>   <Type>
    
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-describe.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-describe.txt
@@ -93,8 +93,8 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION
-   <IndexID>   <Name>   <Database>   <CollectionName>
+   ID          NAME     DATABASE     COLLECTION         TYPE
+   <IndexID>   <Name>   <Database>   <CollectionName>   <Type>
    
 
 Examples

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-list.txt
@@ -85,7 +85,7 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID          NAME     DATABASE     COLLECTION         TYPE{{range .>
+   ID          NAME     DATABASE     COLLECTION         TYPE
    <IndexID>   <Name>   <Database>   <CollectionName>   <Type>
    
 

--- a/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-list.txt
+++ b/docs/mongocli/command/mongocli-atlas-clusters-search-indexes-list.txt
@@ -78,6 +78,17 @@ Inherited Options
      - false
      - Name of the profile to use from your configuration file. To learn about profiles for MongoCLI, see https://dochub.mongodb.org/core/atlas-cli-configuration-file.
 
+Output
+------
+
+If the command succeeds, the CLI returns output similar to the following sample. Values in brackets represent your values.
+
+.. code-block::
+
+   ID          NAME     DATABASE     COLLECTION         TYPE{{range .>
+   <IndexID>   <Name>   <Database>   <CollectionName>   <Type>
+   
+
 Examples
 --------
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/klauspost/compress v1.17.2
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mongodb-forks/digest v1.0.5
-	github.com/mongodb-labs/cobra2snooty v0.16.0
+	github.com/mongodb-labs/cobra2snooty v0.17.0
 	github.com/mongodb/mongodb-atlas-kubernetes v1.9.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mongodb-forks/digest v1.0.5 h1:EJu3wtLZcA0HCvsZpX5yuD193/sW9tHiNvrEM5apXMk=
 github.com/mongodb-forks/digest v1.0.5/go.mod h1:rb+EX8zotClD5Dj4NdgxnJXG9nwrlx3NWKJ8xttz1Dg=
-github.com/mongodb-labs/cobra2snooty v0.16.0 h1:+q89WQ6KCBWKaxKoXnVmgpPk7DsIJv2LTcvMqCSgOD4=
-github.com/mongodb-labs/cobra2snooty v0.16.0/go.mod h1:eZYlGRCR9pVAqS6Wwz2eVQ9i3Dy4EtcG8jVkcfFWS7Y=
+github.com/mongodb-labs/cobra2snooty v0.17.0 h1:Os4RpsIHViw2fT6Wk5d5cG/rItRS0c8Za8sKKhw3oc8=
+github.com/mongodb-labs/cobra2snooty v0.17.0/go.mod h1:TgFBJczSy1fdW6HY5ZGQfC9EOlhrD1ZJ9hWRldG5gTI=
 github.com/mongodb/mongodb-atlas-kubernetes v1.9.0 h1:G0W00WwOMf00slHjQG5I6JhQPzN2zAjee1rQJxA9t+w=
 github.com/mongodb/mongodb-atlas-kubernetes v1.9.0/go.mod h1:S7JpgyRq6Asp/PBNFWppwUTwao7EIFgFau3ltpt3rpA=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=

--- a/internal/cli/atlas/deployments/search/indexes/create_test.go
+++ b/internal/cli/atlas/deployments/search/indexes/create_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/internal/mongodbclient"
+	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/test"
 	"github.com/stretchr/testify/assert"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20231115002/admin"
@@ -126,6 +127,7 @@ func TestCreate_RunLocal(t *testing.T) {
 		},
 		Name:           opts.Name,
 		SearchAnalyzer: &opts.SearchAnalyzer,
+		Type:           pointer.Get(search.DefaultType),
 	}
 
 	indexWithID := &atlasv2.ClusterSearchIndex{
@@ -139,6 +141,7 @@ func TestCreate_RunLocal(t *testing.T) {
 		Name:           opts.Name,
 		SearchAnalyzer: &opts.SearchAnalyzer,
 		IndexID:        &indexID,
+		Type:           pointer.Get(search.DefaultType),
 	}
 
 	mockDB.
@@ -308,6 +311,7 @@ func TestCreate_RunAtlas(t *testing.T) {
 		},
 		Name:           opts.Name,
 		SearchAnalyzer: &opts.SearchAnalyzer,
+		Type:           pointer.Get(search.DefaultType),
 	}
 
 	indexWithID := &atlasv2.ClusterSearchIndex{

--- a/internal/cli/atlas/deployments/search/indexes/describe.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe.go
@@ -33,10 +33,6 @@ var describeTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE
 {{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{if .Type}}{{.Type}}{{else}}` + search.DefaultType + `{{end}}
 `
 
-var describeOutputTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{.Type}}
-`
-
 type DescribeOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
@@ -116,7 +112,7 @@ func DescribeBuilder() *cobra.Command {
 		GroupID: "all",
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",
-			"output":      describeOutputTemplate,
+			"output":      describeTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()

--- a/internal/cli/atlas/deployments/search/indexes/describe.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/deployments/options"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli/atlas/search"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/require"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
@@ -28,8 +29,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var describeTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}
+var describeTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{if .Type}}{{.Type}}{{else}}` + search.DefaultType + `{{end}}
+`
+
+var describeOutputTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{.Type}}
 `
 
 type DescribeOpts struct {
@@ -111,7 +116,7 @@ func DescribeBuilder() *cobra.Command {
 		GroupID: "all",
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",
-			"output":      describeTemplate,
+			"output":      describeOutputTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()

--- a/internal/cli/atlas/deployments/search/indexes/describe_test.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe_test.go
@@ -46,6 +46,7 @@ func TestDescribe_RunLocal(t *testing.T) {
 		expectedDB              = "db1"
 		expectedCollection      = "col1"
 		expectedStatus          = "STEADY"
+		expectedType            = "search"
 	)
 
 	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, expectedLocalDeployment)
@@ -111,6 +112,7 @@ func TestDescribe_RunLocal(t *testing.T) {
 		CollectionName: "coll",
 		Database:       "db",
 		Status:         pointer.GetStringPointerIfNotEmpty(expectedStatus),
+		Type:           pointer.GetStringPointerIfNotEmpty(expectedType),
 	}
 
 	mockMongodbClient.
@@ -123,8 +125,8 @@ func TestDescribe_RunLocal(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	assert.Equal(t, `ID     NAME   DATABASE   COLLECTION   STATUS
-test   name   db         coll         STEADY
+	assert.Equal(t, `ID     NAME   DATABASE   COLLECTION   STATUS   TYPE
+test   name   db         coll         STEADY   search
 `, buf.String())
 	t.Log(buf.String())
 }

--- a/internal/cli/atlas/deployments/search/indexes/list.go
+++ b/internal/cli/atlas/deployments/search/indexes/list.go
@@ -29,8 +29,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS{{range .}}
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}{{end}}
+var listTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE{{range .}}
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{if .Type}}{{.Type}}{{else}}` + search.DefaultType + `{{end}}{{end}}
+`
+
+var listOutputTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE{{range .}}
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{.Type}}{{end}}
 `
 
 type ListOpts struct {
@@ -121,7 +125,7 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		GroupID: "all",
 		Annotations: map[string]string{
-			"output": listTemplate,
+			"output": listOutputTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()

--- a/internal/cli/atlas/deployments/search/indexes/list.go
+++ b/internal/cli/atlas/deployments/search/indexes/list.go
@@ -33,10 +33,6 @@ var listTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE{{range .}}
 {{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{if .Type}}{{.Type}}{{else}}` + search.DefaultType + `{{end}}{{end}}
 `
 
-var listOutputTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE{{range .}}
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{.Type}}{{end}}
-`
-
 type ListOpts struct {
 	cli.GlobalOpts
 	cli.OutputOpts
@@ -125,7 +121,7 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		GroupID: "all",
 		Annotations: map[string]string{
-			"output": listOutputTemplate,
+			"output": listTemplate,
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()

--- a/internal/cli/atlas/deployments/search/indexes/list_test.go
+++ b/internal/cli/atlas/deployments/search/indexes/list_test.go
@@ -49,6 +49,7 @@ func TestList_RunLocal(t *testing.T) {
 		expectedName            = "test"
 		expectedID              = "1"
 		expectedStatus          = "STEADY"
+		expectedType            = "search"
 	)
 
 	buf := new(bytes.Buffer)
@@ -123,6 +124,7 @@ func TestList_RunLocal(t *testing.T) {
 			CollectionName: expectedCollection,
 			Database:       expectedDB,
 			Status:         pointer.GetStringPointerIfNotEmpty(expectedStatus),
+			Type:           pointer.GetStringPointerIfNotEmpty(expectedType),
 		},
 	}
 
@@ -136,9 +138,9 @@ func TestList_RunLocal(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 
-	assert.Equal(t, fmt.Sprintf(`ID    NAME   DATABASE   COLLECTION   STATUS
-%s     %s   %s        %s         %s
-`, expectedID, expectedName, expectedDB, expectedCollection, expectedStatus), buf.String())
+	assert.Equal(t, fmt.Sprintf(`ID    NAME   DATABASE   COLLECTION   STATUS   TYPE
+%s     %s   %s        %s         %s   %s
+`, expectedID, expectedName, expectedDB, expectedCollection, expectedStatus, expectedType), buf.String())
 	t.Log(buf.String())
 }
 

--- a/internal/cli/atlas/search/describe.go
+++ b/internal/cli/atlas/search/describe.go
@@ -44,8 +44,11 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-var describeTemplate = `ID	NAME	DATABASE	COLLECTION
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}
+var describeTemplate = `ID	NAME	DATABASE	COLLECTION	TYPE
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{if .Type }}{{.Type}}{{else}}` + DefaultType + `{{end}}
+`
+var describeOutputTemplate = `ID	NAME	DATABASE	COLLECTION	TYPE
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Type}}
 `
 
 func (opts *DescribeOpts) Run() error {
@@ -67,7 +70,7 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",
-			"output":      describeTemplate,
+			"output":      describeOutputTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the search index with the ID 5f1f40842f2ac35f49190c20 for the cluster named myCluster:
   %s clusters search indexes describe 5f1f40842f2ac35f49190c20 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/search/describe.go
+++ b/internal/cli/atlas/search/describe.go
@@ -47,9 +47,6 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 var describeTemplate = `ID	NAME	DATABASE	COLLECTION	TYPE
 {{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{if .Type }}{{.Type}}{{else}}` + DefaultType + `{{end}}
 `
-var describeOutputTemplate = `ID	NAME	DATABASE	COLLECTION	TYPE
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Type}}
-`
 
 func (opts *DescribeOpts) Run() error {
 	r, err := opts.store.SearchIndex(opts.ConfigProjectID(), opts.clusterName, opts.indexID)
@@ -70,7 +67,7 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"indexIdDesc": "ID of the index.",
-			"output":      describeOutputTemplate,
+			"output":      describeTemplate,
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the search index with the ID 5f1f40842f2ac35f49190c20 for the cluster named myCluster:
   %s clusters search indexes describe 5f1f40842f2ac35f49190c20 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/search/list.go
+++ b/internal/cli/atlas/search/list.go
@@ -48,9 +48,6 @@ func (opts *ListOpts) initStore(ctx context.Context) func() error {
 var listTemplate = `ID	NAME	DATABASE	COLLECTION	TYPE{{range .}}
 {{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{if .Type }}{{.Type}}{{else}}` + DefaultType + `{{end}}{{end}}
 `
-var listOutputTemplate = `ID	NAME	DATABASE	COLLECTION	TYPE{{range .}}
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Type}}{{end}}
-`
 
 func (opts *ListOpts) Run() error {
 	r, err := opts.store.SearchIndexes(opts.ConfigProjectID(), opts.clusterName, opts.dbName, opts.collName)
@@ -69,7 +66,7 @@ func ListBuilder() *cobra.Command {
 		Short: "List all Atlas Search indexes for a cluster.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Read/Write"),
 		Annotations: map[string]string{
-			"output": listOutputTemplate,
+			"output": listTemplate,
 		},
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,

--- a/internal/cli/atlas/search/list.go
+++ b/internal/cli/atlas/search/list.go
@@ -45,8 +45,11 @@ func (opts *ListOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-var listTemplate = `ID	NAME	DATABASE	COLLECTION{{range .}}
-{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}{{end}}
+var listTemplate = `ID	NAME	DATABASE	COLLECTION	TYPE{{range .}}
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{if .Type }}{{.Type}}{{else}}` + DefaultType + `{{end}}{{end}}
+`
+var listOutputTemplate = `ID	NAME	DATABASE	COLLECTION	TYPE{{range .}}
+{{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Type}}{{end}}
 `
 
 func (opts *ListOpts) Run() error {
@@ -62,9 +65,12 @@ func (opts *ListOpts) Run() error {
 func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{
-		Use:     "list",
-		Short:   "List all Atlas Search indexes for a cluster.",
-		Long:    fmt.Sprintf(usage.RequiredRole, "Project Data Access Read/Write"),
+		Use:   "list",
+		Short: "List all Atlas Search indexes for a cluster.",
+		Long:  fmt.Sprintf(usage.RequiredRole, "Project Data Access Read/Write"),
+		Annotations: map[string]string{
+			"output": listOutputTemplate,
+		},
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the JSON-formatted list of Atlas search indexes on the sample_mflix.movies database in the cluster named myCluster:

--- a/internal/mongodbclient/search_index.go
+++ b/internal/mongodbclient/search_index.go
@@ -70,7 +70,7 @@ func (o *database) CreateSearchIndex(ctx context.Context, collection string, idx
 	}
 
 	// Empty these fields so that they are not included into the index definition for the MongoDB command
-	index = removeFields(index, "id", "collectionName", "database")
+	index = removeFields(index, "id", "collectionName", "database", "type")
 
 	indexCommand := bson.D{
 		{


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Add support for vectorSearch in atlas clusters search indexes create and atlas deployments search indexes create

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-204057

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
