### PR TITLE
CLOUDP-220794: add required instance flag to help usage in connection list

### DIFF
--- a/docs/atlascli/command/atlas-streams-connections-create.txt
+++ b/docs/atlascli/command/atlas-streams-connections-create.txt
@@ -22,7 +22,7 @@ Syntax
 .. code-block::
    :caption: Command Syntax
 
-   atlas streams connections create [connectionName] [options]
+   atlas streams connections create [connectionName] --instance <instance_name> [options]
 
 .. Code end marker, please don't delete this comment
 
@@ -41,6 +41,10 @@ Arguments
      - string
      - false
      - Name of the connection
+   * - instance_name
+     - string
+     - true
+     - Name of the instance.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-streams-connections-delete.txt
+++ b/docs/atlascli/command/atlas-streams-connections-delete.txt
@@ -24,7 +24,7 @@ Syntax
 .. code-block::
    :caption: Command Syntax
 
-   atlas streams connections delete <connectionName> [options]
+   atlas streams connections delete <connectionName> --instance <instance_name> [options]
 
 .. Code end marker, please don't delete this comment
 
@@ -43,6 +43,10 @@ Arguments
      - string
      - true
      - Name of the connection
+   * - instance_name
+     - string
+     - true
+     - Name of the instance.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-streams-connections-describe.txt
+++ b/docs/atlascli/command/atlas-streams-connections-describe.txt
@@ -22,7 +22,7 @@ Syntax
 .. code-block::
    :caption: Command Syntax
 
-   atlas streams connections describe <streamConnectionName> [options]
+   atlas streams connections describe <streamConnectionName> --instance <instance_name> [options]
 
 .. Code end marker, please don't delete this comment
 
@@ -41,6 +41,10 @@ Arguments
      - string
      - true
      - Name of the Atlas Stream Processing connection.
+   * - instance_name
+     - string
+     - true
+     - Name of the instance.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-streams-connections-list.txt
+++ b/docs/atlascli/command/atlas-streams-connections-list.txt
@@ -22,9 +22,25 @@ Syntax
 .. code-block::
    :caption: Command Syntax
 
-   atlas streams connections list [options]
+   atlas streams connections list --instance <instance_name> [options]
 
 .. Code end marker, please don't delete this comment
+
+Arguments
+---------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 10 10 60
+
+   * - Name
+     - Type
+     - Required
+     - Description
+   * - instance_name
+     - string
+     - true
+     - Name of the instance.
 
 Options
 -------

--- a/docs/atlascli/command/atlas-streams-connections-update.txt
+++ b/docs/atlascli/command/atlas-streams-connections-update.txt
@@ -22,7 +22,7 @@ Syntax
 .. code-block::
    :caption: Command Syntax
 
-   atlas streams connections update <connectionName> [options]
+   atlas streams connections update <connectionName> --instance <instance_name> [options]
 
 .. Code end marker, please don't delete this comment
 
@@ -41,6 +41,10 @@ Arguments
      - string
      - true
      - Name of the connection.
+   * - instance_name
+     - string
+     - true
+     - Name of the instance.
 
 Options
 -------

--- a/internal/cli/atlas/streams/connection/create.go
+++ b/internal/cli/atlas/streams/connection/create.go
@@ -90,13 +90,14 @@ func CreateBuilder() *cobra.Command {
 		fs: afero.NewOsFs(),
 	}
 	cmd := &cobra.Command{
-		Use:   "create [connectionName]",
+		Use:   "create [connectionName] --instance <instance_name>",
 		Short: "Creates a connection for an Atlas Stream Processing instance.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"connectionNameDesc": "Name of the connection",
 			"output":             createTemplate,
+			"instance_nameDesc":  "Name of the instance.",
 		},
 		Example: fmt.Sprintf(`# create a new connection for Atlas Stream Processing:
   %[1]s streams connection create kafkaprod -i test01 -f kafkaConfig.json

--- a/internal/cli/atlas/streams/connection/delete.go
+++ b/internal/cli/atlas/streams/connection/delete.go
@@ -54,7 +54,7 @@ func DeleteBuilder() *cobra.Command {
 		DeleteOpts: cli.NewDeleteOpts("Atlas Stream Processing connection '%s' deleted\n", "Atlas Stream Processing connection not deleted"),
 	}
 	cmd := &cobra.Command{
-		Use:   "delete <connectionName>",
+		Use:   "delete <connectionName> --instance <instance_name>",
 		Short: "Remove the specified Atlas Stream Processing connection from your project.",
 		Long: `The command prompts you to confirm the operation when you run the command without the --force option.
 
@@ -63,6 +63,7 @@ Before deleting an Atlas Streams Processing connection, you must first stop all 
 		Annotations: map[string]string{
 			"connectionNameDesc": "Name of the connection",
 			"output":             opts.SuccessMessage(),
+			"instance_nameDesc":  "Name of the instance.",
 		},
 		Example: fmt.Sprintf(`# deletes connection 'ExampleConnection' from instance 'ExampleInstance':
   %[1]s streams connection delete ExampleConnection --instance ExampleInstance

--- a/internal/cli/atlas/streams/connection/describe.go
+++ b/internal/cli/atlas/streams/connection/describe.go
@@ -62,12 +62,13 @@ func (opts *DescribeOpts) Run() error {
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:   "describe <streamConnectionName>",
+		Use:   "describe <streamConnectionName> --instance <instance_name>",
 		Short: "Return the details for the specified Atlas Stream Processing connection.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"streamConnectionNameDesc": "Name of the Atlas Stream Processing connection.",
+			"instance_nameDesc":        "Name of the instance.",
 		},
 		Example: fmt.Sprintf(`# retrieves stream connection 'ExampleConnection' in instance 'ExampleInstance':
 %[1]s streams connection describe ExampleConnection --instance ExampleInstance

--- a/internal/cli/atlas/streams/connection/list.go
+++ b/internal/cli/atlas/streams/connection/list.go
@@ -61,11 +61,14 @@ func (opts *ListOpts) Run() error {
 func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
 	cmd := &cobra.Command{
-		Use:     "list",
+		Use:     "list --instance <instance_name>",
 		Short:   "Returns all Atlas Stream Processing connections from your Atlas Stream Processing instance.",
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.ExactArgs(0),
+		Annotations: map[string]string{
+			"instance_nameDesc": "Name of the instance.",
+		},
 		Example: fmt.Sprintf(`# list all connections within ExampleInstance:
 %[1]s streams connection list --instance ExampleInstance
 `, cli.ExampleAtlasEntryPoint()),

--- a/internal/cli/atlas/streams/connection/update.go
+++ b/internal/cli/atlas/streams/connection/update.go
@@ -82,13 +82,14 @@ func UpdateBuilder() *cobra.Command {
 		fs: afero.NewOsFs(),
 	}
 	cmd := &cobra.Command{
-		Use:   "update <connectionName>",
+		Use:   "update <connectionName> --instance <instance_name>",
 		Short: "Modify the details of the specified connection within your Atlas Stream Processing instance.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args:  require.ExactArgs(1),
 		Annotations: map[string]string{
 			"connectionNameDesc": "Name of the connection.",
 			"output":             updateTemplate,
+			"instance_nameDesc":  "Name of the instance.",
 		},
 		Example: fmt.Sprintf(`# update an Atlas Stream Processing connection:
   %[1]s streams connection update kafkaprod --instance test01 -f kafkaConfig.json


### PR DESCRIPTION
## Proposed changes
[CLOUDP-220794](https://jira.mongodb.org/browse/CLOUDP-220794)

The `--instance` flag is required for the connections streams commands so its desirable to display it in the usage docs when accessing `-h` for a command. This PR updates the `Use` to add that in.

## Checklist
[✅ ] Ran make gen-docs 


