### PR TITLE
CLOUDP-222001: Migrate to CLI's own pointer helper

### DIFF
--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -35,7 +35,6 @@ import (
 	akov2common "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
 	akov2provider "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/provider"
 	akov2status "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
-	akov2toptr "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/util/toptr"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20231115002/admin"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -449,17 +448,17 @@ func TestBuildServerlessDeployments(t *testing.T) {
 		}
 
 		cluster := &atlasv2.ServerlessInstanceDescription{
-			Id:             akov2toptr.MakePtr("TestClusterID"),
-			GroupId:        akov2toptr.MakePtr("TestGroupID"),
-			MongoDBVersion: akov2toptr.MakePtr("5.0"),
-			Name:           akov2toptr.MakePtr(clusterName),
-			CreateDate:     akov2toptr.MakePtr(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)),
+			Id:             pointer.Get("TestClusterID"),
+			GroupId:        pointer.Get("TestGroupID"),
+			MongoDBVersion: pointer.Get("5.0"),
+			Name:           pointer.Get(clusterName),
+			CreateDate:     pointer.Get(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)),
 			ProviderSettings: atlasv2.ServerlessProviderSettings{
 				BackingProviderName: "AWS",
-				ProviderName:        akov2toptr.MakePtr("AWS"),
+				ProviderName:        pointer.Get("AWS"),
 				RegionName:          "US_EAST_1",
 			},
-			StateName:               akov2toptr.MakePtr(""),
+			StateName:               pointer.Get(""),
 			ServerlessBackupOptions: nil,
 			ConnectionStrings:       nil,
 			Links:                   nil,

--- a/internal/kubernetes/operator/install.go
+++ b/internal/kubernetes/operator/install.go
@@ -22,11 +22,11 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/internal/kubernetes"
 	"github.com/mongodb/mongodb-atlas-cli/internal/kubernetes/operator/features"
 	"github.com/mongodb/mongodb-atlas-cli/internal/kubernetes/operator/resources"
+	"github.com/mongodb/mongodb-atlas-cli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/internal/store/atlas"
 	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1"
 	akov2common "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
-	akov2toptr "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/util/toptr"
 	"go.mongodb.org/atlas-sdk/v20231115002/admin"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -140,8 +140,8 @@ func (i *Install) ensureProject(orgID, projectName string) (*admin.Group, error)
 		Group: &admin.Group{
 			Name:                      projectName,
 			OrgId:                     orgID,
-			RegionUsageRestrictions:   akov2toptr.MakePtr(""),
-			WithDefaultAlertsSettings: akov2toptr.MakePtr(true),
+			RegionUsageRestrictions:   pointer.Get(""),
+			WithDefaultAlertsSettings: pointer.Get(true),
 		},
 	})
 	if err != nil {

--- a/internal/kubernetes/operator/project/project.go
+++ b/internal/kubernetes/operator/project/project.go
@@ -30,7 +30,6 @@ import (
 	akov2project "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/project"
 	akov2provider "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/provider"
 	akov2status "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
-	akov2toptr "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/util/toptr"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20231115002/admin"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -690,7 +689,7 @@ func buildAuditing(auditingProvider store.AuditingDescriber, projectID string) (
 func buildAlertConfigurations(acProvider atlas.AlertConfigurationLister, projectID, projectName, targetNamespace string, dictionary map[string]string) ([]akov2.AlertConfiguration, []*corev1.Secret, error) {
 	data, err := acProvider.AlertConfigurations(&atlasv2.ListAlertConfigurationsApiParams{
 		GroupId:      projectID,
-		ItemsPerPage: akov2toptr.MakePtr(MaxItems),
+		ItemsPerPage: pointer.Get(MaxItems),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/internal/kubernetes/operator/project/project_test.go
+++ b/internal/kubernetes/operator/project/project_test.go
@@ -37,7 +37,6 @@ import (
 	akov2project "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/project"
 	akov2provider "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/provider"
 	akov2status "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/status"
-	akov2toptr "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/util/toptr"
 	"github.com/stretchr/testify/assert"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20231115002/admin"
 	corev1 "k8s.io/api/core/v1"
@@ -58,7 +57,7 @@ func TestBuildAtlasProject(t *testing.T) {
 	featureValidator := mocks.NewMockFeatureValidator(ctl)
 	t.Run("Can convert Project entity with secrets data", func(t *testing.T) {
 		p := &atlasv2.Group{
-			Id:                        akov2toptr.MakePtr(projectID),
+			Id:                        pointer.Get(projectID),
 			OrgId:                     orgID,
 			Name:                      "TestProjectName",
 			ClusterCount:              0,
@@ -249,15 +248,15 @@ func TestBuildAtlasProject(t *testing.T) {
 			Links: nil,
 			Results: []atlasv2.TeamRole{
 				{
-					TeamId:    akov2toptr.MakePtr(teamID),
+					TeamId:    pointer.Get(teamID),
 					RoleNames: []string{string(akov2.TeamRoleClusterManager)},
 				},
 			},
-			TotalCount: akov2toptr.MakePtr(1),
+			TotalCount: pointer.Get(1),
 		}
 		teams := &atlasv2.TeamResponse{
-			Id:   akov2toptr.MakePtr(teamID),
-			Name: akov2toptr.MakePtr("TestTeamName"),
+			Id:   pointer.Get(teamID),
+			Name: pointer.Get("TestTeamName"),
 		}
 
 		teamUsers := &atlasv2.PaginatedApiAppUser{
@@ -265,11 +264,11 @@ func TestBuildAtlasProject(t *testing.T) {
 				{
 					EmailAddress: "testuser@mooooongodb.com",
 					FirstName:    "TestName",
-					Id:           akov2toptr.MakePtr("TestID"),
+					Id:           pointer.Get("TestID"),
 					LastName:     "TestLastName",
 				},
 			},
-			TotalCount: akov2toptr.MakePtr(1),
+			TotalCount: pointer.Get(1),
 		}
 
 		listOption := &atlas.ListOptions{ItemsPerPage: MaxItems}


### PR DESCRIPTION
## Proposed changes

Due to https://github.com/mongodb/mongodb-atlas-kubernetes/pull/1316 the pointer API there will not be available to consumers. This change moves the Kubernetes code not to rely on that soon disappearing API and instead use the local pointer helper available in the CLI already.

There seem to be no more code affected by the above PR:
```shell
% grep -r mongodb-atlas-kubernetes/pkg/util                         
grep: bin/atlas: binary file matches
% grep -r mongodb-atlas-kubernetes/v2/pkg/util
%
```

_Jira ticket:_ CLOUDP-222001

## Checklist

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
