### PR TITLE
Added link-git-hooks to the developer setup target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ devtools:  ## Install dev tools
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
 
 .PHONY: setup
-setup: deps devtools ## Set up dev env
+setup: deps devtools link-git-hooks ## Set up dev env
 
 .PHONY: link-git-hooks
 link-git-hooks: ## Install git hooks


### PR DESCRIPTION
I've noticed that the "developer setup" target `setup` in our `Makefile` doesn't setup the git hooks.

Added the `link-git-hooks` target as a dependency of `setup`