### PR TITLE
CLOUDP-228171: Update the release logic to skip pushing binary to download center if pre-releasing

### DIFF
--- a/build/package/generate-download-archive-manifest.sh
+++ b/build/package/generate-download-archive-manifest.sh
@@ -17,4 +17,8 @@ set -Eeou pipefail
 
 VERSION="$(git tag --list "${TOOL_NAME}/v*" --sort=taggerdate | tail -1 | cut -d "v" -f 2)"
 
-go run ../tools/release/main.go --file "${FEED_FILE_NAME}" --version "${VERSION}"
+if [[ ${VERSION} =~ "-pre" ]]; then
+  echo "Skipping generate download center manifest for pre-release version: ${VERSION}"
+else
+  go run ../tools/release/main.go --file "${FEED_FILE_NAME}" --version "${VERSION}"
+fi


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

This PR updates the release logic not to update the [download centre](https://www.mongodb.com/try/download/atlascli) when pre-releasing AtlasCLI. A pre-release is a release with a GitHub Tag that includes `-pre`, for example `atlascli/v1.2.3-pre` or `mongocli/v1.2.3-pre`. Example pre-release https://github.com/andreaangiolillo/mongocli-test/releases

These changes allow us to run pre-release the CLI with PCT or by pushing the pre-release tag to the repo.


_Jira ticket:_ CLOUDP-228171

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
