### PR TITLE
task: update golangci-lint to 1.55.2

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: v1.55.0
+          version: v1.55.2
   unit-tests:
     env:
       COVERAGE: coverage.out

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
-GOLANGCI_VERSION=v1.55.0
+GOLANGCI_VERSION=v1.55.2
 COVERAGE=coverage.out
 
 MCLI_SOURCE_FILES?=./cmd/mongocli


### PR DESCRIPTION
## Proposed changes

I'm trying to enable some linters for consistent imports so making a drive by to update to the latest bug fixes