### PR TITLE
task: fix const name typo for bcp

### DIFF
--- a/test/e2e/atlas/backup_compliancepolicy_copyprotection_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_copyprotection_test.go
@@ -41,7 +41,7 @@ func TestBackupCompliancePolicyCopyProtection(t *testing.T) {
 		cmd := exec.Command(
 			cliPath,
 			backupsEntity,
-			compliancepolicyEntity,
+			compliancePolicyEntity,
 			"copyprotection",
 			"enable",
 			"-o=json",
@@ -65,7 +65,7 @@ func TestBackupCompliancePolicyCopyProtection(t *testing.T) {
 		cmd := exec.Command(
 			cliPath,
 			backupsEntity,
-			compliancepolicyEntity,
+			compliancePolicyEntity,
 			"copyprotection",
 			"disable",
 			"-o=json",

--- a/test/e2e/atlas/backup_compliancepolicy_describe_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_describe_test.go
@@ -39,7 +39,7 @@ func TestBackupCompliancePolicyDescribe(t *testing.T) {
 
 	cmd := exec.Command(cliPath,
 		backupsEntity,
-		compliancepolicyEntity,
+		compliancePolicyEntity,
 		"describe",
 		"--projectId",
 		g.projectID,

--- a/test/e2e/atlas/backup_compliancepolicy_enable_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_enable_test.go
@@ -38,7 +38,7 @@ func TestBackupCompliancePolicyEnable(t *testing.T) {
 
 	cmd := exec.Command(cliPath,
 		backupsEntity,
-		compliancepolicyEntity,
+		compliancePolicyEntity,
 		"enable",
 		"--projectId",
 		g.projectID,

--- a/test/e2e/atlas/backup_compliancepolicy_pitrestore_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_pitrestore_test.go
@@ -53,7 +53,7 @@ func TestBackupCompliancePolicyPointInTimeRestore(t *testing.T) {
 		cmd := exec.Command(
 			cliPath,
 			backupsEntity,
-			compliancepolicyEntity,
+			compliancePolicyEntity,
 			"pointintimerestore",
 			"enable",
 			"-o=json",

--- a/test/e2e/atlas/backup_compliancepolicy_policies_describe_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_policies_describe_test.go
@@ -39,7 +39,7 @@ func TestBackupCompliancePolicyPoliciesDescribe(t *testing.T) {
 
 	cmd := exec.Command(cliPath,
 		backupsEntity,
-		compliancepolicyEntity,
+		compliancePolicyEntity,
 		policiesEntity,
 		"describe",
 		"--projectId",

--- a/test/e2e/atlas/backup_compliancepolicy_setup_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_setup_test.go
@@ -55,7 +55,7 @@ func TestBackupCompliancePolicySetup(t *testing.T) {
 
 	cmd := exec.Command(cliPath,
 		backupsEntity,
-		compliancepolicyEntity,
+		compliancePolicyEntity,
 		"setup",
 		"--projectId",
 		g.projectID,

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -92,7 +92,7 @@ const (
 	jobsEntity                   = "jobs"
 	snapshotsEntity              = "snapshots"
 	restoresEntity               = "restores"
-	compliancepolicyEntity       = "compliancepolicy"
+	compliancePolicyEntity       = "compliancepolicy"
 	policiesEntity               = "policies"
 	teamsEntity                  = "teams"
 	setupEntity                  = "setup"
@@ -1018,7 +1018,7 @@ func enableCompliancePolicy(projectID string) error {
 	}
 	cmd := exec.Command(cliPath,
 		backupsEntity,
-		compliancepolicyEntity,
+		compliancePolicyEntity,
 		"enable",
 		"--projectId",
 		projectID,
@@ -1060,7 +1060,7 @@ func setupCompliancePolicy(t *testing.T, projectID string, compliancePolicy *atl
 	}
 	cmd := exec.Command(cliPath,
 		backupsEntity,
-		compliancepolicyEntity,
+		compliancePolicyEntity,
 		"setup",
 		"--projectId",
 		projectID,


### PR DESCRIPTION
Fix a typo `compliancepolicyEntity` -> `compliancePolicyEntity`