### PR TITLE
fix: typo in atlas streams instance update help

### DIFF
--- a/docs/atlascli/command/atlas-streams-instances-update.txt
+++ b/docs/atlascli/command/atlas-streams-instances-update.txt
@@ -107,4 +107,4 @@ Examples
 .. code-block::
 
    # Modify the Atlas Stream Processing instance configuration with the name MyInstance:
-   atlas streams instance update MyInstance --provider AWS --provider VIRGINIA_USA
+   atlas streams instance update MyInstance --provider AWS --region VIRGINIA_USA

--- a/internal/cli/atlas/streams/instance/update.go
+++ b/internal/cli/atlas/streams/instance/update.go
@@ -96,7 +96,7 @@ func UpdateBuilder() *cobra.Command {
 			"output":   updateTemplate,
 		},
 		Example: fmt.Sprintf(`  # Modify the Atlas Stream Processing instance configuration with the name MyInstance:
-  %s streams instance update MyInstance --provider AWS --provider VIRGINIA_USA`, cli.ExampleAtlasEntryPoint()),
+  %s streams instance update MyInstance --provider AWS --region VIRGINIA_USA`, cli.ExampleAtlasEntryPoint()),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = args[0]
 


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ CLOUDP-#213429

Fixes typo in example text within atlascli update instance.

Updated text:
`atlas streams instance update MyInstance --provider AWS --region VIRGINIA_USA`

