### PR TITLE
CLOUDP-222794: check isTenant on cluster upgrade

### DIFF
--- a/internal/cli/atlas/clusters/upgrade.go
+++ b/internal/cli/atlas/clusters/upgrade.go
@@ -95,9 +95,11 @@ func (opts *UpgradeOpts) patchOpts(out *atlas.Cluster) {
 	if opts.diskSizeGB > 0 {
 		out.DiskSizeGB = &opts.diskSizeGB
 	}
-	if opts.tier != "" && out.ProviderSettings != nil {
-		out.ProviderSettings.InstanceSizeName = opts.tier
-		if opts.tier == atlasM2 || opts.tier == atlasM5 {
+	if out.ProviderSettings != nil {
+		if opts.tier != "" {
+			out.ProviderSettings.InstanceSizeName = opts.tier
+		}
+		if isTenant(out.ProviderSettings.InstanceSizeName) {
 			out.BiConnector = nil
 		} else {
 			out.ProviderSettings.ProviderName = out.ProviderSettings.BackingProviderName
@@ -119,6 +121,12 @@ func (opts *UpgradeOpts) patchOpts(out *atlas.Cluster) {
 		}
 	}
 	out.Tags = &tags
+}
+
+func isTenant(instanceSizeName string) bool {
+	return instanceSizeName == atlasM0 ||
+		instanceSizeName == atlasM2 ||
+		instanceSizeName == atlasM5
 }
 
 // UpgradeBuilder atlas cluster(s) upgrade [clusterName] --projectId projectId [--tier M#] [--diskSizeGB N] [--mdbVersion] [--tag key=value].


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

_Jira ticket:_ CLOUDP-222794

Small change for clearer API error message
 
The clusters upgrade command is using the [upgradeSharedCluster](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/upgradeSharedCluster) operation, where M0 is not listed as valid value for "instanceSizeName" 

See documented providerSettings.instanceSizeName field for specific examples

Current behaviour makes an API call to retrieve the resource, then sets opts
If M0 is retrieved and no tier is set in opts, we want a clearer API message stating that M0 is not valid

Current API response:
```
400 (request "CLUSTER_PROVIDER_DOES_NOT_SUPPORT_BI_CONNECTOR") The BI Connector is not supported with the specified cluster provider.
```

After this change:
```
400 (request "CANNOT_CREATE_FREE_CLUSTER_VIA_PUBLIC_API") Cannot create a cluster with instance size M0 via the public api: This project already has another free cluster.
```

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->



## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
