### PR TITLE
CLOUDP-212880: local dev - add support for auth and --bindIpAll flag

### DIFF
--- a/docs/atlascli/command/atlas-deployments-search-indexes-create.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-create.txt
@@ -81,6 +81,10 @@ Options
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
+   * - --password
+     - string
+     - false
+     - Password for the user.
    * - --projectId
      - string
      - false
@@ -89,6 +93,10 @@ Options
      - string
      - false
      - Type of deployment that you want to create. Valid values are ATLAS or LOCAL.
+   * - --username
+     - string
+     - false
+     - Username for authenticating to MongoDB.
    * - -w, --watch
      - 
      - false

--- a/docs/atlascli/command/atlas-deployments-search-indexes-delete.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-delete.txt
@@ -67,6 +67,10 @@ Options
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
+   * - --password
+     - string
+     - false
+     - Password for the user.
    * - --projectId
      - string
      - false
@@ -75,6 +79,10 @@ Options
      - string
      - false
      - Type of deployment that you want to create. Valid values are ATLAS or LOCAL.
+   * - --username
+     - string
+     - false
+     - Username for authenticating to MongoDB.
 
 Inherited Options
 -----------------

--- a/docs/atlascli/command/atlas-deployments-search-indexes-describe.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-describe.txt
@@ -63,6 +63,10 @@ Options
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
+   * - --password
+     - string
+     - false
+     - Password for the user.
    * - --projectId
      - string
      - false
@@ -71,6 +75,10 @@ Options
      - string
      - false
      - Type of deployment that you want to create. Valid values are ATLAS or LOCAL.
+   * - --username
+     - string
+     - false
+     - Username for authenticating to MongoDB.
 
 Inherited Options
 -----------------

--- a/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
+++ b/docs/atlascli/command/atlas-deployments-search-indexes-list.txt
@@ -55,6 +55,10 @@ Options
      - string
      - false
      - Output format. Valid values are json, json-path, go-template, or go-template-file. To see full output, use the -o json option.
+   * - --password
+     - string
+     - false
+     - Password for the user.
    * - --projectId
      - string
      - false
@@ -63,6 +67,10 @@ Options
      - string
      - false
      - Type of deployment that you want to create. Valid values are ATLAS or LOCAL.
+   * - --username
+     - string
+     - false
+     - Username for authenticating to MongoDB.
 
 Inherited Options
 -----------------

--- a/docs/atlascli/command/atlas-deployments-setup.txt
+++ b/docs/atlascli/command/atlas-deployments-setup.txt
@@ -60,7 +60,7 @@ Options
    * - --bindIpAll
      - 
      - false
-     - Flag that indicates whether the port binding should happen for all IPs or only for the localhost interface 127.0.0.1.
+     - Flag that indicates whether the LOCAL deployment port binding should happen for all IPs or only for the localhost interface 127.0.0.1.
    * - --connectWith
      - string
      - false

--- a/docs/atlascli/command/atlas-deployments-setup.txt
+++ b/docs/atlascli/command/atlas-deployments-setup.txt
@@ -57,6 +57,10 @@ Options
      - IP address to grant access to the deployment.
 
        Mutually exclusive with --currentIp.
+   * - --bindIpAll
+     - 
+     - false
+     - Flag that indicates whether the port binding should happen for all IPs or only for the localhost interface 127.0.0.1.
    * - --connectWith
      - string
      - false

--- a/internal/cli/atlas/deployments/connect.go
+++ b/internal/cli/atlas/deployments/connect.go
@@ -58,8 +58,8 @@ func ConnectBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ConnectWith, flag.ConnectWith, "", usage.ConnectWith)
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVar(&opts.DeploymentType, flag.TypeFlag, "", usage.DeploymentType)
-	cmd.Flags().StringVar(&opts.DBUsername, flag.Username, "", usage.DBUsername)
-	cmd.Flags().StringVar(&opts.DBUserPassword, flag.Password, "", usage.Password)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUsername, flag.Username, "", usage.DBUsername)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUserPassword, flag.Password, "", usage.Password)
 	cmd.Flags().StringVar(&opts.ConnectionStringType, flag.ConnectionStringType, options.ConnectionStringTypeStandard, usage.ConnectionStringType)
 
 	_ = cmd.RegisterFlagCompletionFunc(flag.ConnectWith, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cli/atlas/deployments/options/connect_opts_atlas.go
+++ b/internal/cli/atlas/deployments/options/connect_opts_atlas.go
@@ -29,8 +29,6 @@ import (
 type ConnectToAtlasOpts struct {
 	cli.GlobalOpts
 	cli.InputOpts
-	DBUsername           string
-	DBUserPassword       string
 	ConnectionStringType string
 	Store                store.AtlasClusterDescriber
 }
@@ -45,13 +43,13 @@ func (opts *ConnectToAtlasOpts) InitAtlasStore(ctx context.Context) func() error
 
 func (opts *ConnectOpts) validateAndPromptAtlasOpts() error {
 	requiresAuth := opts.ConnectWith == MongoshConnect || opts.ConnectWith == CompassConnect
-	if requiresAuth && opts.DBUsername == "" {
+	if requiresAuth && opts.DeploymentOpts.DBUsername == "" {
 		if err := opts.promptDBUsername(); err != nil {
 			return err
 		}
 	}
 
-	if requiresAuth && opts.DBUserPassword == "" {
+	if requiresAuth && opts.DeploymentOpts.DBUserPassword == "" {
 		if err := opts.promptDBUserPassword(); err != nil {
 			return err
 		}
@@ -79,25 +77,6 @@ func (opts *ConnectToAtlasOpts) validateAndPromptConnectionStringType() error {
 	}
 
 	return nil
-}
-
-func (opts *ConnectToAtlasOpts) promptDBUsername() error {
-	p := &survey.Input{
-		Message: "Username for authenticating to MongoDB deployment",
-	}
-	return telemetry.TrackAskOne(p, &opts.DBUsername)
-}
-
-func (opts *ConnectToAtlasOpts) promptDBUserPassword() error {
-	if !opts.IsTerminalInput() {
-		_, err := fmt.Fscanln(opts.InReader, &opts.DBUserPassword)
-		return err
-	}
-
-	p := &survey.Password{
-		Message: "Password for authenticating to MongoDB deployment",
-	}
-	return telemetry.TrackAskOne(p, &opts.DBUserPassword)
 }
 
 func (opts *ConnectOpts) connectToAtlas() error {

--- a/internal/cli/atlas/deployments/options/deployment_opts.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts.go
@@ -88,6 +88,8 @@ type DeploymentOpts struct {
 	DeploymentType        string
 	MdbVersion            string
 	Port                  int
+	AdminUsername         string
+	AdminUserPassword     string
 	PodmanClient          podman.Client
 	CredStore             store.CredentialsGetter
 	s                     *spinner.Spinner

--- a/internal/cli/atlas/deployments/options/deployment_opts.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts.go
@@ -252,3 +252,7 @@ func (opts *DeploymentOpts) IsLocalDeploymentType() bool {
 func (opts *DeploymentOpts) NoDeploymentTypeSet() bool {
 	return strings.EqualFold(opts.DeploymentType, "")
 }
+
+func (opts *DeploymentOpts) IsAuthEnabled() bool {
+	return opts.AdminUsername != ""
+}

--- a/internal/cli/atlas/deployments/options/deployment_opts.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts.go
@@ -88,8 +88,8 @@ type DeploymentOpts struct {
 	DeploymentType        string
 	MdbVersion            string
 	Port                  int
-	AdminUsername         string
-	AdminUserPassword     string
+	DBUsername            string
+	DBUserPassword        string
 	PodmanClient          podman.Client
 	CredStore             store.CredentialsGetter
 	s                     *spinner.Spinner
@@ -254,5 +254,5 @@ func (opts *DeploymentOpts) NoDeploymentTypeSet() bool {
 }
 
 func (opts *DeploymentOpts) IsAuthEnabled() bool {
-	return opts.AdminUsername != ""
+	return opts.DBUsername != ""
 }

--- a/internal/cli/atlas/deployments/options/deployment_opts_connect_string.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts_connect_string.go
@@ -42,7 +42,7 @@ func (opts *DeploymentOpts) ConnectionString(ctx context.Context) (string, error
 		}
 		opts.updateFields(c)
 	}
-	if opts.AdminUsername != "" {
+	if opts.IsAuthEnabled() {
 		return fmt.Sprintf("mongodb://%s:%s@localhost:%d/?directConnection=true",
 			url.QueryEscape(opts.AdminUsername),
 			url.QueryEscape(opts.AdminUserPassword),

--- a/internal/cli/atlas/deployments/options/deployment_opts_connect_string.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts_connect_string.go
@@ -17,6 +17,7 @@ package options
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strconv"
 
 	"github.com/containers/podman/v4/libpod/define"
@@ -41,5 +42,13 @@ func (opts *DeploymentOpts) ConnectionString(ctx context.Context) (string, error
 		}
 		opts.updateFields(c)
 	}
+	if opts.AdminUsername != "" {
+		return fmt.Sprintf("mongodb://%s:%s@localhost:%d/?directConnection=true",
+			url.QueryEscape(opts.AdminUsername),
+			url.QueryEscape(opts.AdminUserPassword),
+			opts.Port,
+		), nil
+	}
+
 	return fmt.Sprintf("mongodb://localhost:%d/?directConnection=true", opts.Port), nil
 }

--- a/internal/cli/atlas/deployments/options/deployment_opts_connect_string.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts_connect_string.go
@@ -44,8 +44,8 @@ func (opts *DeploymentOpts) ConnectionString(ctx context.Context) (string, error
 	}
 	if opts.IsAuthEnabled() {
 		return fmt.Sprintf("mongodb://%s:%s@localhost:%d/?directConnection=true",
-			url.QueryEscape(opts.AdminUsername),
-			url.QueryEscape(opts.AdminUserPassword),
+			url.QueryEscape(opts.DBUsername),
+			url.QueryEscape(opts.DBUserPassword),
 			opts.Port,
 		), nil
 	}

--- a/internal/cli/atlas/deployments/scripts/start_mongod.sh
+++ b/internal/cli/atlas/deployments/scripts/start_mongod.sh
@@ -32,7 +32,7 @@ then
             --setParameter "searchIndexManagementHostAndPort=$MONGOTHOST"
 else
     python3 /usr/local/bin/docker-entrypoint.py \
-            --transitionToAuth
+            --transitionToAuth \
             --dbpath "$DBPATH" \
             --keyFile "$KEYFILE" \
             --replSet "$REPLSETNAME" \

--- a/internal/cli/atlas/deployments/scripts/start_mongod.sh
+++ b/internal/cli/atlas/deployments/scripts/start_mongod.sh
@@ -20,11 +20,23 @@ then
     chmod 400 "$KEYFILE"
 fi
 
-python3 /usr/local/bin/docker-entrypoint.py \
-        --transitionToAuth \
-        --dbpath "$DBPATH" \
-        --keyFile "$KEYFILE" \
-        --replSet "$REPLSETNAME" \
-        --maxConns "$MAXCONNS" \
-        --setParameter "mongotHost=$MONGOTHOST" \
-        --setParameter "searchIndexManagementHostAndPort=$MONGOTHOST"
+
+if [ -n "$MONGODB_INITDB_ROOT_USERNAME" ] # auth enabled
+then
+    python3 /usr/local/bin/docker-entrypoint.py \
+            --dbpath "$DBPATH" \
+            --keyFile "$KEYFILE" \
+            --replSet "$REPLSETNAME" \
+            --maxConns "$MAXCONNS" \
+            --setParameter "mongotHost=$MONGOTHOST" \
+            --setParameter "searchIndexManagementHostAndPort=$MONGOTHOST"
+else
+    python3 /usr/local/bin/docker-entrypoint.py \
+            --transitionToAuth
+            --dbpath "$DBPATH" \
+            --keyFile "$KEYFILE" \
+            --replSet "$REPLSETNAME" \
+            --maxConns "$MAXCONNS" \
+            --setParameter "mongotHost=$MONGOTHOST" \
+            --setParameter "searchIndexManagementHostAndPort=$MONGOTHOST"
+fi

--- a/internal/cli/atlas/deployments/search/indexes/create.go
+++ b/internal/cli/atlas/deployments/search/indexes/create.go
@@ -283,6 +283,8 @@ func CreateBuilder() *cobra.Command {
 	// Local only
 	cmd.Flags().BoolVarP(&opts.EnableWatch, flag.EnableWatch, flag.EnableWatchShort, false, usage.EnableWatch)
 	cmd.Flags().UintVar(&opts.Timeout, flag.WatchTimeout, 0, usage.WatchTimeout)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUsername, flag.Username, "", usage.DBUsername)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUserPassword, flag.Password, "", usage.Password)
 
 	// Atlas only
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)

--- a/internal/cli/atlas/deployments/search/indexes/delete.go
+++ b/internal/cli/atlas/deployments/search/indexes/delete.go
@@ -133,6 +133,8 @@ func DeleteBuilder() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.Confirm, flag.Force, false, usage.Force)
 	cmd.Flags().StringVar(&opts.DeploymentType, flag.TypeFlag, "", usage.DeploymentType)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUsername, flag.Username, "", usage.DBUsername)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUserPassword, flag.Password, "", usage.Password)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/atlas/deployments/search/indexes/describe.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe.go
@@ -133,6 +133,8 @@ func DescribeBuilder() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.DeploymentType, flag.TypeFlag, "", usage.DeploymentType)
 	cmd.Flags().StringVar(&opts.DeploymentName, flag.DeploymentName, "", usage.DeploymentName)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUsername, flag.Username, "", usage.DBUsername)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUserPassword, flag.Password, "", usage.Password)
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 

--- a/internal/cli/atlas/deployments/search/indexes/list.go
+++ b/internal/cli/atlas/deployments/search/indexes/list.go
@@ -141,6 +141,8 @@ func ListBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DeploymentType, flag.TypeFlag, "", usage.DeploymentType)
 	cmd.Flags().StringVar(&opts.DBName, flag.Database, "", usage.Database)
 	cmd.Flags().StringVar(&opts.Collection, flag.Collection, "", usage.Collection)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUsername, flag.Username, "", usage.DBUsername)
+	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUserPassword, flag.Password, "", usage.Password)
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -99,6 +99,7 @@ type SetupOpts struct {
 	settings      string
 	connectWith   string
 	force         bool
+	bindAllIPs    bool
 	mongodIP      string
 	mongotIP      string
 	s             *spinner.Spinner
@@ -297,8 +298,9 @@ func (opts *SetupOpts) configureMongod(ctx context.Context, keyFileContents stri
 			Ports: map[int]int{
 				opts.Port: internalMongodPort,
 			},
-			Network: opts.LocalNetworkName(),
-			IP:      opts.mongodIP,
+			BindAllIPs: opts.bindAllIPs,
+			Network:    opts.LocalNetworkName(),
+			IP:         opts.mongodIP,
 			// wrap the entrypoint with a chain of commands that
 			// creates the keyfile in the container and sets the 400 permissions for it,
 			// then starts the entrypoint with the local dev config
@@ -769,6 +771,8 @@ func SetupBuilder() *cobra.Command {
 
 	// Local only
 	cmd.Flags().IntVar(&opts.Port, flag.Port, 0, usage.MongodPort)
+	cmd.Flags().BoolVar(&opts.bindAllIPs, flag.BindAllIPs, false, usage.BindAllIPs)
+	_ = cmd.Flags().MarkHidden(flag.BindAllIPs)
 
 	// Atlas only
 	opts.atlasSetup.SetupAtlasFlags(cmd)

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -553,7 +553,7 @@ func (opts *SetupOpts) validateDeploymentTypeFlag() error {
 		return errFlagTypeRequired
 	}
 
-	if opts.IsLocalDeploymentType() && opts.bindIPAll {
+	if !opts.IsLocalDeploymentType() && opts.bindIPAll {
 		return errIncompatibleDeploymentType
 	}
 

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -388,8 +388,8 @@ func (opts *SetupOpts) initReplicaSet(ctx context.Context, adminDB mongodbclient
 
 func (opts *SetupOpts) createAdminUser(ctx context.Context, db mongodbclient.Database) error {
 	return db.CreateUser(ctx,
-		opts.AdminUsername,
-		opts.AdminUserPassword,
+		opts.DBUsername,
+		opts.DBUserPassword,
 		[]string{"userAdminAnyDatabase", "readWriteAnyDatabase"},
 	)
 }
@@ -569,11 +569,11 @@ func (opts *SetupOpts) validateBindIPAllFlag() error {
 		return nil
 	}
 
-	if opts.force && (opts.DeploymentType == "" || opts.AdminUsername == "" || opts.AdminUserPassword == "") {
+	if opts.force && (opts.DeploymentType == "" || opts.DBUsername == "" || opts.DBUserPassword == "") {
 		return errFlagsTypeAndAuthRequired
 	}
 
-	if opts.AdminUsername == "" {
+	if opts.DBUsername == "" {
 		return errFlagUsernameRequired
 	}
 
@@ -610,14 +610,14 @@ func (opts *SetupOpts) validateFlags() error {
 
 func (opts *SetupOpts) promptLocalAdminPassword() error {
 	if !opts.IsTerminalInput() {
-		_, err := fmt.Fscanln(opts.InReader, &opts.AdminUserPassword)
+		_, err := fmt.Fscanln(opts.InReader, &opts.DBUserPassword)
 		return err
 	}
 
 	p := &survey.Password{
 		Message: "Password for authenticating to local deployment",
 	}
-	return telemetry.TrackAskOne(p, &opts.AdminUserPassword)
+	return telemetry.TrackAskOne(p, &opts.DBUserPassword)
 }
 
 func (opts *SetupOpts) setDefaultSettings() error {
@@ -719,7 +719,7 @@ func (opts *SetupOpts) validateAndPrompt() error {
 		return nil
 	}
 
-	if opts.AdminUsername != "" && opts.AdminUserPassword == "" {
+	if opts.DBUsername != "" && opts.DBUserPassword == "" {
 		if err := opts.promptLocalAdminPassword(); err != nil {
 			return err
 		}
@@ -841,8 +841,8 @@ func SetupBuilder() *cobra.Command {
 			}
 
 			opts.force = opts.atlasSetup.Confirm
-			opts.AdminUsername = opts.atlasSetup.DBUsername
-			opts.AdminUserPassword = opts.atlasSetup.DBUserPassword
+			opts.DBUsername = opts.atlasSetup.DBUsername
+			opts.DBUserPassword = opts.atlasSetup.DBUserPassword
 
 			return opts.PreRunE(
 				opts.InitOutput(cmd.OutOrStdout(), ""),

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -371,4 +371,5 @@ const (
 	ConnectionStringType                      = "connectionStringType"                      // ConnectionStringType flag
 	Decompress                                = "decompress"                                // Decompress flag
 	DecompressShort                           = "d"                                         // DecompressShort flag
+	BindAllIPs                                = "bindAllIPs"                                // BindAllIPs flag
 )

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -371,5 +371,5 @@ const (
 	ConnectionStringType                      = "connectionStringType"                      // ConnectionStringType flag
 	Decompress                                = "decompress"                                // Decompress flag
 	DecompressShort                           = "d"                                         // DecompressShort flag
-	BindAllIPs                                = "bindAllIPs"                                // BindAllIPs flag
+	BindIpAll                                 = "bindIpAll"                                 // BindIpAll flag
 )

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -371,5 +371,5 @@ const (
 	ConnectionStringType                      = "connectionStringType"                      // ConnectionStringType flag
 	Decompress                                = "decompress"                                // Decompress flag
 	DecompressShort                           = "d"                                         // DecompressShort flag
-	BindIpAll                                 = "bindIpAll"                                 // BindIpAll flag
+	BindIPAll                                 = "bindIpAll"                                 // BindIpAll flag
 )

--- a/internal/mocks/mock_mongodb_client.go
+++ b/internal/mocks/mock_mongodb_client.go
@@ -157,6 +157,34 @@ func (mr *MockDatabaseMockRecorder) CreateSearchIndex(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSearchIndex", reflect.TypeOf((*MockDatabase)(nil).CreateSearchIndex), arg0, arg1, arg2)
 }
 
+// CreateUser mocks base method.
+func (m *MockDatabase) CreateUser(arg0 context.Context, arg1, arg2 string, arg3 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateUser", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateUser indicates an expected call of CreateUser.
+func (mr *MockDatabaseMockRecorder) CreateUser(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockDatabase)(nil).CreateUser), arg0, arg1, arg2, arg3)
+}
+
+// DropUser mocks base method.
+func (m *MockDatabase) DropUser(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DropUser", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DropUser indicates an expected call of DropUser.
+func (mr *MockDatabaseMockRecorder) DropUser(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropUser", reflect.TypeOf((*MockDatabase)(nil).DropUser), arg0, arg1)
+}
+
 // InitiateReplicaSet mocks base method.
 func (m *MockDatabase) InitiateReplicaSet(arg0 context.Context, arg1, arg2 string, arg3, arg4 int) error {
 	m.ctrl.T.Helper()

--- a/internal/mongodbclient/database.go
+++ b/internal/mongodbclient/database.go
@@ -27,6 +27,7 @@ type Database interface {
 	InsertOne(ctx context.Context, collection string, doc interface{}) (interface{}, error)
 	InitiateReplicaSet(ctx context.Context, rsName string, hostname string, internalPort int, externalPort int) error
 	SearchIndex
+	User
 	Collection(string) Collection
 }
 

--- a/internal/mongodbclient/user.go
+++ b/internal/mongodbclient/user.go
@@ -1,0 +1,52 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbclient
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type User interface {
+	CreateUser(ctx context.Context, username, password string, roles []string) error
+	DropUser(ctx context.Context, username string) error
+}
+
+func (o *database) CreateUser(ctx context.Context, username, password string, roles []string) error {
+	rolesDoc := bson.A{}
+	for _, r := range roles {
+		rolesDoc = append(rolesDoc, bson.D{
+			{Key: "role", Value: r},
+			{Key: "db", Value: o.db.Name()},
+		})
+	}
+
+	return o.db.Client().
+		Database("admin").
+		RunCommand(ctx, bson.D{
+			{Key: "createUser", Value: username},
+			{Key: "pwd", Value: password},
+			{Key: "roles", Value: rolesDoc},
+		}).Err()
+}
+
+func (o *database) DropUser(ctx context.Context, username string) error {
+	return o.db.Client().
+		Database("admin").
+		RunCommand(ctx, bson.D{
+			{Key: "dropUser", Value: username},
+		}).Err()
+}

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -72,6 +72,7 @@ type RunContainerOpts struct {
 	Volumes map[string]string
 	// map[hostPort, containerPort]
 	Ports      map[int]int
+	BindAllIPs bool
 	Network    string
 	EnvVars    map[string]string
 	Args       []string
@@ -360,7 +361,11 @@ func (o *client) RunContainer(ctx context.Context, opts RunContainerOpts) ([]byt
 	}
 
 	for hostPort, containerPort := range opts.Ports {
-		arg = append(arg, "-p", "127.0.0.1:"+strconv.Itoa(hostPort)+":"+strconv.Itoa(containerPort))
+		portMapping := strconv.Itoa(hostPort) + ":" + strconv.Itoa(containerPort)
+		if !opts.BindAllIPs {
+			portMapping = "127.0.0.1:" + portMapping
+		}
+		arg = append(arg, "-p", portMapping)
 	}
 
 	for envVar, value := range opts.EnvVars {

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -72,7 +72,7 @@ type RunContainerOpts struct {
 	Volumes map[string]string
 	// map[hostPort, containerPort]
 	Ports      map[int]int
-	BindIpAll  bool
+	BindIPAll  bool
 	Network    string
 	EnvVars    map[string]string
 	Args       []string
@@ -362,7 +362,7 @@ func (o *client) RunContainer(ctx context.Context, opts RunContainerOpts) ([]byt
 
 	for hostPort, containerPort := range opts.Ports {
 		portMapping := strconv.Itoa(hostPort) + ":" + strconv.Itoa(containerPort)
-		if !opts.BindIpAll {
+		if !opts.BindIPAll {
 			portMapping = "127.0.0.1:" + portMapping
 		}
 		arg = append(arg, "-p", portMapping)

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -72,7 +72,7 @@ type RunContainerOpts struct {
 	Volumes map[string]string
 	// map[hostPort, containerPort]
 	Ports      map[int]int
-	BindAllIPs bool
+	BindIpAll  bool
 	Network    string
 	EnvVars    map[string]string
 	Args       []string
@@ -362,7 +362,7 @@ func (o *client) RunContainer(ctx context.Context, opts RunContainerOpts) ([]byt
 
 	for hostPort, containerPort := range opts.Ports {
 		portMapping := strconv.Itoa(hostPort) + ":" + strconv.Itoa(containerPort)
-		if !opts.BindAllIPs {
+		if !opts.BindIpAll {
 			portMapping = "127.0.0.1:" + portMapping
 		}
 		arg = append(arg, "-p", portMapping)

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -471,5 +471,5 @@ dbName and collection are required only for built-in roles.`
 	requiredForAtlas                          = "Required when creating organizations authenticated with API Keys."
 	Decompress                                = "Flag that indicates whether to decompress the log files."
 	OnlineArchiveFilename                     = "Path to an optional JSON configuration file that defines online archive settings. To learn more about configuration files for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-json-online-archive-config."
-	BindAllIPs                                = "Flag that indicates whether the port binding should happen for all IPs or only for the localhost interface of the host (127.0.0.1)."
+	BindIpAll                                 = "Flag that indicates whether the port binding should happen for all IPs or only for the localhost interface 127.0.0.1."
 )

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -471,4 +471,5 @@ dbName and collection are required only for built-in roles.`
 	requiredForAtlas                          = "Required when creating organizations authenticated with API Keys."
 	Decompress                                = "Flag that indicates whether to decompress the log files."
 	OnlineArchiveFilename                     = "Path to an optional JSON configuration file that defines online archive settings. To learn more about configuration files for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-json-online-archive-config."
+	BindAllIPs                                = "Flag that indicates whether the port binding should happen for all IPs or only for the localhost interface of the host (127.0.0.1)."
 )

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -471,5 +471,5 @@ dbName and collection are required only for built-in roles.`
 	requiredForAtlas                          = "Required when creating organizations authenticated with API Keys."
 	Decompress                                = "Flag that indicates whether to decompress the log files."
 	OnlineArchiveFilename                     = "Path to an optional JSON configuration file that defines online archive settings. To learn more about configuration files for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-json-online-archive-config."
-	BindIpAll                                 = "Flag that indicates whether the port binding should happen for all IPs or only for the localhost interface 127.0.0.1."
+	BindIpAll                                 = "Flag that indicates whether the LOCAL deployment port binding should happen for all IPs or only for the localhost interface 127.0.0.1."
 )

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -471,5 +471,5 @@ dbName and collection are required only for built-in roles.`
 	requiredForAtlas                          = "Required when creating organizations authenticated with API Keys."
 	Decompress                                = "Flag that indicates whether to decompress the log files."
 	OnlineArchiveFilename                     = "Path to an optional JSON configuration file that defines online archive settings. To learn more about configuration files for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-json-online-archive-config."
-	BindIpAll                                 = "Flag that indicates whether the LOCAL deployment port binding should happen for all IPs or only for the localhost interface 127.0.0.1."
+	BindIPAll                                 = "Flag that indicates whether the LOCAL deployment port binding should happen for all IPs or only for the localhost interface 127.0.0.1."
 )

--- a/test/e2e/atlas/deployments_local_test.go
+++ b/test/e2e/atlas/deployments_local_test.go
@@ -406,7 +406,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		req.NoError(err, e)
 
 		outputLines := strings.Split(o, "\n")
-		req.Equal(`NAME      TYPE    MDB VER   STATE`, outputLines[0])
+		req.Equal(`NAME        TYPE    MDB VER   STATE`, outputLines[0])
 
 		cols := strings.Fields(outputLines[1])
 		req.Equal(deploymentName, cols[0])

--- a/test/e2e/atlas/deployments_local_test.go
+++ b/test/e2e/atlas/deployments_local_test.go
@@ -406,7 +406,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		req.NoError(err, e)
 
 		outputLines := strings.Split(o, "\n")
-		req.Equal(`NAME   TYPE    MDB VER   STATE`, outputLines[0])
+		req.Equal(`NAME      TYPE    MDB VER   STATE`, outputLines[0])
 
 		cols := strings.Fields(outputLines[1])
 		req.Equal(deploymentName, cols[0])

--- a/test/e2e/atlas/deployments_local_test.go
+++ b/test/e2e/atlas/deployments_local_test.go
@@ -324,3 +324,313 @@ func TestDeploymentsLocal(t *testing.T) {
 		a.Contains(out, fmt.Sprintf("Starting deployment '%s'", deploymentName))
 	})
 }
+
+func TestDeploymentsLocalWithAuth(t *testing.T) {
+	g := newAtlasE2ETestGenerator(t)
+	g.generateProject("auth_deployment")
+
+	cliPath, err := e2e.AtlasCLIBin()
+	req := require.New(t)
+	req.NoError(err)
+
+	dbUsername := "admin"
+	dbUserPassword := "testpwd"
+
+	t.Run("Setup", func(t *testing.T) {
+		defer func(t *testing.T) {
+			t.Helper()
+			cmd := exec.Command(cliPath,
+				deploymentEntity,
+				"diagnostics",
+				deploymentName,
+			)
+
+			cmd.Env = os.Environ()
+
+			r, errDiag := cmd.CombinedOutput()
+			t.Log("Diagnostics")
+			t.Log(errDiag, string(r))
+		}(t)
+
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			"setup",
+			deploymentName,
+			"--type",
+			"local",
+			"--username",
+			dbUsername,
+			"--password",
+			dbUserPassword,
+			"--bindIpAll",
+			"--force",
+		)
+
+		cmd.Env = os.Environ()
+
+		r, setupErr := cmd.CombinedOutput()
+		req.NoError(setupErr, string(r))
+	})
+
+	t.Cleanup(func() {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			"delete",
+			deploymentName,
+			"--type",
+			"local",
+			"--force",
+		)
+
+		cmd.Env = os.Environ()
+
+		r, delErr := cmd.CombinedOutput()
+		req.NoError(delErr, string(r))
+	})
+
+	t.Run("List deployments", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			"list",
+			"--projectId",
+			g.projectID,
+		)
+
+		cmd.Env = os.Environ()
+
+		o, e, err := splitOutput(cmd)
+		req.NoError(err, e)
+
+		outputLines := strings.Split(o, "\n")
+		req.Equal(`NAME   TYPE    MDB VER   STATE`, outputLines[0])
+
+		cols := strings.Fields(outputLines[1])
+		req.Equal(deploymentName, cols[0])
+		req.Equal("LOCAL", cols[1])
+		req.Contains(cols[2], "7.0.")
+		req.Equal("IDLE", cols[3])
+	})
+
+	ctx := context.Background()
+	var client *mongo.Client
+	var myDB *mongo.Database
+	var myCol *mongo.Collection
+
+	t.Run("Connect to database", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			"connect",
+			deploymentName,
+			"--type",
+			"local",
+			"--username",
+			dbUsername,
+			"--password",
+			dbUserPassword,
+			"--connectWith",
+			"connectionString",
+		)
+
+		cmd.Env = os.Environ()
+
+		r, err := cmd.CombinedOutput()
+		req.NoError(err, string(r))
+
+		connectionString := strings.TrimSpace(string(r))
+		client, err = mongo.Connect(ctx, options.Client().ApplyURI(connectionString))
+		req.NoError(err)
+		myDB = client.Database(databaseName)
+		myCol = myDB.Collection(collectionName)
+	})
+
+	t.Cleanup(func() {
+		_ = client.Disconnect(ctx)
+	})
+
+	t.Run("Seed database", func(t *testing.T) {
+		ids, err := myCol.InsertMany(ctx, []interface{}{
+			bson.M{
+				"name": "test1",
+			}, bson.M{
+				"name": "test2",
+			},
+		})
+		req.NoError(err)
+		t.Log(ids)
+	})
+
+	t.Run("Create Search Index", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			searchEntity,
+			indexEntity,
+			"create",
+			indexName,
+			"--type",
+			"local",
+			"--deploymentName",
+			deploymentName,
+			"--db",
+			databaseName,
+			"--collection",
+			collectionName,
+			"--username",
+			dbUsername,
+			"--password",
+			dbUserPassword,
+			"--type",
+			"LOCAL",
+			"-w",
+		)
+
+		cmd.Env = os.Environ()
+
+		r, err := cmd.CombinedOutput()
+		out := string(r)
+		req.NoError(err, out)
+		a := assert.New(t)
+		a.Contains(out, "Search index created with ID:")
+	})
+
+	var indexID string
+
+	t.Run("Index List", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			searchEntity,
+			indexEntity,
+			"ls",
+			"--deploymentName",
+			deploymentName,
+			"--db",
+			databaseName,
+			"--collection",
+			collectionName,
+			"--type",
+			"LOCAL",
+			"--username",
+			dbUsername,
+			"--password",
+			dbUserPassword,
+		)
+
+		cmd.Env = os.Environ()
+
+		o, e, err := splitOutput(cmd)
+		req.NoError(err, e)
+		a := assert.New(t)
+		a.Contains(o, indexName)
+
+		lines := strings.Split(o, "\n")
+		cols := strings.Fields(lines[1])
+		indexID = cols[0]
+	})
+
+	t.Run("Describe search index", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			searchEntity,
+			indexEntity,
+			"describe",
+			indexID,
+			"--deploymentName",
+			deploymentName,
+			"--type",
+			"LOCAL",
+			"--username",
+			dbUsername,
+			"--password",
+			dbUserPassword,
+		)
+
+		cmd.Env = os.Environ()
+
+		r, err := cmd.CombinedOutput()
+		req.NoError(err, string(r))
+	})
+
+	t.Run("Test Search Index", func(t *testing.T) {
+		c, err := myCol.Aggregate(ctx, bson.A{
+			bson.M{
+				"$search": bson.M{
+					"index": indexName,
+					"text": bson.M{
+						"query": "test1",
+						"path":  "name",
+					},
+				},
+			},
+		})
+		req.NoError(err)
+		var results []bson.M
+		err = c.All(ctx, &results)
+		req.NoError(err)
+		req.Len(results, 1)
+	})
+
+	t.Run("Delete Index", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			searchEntity,
+			indexEntity,
+			"rm",
+			indexID,
+			"--deploymentName",
+			deploymentName,
+			"--force",
+			"--type",
+			"LOCAL",
+			"--username",
+			dbUsername,
+			"--password",
+			dbUserPassword,
+			"--debug",
+		)
+
+		cmd.Env = os.Environ()
+
+		var o, e bytes.Buffer
+		cmd.Stdout = &o
+		cmd.Stderr = &e
+		err := cmd.Run()
+		req.NoError(err, e.String())
+		a := assert.New(t)
+		a.Contains(o.String(), fmt.Sprintf("Index '%s' deleted", indexID))
+	})
+
+	t.Run("Pause Deployment", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			"pause",
+			deploymentName,
+			"--type=LOCAL",
+			"--debug",
+		)
+
+		cmd.Env = os.Environ()
+
+		r, err := cmd.CombinedOutput()
+		out := string(r)
+		req.NoError(err, out)
+		a := assert.New(t)
+		a.Contains(out, fmt.Sprintf("Pausing deployment '%s'", deploymentName))
+	})
+
+	t.Run("Start Deployment", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			"start",
+			deploymentName,
+			"--type=LOCAL",
+			"--debug",
+		)
+
+		cmd.Env = os.Environ()
+
+		r, err := cmd.CombinedOutput()
+		out := string(r)
+		req.NoError(err, out)
+		a := assert.New(t)
+		a.Contains(out, fmt.Sprintf("Starting deployment '%s'", deploymentName))
+	})
+}

--- a/test/e2e/atlas/deployments_local_test.go
+++ b/test/e2e/atlas/deployments_local_test.go
@@ -36,7 +36,6 @@ const (
 	collectionName = "myCol"
 	databaseName   = "myDB"
 	indexName      = "indexTest"
-	deploymentName = "test"
 )
 
 func splitOutput(cmd *exec.Cmd) (string, string, error) {
@@ -48,6 +47,8 @@ func splitOutput(cmd *exec.Cmd) (string, string, error) {
 }
 
 func TestDeploymentsLocal(t *testing.T) {
+	const deploymentName = "test"
+
 	g := newAtlasE2ETestGenerator(t)
 	g.generateProject("deployments")
 
@@ -326,15 +327,18 @@ func TestDeploymentsLocal(t *testing.T) {
 }
 
 func TestDeploymentsLocalWithAuth(t *testing.T) {
+	const (
+		deploymentName = "test-auth"
+		dbUsername     = "admin"
+		dbUserPassword = "testpwd"
+	)
+
 	g := newAtlasE2ETestGenerator(t)
 	g.generateProject("auth_deployment")
 
 	cliPath, err := e2e.AtlasCLIBin()
 	req := require.New(t)
 	req.NoError(err)
-
-	dbUsername := "admin"
-	dbUserPassword := "testpwd"
 
 	t.Run("Setup", func(t *testing.T) {
 		defer func(t *testing.T) {


### PR DESCRIPTION
## Proposed changes
* add support for auth for local deployments
* add --bindIpAll flag, which allows running local dev inside a docker image

_Jira ticket:_ CLOUDP-212880

[e2e test](https://spruce.mongodb.com/task/mongodb_atlas_cli_master_e2e_required_atlas_deployments_local_e2e_patch_2345231d78e89a06918a52ed5a4067bf7a43e99d_656492205623436eb5e65118_23_11_27_12_57_08/tests?execution=0&sortBy=STATUS&sortDir=ASC)