### PR TITLE
CLOUDP-221977: New released Atlas Go SDK can't be used until several hours later

### DIFF
--- a/scripts/update-sdk.sh
+++ b/scripts/update-sdk.sh
@@ -16,9 +16,11 @@
 
 set -euo pipefail
 
-LATEST_SDK_RELEASE=$(curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name' | cut -d '.' -f 1)
-echo  "==> Updating SDK to latest major version $LATEST_SDK_RELEASE"
-gomajor get "go.mongodb.org/atlas-sdk/$LATEST_SDK_RELEASE@latest"
+LATEST_SDK_TAG=$(curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name')
+
+LATEST_SDK_RELEASE=$(echo "${LATEST_SDK_TAG}" | cut -d '.' -f 1)
+echo  "==> Updating SDK to latest major version ${LATEST_SDK_TAG}"
+gomajor get "go.mongodb.org/atlas-sdk/${LATEST_SDK_RELEASE}@${LATEST_SDK_TAG}"
 go mod tidy
-sed -i -r "s|go.mongodb.org/atlas-sdk/v[0-9]*|go.mongodb.org/atlas-sdk/$LATEST_SDK_RELEASE|" build/ci/library_owners.json
+sed -i -r "s|go.mongodb.org/atlas-sdk/v[0-9]*|go.mongodb.org/atlas-sdk/${LATEST_SDK_RELEASE}|" build/ci/library_owners.json
 echo "Done"


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-221977

Don't use "latest" as this can have issues with go.dev caches, using the tag directly should avoid go cache 

Tested locally the script works as expected 