### PR TITLE
CLOUDP-226171: handle safely pointers of slices in the output templates

### DIFF
--- a/internal/templatewriter/templatewriter_test.go
+++ b/internal/templatewriter/templatewriter_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templatewriter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type printTest struct {
+	name        string
+	template    string
+	data        interface{}
+	expected    string
+	expectedErr bool
+}
+
+func Test_Print(t *testing.T) {
+	var buf bytes.Buffer
+
+	tests := []printTest{
+		{
+			name:     "primitive data",
+			template: "name: {{.}}",
+			data:     "Jane",
+			expected: "name: Jane",
+		},
+		{
+			name:     "nil data",
+			template: "name: {{.}}",
+			data:     nil,
+			expected: "name: <no value>",
+		},
+		{
+			name:     "pointer of non empty slice",
+			template: "items: {{range .Items}}{{.}} {{end}}",
+			data:     struct{ Items *[]string }{Items: &[]string{"AWS", "GCP", "Azure"}},
+			expected: "items: AWS GCP Azure ",
+		},
+		{
+			name:        "nil pointer of slice",
+			template:    "items: {{range .Items}}{{.}} {{end}}",
+			data:        struct{ Items *[]string }{Items: nil},
+			expectedErr: true, // expected to fail, as Items is nil
+		},
+		{
+			name:     "nil pointer of slice",
+			template: "items: {{range valueOrEmptySlice .Items}}{{.}} {{end}}",
+			data:     struct{ Items *[]string }{Items: nil},
+			expected: "items: ",
+		},
+		{
+			name:     "non empty slice",
+			template: "items: {{range valueOrEmptySlice .Items}}{{.}} {{end}}",
+			data:     struct{ Items *[]string }{Items: &[]string{"AWS", "GCP", "Azure"}},
+			expected: "items: AWS GCP Azure ",
+		},
+		{
+			name:     "empty slice",
+			template: "items: {{range valueOrEmptySlice .Items}}{{.}} {{end}}",
+			data:     struct{ Items *[]string }{Items: &[]string{}},
+			expected: "items: ",
+		},
+	}
+
+	for _, conf := range tests {
+		t.Run(conf.name, func(t *testing.T) {
+			if conf.expectedErr {
+				require.Error(t, Print(&buf, conf.template, conf.data))
+			} else {
+				require.NoError(t, Print(&buf, conf.template, conf.data))
+				assert.Equal(t, conf.expected, buf.String())
+			}
+		})
+		buf.Reset()
+	}
+}

--- a/internal/templatewriter/templatewriter_test.go
+++ b/internal/templatewriter/templatewriter_test.go
@@ -67,13 +67,13 @@ func Test_Print(t *testing.T) {
 		{
 			name:     "non empty slice",
 			template: "items: {{range valueOrEmptySlice .Items}}{{.}} {{end}}",
-			data:     struct{ Items *[]string }{Items: &[]string{"AWS", "GCP", "Azure"}},
+			data:     struct{ Items []string }{Items: []string{"AWS", "GCP", "Azure"}},
 			expected: "items: AWS GCP Azure ",
 		},
 		{
 			name:     "empty slice",
 			template: "items: {{range valueOrEmptySlice .Items}}{{.}} {{end}}",
-			data:     struct{ Items *[]string }{Items: &[]string{}},
+			data:     struct{ Items []string }{Items: []string{}},
 			expected: "items: ",
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

handle safely pointers of slices in the output templates
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-226171

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->
