### PR TITLE
Rename 'AwsConnectionStatus' to 'ConnectionStatus' so the template re…

### DIFF
--- a/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
+++ b/docs/atlascli/command/atlas-privateEndpoints-aws-interfaces-describe.txt
@@ -93,8 +93,8 @@ If the command succeeds, the CLI returns output similar to the following sample.
 
 .. code-block::
 
-   ID                      STATUS                  ERROR
-   <InterfaceEndpointId>   <AwsConnectionStatus>   <ErrorMessage>
+   ID                      STATUS               ERROR
+   <InterfaceEndpointId>   <ConnectionStatus>   <ErrorMessage>
    
 
 Examples

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -44,7 +44,7 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 }
 
 var describeTemplate = `ID	STATUS	ERROR
-{{.InterfaceEndpointId}}	{{.AwsConnectionStatus}}	{{.ErrorMessage}}
+{{.InterfaceEndpointId}}	{{.ConnectionStatus}}	{{.ErrorMessage}}
 `
 
 func (opts *DescribeOpts) Run() error {


### PR DESCRIPTION
## Proposed changes
Fix broken template, the go template was pointing to a non-existing field `AwsConnectionStatus`

_Jira ticket:_ CLOUDP-228607
