### PR TITLE
CLOUDP-196956: Added Deployments Tags generation

### DIFF
--- a/internal/kubernetes/operator/deployment/deployment.go
+++ b/internal/kubernetes/operator/deployment/deployment.go
@@ -80,6 +80,18 @@ func BuildAtlasAdvancedDeployment(deploymentStore atlas.OperatorClusterStore, va
 		return result
 	}
 
+	convertTags := func(tags []atlasv2.ResourceTag) []*akov2.TagSpec {
+		result := make([]*akov2.TagSpec, 0, len(tags))
+
+		for _, atlasTag := range tags {
+			result = append(result, &akov2.TagSpec{
+				Key:   atlasTag.GetKey(),
+				Value: atlasTag.GetValue(),
+			})
+		}
+		return result
+	}
+
 	replicationSpec := buildReplicationSpec(deployment.GetReplicationSpecs())
 
 	// TODO: DiskSizeGB field skipped on purpose. See https://jira.mongodb.org/browse/CLOUDP-146469
@@ -95,6 +107,7 @@ func BuildAtlasAdvancedDeployment(deploymentStore atlas.OperatorClusterStore, va
 		ReplicationSpecs:         replicationSpec,
 		RootCertType:             deployment.GetRootCertType(),
 		VersionReleaseSystem:     deployment.GetVersionReleaseSystem(),
+		Tags:                     convertTags(deployment.GetTags()),
 	}
 
 	atlasDeployment := &akov2.AtlasDeployment{

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -76,6 +76,12 @@ func TestBuildAtlasAdvancedDeployment(t *testing.T) {
 					Value: pointer.Get("TestValue"),
 				},
 			},
+			Tags: []atlasv2.ResourceTag{
+				{
+					Key:   pointer.Get("TestTagKey"),
+					Value: pointer.Get("TestTagValue"),
+				},
+			},
 			MongoDBMajorVersion: pointer.Get("5.0"),
 			MongoDBVersion:      pointer.Get("5.0"),
 			Name:                pointer.Get(clusterName),
@@ -247,6 +253,12 @@ func TestBuildAtlasAdvancedDeployment(t *testing.T) {
 						{
 							Key:   *cluster.Labels[0].Key,
 							Value: *cluster.Labels[0].Value,
+						},
+					},
+					Tags: []*akov2.TagSpec{
+						{
+							Key:   *cluster.Tags[0].Key,
+							Value: *cluster.Tags[0].Value,
 						},
 					},
 					Name:       clusterName,


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Added Deployment tags for the `atlas kubernetes config generate` command

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-196956](https://jira.mongodb.org/browse/CLOUDP-196956)

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
