### PR TITLE
task: fix unused args for anon functions

### DIFF
--- a/test/e2e/atlas/access_lists_test.go
+++ b/test/e2e/atlas/access_lists_test.go
@@ -34,7 +34,6 @@ func TestAccessList(t *testing.T) {
 	g.generateProject("accessList")
 
 	n, err := e2e.RandInt(255)
-	a := assert.New(t)
 	req := require.New(t)
 	req.NoError(err)
 
@@ -55,11 +54,10 @@ func TestAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err)
 
 		var entries *atlasv2.PaginatedNetworkAccess
-		err = json.Unmarshal(resp, &entries)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &entries))
 
 		found := false
 		for i := range entries.GetResults() {
@@ -69,7 +67,7 @@ func TestAccessList(t *testing.T) {
 			}
 		}
 
-		a.True(found)
+		assert.True(t, found)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -81,10 +79,9 @@ func TestAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 		var entries *atlasv2.PaginatedNetworkAccess
-		err = json.Unmarshal(resp, &entries)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &entries))
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -97,10 +94,9 @@ func TestAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 		var entry *atlasv2.NetworkPermissionEntry
-		err = json.Unmarshal(resp, &entry)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &entry))
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -113,10 +109,10 @@ func TestAccessList(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Project access list entry '%s' deleted\n", entry)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 
 	t.Run("Create Delete After", func(t *testing.T) {
@@ -131,11 +127,10 @@ func TestAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 
 		var entries *atlasv2.PaginatedNetworkAccess
-		err = json.Unmarshal(resp, &entries)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &entries))
 
 		found := false
 		for i := range entries.GetResults() {
@@ -144,7 +139,7 @@ func TestAccessList(t *testing.T) {
 				break
 			}
 		}
-		a.True(found)
+		assert.True(t, found)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -157,10 +152,10 @@ func TestAccessList(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Project access list entry '%s' deleted\n", entry)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 
 	t.Run("Create with CurrentIp", func(t *testing.T) {
@@ -174,12 +169,12 @@ func TestAccessList(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 
 		var entries *atlasv2.PaginatedNetworkAccess
-		err = json.Unmarshal(resp, &entries)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &entries))
 
+		a := assert.New(t)
 		a.NotEmpty(entries.GetResults())
 		a.Len(entries.GetResults(), 1)
 
@@ -196,9 +191,9 @@ func TestAccessList(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Project access list entry '%s' deleted\n", currentIPEntry)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 }

--- a/test/e2e/atlas/access_logs_test.go
+++ b/test/e2e/atlas/access_logs_test.go
@@ -47,10 +47,9 @@ func TestAccessLogs(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 		var entries *atlasv2.MongoDBAccessLogsList
-		err = json.Unmarshal(resp, &entries)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &entries))
 	})
 
 	t.Run("List by hostname", func(t *testing.T) {
@@ -62,9 +61,8 @@ func TestAccessLogs(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 		var entries *atlasv2.MongoDBAccessLogsList
-		err = json.Unmarshal(resp, &entries)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &entries))
 	})
 }

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -282,7 +282,7 @@ func deleteOrgTeams(t *testing.T, cliPath string) {
 	var teams atlasv2.PaginatedTeam
 	require.NoError(t, json.Unmarshal(resp, &teams), string(resp))
 	for _, team := range teams.GetResults() {
-		assert.NoError(t, deleteTeam(team.GetId()))
+		assert.NoError(t, deleteTeam(team.GetId())) //nolint: testifylint // try to delete all
 	}
 }
 

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -282,7 +282,7 @@ func deleteOrgTeams(t *testing.T, cliPath string) {
 	var teams atlasv2.PaginatedTeam
 	require.NoError(t, json.Unmarshal(resp, &teams), string(resp))
 	for _, team := range teams.GetResults() {
-		assert.NoError(t, deleteTeam(team.GetId())) //nolint: testifylint // try to delete all
+		assert.NoError(t, deleteTeam(team.GetId()))
 	}
 }
 

--- a/test/e2e/atlas/backup_export_buckets_test.go
+++ b/test/e2e/atlas/backup_export_buckets_test.go
@@ -56,10 +56,9 @@ func TestExportBuckets(t *testing.T) {
 
 		r.NoError(err, string(resp))
 
-		a := assert.New(t)
 		var exportBucket atlasv2.DiskBackupSnapshotAWSExportBucket
 		r.NoError(json.Unmarshal(resp, &exportBucket))
-		a.Equal(bucketName, exportBucket.GetBucketName())
+		assert.Equal(t, bucketName, exportBucket.GetBucketName())
 		bucketID = exportBucket.GetId()
 	})
 
@@ -107,6 +106,6 @@ func TestExportBuckets(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/atlas/backup_export_jobs_test.go
+++ b/test/e2e/atlas/backup_export_jobs_test.go
@@ -143,10 +143,9 @@ func TestExportJobs(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		r.NoError(err, string(resp))
-		a := assert.New(t)
 		var job atlasv2.DiskBackupExportJob
 		r.NoError(json.Unmarshal(resp, &job))
-		a.Equal(job.GetExportBucketId(), bucketID)
+		assert.Equal(t, job.GetExportBucketId(), bucketID)
 		exportJobID = job.GetId()
 	})
 
@@ -180,10 +179,9 @@ func TestExportJobs(t *testing.T) {
 
 		r.NoError(err, string(resp))
 
-		a := assert.New(t)
 		var job atlasv2.DiskBackupExportJob
 		r.NoError(json.Unmarshal(resp, &job))
-		a.Equal(job.GetExportBucketId(), bucketID)
+		assert.Equal(t, job.GetExportBucketId(), bucketID)
 	})
 
 	t.Run("List jobs", func(t *testing.T) {
@@ -199,9 +197,8 @@ func TestExportJobs(t *testing.T) {
 		r.NoError(err, string(resp))
 
 		var jobs atlasv2.PaginatedApiAtlasDiskBackupExportJob
-		a := assert.New(t)
 		r.NoError(json.Unmarshal(resp, &jobs))
-		a.NotEmpty(jobs)
+		assert.NotEmpty(t, jobs)
 	})
 
 	t.Run("Delete snapshot", func(t *testing.T) {
@@ -215,7 +212,7 @@ func TestExportJobs(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch snapshot deletion", func(t *testing.T) {

--- a/test/e2e/atlas/backup_restores_test.go
+++ b/test/e2e/atlas/backup_restores_test.go
@@ -30,8 +30,7 @@ import (
 
 func TestRestores(t *testing.T) {
 	cliPath, err := e2e.AtlasCLIBin()
-	r := require.New(t)
-	r.NoError(err)
+	require.NoError(t, err)
 
 	var snapshotID, restoreJobID string
 
@@ -57,12 +56,11 @@ func TestRestores(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
-		a := assert.New(t)
 		var snapshot atlasv2.DiskBackupSnapshot
 		require.NoError(t, json.Unmarshal(resp, &snapshot))
-		a.Equal("test-snapshot", snapshot.GetDescription())
+		assert.Equal(t, "test-snapshot", snapshot.GetDescription())
 		snapshotID = snapshot.GetId()
 	})
 
@@ -101,7 +99,7 @@ func TestRestores(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		var result atlasv2.DiskBackupSnapshotRestoreJob
 		require.NoError(t, json.Unmarshal(resp, &result))
 		restoreJobID = result.GetId()
@@ -121,7 +119,7 @@ func TestRestores(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Restores List", func(t *testing.T) {
@@ -136,12 +134,10 @@ func TestRestores(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
-
-		a := assert.New(t)
+		require.NoError(t, err, string(resp))
 		var result atlasv2.PaginatedCloudBackupRestoreJob
 		require.NoError(t, json.Unmarshal(resp, &result), string(resp))
-		a.NotEmpty(result)
+		assert.NotEmpty(t, result)
 	})
 
 	t.Run("Restores Describe", func(t *testing.T) {
@@ -158,12 +154,11 @@ func TestRestores(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
-		a := assert.New(t)
 		var result atlasv2.DiskBackupSnapshotRestoreJob
 		require.NoError(t, json.Unmarshal(resp, &result), string(resp))
-		a.NotEmpty(result)
+		assert.NotEmpty(t, result)
 	})
 
 	t.Run("Delete snapshot", func(t *testing.T) {
@@ -179,7 +174,7 @@ func TestRestores(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch snapshot deletion", func(t *testing.T) {

--- a/test/e2e/atlas/backup_schedule_test.go
+++ b/test/e2e/atlas/backup_schedule_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/test/e2e"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20231115005/admin"
 )
@@ -49,12 +50,10 @@ func TestSchedule(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		r.NoError(err)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(resp, &policy))
 
-		err = json.Unmarshal(resp, &policy)
-		r.NoError(err)
-
-		r.Equal(g.clusterName, policy.GetClusterName())
+		assert.Equal(t, g.clusterName, policy.GetClusterName())
 	})
 
 	t.Run("Update", func(t *testing.T) {
@@ -71,7 +70,7 @@ func TestSchedule(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -86,6 +85,6 @@ func TestSchedule(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/atlas/backup_snapshot_test.go
+++ b/test/e2e/atlas/backup_snapshot_test.go
@@ -17,7 +17,6 @@ package atlas_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -35,7 +34,6 @@ func TestSnapshots(t *testing.T) {
 
 	clusterName, err := RandClusterName()
 	r.NoError(err)
-	fmt.Println(clusterName)
 
 	var snapshotID string
 
@@ -52,10 +50,10 @@ func TestSnapshots(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var cluster *atlasv2.AdvancedClusterDescription
-		r.NoError(json.Unmarshal(resp, &cluster))
+		require.NoError(t, json.Unmarshal(resp, &cluster))
 		ensureCluster(t, cluster, clusterName, e2eSharedMDBVer, 10, false)
 	})
 	t.Cleanup(func() {
@@ -75,12 +73,11 @@ func TestSnapshots(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
-		a := assert.New(t)
 		var snapshot atlasv2.DiskBackupSnapshot
 		require.NoError(t, json.Unmarshal(resp, &snapshot))
-		a.Equal("test-snapshot", snapshot.GetDescription())
+		assert.Equal(t, "test-snapshot", snapshot.GetDescription())
 		snapshotID = snapshot.GetId()
 	})
 
@@ -93,8 +90,8 @@ func TestSnapshots(t *testing.T) {
 			"--clusterName",
 			clusterName)
 		cmd.Env = os.Environ()
-		resp, _ := cmd.CombinedOutput()
-		t.Log(string(resp))
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -107,12 +104,10 @@ func TestSnapshots(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
-
+		require.NoError(t, err, string(resp))
 		var backups atlasv2.PaginatedCloudBackupReplicaSet
-		a := assert.New(t)
-		r.NoError(json.Unmarshal(resp, &backups))
-		a.NotEmpty(backups)
+		require.NoError(t, json.Unmarshal(resp, &backups))
+		assert.NotEmpty(t, backups)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -127,12 +122,11 @@ func TestSnapshots(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
-		a := assert.New(t)
 		var result atlasv2.DiskBackupReplicaSet
-		r.NoError(json.Unmarshal(resp, &result))
-		a.Equal(snapshotID, result.GetId())
+		require.NoError(t, json.Unmarshal(resp, &result))
+		assert.Equal(t, snapshotID, result.GetId())
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -146,8 +140,7 @@ func TestSnapshots(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Watch deletion", func(t *testing.T) {

--- a/test/e2e/atlas/clusters_flags_test.go
+++ b/test/e2e/atlas/clusters_flags_test.go
@@ -61,11 +61,10 @@ func TestClustersFlags(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var cluster *atlasv2.AdvancedClusterDescription
-		err = json.Unmarshal(resp, &cluster)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &cluster))
 
 		ensureCluster(t, cluster, clusterName, e2eMDBVer, 30, true)
 	})
@@ -80,14 +79,11 @@ func TestClustersFlags(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var job *atlasv2.SampleDatasetStatus
-		err = json.Unmarshal(resp, &job)
-		req.NoError(err)
-
-		a := assert.New(t)
-		a.Equal(clusterName, job.GetClusterName())
+		require.NoError(t, json.Unmarshal(resp, &job))
+		assert.Equal(t, clusterName, job.GetClusterName())
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -98,14 +94,11 @@ func TestClustersFlags(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var clusters atlasv2.PaginatedAdvancedClusterDescription
-		err = json.Unmarshal(resp, &clusters)
-		req.NoError(err)
-
-		a := assert.New(t)
-		a.NotEmpty(clusters.Results)
+		require.NoError(t, json.Unmarshal(resp, &clusters))
+		assert.NotEmpty(t, clusters.Results)
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -117,14 +110,11 @@ func TestClustersFlags(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
-		err = json.Unmarshal(resp, &cluster)
-		req.NoError(err)
-
-		a := assert.New(t)
-		a.Equal(clusterName, cluster.GetName())
+		require.NoError(t, json.Unmarshal(resp, &cluster))
+		assert.Equal(t, clusterName, cluster.GetName())
 	})
 
 	t.Run("Describe Connection String", func(t *testing.T) {
@@ -137,11 +127,10 @@ func TestClustersFlags(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var connectionString atlasv2.ClusterConnectionStrings
-		err = json.Unmarshal(resp, &connectionString)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &connectionString))
 
 		a := assert.New(t)
 		a.NotEmpty(connectionString.GetStandard())
@@ -160,7 +149,7 @@ func TestClustersFlags(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Describe Advanced Configuration Settings", func(t *testing.T) {
@@ -173,11 +162,10 @@ func TestClustersFlags(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var config atlasv2.ClusterDescriptionProcessArgs
-		err = json.Unmarshal(resp, &config)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &config))
 
 		a := assert.New(t)
 		a.NotEmpty(config.GetMinimumEnabledTlsProtocol())
@@ -197,7 +185,7 @@ func TestClustersFlags(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Fail Delete for Termination Protection enabled", func(t *testing.T) {
@@ -210,7 +198,7 @@ func TestClustersFlags(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.Error(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Update", func(t *testing.T) {
@@ -225,11 +213,10 @@ func TestClustersFlags(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
-		err = json.Unmarshal(resp, &cluster)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(resp, &cluster))
 
 		ensureCluster(t, &cluster, clusterName, "5.0", 40, false)
 	})
@@ -238,10 +225,9 @@ func TestClustersFlags(t *testing.T) {
 		cmd := exec.Command(cliPath, clustersEntity, "delete", clusterName, "--projectId", g.projectID, "--force", "-w")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 
 		expected := "Cluster deleted"
-		a := assert.New(t)
-		a.Contains(string(resp), expected)
+		assert.Contains(t, string(resp), expected)
 	})
 }

--- a/test/e2e/atlas/clusters_sharded_test.go
+++ b/test/e2e/atlas/clusters_sharded_test.go
@@ -33,7 +33,6 @@ func TestShardedCluster(t *testing.T) {
 	g.generateProject("shardedClusters")
 
 	cliPath, err := e2e.AtlasCLIBin()
-	a := assert.New(t)
 	req := require.New(t)
 	req.NoError(err)
 
@@ -65,8 +64,7 @@ func TestShardedCluster(t *testing.T) {
 		req.NoError(err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
-		err = json.Unmarshal(resp, &cluster)
-		req.NoError(err)
+		req.NoError(json.Unmarshal(resp, &cluster))
 
 		ensureCluster(t, &cluster, shardedClusterName, e2eMDBVer, 30, false)
 	})
@@ -78,7 +76,7 @@ func TestShardedCluster(t *testing.T) {
 		req.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("Deleting cluster '%s'", shardedClusterName)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 
 	t.Run("Watch deletion", func(t *testing.T) {

--- a/test/e2e/atlas/data_federation_db_test.go
+++ b/test/e2e/atlas/data_federation_db_test.go
@@ -61,10 +61,9 @@ func TestDataFederation(t *testing.T) {
 
 		r.NoError(err, string(resp))
 
-		a := assert.New(t)
 		var dataLake atlasv2.DataLakeTenant
 		require.NoError(t, json.Unmarshal(resp, &dataLake))
-		a.Equal(dataFederationName, dataLake.GetName())
+		assert.Equal(t, dataFederationName, dataLake.GetName())
 	})
 
 	t.Run("Describe", func(t *testing.T) {
@@ -77,11 +76,9 @@ func TestDataFederation(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 
 		r.NoError(err, string(resp))
-
-		a := assert.New(t)
 		var dataLake atlasv2.DataLakeTenant
 		require.NoError(t, json.Unmarshal(resp, &dataLake))
-		a.Equal(dataFederationName, dataLake.GetName())
+		assert.Equal(t, dataFederationName, dataLake.GetName())
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -94,9 +91,8 @@ func TestDataFederation(t *testing.T) {
 		r.NoError(err, string(resp))
 
 		var r []atlasv2.DataLakeTenant
-		a := assert.New(t)
 		require.NoError(t, json.Unmarshal(resp, &r))
-		a.NotEmpty(r)
+		assert.NotEmpty(t, r)
 	})
 
 	t.Run("Update", func(t *testing.T) {
@@ -113,9 +109,8 @@ func TestDataFederation(t *testing.T) {
 		r.NoError(err, string(resp))
 
 		var dataLake atlasv2.DataLakeTenant
-		a := assert.New(t)
 		require.NoError(t, json.Unmarshal(resp, &dataLake))
-		a.Equal(updateRegion, dataLake.GetDataProcessRegion().Region)
+		assert.Equal(t, updateRegion, dataLake.GetDataProcessRegion().Region)
 	})
 
 	t.Run("Log", func(t *testing.T) {
@@ -133,7 +128,7 @@ func TestDataFederation(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		resp, err := cmd.CombinedOutput()
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/test/e2e/atlas/deployments_atlas_test.go
+++ b/test/e2e/atlas/deployments_atlas_test.go
@@ -51,7 +51,6 @@ func TestDeploymentsAtlas(t *testing.T) {
 
 	dbUserPassword := dbUserUsername + "~PwD"
 
-	var connectionString string
 	var client *mongo.Client
 	ctx := context.Background()
 
@@ -79,10 +78,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 		cmd.Stdout = &o
 		cmd.Stderr = &e
 		err = cmd.Run()
-		req.NoError(err, e.String())
-
-		connectionString = strings.TrimSpace(o.String())
-		connectionString = strings.Replace(connectionString, "Your connection string: ", "", 1)
+		require.NoError(t, err, e.String())
 	})
 	require.NoError(t, watchCluster(g.projectID, clusterName))
 
@@ -112,7 +108,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 					Password:      dbUserPassword,
 				}),
 		)
-		req.NoError(err)
+		require.NoError(t, err)
 	})
 
 	t.Cleanup(func() {
@@ -129,7 +125,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		assert.Contains(t, string(resp), fmt.Sprintf("Pausing deployment '%s'", clusterName))
 	})
 
@@ -143,9 +139,8 @@ func TestDeploymentsAtlas(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
-		a := assert.New(t)
-		a.Contains(string(resp), fmt.Sprintf("Starting deployment '%s'", clusterName))
+		require.NoError(t, err, string(resp))
+		assert.Contains(t, string(resp), fmt.Sprintf("Starting deployment '%s'", clusterName))
 	})
 	require.NoError(t, watchCluster(g.projectID, clusterName))
 
@@ -169,7 +164,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 
 		r, err := cmd.CombinedOutput()
 		out := string(r)
-		req.NoError(err, out)
+		require.NoError(t, err, out)
 		assert.Contains(t, out, "Search index created")
 	})
 

--- a/test/e2e/atlas/deployments_local_auth_test.go
+++ b/test/e2e/atlas/deployments_local_auth_test.go
@@ -313,7 +313,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		r, err := cmd.CombinedOutput()
 		out := string(r)
 		require.NoError(t, err, out)
-		assert.Contains(t, fmt.Sprintf("Pausing deployment '%s'", deploymentName), out)
+		assert.Contains(t, out, fmt.Sprintf("Pausing deployment '%s'", deploymentName))
 	})
 
 	t.Run("Start Deployment", func(t *testing.T) {

--- a/test/e2e/atlas/deployments_local_auth_test.go
+++ b/test/e2e/atlas/deployments_local_auth_test.go
@@ -75,7 +75,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		r, setupErr := cmd.CombinedOutput()
-		req.NoError(setupErr, string(r))
+		require.NoError(t, setupErr, string(r))
 	})
 
 	t.Cleanup(func() {
@@ -91,7 +91,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		r, delErr := cmd.CombinedOutput()
-		req.NoError(delErr, string(r))
+		require.NoError(t, delErr, string(r))
 	})
 
 	t.Run("List deployments", func(t *testing.T) {
@@ -105,16 +105,16 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		o, e, err := splitOutput(cmd)
-		req.NoError(err, e)
+		require.NoError(t, err, e)
 
 		outputLines := strings.Split(o, "\n")
-		req.Equal(`NAME        TYPE    MDB VER   STATE`, outputLines[0])
+		assert.Equal(t, `NAME        TYPE    MDB VER   STATE`, outputLines[0])
 
 		cols := strings.Fields(outputLines[1])
-		req.Equal(deploymentName, cols[0])
-		req.Equal("LOCAL", cols[1])
-		req.Contains(cols[2], "7.0.")
-		req.Equal("IDLE", cols[3])
+		assert.Equal(t, deploymentName, cols[0])
+		assert.Equal(t, "LOCAL", cols[1])
+		assert.Equal(t, "7.0.", cols[2])
+		assert.Equal(t, "IDLE", cols[3])
 	})
 
 	ctx := context.Background()
@@ -140,7 +140,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		r, err := cmd.CombinedOutput()
-		req.NoError(err, string(r))
+		require.NoError(t, err, string(r))
 
 		connectionString := strings.TrimSpace(string(r))
 		client, err = mongo.Connect(ctx, options.Client().ApplyURI(connectionString))
@@ -249,7 +249,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		r, err := cmd.CombinedOutput()
-		req.NoError(err, string(r))
+		require.NoError(t, err, string(r))
 	})
 
 	t.Run("Test Search Index", func(t *testing.T) {
@@ -264,10 +264,10 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 				},
 			},
 		})
-		req.NoError(err)
+		require.NoError(t, err)
 		var results []bson.M
-		req.NoError(c.All(ctx, &results))
-		req.Len(results, 1)
+		require.NoError(t, c.All(ctx, &results))
+		assert.Len(t, results, 1)
 	})
 
 	t.Run("Delete Index", func(t *testing.T) {
@@ -294,7 +294,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		var o, e bytes.Buffer
 		cmd.Stdout = &o
 		cmd.Stderr = &e
-		req.NoError(cmd.Run(), e.String())
+		require.NoError(t, cmd.Run(), e.String())
 		assert.Contains(t, o.String(), fmt.Sprintf("Index '%s' deleted", indexID))
 	})
 
@@ -312,9 +312,8 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 
 		r, err := cmd.CombinedOutput()
 		out := string(r)
-		req.NoError(err, out)
-		a := assert.New(t)
-		a.Contains(out, fmt.Sprintf("Pausing deployment '%s'", deploymentName))
+		require.NoError(t, err, out)
+		assert.Contains(t, fmt.Sprintf("Pausing deployment '%s'", deploymentName), out)
 	})
 
 	t.Run("Start Deployment", func(t *testing.T) {
@@ -329,7 +328,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		cmd.Env = os.Environ()
 		r, err := cmd.CombinedOutput()
 		out := string(r)
-		req.NoError(err, out)
+		require.NoError(t, err, out)
 		assert.Contains(t, out, fmt.Sprintf("Starting deployment '%s'", deploymentName))
 	})
 }

--- a/test/e2e/atlas/deployments_local_auth_test.go
+++ b/test/e2e/atlas/deployments_local_auth_test.go
@@ -113,7 +113,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		cols := strings.Fields(outputLines[1])
 		assert.Equal(t, deploymentName, cols[0])
 		assert.Equal(t, "LOCAL", cols[1])
-		assert.Equal(t, "7.0.", cols[2])
+		assert.Contains(t, cols[2], "7.0.")
 		assert.Equal(t, "IDLE", cols[3])
 	})
 

--- a/test/e2e/atlas/deployments_local_test.go
+++ b/test/e2e/atlas/deployments_local_test.go
@@ -98,16 +98,16 @@ func TestDeploymentsLocal(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		o, e, err := splitOutput(cmd)
-		req.NoError(err, e)
+		require.NoError(t, err, e)
 
 		outputLines := strings.Split(o, "\n")
 		req.Equal(`NAME   TYPE    MDB VER   STATE`, outputLines[0])
 
 		cols := strings.Fields(outputLines[1])
-		req.Equal(deploymentName, cols[0])
-		req.Equal("LOCAL", cols[1])
-		req.Contains(cols[2], "7.0.")
-		req.Equal("IDLE", cols[3])
+		assert.Equal(t, deploymentName, cols[0])
+		assert.Equal(t, "LOCAL", cols[1])
+		assert.Contains(t, cols[2], "7.0.")
+		assert.Equal(t, "IDLE", cols[3])
 	})
 
 	ctx := context.Background()
@@ -129,11 +129,11 @@ func TestDeploymentsLocal(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		r, err := cmd.CombinedOutput()
-		req.NoError(err, string(r))
+		require.NoError(t, err, string(r))
 
 		connectionString := strings.TrimSpace(string(r))
 		client, err = mongo.Connect(ctx, options.Client().ApplyURI(connectionString))
-		req.NoError(err)
+		require.NoError(t, err)
 		myDB = client.Database(databaseName)
 		myCol = myDB.Collection(collectionName)
 	})
@@ -151,15 +151,14 @@ func TestDeploymentsLocal(t *testing.T) {
 				"name": "test2",
 			},
 		})
-		req.NoError(err)
+		require.NoError(t, err)
 		t.Log(ids)
 
 		b, err := os.ReadFile("sample_embedded_movies.json")
-		req.NoError(err)
+		require.NoError(t, err)
 
 		var movies []interface{}
-		err = json.Unmarshal(b, &movies)
-		req.NoError(err)
+		require.NoError(t, json.Unmarshal(b, &movies))
 
 		ids, err = client.Database(vectorSearchDB).Collection(vectorSearchCol).InsertMany(ctx, movies)
 		req.NoError(err)
@@ -188,9 +187,8 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		r, err := cmd.CombinedOutput()
 		out := string(r)
-		req.NoError(err, out)
-		a := assert.New(t)
-		a.Contains(out, "Search index created with ID:")
+		require.NoError(t, err, out)
+		assert.Contains(t, out, "Search index created with ID:")
 	})
 
 	var indexID string
@@ -215,8 +213,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		o, e, err := splitOutput(cmd)
 		req.NoError(err, e)
-		a := assert.New(t)
-		a.Contains(o, searchIndexName)
+		assert.Contains(t, o, searchIndexName)
 
 		lines := strings.Split(o, "\n")
 		cols := strings.Fields(lines[1])
@@ -239,7 +236,7 @@ func TestDeploymentsLocal(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		r, err := cmd.CombinedOutput()
-		req.NoError(err, string(r))
+		require.NoError(t, err, string(r))
 	})
 
 	t.Run("Test Search Index", func(t *testing.T) {
@@ -254,10 +251,10 @@ func TestDeploymentsLocal(t *testing.T) {
 				},
 			},
 		})
-		req.NoError(err)
+		require.NoError(t, err)
 		var results []bson.M
-		req.NoError(c.All(ctx, &results))
-		req.Len(results, 1)
+		require.NoError(t, c.All(ctx, &results))
+		assert.Len(t, results, 1)
 	})
 
 	t.Run("Delete Index", func(t *testing.T) {
@@ -280,10 +277,8 @@ func TestDeploymentsLocal(t *testing.T) {
 		var o, e bytes.Buffer
 		cmd.Stdout = &o
 		cmd.Stderr = &e
-		err := cmd.Run()
-		req.NoError(err, e.String())
-		a := assert.New(t)
-		a.Contains(o.String(), fmt.Sprintf("Index '%s' deleted", indexID))
+		require.NoError(t, cmd.Run(), e.String())
+		assert.Contains(t, o.String(), fmt.Sprintf("Index '%s' deleted", indexID))
 	})
 
 	t.Run("Create vectorSearch Index", func(t *testing.T) {
@@ -305,9 +300,8 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		r, err := cmd.CombinedOutput()
 		out := string(r)
-		req.NoError(err, out)
-		a := assert.New(t)
-		a.Contains(out, "Search index created with ID:")
+		require.NoError(t, err, out)
+		assert.Contains(t, out, "Search index created with ID:")
 	})
 
 	t.Run("Index List vectorSearch", func(t *testing.T) {
@@ -330,8 +324,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		o, e, err := splitOutput(cmd)
 		req.NoError(err, e)
-		a := assert.New(t)
-		a.Contains(o, "sampleVectorSearch")
+		assert.Contains(t, o, "sampleVectorSearch")
 	})
 
 	t.Run("Test vectorSearch Index", func(t *testing.T) {

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -694,13 +694,13 @@ func deleteAllClustersForProject(t *testing.T, cliPath, projectID string) {
 	clusters := listClustersForProject(t, cliPath, projectID)
 	for _, cluster := range clusters.GetResults() {
 		func(clusterName, state string) {
-			t.Run(fmt.Sprintf("delete cluster %s\n", clusterName), func(t *testing.T) {
+			t.Run("delete cluster "+clusterName, func(t *testing.T) {
 				t.Parallel()
 				if state == deletingState {
 					_ = watchCluster(projectID, clusterName)
 					return
 				}
-				assert.NoError(t, deleteClusterForProject(projectID, clusterName))
+				assert.NoError(t, deleteClusterForProject(projectID, clusterName)) //nolint: testifylint // we want to check all instead of failing early
 			})
 		}(cluster.GetName(), cluster.GetStateName())
 	}
@@ -720,7 +720,7 @@ func deleteDatapipelinesForProject(t *testing.T, cliPath, projectID string) {
 	var pipelines []atlasv2.DataLakeIngestionPipeline
 	require.NoError(t, json.Unmarshal(resp, &pipelines))
 	for _, p := range pipelines {
-		assert.NoError(t, deleteDatalakeForProject(cliPath, projectID, p.GetName()))
+		assert.NoError(t, deleteDatalakeForProject(cliPath, projectID, p.GetName())) //nolint: testifylint // we want to check all instead of failing early
 	}
 }
 
@@ -756,7 +756,7 @@ func deleteAllNetworkPeers(t *testing.T, cliPath, projectID, provider string) {
 		)
 		cmd.Env = os.Environ()
 		resp, err = cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp))
+		assert.NoError(t, err, string(resp)) //nolint: testifylint // we want to check all instead of failing early
 	}
 }
 

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -700,7 +700,7 @@ func deleteAllClustersForProject(t *testing.T, cliPath, projectID string) {
 					_ = watchCluster(projectID, clusterName)
 					return
 				}
-				assert.NoError(t, deleteClusterForProject(projectID, clusterName)) //nolint: testifylint // we want to check all instead of failing early
+				assert.NoError(t, deleteClusterForProject(projectID, clusterName))
 			})
 		}(cluster.GetName(), cluster.GetStateName())
 	}
@@ -720,7 +720,7 @@ func deleteDatapipelinesForProject(t *testing.T, cliPath, projectID string) {
 	var pipelines []atlasv2.DataLakeIngestionPipeline
 	require.NoError(t, json.Unmarshal(resp, &pipelines))
 	for _, p := range pipelines {
-		assert.NoError(t, deleteDatalakeForProject(cliPath, projectID, p.GetName())) //nolint: testifylint // we want to check all instead of failing early
+		assert.NoError(t, deleteDatalakeForProject(cliPath, projectID, p.GetName()))
 	}
 }
 
@@ -756,7 +756,7 @@ func deleteAllNetworkPeers(t *testing.T, cliPath, projectID, provider string) {
 		)
 		cmd.Env = os.Environ()
 		resp, err = cmd.CombinedOutput()
-		assert.NoError(t, err, string(resp)) //nolint: testifylint // we want to check all instead of failing early
+		assert.NoError(t, err, string(resp))
 	}
 }
 

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -799,8 +799,7 @@ func listPrivateEndpointsByProject(t *testing.T, cliPath, projectID, provider st
 	t.Log(string(resp))
 	require.NoError(t, err, string(resp))
 	var privateEndpoints []atlasv2.EndpointService
-	err = json.Unmarshal(resp, &privateEndpoints)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp, &privateEndpoints))
 
 	return privateEndpoints
 }

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -824,7 +824,7 @@ func TestProjectAndTeams(t *testing.T) {
 		})
 
 		checkProject(t, objects, expectedProject, assertions)
-		t.Run("Team is created", func(t *testing.T) {
+		t.Run("Team is created", func(_ *testing.T) {
 			for _, obj := range objects {
 				if team, ok := obj.(*akov2.AtlasTeam); ok {
 					assertions.Equal(expectedTeam, team)

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -36,13 +36,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const operatorNamespace = "atlas-operator"
-const maxAttempts = 12
-const deploymentMaxAttempts = 36
-const poolInterval = 10 * time.Second
+const (
+	operatorNamespace     = "atlas-operator"
+	maxAttempts           = 12
+	deploymentMaxAttempts = 36
+	poolInterval          = 10 * time.Second
+)
 
 func TestKubernetesOperatorInstall(t *testing.T) {
-	a := assert.New(t)
 	req := require.New(t)
 
 	cliPath, err := e2e.AtlasCLIBin()
@@ -57,8 +58,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--operatorVersion", "1.1.0")
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
-		req.Error(inErr, string(resp))
-		a.Equal("Error: version 1.1.0 is not supported\n", string(resp))
+		require.Error(t, inErr, string(resp))
+		assert.Equal(t, "Error: version 1.1.0 is not supported\n", string(resp))
 	})
 
 	t.Run("should failed to install a non-existing version of the operator", func(t *testing.T) {
@@ -69,8 +70,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--operatorVersion", "100.0.0")
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
-		req.Error(inErr, string(resp))
-		a.Equal("Error: version 100.0.0 is not supported\n", string(resp))
+		require.Error(t, inErr, string(resp))
+		assert.Equal(t, "Error: version 100.0.0 is not supported\n", string(resp))
 	})
 
 	t.Run("should failed when unable to setup connection to the cluster", func(t *testing.T) {
@@ -81,8 +82,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--kubeconfig", "/path/to/non/existing/config")
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
-		req.Error(inErr, string(resp))
-		a.Equal("Error: unable to prepare client configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable\n", string(resp))
+		require.Error(t, inErr, string(resp))
+		assert.Equal(t, "Error: unable to prepare client configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable\n", string(resp))
 	})
 
 	t.Run("should install operator with default options", func(t *testing.T) {
@@ -97,8 +98,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
-		req.NoError(inErr, string(resp))
-		a.Equal("Atlas Kubernetes Operator installed successfully\n", string(resp))
+		require.NoError(t, inErr, string(resp))
+		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
 		checkDeployment(t, operator, "default")
 	})
@@ -117,8 +118,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
-		req.NoError(inErr, string(resp))
-		a.Equal("Atlas Kubernetes Operator installed successfully\n", string(resp))
+		require.NoError(t, inErr, string(resp))
+		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
 		checkDeployment(t, operator, operatorNamespace)
 	})
@@ -141,8 +142,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
 		req.NoError(inErr, string(resp))
-		a.Equal("Atlas Kubernetes Operator installed successfully\n", string(resp))
-
+		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 		checkDeployment(t, operator, operatorNamespace)
 	})
 
@@ -162,7 +162,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
 		req.NoError(inErr, string(resp))
-		a.Equal("Atlas Kubernetes Operator installed successfully\n", string(resp))
+		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
 		checkDeployment(t, operator, operatorNamespace)
 	})
@@ -183,8 +183,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
-		req.NoError(inErr, string(resp))
-		a.Equal("Atlas Kubernetes Operator installed successfully\n", string(resp))
+		require.NoError(t, inErr, string(resp))
+		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
 		checkDeployment(t, operator, operatorNamespace)
 
@@ -194,7 +194,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			projectSecret,
 			false,
 		)
-		req.NoError(inErr)
+		require.NoError(t, inErr)
 
 		orgSecret := &corev1.Secret{}
 		inErr = operator.getK8sObject(
@@ -202,7 +202,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			orgSecret,
 			false,
 		)
-		req.Error(inErr)
+		require.Error(t, inErr)
 
 		checkK8sAtlasProject(t, operator, client.ObjectKey{Name: prepareK8sName(projectName), Namespace: operatorNamespace})
 
@@ -259,7 +259,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
 		req.NoError(inErr, string(resp))
-		a.Equal("Atlas Kubernetes Operator installed successfully\n", string(resp))
+		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
 		checkDeployment(t, operator, operatorNamespace)
 		checkK8sAtlasProject(t, operator, client.ObjectKey{Name: prepareK8sName(g.projectName), Namespace: operatorNamespace})
@@ -288,18 +288,17 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
-		req.NoError(inErr, string(resp))
-		a.Equal("Atlas Kubernetes Operator installed successfully\n", string(resp))
+		require.NoError(t, inErr, string(resp))
+		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
 		checkDeployment(t, operator, operatorNamespace)
 
 		deployment := &appsv1.Deployment{}
-		err := operator.getK8sObject(
+		require.NoError(t, operator.getK8sObject(
 			client.ObjectKey{Name: "mongodb-atlas-operator", Namespace: operatorNamespace},
 			deployment,
 			false,
-		)
-		require.NoError(t, err)
+		))
 		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--resourceDeletionProtection=false")
 		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--subresourceDeletionProtection=false")
 

--- a/test/e2e/atlas/live_migrations_test.go
+++ b/test/e2e/atlas/live_migrations_test.go
@@ -52,7 +52,7 @@ func TestLinkToken(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Delete", func(t *testing.T) {
@@ -64,6 +64,6 @@ func TestLinkToken(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 
-		r.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/atlas/search_test.go
+++ b/test/e2e/atlas/search_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 //go:build e2e || (atlas && search)
 
 package atlas_test
@@ -60,9 +61,9 @@ func TestSearch(t *testing.T) {
 
 		file, err := os.Create(fileName)
 		require.NoError(t, err)
-		defer func() {
+		t.Cleanup(func() {
 			require.NoError(t, os.Remove(fileName))
-		}()
+		})
 
 		tpl := template.Must(template.New("").Parse(`
 {
@@ -122,11 +123,9 @@ func TestSearch(t *testing.T) {
 
 		file, err := os.Create(fileName)
 		require.NoError(t, err)
-		defer func() {
-			if e := os.Remove(fileName); e != nil {
-				t.Errorf("error deleting file '%v': %v", fileName, e)
-			}
-		}()
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(fileName))
+		})
 
 		tpl := template.Must(template.New("").Parse(`
 {
@@ -189,9 +188,7 @@ func TestSearch(t *testing.T) {
 		file, err := os.Create(fileName)
 		r.NoError(err)
 		t.Cleanup(func() {
-			if e := os.Remove(fileName); e != nil {
-				t.Errorf("error deleting file '%v': %v", fileName, e)
-			}
+			require.NoError(t, os.Remove(fileName))
 		})
 
 		tpl := template.Must(template.New("").Parse(`
@@ -255,9 +252,7 @@ func TestSearch(t *testing.T) {
 		file, err := os.Create(fileName)
 		r.NoError(err)
 		t.Cleanup(func() {
-			if e := os.Remove(fileName); e != nil {
-				t.Errorf("error deleting file '%v': %v", fileName, e)
-			}
+			require.NoError(t, os.Remove(fileName))
 		})
 
 		tpl := template.Must(template.New("").Parse(`
@@ -363,9 +358,7 @@ func TestSearch(t *testing.T) {
 		file, err := os.Create(fileName)
 		r.NoError(err)
 		t.Cleanup(func() {
-			if e := os.Remove(fileName); e != nil {
-				t.Errorf("error deleting file '%v': %v", fileName, e)
-			}
+			require.NoError(t, os.Remove(fileName))
 		})
 
 		tpl := template.Must(template.New("").Parse(`

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -58,7 +58,7 @@ func TestSetup(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 		assert.Contains(t, string(resp), "Cluster created.", string(resp))
 	})
 	t.Cleanup(func() {
@@ -73,13 +73,13 @@ func TestSetup(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err)
+		require.NoError(t, err, string(resp))
 
 		var entries *atlasv2.PaginatedNetworkAccess
-		err = json.Unmarshal(resp, &entries)
-		req.NoError(err)
-		req.Len(entries.GetResults(), 1, "Expected 1 IP in list of IP's")
-		req.Contains(entries.GetResults()[0].GetIpAddress(), arbitraryAccessListIP, "IP from list does not match added IP")
+		require.NoError(t, json.Unmarshal(resp, &entries))
+
+		assert.Len(t, entries.GetResults(), 1, "Expected 1 IP in list of IP's")
+		assert.Contains(t, entries.GetResults()[0].GetIpAddress(), arbitraryAccessListIP, "IP from list does not match added IP")
 	})
 
 	require.NoError(t, watchCluster(g.projectID, clusterName))

--- a/test/e2e/atlas/streams_test.go
+++ b/test/e2e/atlas/streams_test.go
@@ -35,8 +35,6 @@ func TestStreams(t *testing.T) {
 
 	g := newAtlasE2ETestGenerator(t)
 	g.generateProject("atlasStreams")
-
-	a := assert.New(t)
 	req := require.New(t)
 
 	cliPath, err := e2e.AtlasCLIBin()
@@ -66,7 +64,7 @@ func TestStreams(t *testing.T) {
 		req.NoError(json.Unmarshal(resp, &instances))
 
 		// These instances don't have a default instance, since the projects are instantiated automatically
-		a.Empty(instances.Results, "A new project should have no instances")
+		assert.Empty(t, instances.Results, "A new project should have no instances")
 	})
 
 	t.Run("Creating a streams instance", func(t *testing.T) {
@@ -91,7 +89,7 @@ func TestStreams(t *testing.T) {
 		var instance atlasv2.StreamsTenant
 		req.NoError(json.Unmarshal(resp, &instance))
 
-		a.Equal(*instance.Name, instanceName)
+		assert.Equal(t, instance.GetName(), instanceName)
 	})
 
 	t.Run("List all streams in the e2e project after creating", func(t *testing.T) {
@@ -106,11 +104,12 @@ func TestStreams(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var instances atlasv2.PaginatedApiStreamsTenant
-		req.NoError(json.Unmarshal(resp, &instances))
+		require.NoError(t, json.Unmarshal(resp, &instances))
 
+		a := assert.New(t)
 		a.Len(instances.GetResults(), 1)
 		a.Equal(*instances.GetResults()[0].Name, instanceName)
 		a.Equal("AWS", instances.GetResults()[0].DataProcessRegion.CloudProvider)
@@ -135,6 +134,7 @@ func TestStreams(t *testing.T) {
 		var instance atlasv2.StreamsTenant
 		req.NoError(json.Unmarshal(resp, &instance))
 
+		a := assert.New(t)
 		a.Equal(instanceName, *instance.Name)
 		a.Equal("AWS", instance.DataProcessRegion.CloudProvider)
 		a.Equal("VIRGINIA_USA", instance.DataProcessRegion.Region)
@@ -163,6 +163,7 @@ func TestStreams(t *testing.T) {
 		var instance atlasv2.StreamsTenant
 		req.NoError(json.Unmarshal(resp, &instance))
 
+		a := assert.New(t)
 		a.Equal(*instance.Name, instanceName)
 		a.Equal("AWS", instance.DataProcessRegion.CloudProvider)
 		a.Equal("VIRGINIA_USA", instance.DataProcessRegion.Region)
@@ -191,7 +192,7 @@ func TestStreams(t *testing.T) {
 		var connection atlasv2.StreamsConnection
 		req.NoError(json.Unmarshal(resp, &connection))
 
-		a.Equal(*connection.Name, connectionName)
+		assert.Equal(t, connection.GetName(), connectionName)
 	})
 
 	t.Run("Describing a streams connection", func(t *testing.T) {
@@ -209,11 +210,12 @@ func TestStreams(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		var connection atlasv2.StreamsConnection
-		req.NoError(json.Unmarshal(resp, &connection))
+		require.NoError(t, json.Unmarshal(resp, &connection))
 
+		a := assert.New(t)
 		a.Equal(connectionName, *connection.Name)
 		a.Equal("Kafka", *connection.Type)
 		a.Equal("example.com:8080,fraud.example.com:8000", *connection.BootstrapServers)
@@ -239,9 +241,10 @@ func TestStreams(t *testing.T) {
 		req.NoError(json.Unmarshal(resp, &response))
 
 		connections := response.GetResults()
+		a := assert.New(t)
 		a.Len(connections, 1)
-		a.Equal(connectionName, *connections[0].Name)
-		a.Equal("Kafka", *connections[0].Type)
+		a.Equal(connectionName, connections[0].GetName())
+		a.Equal("Kafka", connections[0].GetType())
 		a.Equal("example.com:8080,fraud.example.com:8000", *connections[0].BootstrapServers)
 	})
 
@@ -266,9 +269,9 @@ func TestStreams(t *testing.T) {
 
 		var connection atlasv2.StreamsConnection
 		req.NoError(json.Unmarshal(resp, &connection))
-
+		a := assert.New(t)
 		a.Equal(*connection.Name, connectionName)
-		a.Equal("SSL", *connection.Security.Protocol)
+		a.Equal("SSL", connection.Security.GetProtocol())
 	})
 
 	t.Run("Deleting a streams connection", func(t *testing.T) {
@@ -286,10 +289,10 @@ func TestStreams(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Atlas Stream Processing connection '%s' deleted\n", connectionName)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 
 	// Runs last after the connection work
@@ -307,9 +310,9 @@ func TestStreams(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		req.NoError(err, string(resp))
+		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Atlas Streams processor instance '%s' deleted\n", instanceName)
-		a.Equal(expected, string(resp))
+		assert.Equal(t, expected, string(resp))
 	})
 }


### PR DESCRIPTION
Linting update now flags unused params on anonymous functions, first of a couple of PRs fixing this (splitting to make the review easy), this one targets the test folder