### PR TITLE
CLOUDP-137380: [CLI] profile names with dots(.) break the cli

### DIFF
--- a/cmd/mongocli/mongocli.go
+++ b/cmd/mongocli/mongocli.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2/core"
+	"github.com/mongodb/mongodb-atlas-cli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/cli/root/mongocli"
 	"github.com/mongodb/mongodb-atlas-cli/internal/config"
-	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
 	"github.com/spf13/cobra"
 )
 
@@ -106,12 +106,8 @@ func initConfig() {
 		log.Fatalf("Error loading config: %v", err)
 	}
 
-	if profile != "" {
-		config.SetName(profile)
-	} else if profile = config.GetString(flag.Profile); profile != "" {
-		config.SetName(profile)
-	} else if availableProfiles := config.List(); len(availableProfiles) == 1 {
-		config.SetName(availableProfiles[0])
+	if err := cli.InitProfile(profile); err != nil {
+		log.Fatalf("Error loading profile: %v", err)
 	}
 }
 

--- a/internal/cli/atlas/clusters/region_tier_autocomplete.go
+++ b/internal/cli/atlas/clusters/region_tier_autocomplete.go
@@ -16,6 +16,7 @@ package clusters
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -38,7 +39,11 @@ type autoCompleteOpts struct {
 
 func (opts *autoCompleteOpts) autocompleteTier() cli.AutoFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		opts.parseFlags(cmd)
+		if err := opts.parseFlags(cmd); err != nil {
+			cobra.CompErrorln(fmt.Sprintf("failed to parse flags: %v", err))
+			return nil, cobra.ShellCompDirectiveError
+		}
+
 		if err := validate.Credentials(); err != nil {
 			cobra.CompErrorln("no credentials")
 			return nil, cobra.ShellCompDirectiveError
@@ -86,7 +91,11 @@ func (opts *autoCompleteOpts) tierSuggestions(toComplete string) ([]string, erro
 
 func (opts *autoCompleteOpts) autocompleteRegion() cli.AutoFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		opts.parseFlags(cmd)
+		if err := opts.parseFlags(cmd); err != nil {
+			cobra.CompErrorln(fmt.Sprintf("failed to parse flags: %v", err))
+			return nil, cobra.ShellCompDirectiveError
+		}
+
 		if err := validate.Credentials(); err != nil {
 			cobra.CompErrorln("no credentials")
 			return nil, cobra.ShellCompDirectiveError
@@ -139,15 +148,13 @@ func (opts *autoCompleteOpts) initStore(ctx context.Context) error {
 	return err
 }
 
-func (opts *autoCompleteOpts) parseFlags(cmd *cobra.Command) {
+func (opts *autoCompleteOpts) parseFlags(cmd *cobra.Command) error {
 	profile := cmd.Flag(flag.Profile).Value.String()
-	if profile != "" {
-		config.SetName(profile)
-	} else if profile = config.GetString(flag.Profile); profile != "" {
-		config.SetName(profile)
-	} else if availableProfiles := config.List(); len(availableProfiles) == 1 {
-		config.SetName(availableProfiles[0])
+
+	if err := cli.InitProfile(profile); err != nil {
+		return err
 	}
+
 	if project := cmd.Flag(flag.ProjectID).Value.String(); project != "" {
 		opts.ProjectID = project
 	}
@@ -159,4 +166,6 @@ func (opts *autoCompleteOpts) parseFlags(cmd *cobra.Command) {
 	if tier := cmd.Flag(flag.Tier).Value.String(); tier != "" {
 		opts.tier = tier
 	}
+
+	return nil
 }

--- a/internal/cli/config/delete.go
+++ b/internal/cli/config/delete.go
@@ -34,7 +34,10 @@ func (opts *DeleteOpts) Run() error {
 		return nil
 	}
 
-	config.SetName(opts.Entry)
+	if err := config.SetName(opts.Entry); err != nil {
+		return err
+	}
+
 	if err := config.Delete(); err != nil {
 		return err
 	}

--- a/internal/cli/config/describe.go
+++ b/internal/cli/config/describe.go
@@ -38,7 +38,11 @@ func (opts *describeOpts) Run() error {
 	if !config.Exists(opts.name) {
 		return fmt.Errorf("you don't have a profile named '%s'", opts.name)
 	}
-	config.SetName(opts.name)
+
+	if err := config.SetName(opts.name); err != nil {
+		return err
+	}
+
 	return opts.Print(config.Map())
 }
 

--- a/internal/cli/config/rename.go
+++ b/internal/cli/config/rename.go
@@ -47,7 +47,10 @@ func (opts *RenameOpts) Run() error {
 		}
 	}
 
-	config.SetName(opts.oldName)
+	if err := config.SetName(opts.oldName); err != nil {
+		return err
+	}
+
 	if err := config.Rename(opts.newName); err != nil {
 		return err
 	}

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -1,0 +1,18 @@
+package cli
+
+import (
+	"github.com/mongodb/mongodb-atlas-cli/internal/config"
+	"github.com/mongodb/mongodb-atlas-cli/internal/flag"
+)
+
+func InitProfile(profile string) error {
+	if profile != "" {
+		return config.SetName(profile)
+	} else if profile = config.GetString(flag.Profile); profile != "" {
+		return config.SetName(profile)
+	} else if availableProfiles := config.List(); len(availableProfiles) == 1 {
+		return config.SetName(availableProfiles[0])
+	}
+
+	return nil
+}

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -1,3 +1,17 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli
 
 import (

--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -107,16 +107,6 @@ func handleSignal() {
 	}, os.Interrupt, syscall.SIGTERM)
 }
 
-func initProfile(profile string) {
-	if profile != "" {
-		config.SetName(profile)
-	} else if profile = config.GetString(flag.Profile); profile != "" {
-		config.SetName(profile)
-	} else if availableProfiles := config.List(); len(availableProfiles) == 1 {
-		config.SetName(availableProfiles[0])
-	}
-}
-
 // Builder conditionally adds children commands as needed.
 func Builder() *cobra.Command {
 	var (
@@ -144,7 +134,9 @@ Use the --help flag with any command for more info on that command.`,
 				log.SetLevel(log.DebugLevel)
 			}
 
-			initProfile(profile)
+			if err := cli.InitProfile(profile); err != nil {
+				return err
+			}
 
 			telemetry.StartTrackingCommand(cmd, args)
 

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -242,6 +242,7 @@ func (p *Profile) Name() string {
 }
 
 var ErrProfileNameHasDots = errors.New("profile should not contain '.'")
+
 func validateName(name string) error {
 	if strings.Contains(name, ".") {
 		return fmt.Errorf("%w: %q", ErrProfileNameHasDots, name)

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -241,9 +241,10 @@ func (p *Profile) Name() string {
 	return p.name
 }
 
+var ErrProfileNameHasDots = errors.New("profile should not contain '.'")
 func validateName(name string) error {
 	if strings.Contains(name, ".") {
-		return errors.New("Profile should not contain '.'")
+		return fmt.Errorf("%w: %q", ErrProfileNameHasDots, name)
 	}
 
 	return nil

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -242,13 +241,23 @@ func (p *Profile) Name() string {
 	return p.name
 }
 
-func SetName(name string) { Default().SetName(name) }
-func (p *Profile) SetName(name string) {
+func validateName(name string) error {
 	if strings.Contains(name, ".") {
-		log.Fatal("Profile should not contain '.'")
+		return errors.New("Profile should not contain '.'")
+	}
+
+	return nil
+}
+
+func SetName(name string) error { return Default().SetName(name) }
+func (p *Profile) SetName(name string) error {
+	if err := validateName(name); err != nil {
+		return err
 	}
 
 	p.name = strings.ToLower(name)
+
+	return nil
 }
 
 func Set(name string, value interface{}) { Default().Set(name, value) }
@@ -628,6 +637,10 @@ func Filename() string {
 // Rename replaces the Profile to a new Profile name, overwriting any Profile that existed before.
 func Rename(newProfileName string) error { return Default().Rename(newProfileName) }
 func (p *Profile) Rename(newProfileName string) error {
+	if err := validateName(newProfileName); err != nil {
+		return err
+	}
+
 	// Configuration needs to be deleted from toml, as viper doesn't support this yet.
 	// FIXME :: change when https://github.com/spf13/viper/pull/519 is merged.
 	configurationAfterDelete := viper.AllSettings()

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -243,6 +244,10 @@ func (p *Profile) Name() string {
 
 func SetName(name string) { Default().SetName(name) }
 func (p *Profile) SetName(name string) {
+	if strings.Contains(name, ".") {
+		log.Fatal("Profile should not contain '.'")
+	}
+
 	p.name = strings.ToLower(name)
 }
 

--- a/internal/config/profile_integration_test.go
+++ b/internal/config/profile_integration_test.go
@@ -117,7 +117,7 @@ func TestProfile_Get_Default(t *testing.T) {
 
 func TestProfile_Get_NonDefault(t *testing.T) {
 	profile := profileWithOneNonDefaultUser()
-	profile.SetName(atlas)
+	require.NoError(t, profile.SetName(atlas))
 
 	require.NoError(t, profile.LoadMongoCLIConfig(false))
 
@@ -134,7 +134,7 @@ func TestProfile_Delete_NonDefault(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
 	require.NoError(t, profile.LoadMongoCLIConfig(false))
 
-	profile.SetName(atlas)
+	require.NoError(t, profile.SetName(atlas))
 
 	require.NoError(t, profile.Delete())
 	require.NoError(t, profile.LoadMongoCLIConfig(false))
@@ -144,16 +144,16 @@ func TestProfile_Delete_NonDefault(t *testing.T) {
 
 func TestProfile_Rename(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
-	profile.SetName(DefaultProfile)
+	require.NoError(t, profile.SetName(DefaultProfile))
 
 	require.NoError(t, profile.LoadMongoCLIConfig(false))
 	defaultDescription := profile.Map()
 	require.NoError(t, profile.Rename(newProfileName))
 	require.NoError(t, profile.LoadMongoCLIConfig(false))
-	profile.SetName(DefaultProfile)
+	require.NoError(t, profile.SetName(DefaultProfile))
 	a := assert.New(t)
 	a.Empty(profile.Map())
-	profile.SetName(newProfileName)
+	require.NoError(t, profile.SetName(newProfileName))
 	descriptionAfterRename := profile.Map()
 	// after renaming, one Profile should exist
 	a.Equal(defaultDescription, descriptionAfterRename, "descriptions should be equal after renaming")
@@ -161,14 +161,14 @@ func TestProfile_Rename(t *testing.T) {
 
 func TestProfile_Rename_OverwriteExisting(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
-	profile.SetName(DefaultProfile)
+	require.NoError(t, profile.SetName(DefaultProfile))
 
 	require.NoError(t, profile.LoadMongoCLIConfig(false))
 	defaultDescription := profile.Map()
 
 	require.NoError(t, profile.Rename(atlas))
 	require.NoError(t, profile.LoadMongoCLIConfig(false))
-	profile.SetName(atlas)
+	require.NoError(t, profile.SetName(atlas))
 	descriptionAfterRename := profile.Map()
 	// after renaming, one Profile should exist
 	assert.Equal(t, defaultDescription, descriptionAfterRename, "descriptions should be equal after renaming")
@@ -178,7 +178,7 @@ func TestProfile_Set(t *testing.T) {
 	profile := profileWithOneDefaultUserOneNonDefault()
 	require.NoError(t, profile.LoadMongoCLIConfig(false))
 
-	profile.SetName(DefaultProfile)
+	require.NoError(t, profile.SetName(DefaultProfile))
 
 	profile.Set(projectID, "newProjectId")
 

--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_MongoCLIConfigHome(t *testing.T) {
@@ -231,4 +232,32 @@ func Test_getConfigHostname(t *testing.T) {
 			assert.Equal(t, expectedHostName, actualHostName)
 		})
 	}
+}
+
+func TestConfig_SetName(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, SetName("default"))
+		require.NoError(t, SetName("default-123"))
+		require.NoError(t, SetName("default-test"))
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		require.Error(t, SetName("d.efault"))
+		require.Error(t, SetName("default.123"))
+		require.Error(t, SetName("default.test"))
+	})
+}
+
+func TestConfig_Rename(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		require.NoError(t, Rename("default"))
+		require.NoError(t, Rename("default-123"))
+		require.NoError(t, Rename("default-test"))
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		require.Error(t, Rename("d.efault"))
+		require.Error(t, Rename("default.123"))
+		require.Error(t, Rename("default.test"))
+	})
 }

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -98,6 +98,7 @@ const (
 	setupEntity                  = "setup"
 	deploymentEntity             = "deployments"
 	deletingState                = "DELETING"
+	authEntity                   = "auth"
 )
 
 // AlertConfig constants.
@@ -106,6 +107,11 @@ const (
 	eventTypeName = "NO_PRIMARY"
 	intervalMin   = 5
 	delayMin      = 0
+)
+
+// Auth constants.
+const (
+	whoami = "whoami"
 )
 
 // Integration constants.

--- a/test/e2e/atlas/profile_test.go
+++ b/test/e2e/atlas/profile_test.go
@@ -24,13 +24,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func verifyProfileValidity(t *testing.T, cliPath string, profile string, profileValid bool) {
+func validateProfile(t *testing.T, cliPath string, profile string, profileValid bool) {
 	t.Helper()
 
 	// Setup the command
 	cmd := exec.Command(cliPath,
-		"auth",
-		"whoami",
+		authEntity,
+		whoami,
 		"--profile", profile)
 
 	cmd.Env = os.Environ()
@@ -57,14 +57,14 @@ func TestProfile(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("profile name valid", func(t *testing.T) {
-		verifyProfileValidity(t, cliPath, "default", true)
-		verifyProfileValidity(t, cliPath, "default-123", true)
-		verifyProfileValidity(t, cliPath, "default-test", true)
+		validateProfile(t, cliPath, "default", true)
+		validateProfile(t, cliPath, "default-123", true)
+		validateProfile(t, cliPath, "default-test", true)
 	})
 
 	t.Run("profile name invalid", func(t *testing.T) {
-		verifyProfileValidity(t, cliPath, "d.efault", false)
-		verifyProfileValidity(t, cliPath, "default.123", false)
-		verifyProfileValidity(t, cliPath, "default.test", false)
+		validateProfile(t, cliPath, "d.efault", false)
+		validateProfile(t, cliPath, "default.123", false)
+		validateProfile(t, cliPath, "default.test", false)
 	})
 }

--- a/test/e2e/atlas/profile_test.go
+++ b/test/e2e/atlas/profile_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || (atlas && processes)
+//go:build e2e || (atlas && generic)
 
 package atlas_test
 

--- a/test/e2e/atlas/profile_test.go
+++ b/test/e2e/atlas/profile_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build e2e || (atlas && processes)
+
+package atlas_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func verifyProfileValidity(t *testing.T, cliPath string, profile string, profileValid bool) {
+	t.Helper()
+
+	// Setup the command
+	cmd := exec.Command(cliPath,
+		"auth",
+		"whoami",
+		"--profile", profile)
+
+	cmd.Env = os.Environ()
+
+	// Execute the command
+	resp, err := cmd.CombinedOutput()
+
+	// We only care about errors that happened due to something other than a non-zero exit code
+	if err != nil {
+		require.ErrorContains(t, err, "exit status")
+	}
+
+	response := string(resp)
+
+	if profileValid {
+		require.NotContains(t, response, "Profile should not contain '.'")
+	} else {
+		require.NotContains(t, response, "not logged in", "Logged in as")
+	}
+}
+
+func TestProfile(t *testing.T) {
+	cliPath, err := e2e.AtlasCLIBin()
+	require.NoError(t, err)
+
+	t.Run("profile name valid", func(t *testing.T) {
+		verifyProfileValidity(t, cliPath, "default", true)
+		verifyProfileValidity(t, cliPath, "default-123", true)
+		verifyProfileValidity(t, cliPath, "default-test", true)
+	})
+
+	t.Run("profile name invalid", func(t *testing.T) {
+		verifyProfileValidity(t, cliPath, "d.efault", false)
+		verifyProfileValidity(t, cliPath, "default.123", false)
+		verifyProfileValidity(t, cliPath, "default.test", false)
+	})
+}

--- a/test/e2e/atlas/profile_test.go
+++ b/test/e2e/atlas/profile_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 MongoDB Inc
+// Copyright 2024 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Proposed changes

Profiles containing dots (`.`) break the CLI.
This PR disallows the usage of dots in profile names.

_Jira ticket:_ CLOUDP-137380

## Further comments

Added `e2e` tests to verify multiple valid and invalid profile names. I'm doing this using the `atlas auth who --profile [profile-name]` command because this command doesn't cause any side-effects. It also doesn't matter if you're actually logged in or not.
