### PR TITLE
task: simplify nil check for total count

### DIFF
--- a/internal/cli/default_setter_opts.go
+++ b/internal/cli/default_setter_opts.go
@@ -151,10 +151,10 @@ func (opts *DefaultSetterOpts) orgs(filter string) (results interface{}, err err
 	}
 	switch r := orgs.(type) {
 	case *atlasv2.PaginatedOrganization:
-		if r.TotalCount == nil || *r.TotalCount == 0 {
+		if r.GetTotalCount() == 0 {
 			return nil, errNoResults
 		}
-		if *r.TotalCount > resultsLimit {
+		if r.GetTotalCount() > resultsLimit {
 			return nil, errTooManyResults
 		}
 		results = r.Results


### PR DESCRIPTION
Getters on the new SDK are nil safe, we should prefer to use those 