### PR TITLE
Fixed broken template field name in ops-manager (URL -> DownloadURL)

### DIFF
--- a/internal/cli/opsmanager/logs/jobs_list.go
+++ b/internal/cli/opsmanager/logs/jobs_list.go
@@ -42,7 +42,7 @@ func (opts *JobsListOpts) initStore(ctx context.Context) func() error {
 }
 
 var listTemplate = `ID	CREATED AT	EXPIRES AT	STATUS	URL	REDACTED{{range valueOrEmptySlice .Results}}
-{{.ID}}	{{.CreationDate}}	{{.ExpirationDate}}	{{.Status}}	{{.URL}}	{{.Redacted}}{{end}}
+{{.ID}}	{{.CreationDate}}	{{.ExpirationDate}}	{{.Status}}	{{.DownloadURL}}	{{.Redacted}}{{end}}
 `
 
 func (opts *JobsListOpts) Run() error {


### PR DESCRIPTION
## Proposed changes

This template: [internal/cli/atlas/privateendpoints/aws/interfaces/describe.go:30:6](https://github.com/mongodb/mongodb-atlas-cli/blob/a7deee87bb8d68a1e6085f0067a679fcb8489e24/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go#L46).

Is referring to a field `Url` which was renamed [a while ago](https://github.com/mongodb/go-client-mongodb-ops-manager/commit/a49c3a36369741f45037f55ed658db1742bd1982#diff-5c807e2c947d60cec925c404bb49befffa9688244d3786286d5036cabffee2af) to `DownloadURL`.

I've updated the template accordingly

_Jira ticket:_ CLOUDP-228643