### PR TITLE
fix: correctly check for error in deployments

### DIFF
--- a/internal/cli/atlas/deployments/options/deployment_opts_pre_run.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts_pre_run.go
@@ -36,7 +36,7 @@ func (opts *DeploymentOpts) SelectDeployments(ctx context.Context, projectID str
 			if opts.IsAtlasDeploymentType() {
 				return Deployment{}, atlasErr
 			}
-			if atlasErr != ErrNotAuthenticated {
+			if !errors.Is(atlasErr, ErrNotAuthenticated) {
 				_, _ = log.Warningf("Warning: failed to retrieve Atlas deployments because %q\n", atlasErr.Error())
 			}
 		}


### PR DESCRIPTION
error checking should use `errors.Is`, this fixes this case I saw