### PR TITLE
task: fix unused args for anon functions

### DIFF
--- a/internal/cli/atlas/accesslists/create.go
+++ b/internal/cli/atlas/accesslists/create.go
@@ -177,7 +177,7 @@ The command doesn't overwrite existing entries in the access list. Instead, it a
 				opts.validateCurrentIPFlag(cmd, args),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
 			if len(args) == 0 {
 				opts.entry, err = IPAddress()

--- a/internal/cli/atlas/accesslists/delete.go
+++ b/internal/cli/atlas/accesslists/delete.go
@@ -73,7 +73,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/accesslists/describe.go
+++ b/internal/cli/atlas/accesslists/describe.go
@@ -69,14 +69,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the access list entry 192.0.2.0/24 in the project with ID 5e2211c17a3e5a48f5497de3:
   %s accessLists describe 192.0.2.0/24 --output json --projectId 5e1234c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/accesslists/list.go
+++ b/internal/cli/atlas/accesslists/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: `  # Return a JSON-formatted list of all access list entries for the project with ID 5e1234c17a3e5a48f5497de3:		
   atlas accessLists list --output json --projectId 5e1234c17a3e5a48f5497de3`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/accesslogs/list.go
+++ b/internal/cli/atlas/accesslogs/list.go
@@ -121,14 +121,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all authentication requests made against the cluster named Cluster0 for the project with ID 618d48e05277a606ed2496fe:		
   %s accesslogs list --output json --projectId 618d48e05277a606ed2496fe --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateInput,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/alerts/acknowledge.go
+++ b/internal/cli/atlas/alerts/acknowledge.go
@@ -96,7 +96,7 @@ func AcknowledgeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"ack"},
 		Args:    require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.forever && opts.until != "" {
 				return fmt.Errorf("--%s and --%s are exclusive", flag.Forever, flag.Until)
 			}
@@ -112,7 +112,7 @@ func AcknowledgeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Acknowledge an alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3 until January 1 2028:
   %s alerts acknowledge 5d1113b25a115342acc2d1aa --until 2028-01-01T20:24:26Z --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/alerts/describe.go
+++ b/internal/cli/atlas/alerts/describe.go
@@ -76,14 +76,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s alerts describe 5d1113b25a115342acc2d1aa --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/alerts/list.go
+++ b/internal/cli/atlas/alerts/list.go
@@ -80,14 +80,14 @@ func ListBuilder() *cobra.Command {
 			"output": listTemplate,
 		},
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/alerts/settings/create.go
+++ b/internal/cli/atlas/alerts/settings/create.go
@@ -93,7 +93,7 @@ func CreateBuilder() *cobra.Command {
   --output json --projectId 5df90590f10fab5e33de2305
   # Create alert using json file containing alert configuration
   %s alerts settings create 5d1113b25a115342acc2d1aa --file alerts.json`, cli.ExampleAtlasEntryPoint(), cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				func() error {
@@ -106,7 +106,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/alerts/settings/delete.go
+++ b/internal/cli/atlas/alerts/settings/delete.go
@@ -70,7 +70,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/alerts/settings/describe.go
+++ b/internal/cli/atlas/alerts/settings/describe.go
@@ -69,14 +69,14 @@ func describeBuilder() *cobra.Command {
 		},
 		Aliases: []string{"get"},
 		Args:    require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), settingsTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/alerts/settings/disable.go
+++ b/internal/cli/atlas/alerts/settings/disable.go
@@ -59,7 +59,7 @@ func DisableBuilder() *cobra.Command {
 		Use:   "disable <alertConfigId>",
 		Short: "Disables one alert configuration for the specified project.",
 		Args:  require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -70,7 +70,7 @@ func DisableBuilder() *cobra.Command {
 			"alertConfigIdDesc": "ID of the alert configuration you want to disable.",
 			"output":            disableTemplate,
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/alerts/settings/enable.go
+++ b/internal/cli/atlas/alerts/settings/enable.go
@@ -60,7 +60,7 @@ func EnableBuilder() *cobra.Command {
 		Use:   "enable <alertConfigId>",
 		Short: "Enables one alert configuration for the specified project.",
 		Args:  require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -73,7 +73,7 @@ func EnableBuilder() *cobra.Command {
 			"alertConfigIdDesc": "ID of the alert you want to enable.",
 			"output":            enableTemplate,
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/alerts/settings/fields_type.go
+++ b/internal/cli/atlas/alerts/settings/fields_type.go
@@ -63,11 +63,11 @@ func FieldsTypeBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of accepted field types for the matchersFieldName option:
   %s alerts settings fields type --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/alerts/settings/list.go
+++ b/internal/cli/atlas/alerts/settings/list.go
@@ -80,14 +80,14 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{},
 		Aliases:     []string{"ls"},
 		Args:        require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), settingsListTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/alerts/settings/update.go
+++ b/internal/cli/atlas/alerts/settings/update.go
@@ -94,7 +94,7 @@ func UpdateBuilder() *cobra.Command {
 		--output json --projectId 5df90590f10fab5e33de2305
   # Update alert using json file input containing alert configuration
   %s alerts settings update 5d1113b25a115342acc2d1aa --file alerts.json`, cli.ExampleAtlasEntryPoint(), cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				func() error {
@@ -107,7 +107,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/alerts/unacknowledge.go
+++ b/internal/cli/atlas/alerts/unacknowledge.go
@@ -83,14 +83,14 @@ func UnacknowledgeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Unacknowledge the alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s alerts unacknowledge 5d1113b25a115342acc2d1aa --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), unackTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/atlas.go
+++ b/internal/cli/atlas/atlas.go
@@ -54,7 +54,7 @@ func Builder() *cobra.Command {
 		Use:        Use,
 		Short:      "MongoDB Atlas operations.",
 		Deprecated: deprecatedMessage,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.InitFlow(config.Default())(); err != nil {
 				return err
 			}

--- a/internal/cli/atlas/auditing/describe.go
+++ b/internal/cli/atlas/auditing/describe.go
@@ -67,14 +67,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the default project:
   %s auditing describe --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/copyprotection/disable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/copyprotection/disable.go
@@ -84,14 +84,14 @@ func DisableBuilder() *cobra.Command {
 		Use:   use,
 		Short: "Disable copy protection of the backup compliance policy for your project.",
 		Args:  require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), disableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/copyprotection/enable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/copyprotection/enable.go
@@ -84,14 +84,14 @@ func EnableBuilder() *cobra.Command {
 		Use:   use,
 		Args:  require.NoArgs,
 		Short: "Enable copy protection of the backup compliance policy for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), enableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/describe.go
+++ b/internal/cli/atlas/backup/compliancepolicy/describe.go
@@ -55,14 +55,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return the backup compliance policy for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), bcpTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/enable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/enable.go
@@ -68,7 +68,7 @@ func (opts *EnableOpts) enableWatcher() (bool, error) {
 	if res.GetState() == "" {
 		return false, fmt.Errorf("could not access State field")
 	}
-	return (res.GetState() == active), nil
+	return res.GetState() == active, nil
 }
 
 func newEnableConfirmationQuestion() survey.Prompt {
@@ -112,14 +112,14 @@ func EnableBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Enable Backup Compliance Policy without any configuration.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), enableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/disable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/disable.go
@@ -84,14 +84,14 @@ func DisableBuilder() *cobra.Command {
 		Use:   use,
 		Short: "Disable encryption-at-rest for the backup compliance policy for your project.",
 		Args:  require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), disableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/enable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/encryptionatrest/enable.go
@@ -84,14 +84,14 @@ func EnableBuilder() *cobra.Command {
 		Use:   use,
 		Args:  require.NoArgs,
 		Short: "Enable encryption-at-rest for the backup compliance policy for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), enableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/enable.go
+++ b/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/enable.go
@@ -92,7 +92,7 @@ func EnableBuilder() *cobra.Command {
 		Use:   use,
 		Args:  require.NoArgs,
 		Short: "Enable Point-in-Time restores of the backup compliance policy for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.validateRestoreWindowDays,
@@ -100,7 +100,7 @@ func EnableBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), enableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/policies/describe.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/describe.go
@@ -62,14 +62,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return the individual policy items of the backup compliance policy for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describePoliciesTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/create.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/create.go
@@ -89,14 +89,14 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create the on-demand policy item of the backup compliance policy for your project.",
 		Example: `  # Create a backup compliance on-demand policy with a retention of two weeks:
   atlas backups compliancepolicy policies ondemand create --retentionUnit weeks --retentionValue 2`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/describe.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/describe.go
@@ -58,14 +58,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return the on-demand policy item of the backup compliance policy for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/update.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/update.go
@@ -27,14 +27,14 @@ func UpdateBuilder() *cobra.Command {
 		Short: "Update the on-demand policy of the backup compliance for your project.",
 		Example: `  # Update a backup compliance on-demand policy and set it's retention to one week:
   atlas backups compliancepolicy policies ondemand update --retentionUnit weeks --retentionValue 1`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/create.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/create.go
@@ -91,14 +91,14 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create a scheduled policy item for the backup compliance policy for your project.",
 		Example: `  # Create a backup compliance schedule policy with a weekly frequency, where the snapshot occurs on Monday and has a retention of two months:
   atlas backups compliancepolicy policies scheduled create --frequencyType weekly --frequencyInterval 1 --retentionUnit months --retentionValue 2`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/describe.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/describe.go
@@ -61,14 +61,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get", "list", "ls"},
 		Short:   "Return the scheduled policy items of the backup compliance policy for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/update.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/update.go
@@ -84,14 +84,14 @@ func UpdateBuilder() *cobra.Command {
 		Short: "Update a scheduled policy item for the backup compliance policy for your project.",
 		Example: `  # Update a backup compliance schedule policy with a weekly frequency, where the snapshot occurs on Monday and has a retention of two months:
   atlas backups compliancepolicy policies scheduled update --scheduledPolicyId 6567f8ad00e6a55f9e448087 --frequencyType weekly --frequencyInterval 1 --retentionUnit months --retentionValue 2`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/compliancepolicy/setup.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup.go
@@ -86,7 +86,7 @@ func (opts *SetupOpts) setupWatcher() (bool, error) {
 	if res.GetState() == "" {
 		return false, errors.New("could not access State field")
 	}
-	return (res.GetState() == active), nil
+	return res.GetState() == active, nil
 }
 
 func newSetupConfirmationQuestion() survey.Prompt {
@@ -131,14 +131,14 @@ func SetupBuilder() *cobra.Command {
 		Use:     use,
 		Aliases: cli.GenerateAliases(use),
 		Short:   "Setup the backup compliance policy for your project with a configuration file.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), setupTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := file.Load(opts.fs, opts.path, opts.policy); err != nil {
 				return err
 			}

--- a/internal/cli/atlas/backup/exports/buckets/create.go
+++ b/internal/cli/atlas/backup/exports/buckets/create.go
@@ -82,7 +82,7 @@ func CreateBuilder() *cobra.Command {
 			"bucketNameDesc": "Name of the existing S3 bucket that the provided role ID is authorized to access.",
 			"output":         createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				func() error {
@@ -92,7 +92,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.bucketName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/backup/exports/buckets/delete.go
+++ b/internal/cli/atlas/backup/exports/buckets/delete.go
@@ -66,13 +66,13 @@ func DeleteBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # The following deletes the continuous backup export bucket specified by ID:
   %s backup exports buckets delete --bucketId dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Prompt(); err != nil {
 				return err
 			}

--- a/internal/cli/atlas/backup/exports/buckets/describe.go
+++ b/internal/cli/atlas/backup/exports/buckets/describe.go
@@ -68,14 +68,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup export bucket with the ID dbdb00ca12345678f901a234:
   %s backup exports buckets describe dbdb00ca12345678f901a234`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/exports/buckets/list.go
+++ b/internal/cli/atlas/backup/exports/buckets/list.go
@@ -70,14 +70,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return all continuous backup export buckets for your project:
   %s backup exports buckets list`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/exports/jobs/create.go
+++ b/internal/cli/atlas/backup/exports/jobs/create.go
@@ -92,14 +92,14 @@ func CreateBuilder() *cobra.Command {
 			"output": createTemplate,
 		},
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/exports/jobs/describe.go
+++ b/internal/cli/atlas/backup/exports/jobs/describe.go
@@ -70,14 +70,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup export job with the ID 5df90590f10fab5e33de2305 for the cluster named Cluster0:
   %s backup exports jobs describe --clusterName Cluster0 --exportID 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/exports/jobs/list.go
+++ b/internal/cli/atlas/backup/exports/jobs/list.go
@@ -81,7 +81,7 @@ func ListBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/exports/jobs/watch.go
+++ b/internal/cli/atlas/backup/exports/jobs/watch.go
@@ -79,14 +79,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 		},
 		Example: fmt.Sprintf(`  # Watch the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the cluster named Cluster0 until it becomes available:
   %s backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/backup/restores/describe.go
+++ b/internal/cli/atlas/backup/restores/describe.go
@@ -69,14 +69,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the cluster named Cluster0:
   %s backup restore describe 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), restoreDescribeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/backup/restores/list.go
+++ b/internal/cli/atlas/backup/restores/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return all continuous backup restore jobs for the cluster Cluster0:
   %s backup restore list Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), restoreListTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/backup/restores/start.go
+++ b/internal/cli/atlas/backup/restores/start.go
@@ -194,7 +194,7 @@ func StartBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), startTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/backup/restores/watch.go
+++ b/internal/cli/atlas/backup/restores/watch.go
@@ -82,14 +82,14 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 		},
 		Example: fmt.Sprintf(`  # Watch the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the restore source cluster named Cluster0 until it becomes available:
   %s backup restore watch 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/backup/schedule/delete.go
+++ b/internal/cli/atlas/backup/schedule/delete.go
@@ -72,7 +72,7 @@ func DeleteBuilder() *cobra.Command {
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.PromptWithMessage(confirmationMessage); err != nil {
 				return err
 			}

--- a/internal/cli/atlas/backup/schedule/describe.go
+++ b/internal/cli/atlas/backup/schedule/describe.go
@@ -72,14 +72,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the cloud backup schedule for the cluster named Cluster0:
   %s backup schedule describe Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), scheduleDescribeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/backup/schedule/update.go
+++ b/internal/cli/atlas/backup/schedule/update.go
@@ -346,7 +346,7 @@ func UpdateBuilder() *cobra.Command {
   
   # Update a snapshot backup policy for a cluster named Cluster0 to export snapshots monthly to an S3 bucket:
   %[1]s backup schedule update --clusterName Cluster0 --exportBucketId 62c569f85b7a381c093cc539 --exportFrequencyType monthly`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -358,7 +358,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.validateBackupPolicy(cmd),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd)
 		},
 	}

--- a/internal/cli/atlas/backup/snapshots/create.go
+++ b/internal/cli/atlas/backup/snapshots/create.go
@@ -83,14 +83,14 @@ func CreateBuilder() *cobra.Command {
 			"clusterNameDesc": "Name of the Atlas cluster whose snapshot you want to restore.",
 			"output":          createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/backup/snapshots/delete.go
+++ b/internal/cli/atlas/backup/snapshots/delete.go
@@ -64,10 +64,10 @@ func DeleteBuilder() *cobra.Command {
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to delete.",
 			"output":         opts.SuccessMessage(),
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.Entry = args[0]
 			if err := opts.Prompt(); err != nil {
 				return err

--- a/internal/cli/atlas/backup/snapshots/describe.go
+++ b/internal/cli/atlas/backup/snapshots/describe.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package snapshots
 
 import (
@@ -69,14 +70,14 @@ func DescribeBuilder() *cobra.Command {
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to retrieve.",
 			"output":         describeTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.snapshot = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/backup/snapshots/list.go
+++ b/internal/cli/atlas/backup/snapshots/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of snapshots for the cluster named myDemo 
   %s backups snapshots list myDemo --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/backup/snapshots/watch.go
+++ b/internal/cli/atlas/backup/snapshots/watch.go
@@ -80,14 +80,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to watch.",
 			"output":         watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/authorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/authorize.go
@@ -72,14 +72,14 @@ func AuthorizeBuilder() *cobra.Command {
 			"roleIdDesc": "Unique ID of the role to authorize.",
 			"output":     authorizeTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), authorizeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.roleID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/create.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/create.go
@@ -69,14 +69,14 @@ func CreateBuilder() *cobra.Command {
 			"output": createTemplate,
 		},
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/aws/deauthorize.go
@@ -84,10 +84,10 @@ func DeauthorizeBuilder() *cobra.Command {
 			"roleIdDesc": "Unique ID of the role to authorize.",
 			"output":     deauthorizeSuccess,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.Entry = args[0]
 			if err := opts.PromptWithMessage(confirmationMessage); err != nil {
 				return err

--- a/internal/cli/atlas/cloudproviders/accessroles/list.go
+++ b/internal/cli/atlas/cloudproviders/accessroles/list.go
@@ -63,14 +63,14 @@ func ListBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/clusters/advancedsettings/describe.go
+++ b/internal/cli/atlas/clusters/advancedsettings/describe.go
@@ -67,14 +67,14 @@ func DescribeBuilder() *cobra.Command {
 			"clusterNameDesc": "Name of the Atlas cluster for which you want to retrieve configuration settings.",
 		},
 		Example: fmt.Sprintf(`  %s clusters advancedSettings describe Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/advancedsettings/update.go
+++ b/internal/cli/atlas/clusters/advancedsettings/update.go
@@ -148,7 +148,7 @@ Atlas supports this command only for M10+ clusters.
 				opts.InitOutput(cmd.OutOrStdout(), updateTmpl),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Annotations: map[string]string{

--- a/internal/cli/atlas/clusters/availableregions/list.go
+++ b/internal/cli/atlas/clusters/availableregions/list.go
@@ -75,7 +75,7 @@ func ListBuilder() *cobra.Command {
 
   # List available regions by tier for a given provider:
   atlas cluster availableRegions list --provider GCP`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.tier != "" && opts.provider == "" {
 				return fmt.Errorf("tier search also requires a %s flag", flag.Provider)
 			}
@@ -86,7 +86,7 @@ func ListBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/clusters/connectionstring/describe.go
+++ b/internal/cli/atlas/clusters/connectionstring/describe.go
@@ -73,14 +73,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted connection strings for the cluster named myCluster:
   %s clusters connectionStrings describe myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplateStandard),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 
 			if opts.csType == "private" {

--- a/internal/cli/atlas/clusters/create.go
+++ b/internal/cli/atlas/clusters/create.go
@@ -269,10 +269,10 @@ For full control of your deployment, or to create multi-cloud clusters, provide 
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.PostRun()
 		},
 		Annotations: map[string]string{
@@ -322,11 +322,11 @@ For full control of your deployment, or to create multi-cloud clusters, provide 
 	cmd.MarkFlagsMutuallyExclusive(flag.File, flag.Shards)
 	cmd.MarkFlagsMutuallyExclusive(flag.File, flag.Tag)
 
-	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"REPLICASET", "SHARDED", "GEOSHARDED"}, cobra.ShellCompDirectiveDefault
 	})
 
-	_ = cmd.RegisterFlagCompletionFunc(flag.Provider, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc(flag.Provider, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"AWS", "AZURE", "GCP"}, cobra.ShellCompDirectiveDefault
 	})
 

--- a/internal/cli/atlas/clusters/delete.go
+++ b/internal/cli/atlas/clusters/delete.go
@@ -106,10 +106,10 @@ Deleting a cluster also deletes any backup snapshots for that cluster.
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.PostRun()
 		},
 	}

--- a/internal/cli/atlas/clusters/describe.go
+++ b/internal/cli/atlas/clusters/describe.go
@@ -69,14 +69,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the cluster named myCluster:
   %s clusters describe myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/failover.go
+++ b/internal/cli/atlas/clusters/failover.go
@@ -70,7 +70,7 @@ func FailoverBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.PromptWithMessage("Are you sure you want to start a failover test for %q")
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/clusters/indexes/create.go
+++ b/internal/cli/atlas/clusters/indexes/create.go
@@ -117,10 +117,10 @@ func CreateBuilder() *cobra.Command {
   # Create a compound index named property_room_bedrooms on the
   listings collection of the realestate database:
   %[1]s clusters indexes create property_room_bedrooms --clusterName Cluster0 --collection listings --db realestate --key property_type:1 --key room_type:1 --key bedrooms:1`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				opts.name = args[0]
 			}

--- a/internal/cli/atlas/clusters/list.go
+++ b/internal/cli/atlas/clusters/list.go
@@ -70,14 +70,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all clusters for the project with ID 5e2211c17a3e5a48f5497de3:
   %s clusters list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/clusters/load_sample_data.go
+++ b/internal/cli/atlas/clusters/load_sample_data.go
@@ -65,14 +65,14 @@ func LoadSampleDataBuilder(deprecate bool) *cobra.Command {
 			"clusterNameDesc": "Label that identifies the cluster that you want to load sample data into.",
 			"output":          addTmpl,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), addTmpl),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/onlinearchive/create.go
+++ b/internal/cli/atlas/clusters/onlinearchive/create.go
@@ -130,14 +130,14 @@ To learn more about online archives, see https://www.mongodb.com/docs/atlas/onli
   
   # Create an online archive for the sample_mflix.movies collection in a cluster named myTestCluster using a profile named egAtlasProfile when the current date is greater than the value of the released date plus 2 days. Data is partitioned based on the title field, year field, and released field from the documents in the collection:
   %[1]s clusters onlineArchive create --clusterName myTestCluster --db sample_mflix --collection movies --dateField released --archiveAfter 2 --partition title,year --output json -P egAtlasProfile `, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/clusters/onlinearchive/delete.go
+++ b/internal/cli/atlas/clusters/onlinearchive/delete.go
@@ -74,7 +74,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/clusters/onlinearchive/describe.go
+++ b/internal/cli/atlas/clusters/onlinearchive/describe.go
@@ -71,14 +71,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
   %s clusters onlineArchives describe 5f189832e26ec075e10c32d3 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := validate.ObjectID(args[0]); err != nil {
 				return err
 			}

--- a/internal/cli/atlas/clusters/onlinearchive/list.go
+++ b/internal/cli/atlas/clusters/onlinearchive/list.go
@@ -71,14 +71,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of online archives for the cluster named myCluster:
   %s clusters onlineArchives list --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/clusters/onlinearchive/pause.go
+++ b/internal/cli/atlas/clusters/onlinearchive/pause.go
@@ -74,14 +74,14 @@ func PauseBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Pause the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
   %s clusters onlineArchives pause 5f189832e26ec075e10c32d3 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), pauseTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/onlinearchive/start.go
+++ b/internal/cli/atlas/clusters/onlinearchive/start.go
@@ -72,14 +72,14 @@ func StartBuilder() *cobra.Command {
 			"archiveIdDesc": "Unique identifier of the online archive to start.",
 			"output":        startTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), startTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/onlinearchive/update.go
+++ b/internal/cli/atlas/clusters/onlinearchive/update.go
@@ -108,14 +108,14 @@ func UpdateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Update the archiving rule to archive after 5 days for the online archive with the ID 5f189832e26ec075e10c32d3 for the cluster named myCluster:
   %s clusters onlineArchives update 5f189832e26ec075e10c32d3 --clusterName --archiveAfter 5 myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/onlinearchive/watch.go
+++ b/internal/cli/atlas/clusters/onlinearchive/watch.go
@@ -81,14 +81,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"archiveIdDesc": "Unique identifier of the online archive to watch.",
 			"output":        watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/pause.go
+++ b/internal/cli/atlas/clusters/pause.go
@@ -68,14 +68,14 @@ func PauseBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Pause the cluster named myCluster for the project with ID 5e2211c17a3e5a48f5497de3:
   %s clusters pause myCluster --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), pauseTmpl),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/region_tier_autocomplete.go
+++ b/internal/cli/atlas/clusters/region_tier_autocomplete.go
@@ -38,7 +38,7 @@ type autoCompleteOpts struct {
 }
 
 func (opts *autoCompleteOpts) autocompleteTier() cli.AutoFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if err := opts.parseFlags(cmd); err != nil {
 			cobra.CompErrorln(fmt.Sprintf("failed to parse flags: %v", err))
 			return nil, cobra.ShellCompDirectiveError
@@ -90,7 +90,7 @@ func (opts *autoCompleteOpts) tierSuggestions(toComplete string) ([]string, erro
 }
 
 func (opts *autoCompleteOpts) autocompleteRegion() cli.AutoFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if err := opts.parseFlags(cmd); err != nil {
 			cobra.CompErrorln(fmt.Sprintf("failed to parse flags: %v", err))
 			return nil, cobra.ShellCompDirectiveError

--- a/internal/cli/atlas/clusters/sampledata/describe.go
+++ b/internal/cli/atlas/clusters/sampledata/describe.go
@@ -69,14 +69,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the sample data load job:
   %s clusters sampleData describe 5e98249d937cfc52efdc2a9f --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/sampledata/load.go
+++ b/internal/cli/atlas/clusters/sampledata/load.go
@@ -67,14 +67,14 @@ func LoadBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Load sample data into the cluster named myCluster:
   %s clusters sampleData load myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), addTmpl),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/sampledata/watch.go
+++ b/internal/cli/atlas/clusters/sampledata/watch.go
@@ -78,14 +78,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"idDesc": "Unique identifier of the sample data job.",
 			"output": watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/start.go
+++ b/internal/cli/atlas/clusters/start.go
@@ -68,14 +68,14 @@ func StartBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Start a cluster named myCluster for the project with ID 5e2211c17a3e5a48f5497de3:
   %s clusters start myCluster --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), startTmpl),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/clusters/update.go
+++ b/internal/cli/atlas/clusters/update.go
@@ -168,7 +168,7 @@ You can't change the name of the cluster or downgrade the MongoDB version of you
 				opts.InitOutput(cmd.OutOrStdout(), updateTmpl),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Annotations: map[string]string{

--- a/internal/cli/atlas/clusters/upgrade.go
+++ b/internal/cli/atlas/clusters/upgrade.go
@@ -154,7 +154,7 @@ func UpgradeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), upgradeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Annotations: map[string]string{

--- a/internal/cli/atlas/clusters/watch.go
+++ b/internal/cli/atlas/clusters/watch.go
@@ -88,14 +88,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"clusterNameDesc": "Name of the cluster to watch.",
 			"output":          watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/config/init.go
+++ b/internal/cli/atlas/config/init.go
@@ -106,10 +106,10 @@ func InitBuilder() *cobra.Command {
 
   # To configure the tool to work with Atlas for Government:
   atlas config init --gov`,
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(cmd *cobra.Command, _ []string) {
 			opts.OutWriter = cmd.OutOrStdout()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd.Context())
 		},
 		Args: require.NoArgs,

--- a/internal/cli/atlas/customdbroles/create.go
+++ b/internal/cli/atlas/customdbroles/create.go
@@ -97,7 +97,7 @@ func CreateBuilder() *cobra.Command {
 			"roleNameDesc": "Name of the custom role to create.",
 			"output":       createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -105,7 +105,7 @@ func CreateBuilder() *cobra.Command {
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.roleName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/customdbroles/delete.go
+++ b/internal/cli/atlas/customdbroles/delete.go
@@ -67,7 +67,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/customdbroles/describe.go
+++ b/internal/cli/atlas/customdbroles/describe.go
@@ -75,7 +75,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/customdbroles/list.go
+++ b/internal/cli/atlas/customdbroles/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/customdbroles/update.go
+++ b/internal/cli/atlas/customdbroles/update.go
@@ -104,7 +104,7 @@ func UpdateBuilder() *cobra.Command {
 			"output":       updateTemplate,
 		},
 		Args: require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -112,7 +112,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.roleName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/customdns/aws/describe.go
+++ b/internal/cli/atlas/customdns/aws/describe.go
@@ -65,14 +65,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the details for the custom DNS configuration deployed to AWS in the project with ID 618d48e05277a606ed2496fe:		
   %s customDns aws describe --projectId 618d48e05277a606ed2496fe `, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/customdns/aws/disable.go
+++ b/internal/cli/atlas/customdns/aws/disable.go
@@ -62,14 +62,14 @@ func DisableBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Disable the custom DNS configuration deployed to AWS in the project with ID 618d48e05277a606ed2496fe:		
   %s customDns aws disable --projectId 618d48e05277a606ed2496fe `, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), disableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/customdns/aws/enable.go
+++ b/internal/cli/atlas/customdns/aws/enable.go
@@ -62,14 +62,14 @@ func EnableBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Enable the custom DNS configuration deployed to AWS in the project with ID 618d48e05277a606ed2496fe:		
   %s customDns aws enable --projectId 618d48e05277a606ed2496fe `, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), enableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/create.go
+++ b/internal/cli/atlas/datafederation/create.go
@@ -125,7 +125,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/delete.go
+++ b/internal/cli/atlas/datafederation/delete.go
@@ -74,7 +74,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/describe.go
+++ b/internal/cli/atlas/datafederation/describe.go
@@ -71,14 +71,14 @@ func DescribeBuilder() *cobra.Command {
 		Example: `# retrieves data federation 'DataFederation1':
   atlas dataFederation describe DataFederation1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datafederation/list.go
+++ b/internal/cli/atlas/datafederation/list.go
@@ -70,14 +70,14 @@ func ListBuilder() *cobra.Command {
 		Example: `# list all data federation databases:
   atlas dataFederation list
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/logs.go
+++ b/internal/cli/atlas/datafederation/logs.go
@@ -79,13 +79,13 @@ func LogBuilder() *cobra.Command {
 		Example: `# download logs of data federation database 'DataFederation1':
   atlas dataFederation logs DataFederation1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/datafederation/privateendpoints/create.go
+++ b/internal/cli/atlas/datafederation/privateendpoints/create.go
@@ -88,7 +88,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/privateendpoints/delete.go
+++ b/internal/cli/atlas/datafederation/privateendpoints/delete.go
@@ -74,7 +74,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/privateendpoints/describe.go
+++ b/internal/cli/atlas/datafederation/privateendpoints/describe.go
@@ -71,14 +71,14 @@ func DescribeBuilder() *cobra.Command {
 		Example: `# retrieves data federation private endpoint '507f1f77bcf86cd799439011':
   atlas dataFederation privateEndpoints describe 507f1f77bcf86cd799439011
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datafederation/privateendpoints/list.go
+++ b/internal/cli/atlas/datafederation/privateendpoints/list.go
@@ -69,14 +69,14 @@ func ListBuilder() *cobra.Command {
 		Example: `# list all data federation private endpoints:
   atlas dataFederation privateEndpoints list
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/querylimits/create.go
+++ b/internal/cli/atlas/datafederation/querylimits/create.go
@@ -96,7 +96,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/querylimits/delete.go
+++ b/internal/cli/atlas/datafederation/querylimits/delete.go
@@ -75,7 +75,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/querylimits/describe.go
+++ b/internal/cli/atlas/datafederation/querylimits/describe.go
@@ -72,14 +72,14 @@ func DescribeBuilder() *cobra.Command {
 		Example: `# retrieves data federation query limits "bytesProcessed.query" for 'DataFederation1':
   atlas dataFederation queryLimits describe bytesProcessed.query --tenantName DataFederation1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.limitName = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datafederation/querylimits/list.go
+++ b/internal/cli/atlas/datafederation/querylimits/list.go
@@ -70,14 +70,14 @@ func ListBuilder() *cobra.Command {
 		Example: `# list all data federation query limits:
   atlas dataFederation queryLimits list
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datafederation/update.go
+++ b/internal/cli/atlas/datafederation/update.go
@@ -125,7 +125,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalake/create.go
+++ b/internal/cli/atlas/datalake/create.go
@@ -92,7 +92,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalake/delete.go
+++ b/internal/cli/atlas/datalake/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalake/describe.go
+++ b/internal/cli/atlas/datalake/describe.go
@@ -77,7 +77,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalake/list.go
+++ b/internal/cli/atlas/datalake/list.go
@@ -66,14 +66,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all federated database instances in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s dataLakes list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalake/update.go
+++ b/internal/cli/atlas/datalake/update.go
@@ -111,7 +111,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/availableschedules/list.go
+++ b/internal/cli/atlas/datalakepipelines/availableschedules/list.go
@@ -69,14 +69,14 @@ func ListBuilder() *cobra.Command {
 		Example: `# list available schedules for data lake pipeline called 'Pipeline1':
   atlas dataLakePipelines availableSchedules list Pipeline1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/availablesnapshots/list.go
+++ b/internal/cli/atlas/datalakepipelines/availablesnapshots/list.go
@@ -91,7 +91,7 @@ func ListBuilder() *cobra.Command {
 		Example: `# list available backup schedules for data lake pipeline called 'Pipeline1':
   atlas dataLakePipelines availableSnapshots list Pipeline1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -99,7 +99,7 @@ func ListBuilder() *cobra.Command {
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/create.go
+++ b/internal/cli/atlas/datalakepipelines/create.go
@@ -173,7 +173,7 @@ func CreateBuilder() *cobra.Command {
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/datasets/delete.go
+++ b/internal/cli/atlas/datalakepipelines/datasets/delete.go
@@ -75,7 +75,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/delete.go
+++ b/internal/cli/atlas/datalakepipelines/delete.go
@@ -75,7 +75,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/describe.go
+++ b/internal/cli/atlas/datalakepipelines/describe.go
@@ -71,14 +71,14 @@ func DescribeBuilder() *cobra.Command {
 		Example: `# retrieves pipeline 'Pipeline1':
   atlas dataLakePipelines describe Pipeline1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datalakepipelines/list.go
+++ b/internal/cli/atlas/datalakepipelines/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: `# list all pipelines:
   atlas dataLakePipelines list`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/pause.go
+++ b/internal/cli/atlas/datalakepipelines/pause.go
@@ -69,14 +69,14 @@ func PauseBuilder() *cobra.Command {
 		Example: `# pause pipeline 'Pipeline1':
   atlas dataLakePipelines pause Pipeline1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), pauseTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datalakepipelines/runs/describe.go
+++ b/internal/cli/atlas/datalakepipelines/runs/describe.go
@@ -72,14 +72,14 @@ func DescribeBuilder() *cobra.Command {
 		Example: `# retrieves pipeline run '507f1f77bcf86cd799439011':
   atlas dataLakePipelines runs describe 507f1f77bcf86cd799439011
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datalakepipelines/runs/list.go
+++ b/internal/cli/atlas/datalakepipelines/runs/list.go
@@ -71,14 +71,14 @@ func ListBuilder() *cobra.Command {
 		Example: `# list all pipeline runs:
   atlas dataLakePipelines runs list
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/runs/watch.go
+++ b/internal/cli/atlas/datalakepipelines/runs/watch.go
@@ -80,14 +80,14 @@ func WatchBuilder() *cobra.Command {
 		Example: `# watches the pipeline 'Pipeline1':
   atlas dataLakePipelines watch Pipeline1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datalakepipelines/start.go
+++ b/internal/cli/atlas/datalakepipelines/start.go
@@ -69,14 +69,14 @@ func StartBuilder() *cobra.Command {
 		Example: `# start pipeline 'Pipeline1':
   atlas dataLakePipelines start Pipeline1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), startTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datalakepipelines/trigger.go
+++ b/internal/cli/atlas/datalakepipelines/trigger.go
@@ -70,14 +70,14 @@ func TriggerBuilder() *cobra.Command {
 		Example: `# trigger pipeline 'Pipeline1':
   atlas dataLakePipelines trigger Pipeline1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), triggerTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/datalakepipelines/update.go
+++ b/internal/cli/atlas/datalakepipelines/update.go
@@ -166,7 +166,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/datalakepipelines/watch.go
+++ b/internal/cli/atlas/datalakepipelines/watch.go
@@ -79,14 +79,14 @@ func WatchBuilder() *cobra.Command {
 		Example: `# watches the pipeline 'Pipeline1':
   atlas dataLakePipelines watch Pipeline1
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/dbusers/certs/create.go
+++ b/internal/cli/atlas/dbusers/certs/create.go
@@ -67,14 +67,14 @@ func CreateBuilder() *cobra.Command {
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create an Atlas-managed X.509 certificate that expires in 5 months for a MongoDB user named dbuser for the project with ID 5e2211c17a3e5a48f5497de3:
   %s dbusers certs create --username dbuser --monthsUntilExpiration 5 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/dbusers/certs/list.go
+++ b/internal/cli/atlas/dbusers/certs/list.go
@@ -81,7 +81,7 @@ The user you specify must authenticate using X.509 certificates.`,
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/dbusers/create.go
+++ b/internal/cli/atlas/dbusers/create.go
@@ -206,7 +206,7 @@ func CreateBuilder() *cobra.Command {
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Prompt(); err != nil {
 				return err
 			}

--- a/internal/cli/atlas/dbusers/delete.go
+++ b/internal/cli/atlas/dbusers/delete.go
@@ -77,7 +77,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/dbusers/describe.go
+++ b/internal/cli/atlas/dbusers/describe.go
@@ -93,7 +93,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/dbusers/list.go
+++ b/internal/cli/atlas/dbusers/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all database users for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s dbusers list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/dbusers/update.go
+++ b/internal/cli/atlas/dbusers/update.go
@@ -117,7 +117,7 @@ func UpdateBuilder() *cobra.Command {
 			"usernameDesc": "Username to update in the MongoDB database.",
 			"output":       updateTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.validateAuthDB,
@@ -125,7 +125,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.currentUsername = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/deployments/connect.go
+++ b/internal/cli/atlas/deployments/connect.go
@@ -50,7 +50,7 @@ func ConnectBuilder() *cobra.Command {
 				opts.InitAtlasStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return Run(cmd.Context(), opts)
 		},
 	}
@@ -62,10 +62,10 @@ func ConnectBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.DeploymentOpts.DBUserPassword, flag.Password, "", usage.Password)
 	cmd.Flags().StringVar(&opts.ConnectionStringType, flag.ConnectionStringType, options.ConnectionStringTypeStandard, usage.ConnectionStringType)
 
-	_ = cmd.RegisterFlagCompletionFunc(flag.ConnectWith, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc(flag.ConnectWith, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return options.ConnectWithOptions, cobra.ShellCompDirectiveDefault
 	})
-	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return options.DeploymentTypeOptions, cobra.ShellCompDirectiveDefault
 	})
 

--- a/internal/cli/atlas/deployments/delete.go
+++ b/internal/cli/atlas/deployments/delete.go
@@ -143,10 +143,10 @@ Deleting a Local deployment also deletes any local data volumes.
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd.Context())
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.PostRun()
 		},
 	}

--- a/internal/cli/atlas/deployments/diagnostics.go
+++ b/internal/cli/atlas/deployments/diagnostics.go
@@ -108,7 +108,7 @@ func DiagnosticsBuilder() *cobra.Command {
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd.Context())
 		},
 	}

--- a/internal/cli/atlas/deployments/list.go
+++ b/internal/cli/atlas/deployments/list.go
@@ -86,15 +86,15 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd.Context())
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.PostRun()
 		},
 	}
@@ -102,7 +102,7 @@ func ListBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVar(&opts.DeploymentType, flag.TypeFlag, "", usage.DeploymentType)
 
-	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return options.DeploymentTypeOptions, cobra.ShellCompDirectiveDefault
 	})
 	_ = cmd.Flags().MarkHidden(flag.TypeFlag)

--- a/internal/cli/atlas/deployments/logs.go
+++ b/internal/cli/atlas/deployments/logs.go
@@ -196,13 +196,13 @@ func LogsBuilder() *cobra.Command {
 		Aliases: []string{"log"},
 		Args:    require.NoArgs,
 		GroupID: "local",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), ""))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd.Context())
 		},
 	}

--- a/internal/cli/atlas/deployments/options/deployment_opts.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts.go
@@ -215,7 +215,7 @@ func (opts *DeploymentOpts) promptDeploymentType() error {
 		Message: PromptTypeMessage,
 		Options: DeploymentTypeOptions,
 		Help:    usage.DeploymentType,
-		Description: func(value string, index int) string {
+		Description: func(value string, _ int) string {
 			return deploymentTypeDescription[value]
 		},
 	}

--- a/internal/cli/atlas/deployments/options/deployment_opts_connect_with.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts_connect_with.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package options
 
 import (
@@ -49,7 +50,7 @@ func (opts *DeploymentOpts) PromptConnectWith() (string, error) {
 	p := &survey.Select{
 		Message: fmt.Sprintf("How would you like to connect to %s?", opts.DeploymentName),
 		Options: ConnectWithOptions,
-		Description: func(value string, index int) string {
+		Description: func(value string, _ int) string {
 			return connectWithDescription[value]
 		},
 	}

--- a/internal/cli/atlas/deployments/options/deployment_opts_select.go
+++ b/internal/cli/atlas/deployments/options/deployment_opts_select.go
@@ -89,7 +89,7 @@ func (opts *DeploymentOpts) SelectLocal(ctx context.Context) error {
 		Message: "Select a deployment",
 		Options: names,
 		Help:    usage.ClusterName,
-		Description: func(value string, index int) string {
+		Description: func(_ string, _ int) string {
 			return deploymentTypeLocal
 		},
 	}, &opts.DeploymentName, survey.WithValidator(survey.Required))

--- a/internal/cli/atlas/deployments/pause.go
+++ b/internal/cli/atlas/deployments/pause.go
@@ -134,7 +134,7 @@ func PauseBuilder() *cobra.Command {
 			"deploymentNameDesc": "Name of the deployment.",
 			"output":             pauseTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.config = config.Default()
 			opts.CredStore = config.Default()
 
@@ -150,7 +150,7 @@ func PauseBuilder() *cobra.Command {
 			return opts.Run(cmd.Context())
 		},
 
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.PostRunMessages()
 		},
 	}

--- a/internal/cli/atlas/deployments/search/indexes/create.go
+++ b/internal/cli/atlas/deployments/search/indexes/create.go
@@ -242,7 +242,7 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"indexNameDesc": "Name of the index.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
 			opts.WatchOpts.OutWriter = w
 
@@ -267,7 +267,7 @@ func CreateBuilder() *cobra.Command {
 			}
 			return opts.Run(cmd.Context())
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PostRun(cmd.Context())
 		},
 	}

--- a/internal/cli/atlas/deployments/search/indexes/delete.go
+++ b/internal/cli/atlas/deployments/search/indexes/delete.go
@@ -113,7 +113,7 @@ func DeleteBuilder() *cobra.Command {
 			"indexIdDesc": "ID of the index.",
 			"output":      opts.SuccessMessage(),
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
 				opts.initStore(cmd.Context()),

--- a/internal/cli/atlas/deployments/search/indexes/describe.go
+++ b/internal/cli/atlas/deployments/search/indexes/describe.go
@@ -114,7 +114,7 @@ func DescribeBuilder() *cobra.Command {
 			"indexIdDesc": "ID of the index.",
 			"output":      describeTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
 			return opts.PreRunE(
 				opts.InitOutput(w, describeTemplate),

--- a/internal/cli/atlas/deployments/search/indexes/list.go
+++ b/internal/cli/atlas/deployments/search/indexes/list.go
@@ -123,7 +123,7 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
 			return opts.PreRunE(
 				opts.InitOutput(w, listTemplate),
@@ -132,7 +132,7 @@ func ListBuilder() *cobra.Command {
 				opts.initMongoDBClient,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd.Context())
 		},
 	}

--- a/internal/cli/atlas/deployments/setup.go
+++ b/internal/cli/atlas/deployments/setup.go
@@ -451,7 +451,7 @@ func (opts *SetupOpts) promptSettings() error {
 		Message: "How do you want to set up your local Atlas deployment?",
 		Options: settingOptions,
 		Default: opts.settings,
-		Description: func(value string, index int) string {
+		Description: func(value string, _ int) string {
 			return settingsDescription[value]
 		},
 	}
@@ -644,13 +644,15 @@ func (opts *SetupOpts) setDefaultSettings() error {
 	}
 
 	if defaultValuesSet {
-		templatewriter.Print(os.Stderr, `
+		if err := templatewriter.Print(os.Stderr, `
 [Default Settings]
 Deployment Name	{{.DeploymentName}}
 MongoDB Version	{{.MdbVersion}}
 Port	{{.Port}}
 
-`, opts)
+`, opts); err != nil {
+			return err
+		}
 		if !opts.force {
 			if err := opts.promptSettings(); err != nil {
 				return err
@@ -665,7 +667,7 @@ func (opts *SetupOpts) promptConnect() error {
 	p := &survey.Select{
 		Message: fmt.Sprintf("How would you like to connect to %s?", opts.DeploymentName),
 		Options: connectWithOptions,
-		Description: func(value string, index int) string {
+		Description: func(value string, _ int) string {
 			return connectWithDescription[value]
 		},
 	}
@@ -686,7 +688,7 @@ func (opts *SetupOpts) runConnectWith(cs string) error {
 
 	switch opts.connectWith {
 	case skipConnect:
-		fmt.Fprintln(os.Stderr, "connection skipped")
+		_, _ = fmt.Fprintln(os.Stderr, "connection skipped")
 	case options.CompassConnect:
 		if !compass.Detect() {
 			return options.ErrCompassNotInstalled
@@ -851,7 +853,7 @@ func SetupBuilder() *cobra.Command {
 				opts.initMongoDBClient(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd.Context())
 		},
 	}
@@ -875,13 +877,13 @@ func SetupBuilder() *cobra.Command {
 	cmd.Flags().Lookup(flag.SkipSampleData).Usage = usage.SkipSampleDataDeployment
 	cmd.Flags().Lookup(flag.Force).Usage = usage.ForceDeploymentsSetup
 
-	_ = cmd.RegisterFlagCompletionFunc(flag.MDBVersion, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc(flag.MDBVersion, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return mdbVersions, cobra.ShellCompDirectiveDefault
 	})
-	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc(flag.TypeFlag, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return options.DeploymentTypeOptions, cobra.ShellCompDirectiveDefault
 	})
-	_ = cmd.RegisterFlagCompletionFunc(flag.ConnectWith, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = cmd.RegisterFlagCompletionFunc(flag.ConnectWith, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return connectWithOptions, cobra.ShellCompDirectiveDefault
 	})
 	return cmd

--- a/internal/cli/atlas/deployments/start.go
+++ b/internal/cli/atlas/deployments/start.go
@@ -133,7 +133,7 @@ func StartBuilder() *cobra.Command {
 			"deploymentNameDesc": "Name of the deployment.",
 			"output":             startTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
@@ -145,7 +145,7 @@ func StartBuilder() *cobra.Command {
 			}
 			return opts.Run(cmd.Context())
 		},
-		PostRunE: func(cmd *cobra.Command, args []string) error {
+		PostRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.PostRunMessages()
 		},
 	}

--- a/internal/cli/atlas/events/list.go
+++ b/internal/cli/atlas/events/list.go
@@ -140,7 +140,7 @@ func ListBuilder() *cobra.Command {
 `,
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.orgID != "" && opts.projectID != "" {
 				return fmt.Errorf("both --%s and --%s set", flag.ProjectID, flag.OrgID)
 			}
@@ -150,7 +150,7 @@ func ListBuilder() *cobra.Command {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/events/orgs_list.go
+++ b/internal/cli/atlas/events/orgs_list.go
@@ -94,14 +94,14 @@ func OrgListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of events for the organization with the ID 5dd5a6b6f10fab1d71a58495:
   %s events organizations list --orgId 5dd5a6b6f10fab1d71a58495 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/events/projects_list.go
+++ b/internal/cli/atlas/events/projects_list.go
@@ -98,14 +98,14 @@ func ProjectListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of events for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s events projects list --Id 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/integrations/create/datadog.go
+++ b/internal/cli/atlas/integrations/create/datadog.go
@@ -84,14 +84,14 @@ Datadog integration is available only for M10+ clusters.
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Integrate Datadog with Atlas for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create DATADOG --apiKey a1a23bcdef45ghijk6789 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplateDatadog),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/integrations/create/new_relic.go
+++ b/internal/cli/atlas/integrations/create/new_relic.go
@@ -80,14 +80,14 @@ func NewRelicBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": createTemplateNewRelic,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplateNewRelic),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Deprecated: "The NEW_RELIC integration is deprecated and no longer supported",

--- a/internal/cli/atlas/integrations/create/ops_genie.go
+++ b/internal/cli/atlas/integrations/create/ops_genie.go
@@ -80,14 +80,14 @@ func OpsGenieBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Integrate Opsgenie with Atlas for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create OPS_GENIE --apiKey a1a23bcdef45ghijk6789 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplateOpsGenie),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/integrations/create/pager_duty.go
+++ b/internal/cli/atlas/integrations/create/pager_duty.go
@@ -78,14 +78,14 @@ func PagerDutyBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Integrate PagerDuty with Atlas for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create PAGER_DUTY --serviceKey a1a23bcdef45ghijk6789 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplatePagerDuty),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/integrations/create/victor_ops.go
+++ b/internal/cli/atlas/integrations/create/victor_ops.go
@@ -82,14 +82,14 @@ The requesting API key must have the Organization Owner or Project Owner role to
 		Example: fmt.Sprintf(`  # Integrate Splunk On-Call with Atlas using the routing key operations for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create VICTOR_OPS --apiKey a1a23bcdef45ghijk6789 --routingKey operations --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplateVictorOps),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/integrations/create/webhook.go
+++ b/internal/cli/atlas/integrations/create/webhook.go
@@ -80,14 +80,14 @@ func WebhookBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Integrate a webhook with Atlas that uses the secret mySecret for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations create WEBHOOK --url http://9b4ac7aa.abc.io/payload --secret mySecret --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplateWebhook),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/integrations/delete.go
+++ b/internal/cli/atlas/integrations/delete.go
@@ -73,7 +73,7 @@ func DeleteBuilder() *cobra.Command {
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/integrations/describe.go
+++ b/internal/cli/atlas/integrations/describe.go
@@ -117,7 +117,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), opts.template()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/integrations/list.go
+++ b/internal/cli/atlas/integrations/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of active third-party integrations for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s integrations list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/kubernetes/config/apply.go
+++ b/internal/cli/atlas/kubernetes/config/apply.go
@@ -145,7 +145,7 @@ func ApplyBuilder() *cobra.Command {
 
   # Export and apply all supported resources of a specific project to a specific namespace restricting the version of the Atlas Kubernetes Operator:
   atlas kubernetes config apply --projectId=<projectId> --targetNamespace=<namespace> --operatorVersion=1.5.1`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.ValidateOrgID,
@@ -154,7 +154,7 @@ func ApplyBuilder() *cobra.Command {
 				opts.initStores(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/kubernetes/config/generate.go
+++ b/internal/cli/atlas/kubernetes/config/generate.go
@@ -126,7 +126,7 @@ func GenerateBuilder() *cobra.Command {
 
   # Export Project, DatabaseUsers, Clusters and specific DataFederation resources for a specific project to a specific namespace:
   atlas kubernetes config generate --projectId=<projectId> --dataFederationName=<data-federation-name-1, data-federation-name-2> --targetNamespace=<namespace>`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.ValidateOrgID,
@@ -135,7 +135,7 @@ func GenerateBuilder() *cobra.Command {
 				opts.initStores(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/kubernetes/operator/install.go
+++ b/internal/cli/atlas/kubernetes/operator/install.go
@@ -181,7 +181,7 @@ The key is scoped to the project when you specify the --projectName option and t
 
 	# Install the operator and disable deletion protection for sub-resources (Atlas project integrations, private endpoints, etc.):
 	atlas kubernetes operator install --subresourceDeletionProtection=false`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			opts.versionProvider = version.NewOperatorVersion(github.NewClient(nil))
 
 			return opts.PreRunE(
@@ -192,7 +192,7 @@ The key is scoped to the project when you specify the --projectName option and t
 				opts.ValidateWatchNamespace,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.Run(cmd.Context())
 		},
 	}

--- a/internal/cli/atlas/livemigrations/create.go
+++ b/internal/cli/atlas/livemigrations/create.go
@@ -64,7 +64,7 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
@@ -72,7 +72,7 @@ func CreateBuilder() *cobra.Command {
 				opts.Validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/livemigrations/cutover.go
+++ b/internal/cli/atlas/livemigrations/cutover.go
@@ -61,14 +61,14 @@ func CutoverBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": cutoverTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), cutoverTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/livemigrations/describe.go
+++ b/internal/cli/atlas/livemigrations/describe.go
@@ -59,13 +59,13 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return a push live migration job.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/livemigrations/link/create.go
+++ b/internal/cli/atlas/livemigrations/link/create.go
@@ -70,14 +70,14 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/livemigrations/link/delete.go
+++ b/internal/cli/atlas/livemigrations/link/delete.go
@@ -55,14 +55,14 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": opts.SuccessMessage(),
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			opts.Entry = opts.ConfigOrgID()
 			return opts.Run()
 		},

--- a/internal/cli/atlas/livemigrations/validation/create.go
+++ b/internal/cli/atlas/livemigrations/validation/create.go
@@ -64,7 +64,7 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
@@ -72,7 +72,7 @@ func CreateBuilder() *cobra.Command {
 				opts.Validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/livemigrations/validation/describe.go
+++ b/internal/cli/atlas/livemigrations/validation/describe.go
@@ -62,14 +62,14 @@ func DescribeBuilder() *cobra.Command {
 		Aliases:     []string{"get"},
 		Short:       "Return one validation job.",
 		Annotations: map[string]string{"output": describeTemplate},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/logs/decrypt.go
+++ b/internal/cli/atlas/logs/decrypt.go
@@ -111,10 +111,10 @@ func DecryptBuilder() *cobra.Command {
   # Decrypt using Azure credentials:
   atlas logs decrypt --file /path/to/logFile.json --azureClientId <clientId> --azureTenantId <tenantId> --azureSecret <secret>
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.initDefaultOut)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/logs/download.go
+++ b/internal/cli/atlas/logs/download.go
@@ -173,7 +173,7 @@ To find the hostnames for an Atlas project, use the process list command.
 			opts.name = args[1]
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()), opts.initDefaultOut)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 

--- a/internal/cli/atlas/maintenance/clear.go
+++ b/internal/cli/atlas/maintenance/clear.go
@@ -81,7 +81,7 @@ func ClearBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Clear the current maintenance window for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s maintenanceWindows clear --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -89,7 +89,7 @@ func ClearBuilder() *cobra.Command {
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/maintenance/defer.go
+++ b/internal/cli/atlas/maintenance/defer.go
@@ -62,14 +62,14 @@ func DeferBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Defer scheduled maintenance for one week for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s maintenanceWindows defer --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), deferTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/maintenance/describe.go
+++ b/internal/cli/atlas/maintenance/describe.go
@@ -63,14 +63,14 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the maintenance window for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s maintenanceWindows describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/maintenance/update.go
+++ b/internal/cli/atlas/maintenance/update.go
@@ -74,7 +74,7 @@ func UpdateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Update the maintenance window to midnight on Saturdays for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s maintenanceWindows update --dayOfWeek 7 --hourOfDay 0 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if !opts.startASAP {
 				_ = cmd.MarkFlagRequired(flag.DayOfWeek)
 				_ = cmd.MarkFlagRequired(flag.HourOfDay)
@@ -85,7 +85,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/metrics/databases/describe.go
+++ b/internal/cli/atlas/metrics/databases/describe.go
@@ -81,7 +81,7 @@ func DescribeBuilder() *cobra.Command {
 			`  # Return the JSON-formatted database metrics from the last 36 hours with 5-minute granularity for the database named testDB in the host atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 
   %s metrics databases describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H --output json`,
 			cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.ValidatePeriodStartEnd,
@@ -89,7 +89,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), databasesMetricTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
 			opts.host, opts.port, err = cli.GetHostnameAndPort(args[0])
 			if err != nil {

--- a/internal/cli/atlas/metrics/databases/list.go
+++ b/internal/cli/atlas/metrics/databases/list.go
@@ -78,14 +78,14 @@ func ListBuilder() *cobra.Command {
   %s metrics databases list atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 --output json`,
 			cli.ExampleAtlasEntryPoint()),
 		Args: require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), databasesListTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
 			if opts.host, opts.port, err = cli.GetHostnameAndPort(args[0]); err != nil {
 				return err

--- a/internal/cli/atlas/metrics/disks/describe.go
+++ b/internal/cli/atlas/metrics/disks/describe.go
@@ -81,7 +81,7 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted disk metrics from the last 36 hours with 5-minute granularity for the database named testDB in the host atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
   %s metrics disks describe atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 testDB --granularity PT1M --period P1DT12H --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.ValidatePeriodStartEnd,
@@ -89,7 +89,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), diskMetricTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
 			opts.host, opts.port, err = cli.GetHostnameAndPort(args[0])
 			if err != nil {

--- a/internal/cli/atlas/metrics/disks/list.go
+++ b/internal/cli/atlas/metrics/disks/list.go
@@ -78,14 +78,14 @@ $ %s processes list
 		Example: fmt.Sprintf(
 			`  # Return a JSON-formatted list of disks and partitions for the host atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
   %s metrics disks list atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
 			opts.host, opts.port, err = cli.GetHostnameAndPort(args[0])
 			if err != nil {

--- a/internal/cli/atlas/metrics/processes/processes.go
+++ b/internal/cli/atlas/metrics/processes/processes.go
@@ -79,7 +79,7 @@ func Builder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted process metrics for the host atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017
   %s metrics processes atlas-lnmtkm-shard-00-00.ajlj3.mongodb.net:27017 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.ValidatePeriodStartEnd,
@@ -87,7 +87,7 @@ func Builder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), metricTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
 			opts.host, opts.port, err = cli.GetHostnameAndPort(args[0])
 			if err != nil {

--- a/internal/cli/atlas/networking/containers/delete.go
+++ b/internal/cli/atlas/networking/containers/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/networking/containers/list.go
+++ b/internal/cli/atlas/networking/containers/list.go
@@ -83,14 +83,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of network peering containers in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s networking containers list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/networking/peering/create/aws.go
+++ b/internal/cli/atlas/networking/peering/create/aws.go
@@ -133,14 +133,14 @@ func AwsBuilder() *cobra.Command {
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create a network peering connection between the Atlas VPC in CIDR block 192.168.0.0/24 and your AWS VPC in CIDR block 10.0.0.0/24 for AWS account number 854333054055:
   %s networking peering create aws --accountId 854333054055 --atlasCidrBlock 192.168.0.0/24 --region us-east-1 --routeTableCidrBlock 10.0.0.0/24 --vpcId vpc-078ac381aa90e1e63`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/networking/peering/create/azure.go
+++ b/internal/cli/atlas/networking/peering/create/azure.go
@@ -147,14 +147,14 @@ To learn more about network peering connections, see https://www.mongodb.com/doc
 		Example: fmt.Sprintf(`  # Create a network peering connection between the Atlas VPC in CIDR block 192.168.0.0/24 and your Azure VNet named atlascli-test in in US_EAST_2:
   %s networking peering create azure --atlasCidrBlock 192.168.0.0/24 --directoryId 56657fdb-ca45-40dc-fr56-77fd8b6d2b37 --subscriptionId 345654f3-77cf-4084-9e06-8943a079ed75 --resourceGroup atlascli-test --region US_EAST_2 --vnet atlascli-test`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/networking/peering/create/gcp.go
+++ b/internal/cli/atlas/networking/peering/create/gcp.go
@@ -118,14 +118,14 @@ func GCPBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Create a network peering connection between the Atlas VPC in CIDR block 192.168.0.0/24 and your GCP VPC with the GCP project ID grandiose-branch-256701 in the network named cli-test:
   %s networking peering create gcp --atlasCidrBlock 192.168.0.0/24 --gcpProjectId grandiose-branch-256701 --network cli-test --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/networking/peering/delete.go
+++ b/internal/cli/atlas/networking/peering/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/networking/peering/list.go
+++ b/internal/cli/atlas/networking/peering/list.go
@@ -75,14 +75,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for all network peering connections in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s networking peering list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/networking/peering/watch.go
+++ b/internal/cli/atlas/networking/peering/watch.go
@@ -108,14 +108,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"peerIdDesc": "Unique ID of the network peering connection that you want to watch.",
 			"output":     watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/organizations/apikeys/accesslists/create.go
+++ b/internal/cli/atlas/organizations/apikeys/accesslists/create.go
@@ -102,14 +102,14 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if opts.currentIP {
 				publicIP := storeHelper.IPAddress()
 				if publicIP == "" {

--- a/internal/cli/atlas/organizations/apikeys/accesslists/delete.go
+++ b/internal/cli/atlas/organizations/apikeys/accesslists/delete.go
@@ -71,7 +71,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/apikeys/accesslists/list.go
+++ b/internal/cli/atlas/organizations/apikeys/accesslists/list.go
@@ -80,14 +80,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of access list entries for the API key with the ID 5f24084d8dbffa3ad3f21234 in the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys accessLists list --apiKey 5f24084d8dbffa3ad3f21234 --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/organizations/apikeys/create.go
+++ b/internal/cli/atlas/organizations/apikeys/create.go
@@ -81,14 +81,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create an organization API key with organization owner access in the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys create --role ORG_OWNER --desc "My API Key" --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/apikeys/delete.go
+++ b/internal/cli/atlas/organizations/apikeys/delete.go
@@ -72,7 +72,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/apikeys/describe.go
+++ b/internal/cli/atlas/organizations/apikeys/describe.go
@@ -72,14 +72,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the organization API key with the ID 5f24084d8dbffa3ad3f21234 for the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys describe 5f24084d8dbffa3ad3f21234 --orgId 5a1b39eec902201990f12345 -output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/organizations/apikeys/list.go
+++ b/internal/cli/atlas/organizations/apikeys/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of organization API keys for the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys list --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/apikeys/update.go
+++ b/internal/cli/atlas/organizations/apikeys/update.go
@@ -82,14 +82,14 @@ To view possible values for the apiKeyId argument, run %s organizations apiKeys 
 		},
 		Example: fmt.Sprintf(`  # Modify the role and description for the API key with the ID 5f24084d8dbffa3ad3f21234 for the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys assign 5f24084d8dbffa3ad3f21234 --role ORG_MEMBER --desc "User1 Member Key" --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/organizations/create_atlas.go
+++ b/internal/cli/atlas/organizations/create_atlas.go
@@ -134,7 +134,7 @@ func CreateAtlasBuilder() *cobra.Command {
 		},
 		Example: `  # Create an Atlas organization with the name myOrg:
   atlas organizations create myOrg --output json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if len(opts.apiKeyRole) > 0 {
 				createAtlasTemplate += `API Key '{{.APIKey.ID}}' created.
 Public API Key '{{.APIKey.PublicKey}}'
@@ -147,7 +147,7 @@ Private API Key '{{.APIKey.PrivateKey}}'
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/organizations/delete.go
+++ b/internal/cli/atlas/organizations/delete.go
@@ -70,7 +70,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/describe.go
+++ b/internal/cli/atlas/organizations/describe.go
@@ -70,13 +70,13 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the organization with the ID 5e2211c17a3e5a48f5497de3:
   %s organizations describe 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/organizations/invitations/delete.go
+++ b/internal/cli/atlas/organizations/invitations/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/invitations/describe.go
+++ b/internal/cli/atlas/organizations/invitations/describe.go
@@ -69,14 +69,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the pending invitation with the ID 5dd56c847a3e5a1f363d424d for the organization with the ID 5f71e5255afec75a3d0f96dc:
   %s organizations invitations describe 5dd56c847a3e5a1f363d424d --orgId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/organizations/invitations/list.go
+++ b/internal/cli/atlas/organizations/invitations/list.go
@@ -73,14 +73,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of pending invitations to the organization with the ID 5f71e5255afec75a3d0f96dc:
   %s organizations invitations list --orgId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/invitations/update.go
+++ b/internal/cli/atlas/organizations/invitations/update.go
@@ -103,7 +103,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/list.go
+++ b/internal/cli/atlas/organizations/list.go
@@ -85,13 +85,13 @@ func ListBuilder() *cobra.Command {
   
   # Return a JSON-formatted list that includes the organizations named org1 and Org1, but doesn't return org123:
   %[1]s organizations list --name org1 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/organizations/users/list.go
+++ b/internal/cli/atlas/organizations/users/list.go
@@ -72,7 +72,7 @@ func ListBuilder() *cobra.Command {
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all users for the organization with the ID 5e2211c17a3e5a48f5497de3:
   %s organizations users list --orgId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.PreRunE(
 				opts.ValidateOrgID,
@@ -80,7 +80,7 @@ func ListBuilder() *cobra.Command {
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/performanceadvisor/namespaces/list.go
+++ b/internal/cli/atlas/performanceadvisor/namespaces/list.go
@@ -91,14 +91,14 @@ If you don't set the duration option or the since option, this command returns d
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of namespaces for collections with slow queries for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s performanceAdvisor namespaces list --processName atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/performanceadvisor/slowoperationthreshold/disable.go
+++ b/internal/cli/atlas/performanceadvisor/slowoperationthreshold/disable.go
@@ -65,13 +65,13 @@ func DisableBuilder() *cobra.Command {
 			"output": DisableTemplate,
 		},
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/performanceadvisor/slowoperationthreshold/enable.go
+++ b/internal/cli/atlas/performanceadvisor/slowoperationthreshold/enable.go
@@ -66,13 +66,13 @@ func EnableBuilder() *cobra.Command {
 		},
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/performanceadvisor/slowquerylogs/list.go
+++ b/internal/cli/atlas/performanceadvisor/slowquerylogs/list.go
@@ -102,14 +102,14 @@ If you don't set the duration option or the since option, this command returns d
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of log lines for collections with slow queries for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s performanceAdvisor slowQueryLogs list --processName atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/atlas/performanceadvisor/suggestedindexes/list.go
@@ -102,14 +102,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of suggested indexes for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s performanceAdvisor suggestedIndexes list --processName atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/aws/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/create.go
@@ -79,14 +79,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create a private endpoint connection for AWS in the us-east-1 region for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws create --region us-east-1 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/describe.go
@@ -65,9 +65,11 @@ func DescribeBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe <privateEndpointId>",
 		Aliases: []string{"get"},
-		Args: cobra.MatchAll(require.ExactArgs(1), func(cmd *cobra.Command, args []string) error {
-			return validate.ObjectID(args[0])
-		}),
+		Args: cobra.MatchAll(
+			require.ExactArgs(1),
+			func(_ *cobra.Command, args []string) error {
+				return validate.ObjectID(args[0])
+			}),
 		Short: "Return the details for the specified AWS private endpoints for your project.",
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Annotations: map[string]string{
@@ -84,7 +86,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/create.go
@@ -80,14 +80,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create a new interface for an AWS private endpoint with the ID 5f4fc14da2b47835a58c63a2 in Atlas and the ID vpce-00713b5e644e830a3 in AWS for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws interfaces create 5f4fc14da2b47835a58c63a2 --privateEndpointId vpce-00713b5e644e830a3 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.interfaceEndpointID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/delete.go
@@ -63,10 +63,10 @@ func DeleteBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Remove the AWS private endpoint interface with the ID vpce-00713b5e644e830a3 in AWS from the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws interfaces delete vpce-00713b5e644e830a3 --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.Entry = args[0]
 			if err := opts.Prompt(); err != nil {
 				return err

--- a/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/aws/interfaces/describe.go
@@ -82,7 +82,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/aws/list.go
+++ b/internal/cli/atlas/privateendpoints/aws/list.go
@@ -69,14 +69,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all AWS private endpoints for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints aws list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/aws/watch.go
+++ b/internal/cli/atlas/privateendpoints/aws/watch.go
@@ -80,14 +80,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
 			"output":                watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/privateendpoints/azure/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/create.go
@@ -79,14 +79,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create a private endpoint connection for Azure in the eastus region for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure create --region eastus --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/azure/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/azure/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/describe.go
@@ -79,7 +79,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/create.go
@@ -82,14 +82,14 @@ func CreateBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Create a new interface for an Azure private endpoint with the ID 5f4fc14da2b47835a58c63a2 in Atlas and the ID /subscriptions/4e133d35-e734-4385-a565-c0945567ae346/resourceGroups/rg_95847a959b876e255dbb9b33_dfragd7w/providers/Microsoft.Network/privateEndpoints/test-endpoint in Azure for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure interfaces create 5f4fc14da2b47835a58c63a2 --privateEndpointId /subscriptions/4e133d35-e734-4385-a565-c0945567ae346/resourceGroups/rg_95847a959b876e255dbb9b33_dfragd7w/providers/Microsoft.Network/privateEndpoints/test-endpoint --projectId 5e2211c17a3e5a48f5497de3 --privateEndpointIpAddress 192.0.2.5
   --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.interfaceEndpointID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/delete.go
@@ -63,10 +63,10 @@ func DeleteBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Remove the Azure private endpoint interface with the ID /subscriptions/4e133d35-e734-4385-a565-c0945567ae346/resourceGroups/rg_95847a959b876e255dbb9b33_dfragd7w/providers/Microsoft.Network/privateEndpoints/cli-test in Azure from the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure interfaces delete /subscriptions/4e133d35-e734-4385-a565-c0945567ae346/resourceGroups/rg_95847a959b876e255dbb9b33_dfragd7w/providers/Microsoft.Network/privateEndpoints/cli-test --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.Entry = args[0]
 			if err := opts.Prompt(); err != nil {
 				return err

--- a/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/azure/interfaces/describe.go
@@ -80,7 +80,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/azure/list.go
+++ b/internal/cli/atlas/privateendpoints/azure/list.go
@@ -69,14 +69,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all Azure private endpoints for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints azure list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/azure/watch.go
+++ b/internal/cli/atlas/privateendpoints/azure/watch.go
@@ -80,14 +80,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"privateEndpointIdDesc": "Unique 24-character alphanumeric string that identifies the private endpoint in Atlas.",
 			"output":                watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/privateendpoints/create.go
+++ b/internal/cli/atlas/privateendpoints/create.go
@@ -74,14 +74,14 @@ func CreateBuilder() *cobra.Command {
 			"output": createTemplate,
 		},
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Deprecated: "Please use atlas privateEndpoints aws create [--region region] [--projectId projectId]",

--- a/internal/cli/atlas/privateendpoints/datalake/aws/create.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/create.go
@@ -83,14 +83,14 @@ Your API key must have the GROUP_ATLAS_ADMIN (Project Owner) role to create a pr
 			"output": createTemplate,
 		},
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/datalake/aws/delete.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/delete.go
@@ -68,7 +68,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/describe.go
@@ -78,7 +78,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/datalake/aws/list.go
+++ b/internal/cli/atlas/privateendpoints/datalake/aws/list.go
@@ -78,14 +78,14 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/delete.go
+++ b/internal/cli/atlas/privateendpoints/delete.go
@@ -65,7 +65,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Deprecated: "Please use atlas privateEndpoints aws delete <ID> [--projectId projectId]",

--- a/internal/cli/atlas/privateendpoints/describe.go
+++ b/internal/cli/atlas/privateendpoints/describe.go
@@ -72,7 +72,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Deprecated: "Please use atlas privateEndpoints aws describe <ID> [--projectId projectId]",

--- a/internal/cli/atlas/privateendpoints/gcp/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/create.go
@@ -76,14 +76,14 @@ func CreateBuilder() *cobra.Command {
 			"output": createTemplate,
 		},
 		Example: fmt.Sprintf(`  %s privateEndpoints gcp create --region CENTRAL_US`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/gcp/delete.go
+++ b/internal/cli/atlas/privateendpoints/gcp/delete.go
@@ -71,7 +71,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/gcp/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/describe.go
@@ -78,7 +78,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/create.go
@@ -108,7 +108,7 @@ func CreateBuilder() *cobra.Command {
   --gcpProjectId mcli-private-endpoints \
   --endpoint endpoint-0@10.142.0.2,endpoint-1@10.142.0.3,endpoint-2@10.142.0.4,endpoint-3@10.142.0.5,endpoint-4@10.142.0.6,endpoint-5@10.142.0.7`,
 			cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.validateEndpoints,
 				opts.ValidateProjectID,
@@ -116,7 +116,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.privateEndpointGroupID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/delete.go
@@ -65,10 +65,10 @@ func DeleteBuilder() *cobra.Command {
 			`  %s privateEndpoints gcp interfaces delete endpoint-1 \
   --endpointServiceId 61eaca605af86411903de1dd`,
 			cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.Entry = args[0]
 			if err := opts.Prompt(); err != nil {
 				return err

--- a/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/gcp/interfaces/describe.go
@@ -80,7 +80,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/gcp/list.go
+++ b/internal/cli/atlas/privateendpoints/gcp/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Read Only"),
 		Example: fmt.Sprintf(`  %s privateEndpoint gcp ls`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/gcp/watch.go
+++ b/internal/cli/atlas/privateendpoints/gcp/watch.go
@@ -79,14 +79,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 		},
 		Example: fmt.Sprintf(`  %s privateEndpoint gcp watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
 		Args:    require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/privateendpoints/interfaces/create.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/create.go
@@ -64,14 +64,14 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.interfaceEndpointID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/privateendpoints/interfaces/delete.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/delete.go
@@ -58,10 +58,10 @@ func DeleteBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": opts.SuccessMessage(),
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.Entry = args[0]
 			if err := opts.Prompt(); err != nil {
 				return err

--- a/internal/cli/atlas/privateendpoints/interfaces/describe.go
+++ b/internal/cli/atlas/privateendpoints/interfaces/describe.go
@@ -73,7 +73,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Deprecated: "Please use atlas privateEndpoints aws interfaces describe <atlasPrivateEndpointId> [--privateEndpointId privateEndpointID] [--projectId projectId]",

--- a/internal/cli/atlas/privateendpoints/list.go
+++ b/internal/cli/atlas/privateendpoints/list.go
@@ -66,14 +66,14 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 		Deprecated: "Please use atlas privateEndpoints aws list|ls [--projectId projectId]",

--- a/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/describe.go
@@ -67,14 +67,14 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the regionalized private endpoint setting for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/disable.go
@@ -64,14 +64,14 @@ func DisableBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Disable the regionalied private endpoint setting in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes disable --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), disableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
+++ b/internal/cli/atlas/privateendpoints/regionalmodes/enable.go
@@ -65,14 +65,14 @@ func EnableBuilder() *cobra.Command {
 
 		Example: fmt.Sprintf(`  # Enable the regionalied private endpoint setting in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s privateEndpoints regionalModes enable --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), enableTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/privateendpoints/watch.go
+++ b/internal/cli/atlas/privateendpoints/watch.go
@@ -72,7 +72,7 @@ Once the endpoint reaches the expected state, the command prints "Private endpoi
 If you run the command in the terminal, it blocks the terminal session until the resource becomes available or fails.
 You can interrupt the command's polling at any time with CTRL-C.`,
 		Args: require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -83,7 +83,7 @@ You can interrupt the command's polling at any time with CTRL-C.`,
 			"output": watchTemplate,
 		},
 		Example: fmt.Sprintf(`  %s privateEndpoint watch vpce-abcdefg0123456789`, cli.ExampleAtlasEntryPoint()),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/processes/describe.go
+++ b/internal/cli/atlas/processes/describe.go
@@ -80,14 +80,14 @@ func DescribeBuilder() *cobra.Command {
 			"hostname:portDesc": "Hostname and port number of the instance running the Atlas MongoDB process.",
 			"output":            describeTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			var err error
 			opts.host, opts.port, err = cli.GetHostnameAndPort(args[0])
 			if err != nil {

--- a/internal/cli/atlas/processes/list.go
+++ b/internal/cli/atlas/processes/list.go
@@ -87,14 +87,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all MongoDB processes in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s processes list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/processes/process_autocomplete.go
+++ b/internal/cli/atlas/processes/process_autocomplete.go
@@ -35,7 +35,7 @@ type AutoCompleteOpts struct {
 }
 
 func (opts *AutoCompleteOpts) AutocompleteProcesses() cli.AutoFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if err := opts.parseFlags(cmd); err != nil {
 			cobra.CompErrorln(fmt.Sprintf("failed to parse flags: %v", err))
 			return nil, cobra.ShellCompDirectiveError

--- a/internal/cli/atlas/projects/apikeys/assign.go
+++ b/internal/cli/atlas/projects/apikeys/assign.go
@@ -77,7 +77,7 @@ To view possible values for the ID argument, run %s organizations apiKeys list.`
 		},
 		Example: fmt.Sprintf(`  # Assign an organization API key with the ID 5f46ae53d58b421fe3edc115 and grant the GROUP_DATA_ACCESS_READ_WRITE role for the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys assign 5f46ae53d58b421fe3edc115 --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_DATA_ACCESS_READ_WRITE --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.PreRunE(
 				opts.ValidateProjectID,
@@ -85,7 +85,7 @@ To view possible values for the ID argument, run %s organizations apiKeys list.`
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/projects/apikeys/create.go
+++ b/internal/cli/atlas/projects/apikeys/create.go
@@ -78,14 +78,14 @@ func CreateBuilder() *cobra.Command {
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create an organization API key with the ORG_OWNER role and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role ORG_OWNER --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/apikeys/delete.go
+++ b/internal/cli/atlas/projects/apikeys/delete.go
@@ -74,7 +74,7 @@ To view possible values for the ID argument, run %[1]s organizations apiKeys lis
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/apikeys/list.go
+++ b/internal/cli/atlas/projects/apikeys/list.go
@@ -73,14 +73,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of organization API keys assigned to the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys list --projectId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/create.go
+++ b/internal/cli/atlas/projects/create.go
@@ -107,14 +107,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create a project in the organization with the ID 5e2211c17a3e5a48f5497de3 using default alert settings:
   %s projects create my-project --orgId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/projects/delete.go
+++ b/internal/cli/atlas/projects/delete.go
@@ -68,7 +68,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/describe.go
+++ b/internal/cli/atlas/projects/describe.go
@@ -70,11 +70,11 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects describe 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/projects/invitations/delete.go
+++ b/internal/cli/atlas/projects/invitations/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/invitations/describe.go
+++ b/internal/cli/atlas/projects/invitations/describe.go
@@ -71,11 +71,11 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the pending invitation with the ID 5dd56c847a3e5a1f363d424d for the project with the ID 5f71e5255afec75a3d0f96dc:
   %s projects invitations describe 5dd56c847a3e5a1f363d424d --projectId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/projects/invitations/list.go
+++ b/internal/cli/atlas/projects/invitations/list.go
@@ -74,11 +74,11 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of pending invitations to the project with the ID 5f71e5255afec75a3d0f96dc:
   %s projects invitations list --projectId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/invitations/update.go
+++ b/internal/cli/atlas/projects/invitations/update.go
@@ -102,7 +102,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/list.go
+++ b/internal/cli/atlas/projects/list.go
@@ -76,11 +76,11 @@ func ListBuilder() *cobra.Command {
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all projects:
   %s projects list --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/settings/describe.go
+++ b/internal/cli/atlas/projects/settings/describe.go
@@ -64,14 +64,14 @@ func DescribeBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
   %s projects settings describe -P myprofile --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/settings/update.go
+++ b/internal/cli/atlas/projects/settings/update.go
@@ -84,7 +84,7 @@ func UpdateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # This example uses the profile named "myprofile" for accessing Atlas.
   %s projects settings update --disableCollectDatabaseSpecificsStatistics -P myprofile --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			preRun := opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -93,7 +93,7 @@ func UpdateBuilder() *cobra.Command {
 			opts.newProjectSettings()
 			return preRun
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/teams/add.go
+++ b/internal/cli/atlas/projects/teams/add.go
@@ -88,7 +88,7 @@ func AddBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), addTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/teams/delete.go
+++ b/internal/cli/atlas/projects/teams/delete.go
@@ -72,7 +72,7 @@ func DeleteBuilder() *cobra.Command {
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/teams/list.go
+++ b/internal/cli/atlas/projects/teams/list.go
@@ -69,14 +69,14 @@ func ListBuilder() *cobra.Command {
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all teams for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects teams list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/teams/update.go
+++ b/internal/cli/atlas/projects/teams/update.go
@@ -84,7 +84,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/users/delete.go
+++ b/internal/cli/atlas/projects/users/delete.go
@@ -71,7 +71,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/projects/users/list.go
+++ b/internal/cli/atlas/projects/users/list.go
@@ -73,14 +73,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all users for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects users list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/search/create.go
+++ b/internal/cli/atlas/search/create.go
@@ -117,7 +117,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				opts.Name = args[0]
 			}

--- a/internal/cli/atlas/search/delete.go
+++ b/internal/cli/atlas/search/delete.go
@@ -74,7 +74,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/search/describe.go
+++ b/internal/cli/atlas/search/describe.go
@@ -71,14 +71,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the search index with the ID 5f1f40842f2ac35f49190c20 for the cluster named myCluster:
   %s clusters search indexes describe 5f1f40842f2ac35f49190c20 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := validate.ObjectID(args[0]); err != nil {
 				return err
 			}

--- a/internal/cli/atlas/search/list.go
+++ b/internal/cli/atlas/search/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the JSON-formatted list of Atlas search indexes on the sample_mflix.movies database in the cluster named myCluster:
   %s clusters search indexes list --clusterName myCluster --db sample_mflix --collection movies --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/search/update.go
+++ b/internal/cli/atlas/search/update.go
@@ -99,7 +99,7 @@ func UpdateBuilder() *cobra.Command {
 		Args: require.ExactArgs(1),
 		Example: fmt.Sprintf(`  # Modify the search index with the ID 5f2099cd683fc55fbb30bef6 for the cluster named myCluster:
   %s clusters search indexes update 5f2099cd683fc55fbb30bef6 --clusterName myCluster --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.Filename == "" {
 				_ = cmd.MarkFlagRequired(flag.IndexName)
 				_ = cmd.MarkFlagRequired(flag.Database)
@@ -113,7 +113,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/security/customercerts/create.go
+++ b/internal/cli/atlas/security/customercerts/create.go
@@ -79,14 +79,14 @@ func CreateBuilder() *cobra.Command {
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Save the file named ca.pem stored in the files directory to the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts create --casFile files/ca.pem --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/security/customercerts/describe.go
+++ b/internal/cli/atlas/security/customercerts/describe.go
@@ -63,14 +63,14 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the customer-managed X.509 configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts describe --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/security/customercerts/disable.go
+++ b/internal/cli/atlas/security/customercerts/disable.go
@@ -83,14 +83,14 @@ func DisableBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Disable the customer-managed X.509 configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security customerCerts disable --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context())); err != nil {
 				return err
 			}
 
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/security/ldap/delete.go
+++ b/internal/cli/atlas/security/ldap/delete.go
@@ -59,14 +59,14 @@ func DeleteBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Remove the current LDAP configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security ldap delete --projectId 5e2211c17a3e5a48f5497de3`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			opts.Entry = opts.ConfigProjectID()
 			return opts.Run()
 		},

--- a/internal/cli/atlas/security/ldap/get.go
+++ b/internal/cli/atlas/security/ldap/get.go
@@ -65,14 +65,14 @@ func GetBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the current LDAP configuration in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security ldap get --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), getTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/security/ldap/save.go
+++ b/internal/cli/atlas/security/ldap/save.go
@@ -145,7 +145,7 @@ func SaveBuilder() *cobra.Command {
   --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername 
   "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com" 
   --bindPassword changeMe`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -153,7 +153,7 @@ func SaveBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), saveTemplate),
 				opts.InitInput(cmd.InOrStdin()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/security/ldap/status.go
+++ b/internal/cli/atlas/security/ldap/status.go
@@ -67,13 +67,13 @@ func StatusBuilder() *cobra.Command {
 			"requestIdDesc": "ID of the request to verify an LDAP configuration.",
 			"output":        verifyStatusTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), verifyStatusTemplate))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/security/ldap/verify.go
+++ b/internal/cli/atlas/security/ldap/verify.go
@@ -113,7 +113,7 @@ func VerifyBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Request the JSON-formatted verification of the LDAP configuration for the atlas-ldaps-01.ldap.myteam.com host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s security ldap verify --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com" --bindPassword changeMe --projectId 5e2211c17a3e5a48f5497de3 --output json
 `, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -123,7 +123,7 @@ func VerifyBuilder() *cobra.Command {
 			}
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/security/ldap/watch.go
+++ b/internal/cli/atlas/security/ldap/watch.go
@@ -79,14 +79,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"requestIdDesc": "ID of the request to verify an LDAP configuration.",
 			"output":        watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/serverless/backup/restores/create.go
+++ b/internal/cli/atlas/serverless/backup/restores/create.go
@@ -167,7 +167,7 @@ func CreateBuilder() *cobra.Command {
          --deliveryType download \
          --clusterName myDemo \
          --snapshotId 5e7e00128f8ce03996a47179`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			set := false
 
 			if opts.isAutomatedRestore() {
@@ -201,7 +201,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/serverless/backup/restores/describe.go
+++ b/internal/cli/atlas/serverless/backup/restores/describe.go
@@ -66,14 +66,14 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the serverless isntance named Cluster0:
   %s serverless backup restore describe --restoreJobId 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), restoreDescribeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/serverless/backup/restores/list.go
+++ b/internal/cli/atlas/serverless/backup/restores/list.go
@@ -71,14 +71,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return all continuous backup restore jobs for the serverless instance Instance0:
   %s serverless backup restore list Instance0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), restoreListTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/serverless/backup/restores/watch.go
+++ b/internal/cli/atlas/serverless/backup/restores/watch.go
@@ -81,14 +81,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 		},
 		Example: fmt.Sprintf(`  # Watch the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the cluster named Cluster0 until it becomes available:
   %s serverless backup restore watch --restoreJobId 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/serverless/backup/snapshots/describe.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/describe.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package snapshots
 
 import (
@@ -66,14 +67,14 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{"output": describeTemplate},
 		Example: fmt.Sprintf(`  # Return the details for the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the instance named myDemo:
   %s serverless backups snapshots describe --snapshotId 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/serverless/backup/snapshots/list.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/list.go
@@ -71,14 +71,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of snapshots for the instance named myDemo 
   %s serverless backups snapshots list myDemo --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/serverless/backup/snapshots/watch.go
+++ b/internal/cli/atlas/serverless/backup/snapshots/watch.go
@@ -78,14 +78,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Example: fmt.Sprintf(`  # Watch the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 in the cluster named myDemo until it becomes available:
   %s backups snapshots watch 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/serverless/create.go
+++ b/internal/cli/atlas/serverless/create.go
@@ -99,14 +99,14 @@ func CreateBuilder() *cobra.Command {
 			"instanceNameDesc": "Human-readable label that identifies your serverless instance.",
 			"output":           createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.instanceName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/serverless/delete.go
+++ b/internal/cli/atlas/serverless/delete.go
@@ -67,7 +67,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/serverless/describe.go
+++ b/internal/cli/atlas/serverless/describe.go
@@ -75,7 +75,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/serverless/list.go
+++ b/internal/cli/atlas/serverless/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/serverless/update.go
+++ b/internal/cli/atlas/serverless/update.go
@@ -96,14 +96,14 @@ func UpdateBuilder() *cobra.Command {
 			"instanceNameDesc": "Human-readable label that identifies your serverless instance.",
 			"output":           updateTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.instanceName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/serverless/watch.go
+++ b/internal/cli/atlas/serverless/watch.go
@@ -79,14 +79,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 			"instanceNameDesc": "Name of the instance to watch.",
 			"output":           watchTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), watchTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/setup/setup_cmd.go
+++ b/internal/cli/atlas/setup/setup_cmd.go
@@ -574,7 +574,7 @@ func Builder() *cobra.Command {
   atlas setup --clusterName Test --provider GCP --username dbuserTest`,
 		Hidden: false,
 		Args:   require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			defaultProfile := config.Default()
 			opts.config = defaultProfile
 			opts.OutWriter = cmd.OutOrStdout()
@@ -605,7 +605,7 @@ func Builder() *cobra.Command {
 
 			return opts.PreRunE(preRun...)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			opts.flags = cmd.Flags()
 			return opts.Run(cmd.Context())
 		},

--- a/internal/cli/atlas/streams/connection/create.go
+++ b/internal/cli/atlas/streams/connection/create.go
@@ -114,7 +114,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/streams/connection/delete.go
+++ b/internal/cli/atlas/streams/connection/delete.go
@@ -81,7 +81,7 @@ Before deleting an Atlas Streams Processing connection, you must first stop all 
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/streams/connection/describe.go
+++ b/internal/cli/atlas/streams/connection/describe.go
@@ -72,14 +72,14 @@ func DescribeBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`# retrieves stream connection 'ExampleConnection' in instance 'ExampleInstance':
 %[1]s streams connection describe ExampleConnection --instance ExampleInstance
 `, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 
 			return opts.Run()

--- a/internal/cli/atlas/streams/connection/list.go
+++ b/internal/cli/atlas/streams/connection/list.go
@@ -69,14 +69,14 @@ func ListBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`# list all connections within ExampleInstance:
 %[1]s streams connection list --instance ExampleInstance
 `, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/streams/connection/update.go
+++ b/internal/cli/atlas/streams/connection/update.go
@@ -101,7 +101,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/streams/instance/create.go
+++ b/internal/cli/atlas/streams/instance/create.go
@@ -90,7 +90,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/streams/instance/delete.go
+++ b/internal/cli/atlas/streams/instance/delete.go
@@ -81,7 +81,7 @@ Before deleting an Atlas Streams Processing instance, you must first stop all pr
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/streams/instance/describe.go
+++ b/internal/cli/atlas/streams/instance/describe.go
@@ -90,7 +90,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/streams/instance/list.go
+++ b/internal/cli/atlas/streams/instance/list.go
@@ -77,14 +77,14 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/streams/instance/update.go
+++ b/internal/cli/atlas/streams/instance/update.go
@@ -106,7 +106,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/teams/create.go
+++ b/internal/cli/atlas/teams/create.go
@@ -75,14 +75,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create a team named myTeam in the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams create myTeam --username user1@example.com,user2@example.com --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/teams/delete.go
+++ b/internal/cli/atlas/teams/delete.go
@@ -70,7 +70,7 @@ func DeleteBuilder() *cobra.Command {
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/teams/describe.go
+++ b/internal/cli/atlas/teams/describe.go
@@ -96,7 +96,7 @@ func DescribeBuilder() *cobra.Command {
 
 ` + fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
@@ -104,7 +104,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/teams/list.go
+++ b/internal/cli/atlas/teams/list.go
@@ -73,14 +73,14 @@ func ListBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of the teams for the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams list --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/teams/rename.go
+++ b/internal/cli/atlas/teams/rename.go
@@ -75,14 +75,14 @@ func RenameBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Rename a team in the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams rename newName --teamId 5e1234c17a3e5a48f5497de3 --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), renameTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/atlas/teams/users/add.go
+++ b/internal/cli/atlas/teams/users/add.go
@@ -89,7 +89,7 @@ func AddBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), addTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/teams/users/delete.go
+++ b/internal/cli/atlas/teams/users/delete.go
@@ -71,7 +71,7 @@ func DeleteBuilder() *cobra.Command {
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/teams/users/list.go
+++ b/internal/cli/atlas/teams/users/list.go
@@ -71,14 +71,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of the users for the team with the ID 5f6a5c6c713184005d72fe6e in the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams users list --teamId 5f6a5c6c713184005d72fe6e --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/users/describe.go
+++ b/internal/cli/atlas/users/describe.go
@@ -91,14 +91,14 @@ func DescribeBuilder() *cobra.Command {
 		
 User accounts and API keys with any role can run this command.`,
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return prerun.ExecuteE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/atlas/users/invite.go
+++ b/internal/cli/atlas/users/invite.go
@@ -186,13 +186,13 @@ func InviteBuilder() *cobra.Command {
   
   # Create the MongoDB user with the username user@example.com and invite them to the project with the ID 5f71e5255afec75a3d0f96dc with GROUP_READ_ONLY access:
   %[1]s users invite --email user@example.com --username user@example.com --projectRole 5f71e5255afec75a3d0f96dc:GROUP_READ_ONLY --firstName Example --lastName User --country US --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return prerun.ExecuteE(
 				opts.InitOutput(cmd.OutOrStdout(), inviteTemplate),
 				opts.InitInput(cmd.InOrStdin()),
 				opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Prompt(); err != nil {
 				return err
 			}

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -300,7 +300,7 @@ func LoginBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Log in to your MongoDB %s account in interactive mode:
   %s auth login
 `, tool(), config.BinName()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			defaultProfile := config.Default()
 			return prerun.ExecuteE(
@@ -311,7 +311,7 @@ func LoginBuilder() *cobra.Command {
 				validate.NoAccessToken,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.LoginRun(cmd.Context())
 		},
 		Args: require.NoArgs,

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -80,12 +80,12 @@ func LogoutBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # To log out from the CLI:
   %s auth logout
 `, config.BinName()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			opts.config = config.Default()
 			return opts.initFlow()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if config.RefreshToken() == "" {
 				return ErrUnauthenticated
 			}

--- a/internal/cli/auth/register.go
+++ b/internal/cli/auth/register.go
@@ -102,7 +102,7 @@ func RegisterBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # To start the interactive setup:
   %s auth register
 `, config.BinName()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			defaultProfile := config.Default()
 			return prerun.ExecuteE(
@@ -112,7 +112,7 @@ func RegisterBuilder() *cobra.Command {
 				validate.NoAPIKeys,
 				validate.NoAccessToken)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			_, _ = fmt.Fprintf(opts.OutWriter, "Create and verify your MongoDB Atlas account from the web browser and return to Atlas CLI after activation.\n")
 
 			return opts.RegisterRun(cmd.Context())

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -53,10 +53,10 @@ func WhoAmIBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # See the logged account:
   %s auth whoami
 `, config.BinName()),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(cmd *cobra.Command, _ []string) {
 			opts.OutWriter = cmd.OutOrStdout()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			var err error
 			if opts.account, err = AccountWithAccessToken(); err != nil {
 				return err

--- a/internal/cli/cloudmanager/cloud_manager.go
+++ b/internal/cli/cloudmanager/cloud_manager.go
@@ -48,7 +48,7 @@ func Builder() *cobra.Command {
 		Use:     "cloud-manager",
 		Aliases: []string{"cm"},
 		Short:   "MongoDB Cloud Manager operations.",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			log.SetWriter(cmd.ErrOrStderr())
 			if debugLevel {
 				log.SetLevel(log.DebugLevel)

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -133,12 +133,12 @@ To find out more, see the documentation: https://docs.mongodb.com/mongocli/stabl
   # Configure a profile to interact with Ops Manager:
   mongocli config --service ops-manager
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opt.OutWriter = cmd.OutOrStdout()
 			return opt.validateService()
 		},
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return opt.Run(cmd.Context())
 		},
 		Annotations: map[string]string{

--- a/internal/cli/config/delete.go
+++ b/internal/cli/config/delete.go
@@ -63,7 +63,7 @@ func DeleteBuilder() *cobra.Command {
 			"nameDesc": "Name of the profile.",
 			"output":   opts.SuccessMessage(),
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			opts.Entry = args[0]
 			if !config.Exists(opts.Entry) {
 				return fmt.Errorf("profile %v does not exist", opts.Entry)
@@ -71,7 +71,7 @@ func DeleteBuilder() *cobra.Command {
 
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/config/describe.go
+++ b/internal/cli/config/describe.go
@@ -57,10 +57,10 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"nameDesc": "Label that identifies the profile.",
 		},
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(cmd *cobra.Command, _ []string) {
 			opts.OutWriter = cmd.OutOrStdout()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/config/edit.go
+++ b/internal/cli/config/edit.go
@@ -51,7 +51,7 @@ func EditBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # To open the config
   %s config edit
 `, config.BinName()),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opt.Run()
 		},
 		Annotations: map[string]string{

--- a/internal/cli/config/list.go
+++ b/internal/cli/config/list.go
@@ -45,10 +45,10 @@ func ListBuilder() *cobra.Command {
 		Short:   "Return a list of available profiles by name.",
 		Long:    `If you did not specify a name for your profile, it displays as the default profile.`,
 		Example: fmt.Sprintf("  %s config ls", config.BinName()),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRun: func(cmd *cobra.Command, _ []string) {
 			o.OutWriter = cmd.OutOrStdout()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return o.Run()
 		},
 	}

--- a/internal/cli/config/rename.go
+++ b/internal/cli/config/rename.go
@@ -73,7 +73,7 @@ func RenameBuilder() *cobra.Command {
 			"newProfileNameDesc": "New name of the profile.",
 		},
 		Args: require.ExactArgs(argsN),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			o.oldName = args[0]
 			o.newName = args[1]
 			return o.Run()

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -101,7 +101,7 @@ func SetBuilder() *cobra.Command {
 			"valueDesc":        "Value for the property to set in the profile.",
 		},
 		ValidArgs: config.Properties(),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts := &SetOpts{
 				store: config.Default(),
 				prop:  args[0],

--- a/internal/cli/decryption/list_key_provider.go
+++ b/internal/cli/decryption/list_key_provider.go
@@ -57,12 +57,12 @@ func KeyProvidersListBuilder() *cobra.Command {
 		Short:   "Lists all key provider configurations found in the encrypted audit log file.",
 		Example: `
   mongocli ops-manager listKeyProvider --file log.gz`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.InitOutput(cmd.OutOrStdout(), listTmpl),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/globalaccesslists/create.go
+++ b/internal/cli/iam/globalaccesslists/create.go
@@ -71,11 +71,11 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create an IP access list entry for your global API key.",
 		Example: `  # Create an access list entry for your global API key to allow access from 192.0.2.0/24:
   mongocli iam globalAccessLists create --cidr 192.0.2.0/24 --desc "My Global IP" --output json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/globalaccesslists/delete.go
+++ b/internal/cli/iam/globalaccesslists/delete.go
@@ -66,7 +66,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/globalaccesslists/describe.go
+++ b/internal/cli/iam/globalaccesslists/describe.go
@@ -67,11 +67,11 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: `  # Return the JSON-formatted details for the access list entry with the ID 5f5bad7a57aef32b04ed0210 from the access list for the global API key:
   mongocli iam globalAccessLists describe 5f5bad7a57aef32b04ed0210 --output json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/globalaccesslists/list.go
+++ b/internal/cli/iam/globalaccesslists/list.go
@@ -68,11 +68,11 @@ func ListBuilder() *cobra.Command {
 		Short: "Return all IP access list entries for your global API key.",
 		Example: `  # Return a JSON-formatted list of all access list entries for the global API key:
   mongocli iam globalAccessLists list --output json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/globalapikeys/create.go
+++ b/internal/cli/iam/globalapikeys/create.go
@@ -72,11 +72,11 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create a global API key for your Ops Manager instance.",
 		Example: `  # Create a global API key that grants GLOBAL_READ_ONLY and GLOBAL_USER_ADMIN access for your Ops Manager instance:
   mongocli iam globalApiKeys create --desc "My Global API key" --role "GLOBAL_READ_ONLY","GLOBAL_USER_ADMIN" --output json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/globalapikeys/delete.go
+++ b/internal/cli/iam/globalapikeys/delete.go
@@ -66,7 +66,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/globalapikeys/describe.go
+++ b/internal/cli/iam/globalapikeys/describe.go
@@ -67,11 +67,11 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: `  # Return the JSON-formatted details for the global API key with the ID 5f5bad7a57aef32b04ed0210:
   mongocli iam globalApiKeys describe 5f5bad7a57aef32b04ed0210 --output json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/globalapikeys/list.go
+++ b/internal/cli/iam/globalapikeys/list.go
@@ -65,11 +65,11 @@ func ListBuilder() *cobra.Command {
 		Example: `  # Return a JSON-formatted list of global API keys:
   mongocli iam globalApiKeys list --output json`,
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/globalapikeys/update.go
+++ b/internal/cli/iam/globalapikeys/update.go
@@ -74,11 +74,11 @@ func UpdateBuilder() *cobra.Command {
 		},
 		Example: `  # Modify the roles and description for the global API key with the ID 5f5bad7a57aef32b04ed0210:
   mongocli iam globalApiKeys update 5f5bad7a57aef32b04ed0210 --desc "My Sample Global API Key" --role GLOBAL_MONITORING_ADMIN --output json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/iam.go
+++ b/internal/cli/iam/iam.go
@@ -35,7 +35,7 @@ func Builder() *cobra.Command {
 	var debugLevel bool
 	cmd := &cobra.Command{
 		Use: "iam",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			log.SetWriter(cmd.ErrOrStderr())
 			if debugLevel {
 				log.SetLevel(log.DebugLevel)

--- a/internal/cli/iam/organizations/apikeys/accesslists/create.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/create.go
@@ -99,14 +99,14 @@ func CreateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if opts.currentIP {
 				publicIP := store.IPAddress()
 				if publicIP == "" {

--- a/internal/cli/iam/organizations/apikeys/accesslists/delete.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/delete.go
@@ -71,7 +71,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/apikeys/accesslists/list.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/list.go
@@ -71,14 +71,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of access list entries for the API key with the ID 5f24084d8dbffa3ad3f21234 in the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys accessLists list --apiKey 5f24084d8dbffa3ad3f21234 --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/organizations/apikeys/create.go
+++ b/internal/cli/iam/organizations/apikeys/create.go
@@ -81,14 +81,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create an organization API key with organization owner access in the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys create --role ORG_OWNER --desc "My API Key" --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/apikeys/delete.go
+++ b/internal/cli/iam/organizations/apikeys/delete.go
@@ -72,7 +72,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/apikeys/describe.go
+++ b/internal/cli/iam/organizations/apikeys/describe.go
@@ -72,14 +72,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the organization API key with the ID 5f24084d8dbffa3ad3f21234 for the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys describe 5f24084d8dbffa3ad3f21234 --orgId 5a1b39eec902201990f12345 -output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/organizations/apikeys/list.go
+++ b/internal/cli/iam/organizations/apikeys/list.go
@@ -67,14 +67,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of organization API keys for the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys list --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/apikeys/update.go
+++ b/internal/cli/iam/organizations/apikeys/update.go
@@ -82,14 +82,14 @@ To view possible values for the apiKeyId argument, run %s organizations apiKeys 
 		},
 		Example: fmt.Sprintf(`  # Modify the role and description for the API key with the ID 5f24084d8dbffa3ad3f21234 for the organization with the ID 5a1b39eec902201990f12345:
   %s organizations apiKeys assign 5f24084d8dbffa3ad3f21234 --role ORG_MEMBER --desc "User1 Member Key" --orgId 5a1b39eec902201990f12345 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/organizations/create.go
+++ b/internal/cli/iam/organizations/create.go
@@ -66,13 +66,13 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: `  # Create an Ops Manager organization with the name myOrg:
   mongocli iam organizations create myOrg --output json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return prerun.ExecuteE(
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 
 			return opts.Run()

--- a/internal/cli/iam/organizations/delete.go
+++ b/internal/cli/iam/organizations/delete.go
@@ -70,7 +70,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/describe.go
+++ b/internal/cli/iam/organizations/describe.go
@@ -72,13 +72,13 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the organization with the ID 5e2211c17a3e5a48f5497de3:
   %s organizations describe 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/organizations/invitations/delete.go
+++ b/internal/cli/iam/organizations/invitations/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/invitations/describe.go
+++ b/internal/cli/iam/organizations/invitations/describe.go
@@ -70,14 +70,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the pending invitation with the ID 5dd56c847a3e5a1f363d424d for the organization with the ID 5f71e5255afec75a3d0f96dc:
   %s organizations invitations describe 5dd56c847a3e5a1f363d424d --orgId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/organizations/invitations/list.go
+++ b/internal/cli/iam/organizations/invitations/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of pending invitations to the organization with the ID 5f71e5255afec75a3d0f96dc:
   %s organizations invitations list --orgId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/invitations/update.go
+++ b/internal/cli/iam/organizations/invitations/update.go
@@ -103,7 +103,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/list.go
+++ b/internal/cli/iam/organizations/list.go
@@ -83,13 +83,13 @@ func ListBuilder() *cobra.Command {
   
   # Return a JSON-formatted list that includes the organizations named org1 and Org1, but doesn't return org123:
   %[1]s organizations list --name org1 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/organizations/users/list.go
+++ b/internal/cli/iam/organizations/users/list.go
@@ -72,7 +72,7 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all users for the organization with the ID 5e2211c17a3e5a48f5497de3:
   %s organizations users list --orgId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.PreRunE(
 				opts.ValidateOrgID,
@@ -80,7 +80,7 @@ func ListBuilder() *cobra.Command {
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/apikeys/assign.go
+++ b/internal/cli/iam/projects/apikeys/assign.go
@@ -76,7 +76,7 @@ To view possible values for the ID argument, run %s organizations apiKeys list.`
 		},
 		Example: fmt.Sprintf(`  # Assign an organization API key with the ID 5f46ae53d58b421fe3edc115 and grant the GROUP_DATA_ACCESS_READ_WRITE role for the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys assign 5f46ae53d58b421fe3edc115 --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_DATA_ACCESS_READ_WRITE --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.PreRunE(
 				opts.ValidateProjectID,
@@ -84,7 +84,7 @@ To view possible values for the ID argument, run %s organizations apiKeys list.`
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/projects/apikeys/create.go
+++ b/internal/cli/iam/projects/apikeys/create.go
@@ -78,14 +78,14 @@ func CreateBuilder() *cobra.Command {
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Create an organization API key with the ORG_OWNER role and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role ORG_OWNER --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/apikeys/delete.go
+++ b/internal/cli/iam/projects/apikeys/delete.go
@@ -74,7 +74,7 @@ To view possible values for the ID argument, run %[1]s organizations apiKeys lis
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/apikeys/list.go
+++ b/internal/cli/iam/projects/apikeys/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of organization API keys assigned to the project with ID 5e2211c17a3e5a48f5497de3:
   %s projects apiKeys list --projectId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/create.go
+++ b/internal/cli/iam/projects/create.go
@@ -155,14 +155,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create a project in the organization with the ID 5e2211c17a3e5a48f5497de3 using default alert settings:
   %s projects create --orgId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			if !config.IsCloud() {
 				opts.Template += "Agent API Key: '{{.AgentAPIKey}}'\n"
 			}
 			return opts.PreRunE(opts.initStore(cmd.Context()), opts.initServiceVersion, opts.validateOwnerID, opts.validateWithoutDefaultAlertSettings)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/projects/delete.go
+++ b/internal/cli/iam/projects/delete.go
@@ -68,7 +68,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/describe.go
+++ b/internal/cli/iam/projects/describe.go
@@ -70,11 +70,11 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects describe 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/projects/invitations/delete.go
+++ b/internal/cli/iam/projects/invitations/delete.go
@@ -69,7 +69,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/invitations/describe.go
+++ b/internal/cli/iam/projects/invitations/describe.go
@@ -71,11 +71,11 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details of the pending invitation with the ID 5dd56c847a3e5a1f363d424d for the project with the ID 5f71e5255afec75a3d0f96dc:
   %s projects invitations describe 5dd56c847a3e5a1f363d424d --projectId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/projects/invitations/list.go
+++ b/internal/cli/iam/projects/invitations/list.go
@@ -73,11 +73,11 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of pending invitations to the project with the ID 5f71e5255afec75a3d0f96dc:
   %s projects invitations list --projectId 5f71e5255afec75a3d0f96dc --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/invitations/update.go
+++ b/internal/cli/iam/projects/invitations/update.go
@@ -102,7 +102,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/list.go
+++ b/internal/cli/iam/projects/list.go
@@ -78,11 +78,11 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all projects:
   %s projects list --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/teams/add.go
+++ b/internal/cli/iam/projects/teams/add.go
@@ -87,7 +87,7 @@ func AddBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), addTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/teams/delete.go
+++ b/internal/cli/iam/projects/teams/delete.go
@@ -72,7 +72,7 @@ func DeleteBuilder() *cobra.Command {
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/teams/list.go
+++ b/internal/cli/iam/projects/teams/list.go
@@ -69,14 +69,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all teams for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects teams list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/teams/update.go
+++ b/internal/cli/iam/projects/teams/update.go
@@ -84,7 +84,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/users/delete.go
+++ b/internal/cli/iam/projects/users/delete.go
@@ -71,7 +71,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/projects/users/list.go
+++ b/internal/cli/iam/projects/users/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of all users for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s projects users list --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/teams/create.go
+++ b/internal/cli/iam/teams/create.go
@@ -75,14 +75,14 @@ func CreateBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Create a team named myTeam in the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams create myTeam --username user1@example.com,user2@example.com --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/iam/teams/delete.go
+++ b/internal/cli/iam/teams/delete.go
@@ -70,7 +70,7 @@ func DeleteBuilder() *cobra.Command {
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/teams/describe.go
+++ b/internal/cli/iam/teams/describe.go
@@ -96,7 +96,7 @@ func DescribeBuilder() *cobra.Command {
 
 ` + fmt.Sprintf(usage.RequiredRole, "Organization Member"),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
@@ -104,7 +104,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/teams/list.go
+++ b/internal/cli/iam/teams/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of the teams for the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams list --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/teams/users/add.go
+++ b/internal/cli/iam/teams/users/add.go
@@ -77,7 +77,7 @@ func AddBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), addTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/teams/users/delete.go
+++ b/internal/cli/iam/teams/users/delete.go
@@ -71,7 +71,7 @@ func DeleteBuilder() *cobra.Command {
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/teams/users/list.go
+++ b/internal/cli/iam/teams/users/list.go
@@ -66,14 +66,14 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of the users for the team with the ID 5f6a5c6c713184005d72fe6e in the organization with ID 5e2211c17a3e5a48f5497de3:
   %s teams users list --teamId 5f6a5c6c713184005d72fe6e --orgId 5e1234c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/users/delete.go
+++ b/internal/cli/iam/users/delete.go
@@ -66,7 +66,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/users/describe.go
+++ b/internal/cli/iam/users/describe.go
@@ -96,14 +96,14 @@ func DescribeBuilder() *cobra.Command {
 		
 User accounts and API keys with any role can run this command.`,
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return prerun.ExecuteE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 				opts.validate,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/iam/users/invite.go
+++ b/internal/cli/iam/users/invite.go
@@ -252,14 +252,14 @@ func InviteBuilder() *cobra.Command {
   
   # Create the MongoDB user with the username user@example.com and invite them to the project with the ID 5f71e5255afec75a3d0f96dc with GROUP_READ_ONLY access:
   %[1]s users invite --email user@example.com --username user@example.com --projectRole 5f71e5255afec75a3d0f96dc:GROUP_READ_ONLY --firstName Example --lastName User --country US --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if config.Service() != config.OpsManagerService {
 				_ = cmd.MarkFlagRequired(flag.Country)
 			}
 
 			return prerun.ExecuteE(opts.InitOutput(cmd.OutOrStdout(), ""), opts.InitInput(cmd.InOrStdin()), opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Prompt(); err != nil {
 				return err
 			}

--- a/internal/cli/mongocli/alerts/acknowledge.go
+++ b/internal/cli/mongocli/alerts/acknowledge.go
@@ -82,7 +82,7 @@ func AcknowledgeBuilder() *cobra.Command {
 		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"ack"},
 		Args:    require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.forever && opts.until != "" {
 				return fmt.Errorf("--%s and --%s are exclusive", flag.Forever, flag.Until)
 			}
@@ -97,7 +97,7 @@ func AcknowledgeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Acknowledge an alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3 until January 1 2028:
   %s alerts acknowledge 5d1113b25a115342acc2d1aa --until 2028-01-01T20:24:26Z --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/alerts/describe.go
+++ b/internal/cli/mongocli/alerts/describe.go
@@ -71,14 +71,14 @@ func DescribeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return the JSON-formatted details for the alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s alerts describe 5d1113b25a115342acc2d1aa --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/alerts/global_list.go
+++ b/internal/cli/mongocli/alerts/global_list.go
@@ -68,11 +68,11 @@ func GlobalListBuilder() *cobra.Command {
 		Short:   "Returns all global alerts for the specified Ops Manager project.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/alerts/list.go
+++ b/internal/cli/mongocli/alerts/list.go
@@ -82,14 +82,14 @@ func ListBuilder() *cobra.Command {
 			"output": listTemplate,
 		},
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/alerts/settings/create.go
+++ b/internal/cli/mongocli/alerts/settings/create.go
@@ -76,14 +76,14 @@ func CreateBuilder() *cobra.Command {
   --notificationType USER --notificationEmailEnabled \
   --notificationUsername john@example.com \
   --output json --projectId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/alerts/settings/delete.go
+++ b/internal/cli/mongocli/alerts/settings/delete.go
@@ -70,7 +70,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/alerts/settings/disable.go
+++ b/internal/cli/mongocli/alerts/settings/disable.go
@@ -60,7 +60,7 @@ func DisableBuilder() *cobra.Command {
 		Use:   "disable <alertConfigId>",
 		Short: "Disables one alert configuration for the specified project.",
 		Args:  require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -72,7 +72,7 @@ func DisableBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"alertConfigIdDesc": "ID of the alert configuration you want to disable.",
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/alerts/settings/enable.go
+++ b/internal/cli/mongocli/alerts/settings/enable.go
@@ -59,7 +59,7 @@ func EnableBuilder() *cobra.Command {
 		Use:   "enable <alertConfigId>",
 		Short: "Enables one alert configuration for the specified project.",
 		Args:  require.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -69,7 +69,7 @@ func EnableBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"alertConfigIdDesc": "ID of the alert you want to enable.",
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/alerts/settings/fields_type.go
+++ b/internal/cli/mongocli/alerts/settings/fields_type.go
@@ -63,11 +63,11 @@ func FieldsTypeBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of accepted field types for the matchersFieldName option:
   %s alerts settings fields type --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/alerts/settings/list.go
+++ b/internal/cli/mongocli/alerts/settings/list.go
@@ -67,14 +67,14 @@ func ListBuilder() *cobra.Command {
   %s alerts settings list --projectId 5df90590f10fab5e33de2305 --output json`, cli.ExampleAtlasEntryPoint()),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), settingsListTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/alerts/settings/update.go
+++ b/internal/cli/mongocli/alerts/settings/update.go
@@ -76,14 +76,14 @@ func UpdateBuilder() *cobra.Command {
 		--notificationType USER --notificationEmailEnabled \
 		--notificationUsername john@example.com \
 		--output json --projectId 5df90590f10fab5e33de2305`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/alerts/unacknowledge.go
+++ b/internal/cli/mongocli/alerts/unacknowledge.go
@@ -77,14 +77,14 @@ func UnacknowledgeBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Unacknowledge the alert with the ID 5d1113b25a115342acc2d1aa in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s alerts unacknowledge 5d1113b25a115342acc2d1aa --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), unackTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.alertID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/backup/restores/list.go
+++ b/internal/cli/mongocli/backup/restores/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return all continuous backup restore jobs for the cluster Cluster0:
   %s backup restore list Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), restoreListTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 
 			return opts.Run()

--- a/internal/cli/mongocli/backup/restores/start.go
+++ b/internal/cli/mongocli/backup/restores/start.go
@@ -193,7 +193,7 @@ func StartBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), startTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/backup/snapshots/create.go
+++ b/internal/cli/mongocli/backup/snapshots/create.go
@@ -83,14 +83,14 @@ func CreateBuilder() *cobra.Command {
 			"clusterNameDesc": "Name of the Atlas cluster whose snapshot you want to restore.",
 			"output":          createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/backup/snapshots/delete.go
+++ b/internal/cli/mongocli/backup/snapshots/delete.go
@@ -64,10 +64,10 @@ func DeleteBuilder() *cobra.Command {
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to delete.",
 			"output":         opts.SuccessMessage(),
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.Entry = args[0]
 			if err := opts.Prompt(); err != nil {
 				return err

--- a/internal/cli/mongocli/backup/snapshots/describe.go
+++ b/internal/cli/mongocli/backup/snapshots/describe.go
@@ -70,14 +70,14 @@ func DescribeBuilder() *cobra.Command {
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to retrieve.",
 			"output":         describeTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.snapshot = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/backup/snapshots/list.go
+++ b/internal/cli/mongocli/backup/snapshots/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of snapshots for the cluster named myDemo 
   %s backups snapshots list myDemo --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 
 			return opts.Run()

--- a/internal/cli/mongocli/backup/snapshots/watch.go
+++ b/internal/cli/mongocli/backup/snapshots/watch.go
@@ -77,14 +77,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Annotations: map[string]string{
 			"snapshotIdDesc": "Unique identifier of the snapshot you want to watch.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), "\nSnapshot changes completed.\n"),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/events/list.go
+++ b/internal/cli/mongocli/events/list.go
@@ -113,7 +113,7 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"output": listTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.orgID != "" && opts.projectID != "" {
 				return fmt.Errorf("both --%s and --%s set", flag.ProjectID, flag.OrgID)
 			}
@@ -123,7 +123,7 @@ func ListBuilder() *cobra.Command {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/events/orgs_list.go
+++ b/internal/cli/mongocli/events/orgs_list.go
@@ -74,14 +74,14 @@ func OrgListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of events for the organization with the ID 5dd5a6b6f10fab1d71a58495:
   %s events organizations list --orgId 5dd5a6b6f10fab1d71a58495 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/events/projects_list.go
+++ b/internal/cli/mongocli/events/projects_list.go
@@ -74,14 +74,14 @@ func ProjectListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of events for the project with the ID 5e2211c17a3e5a48f5497de3:
   %s events projects list --Id 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/performanceadvisor/namespaces/list.go
+++ b/internal/cli/mongocli/performanceadvisor/namespaces/list.go
@@ -84,7 +84,7 @@ If you don't set the duration option or the since option, this command returns d
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of namespaces for collections with slow queries for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s performanceAdvisor namespaces list --processName atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -92,7 +92,7 @@ If you don't set the duration option or the since option, this command returns d
 				opts.MarkRequiredFlagsByService(cmd),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/performanceadvisor/slowoperationthreshold/disable.go
+++ b/internal/cli/mongocli/performanceadvisor/slowoperationthreshold/disable.go
@@ -61,13 +61,13 @@ func DisableBuilder() *cobra.Command {
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/performanceadvisor/slowoperationthreshold/enable.go
+++ b/internal/cli/mongocli/performanceadvisor/slowoperationthreshold/enable.go
@@ -62,13 +62,13 @@ func EnableBuilder() *cobra.Command {
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/performanceadvisor/slowquerylogs/list.go
+++ b/internal/cli/mongocli/performanceadvisor/slowquerylogs/list.go
@@ -91,7 +91,7 @@ If you don't set the duration option or the since option, this command returns d
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of log lines for collections with slow queries for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s performanceAdvisor slowQueryLogs list --processName atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -99,7 +99,7 @@ If you don't set the duration option or the since option, this command returns d
 				opts.MarkRequiredFlagsByService(cmd),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/mongocli/performanceadvisor/suggestedindexes/list.go
@@ -90,7 +90,7 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of suggested indexes for the atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 host in the project with the ID 5e2211c17a3e5a48f5497de3:
   %s performanceAdvisor suggestedIndexes list --processName atlas-111ggi-shard-00-00.111xx.mongodb.net:27017 --projectId 5e2211c17a3e5a48f5497de3 --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -98,7 +98,7 @@ func ListBuilder() *cobra.Command {
 				opts.MarkRequiredFlagsByService(cmd),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/backup/restores/create.go
+++ b/internal/cli/mongocli/serverless/backup/restores/create.go
@@ -167,7 +167,7 @@ func CreateBuilder() *cobra.Command {
          --deliveryType download \
          --clusterName myDemo \
          --snapshotId 5e7e00128f8ce03996a47179`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			set := false
 
 			if opts.isAutomatedRestore() {
@@ -201,7 +201,7 @@ func CreateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/backup/restores/describe.go
+++ b/internal/cli/mongocli/serverless/backup/restores/describe.go
@@ -66,14 +66,14 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the details for the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the serverless isntance named Cluster0:
   %s serverless backup restore describe --restoreJobId 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), restoreDescribeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/backup/restores/list.go
+++ b/internal/cli/mongocli/serverless/backup/restores/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return all continuous backup restore jobs for the serverless instance Instance0:
   %s serverless backup restore list Instance0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), restoreListTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 
 			return opts.Run()

--- a/internal/cli/mongocli/serverless/backup/restores/watch.go
+++ b/internal/cli/mongocli/serverless/backup/restores/watch.go
@@ -77,14 +77,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Args: require.NoArgs,
 		Example: fmt.Sprintf(`  # Watch the continuous backup restore job with the ID 507f1f77bcf86cd799439011 for the cluster named Cluster0 until it becomes available:
   %s serverless backup restore watch --restoreJobId 507f1f77bcf86cd799439011 --clusterName Cluster0`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), "\nRestore completed.\n"),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/backup/snapshots/describe.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/describe.go
@@ -65,14 +65,14 @@ func DescribeBuilder() *cobra.Command {
 		Args:  require.NoArgs,
 		Example: fmt.Sprintf(`  # Return the details for the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 for the instance named myDemo:
   %s serverless backups snapshots describe --snapshotId 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/backup/snapshots/list.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		},
 		Example: fmt.Sprintf(`  # Return a JSON-formatted list of snapshots for the instance named myDemo 
   %s serverless backups snapshots list myDemo --output json`, cli.ExampleAtlasEntryPoint()),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterName = args[0]
 
 			return opts.Run()

--- a/internal/cli/mongocli/serverless/backup/snapshots/watch.go
+++ b/internal/cli/mongocli/serverless/backup/snapshots/watch.go
@@ -73,14 +73,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Example: fmt.Sprintf(`  # Watch the backup snapshot with the ID 5f4007f327a3bd7b6f4103c5 in the cluster named myDemo until it becomes available:
   %s backups snapshots watch 5f4007f327a3bd7b6f4103c5 --clusterName myDemo`, cli.ExampleAtlasEntryPoint()),
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), "\nSnapshot changes completed.\n"),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/create.go
+++ b/internal/cli/mongocli/serverless/create.go
@@ -84,14 +84,14 @@ func CreateBuilder() *cobra.Command {
 			"instanceNameDesc": "Human-readable label that identifies your serverless instance.",
 			"output":           createTemplate,
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.instanceName = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/mongocli/serverless/delete.go
+++ b/internal/cli/mongocli/serverless/delete.go
@@ -67,7 +67,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/describe.go
+++ b/internal/cli/mongocli/serverless/describe.go
@@ -75,7 +75,7 @@ func DescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/list.go
+++ b/internal/cli/mongocli/serverless/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 			"output": listTemplate,
 		},
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/mongocli/serverless/watch.go
+++ b/internal/cli/mongocli/serverless/watch.go
@@ -76,14 +76,14 @@ You can interrupt the command's polling at any time with CTRL-C.
 		Annotations: map[string]string{
 			"instanceNameDesc": "Name of the instance to watch.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), "\nInstance available.\n"),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/blockstore/create.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/create.go
@@ -58,11 +58,11 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a backup blockstore configuration.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/blockstore/delete.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/delete.go
@@ -63,7 +63,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/blockstore/describe.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/describe.go
@@ -65,11 +65,11 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Blockstore identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.blockstoreID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/blockstore/list.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/list.go
@@ -63,11 +63,11 @@ func ListBuilder() *cobra.Command {
 		Short:   "List backup blockstore configurations.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/blockstore/update.go
+++ b/internal/cli/opsmanager/admin/backup/blockstore/update.go
@@ -63,11 +63,11 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Blockstore identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.ID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/filesystem/create.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/create.go
@@ -72,11 +72,11 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a file system configuration.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/filesystem/delete.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/delete.go
@@ -63,7 +63,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/filesystem/describe.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/describe.go
@@ -65,11 +65,11 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Configuration identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.ID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/filesystem/list.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/list.go
@@ -63,11 +63,11 @@ func ListBuilder() *cobra.Command {
 		Short:   "List file system configurations.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/filesystem/update.go
+++ b/internal/cli/opsmanager/admin/backup/filesystem/update.go
@@ -77,11 +77,11 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Configuration identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.ID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/oplog/create.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/create.go
@@ -59,11 +59,11 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a backup oplog configuration.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/oplog/delete.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/delete.go
@@ -63,7 +63,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/oplog/describe.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/describe.go
@@ -65,11 +65,11 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"nameDesc": "Oplog name.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.oplogID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/oplog/list.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/list.go
@@ -63,11 +63,11 @@ func ListBuilder() *cobra.Command {
 		Short:   "List backup oplog configurations.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/oplog/update.go
+++ b/internal/cli/opsmanager/admin/backup/oplog/update.go
@@ -66,11 +66,11 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Oplog identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.ID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/s3/create.go
+++ b/internal/cli/opsmanager/admin/backup/s3/create.go
@@ -89,11 +89,11 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a backup S3 blockstore configuration.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/s3/delete.go
+++ b/internal/cli/opsmanager/admin/backup/s3/delete.go
@@ -63,7 +63,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/s3/describe.go
+++ b/internal/cli/opsmanager/admin/backup/s3/describe.go
@@ -65,11 +65,11 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Configuration identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.blockstoreID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/s3/list.go
+++ b/internal/cli/opsmanager/admin/backup/s3/list.go
@@ -63,11 +63,11 @@ func ListBuilder() *cobra.Command {
 		Short:   "List backup s3 blockstore configurations.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/s3/update.go
+++ b/internal/cli/opsmanager/admin/backup/s3/update.go
@@ -94,11 +94,11 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Blockstore identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.ID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/sync/create.go
+++ b/internal/cli/opsmanager/admin/backup/sync/create.go
@@ -58,11 +58,11 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a backup sync configuration.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/sync/delete.go
+++ b/internal/cli/opsmanager/admin/backup/sync/delete.go
@@ -63,7 +63,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/sync/describe.go
+++ b/internal/cli/opsmanager/admin/backup/sync/describe.go
@@ -65,11 +65,11 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Configuration identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.syncID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/admin/backup/sync/list.go
+++ b/internal/cli/opsmanager/admin/backup/sync/list.go
@@ -63,11 +63,11 @@ func ListBuilder() *cobra.Command {
 		Short:   "List backup sync configurations.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/admin/backup/sync/update.go
+++ b/internal/cli/opsmanager/admin/backup/sync/update.go
@@ -64,11 +64,11 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Configuration identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.ID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/agents/apikeys/create.go
+++ b/internal/cli/opsmanager/agents/apikeys/create.go
@@ -65,14 +65,14 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an Agent API Key for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/agents/apikeys/delete.go
+++ b/internal/cli/opsmanager/agents/apikeys/delete.go
@@ -65,7 +65,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/agents/apikeys/list.go
+++ b/internal/cli/opsmanager/agents/apikeys/list.go
@@ -59,14 +59,14 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List available MongoDB Agent API Keys for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/agents/list.go
+++ b/internal/cli/opsmanager/agents/list.go
@@ -70,14 +70,14 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"AUTOMATION|MONITORING|BACKUPDesc": "Agent type",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.agentType = strings.ToUpper(args[0])
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/agents/upgrade.go
+++ b/internal/cli/opsmanager/agents/upgrade.go
@@ -57,14 +57,14 @@ func UpgradeBuilder() *cobra.Command {
 		Use:   "upgrade",
 		Args:  require.NoArgs,
 		Short: "Upgrade MongoDB Agents to the latest available version.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), upgradeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/agents/versions/list.go
+++ b/internal/cli/opsmanager/agents/versions/list.go
@@ -59,14 +59,14 @@ func ListBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List MongoDB Agent versions in the provided project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/automation/describe.go
+++ b/internal/cli/opsmanager/automation/describe.go
@@ -57,14 +57,14 @@ func DescribeBuilder() *cobra.Command {
 		Aliases: []string{"show", "get"},
 		Short:   "Get the current automation configuration for a project.",
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), "use json output"),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/automation/status.go
+++ b/internal/cli/opsmanager/automation/status.go
@@ -56,14 +56,14 @@ func StatusBuilder() *cobra.Command {
 		Use:   "status",
 		Short: "Show the current status of the automation config.",
 		Args:  require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), ""),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/automation/update.go
+++ b/internal/cli/opsmanager/automation/update.go
@@ -68,10 +68,10 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update the current automation configuration for a project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/automation/watch.go
+++ b/internal/cli/opsmanager/automation/watch.go
@@ -74,14 +74,14 @@ If you run the command in the terminal, it blocks the terminal session until the
 You can interrupt the command's polling at any time with CTRL-C.`,
 		Example: `  mongocli ops-manager automation watch`,
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), "\nChanges deployed successfully\n"),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/backup/checkpoints_list.go
+++ b/internal/cli/opsmanager/backup/checkpoints_list.go
@@ -79,7 +79,7 @@ func AtlasBackupsCheckpointsListBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), checkpointsTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/backup/config/describe.go
+++ b/internal/cli/opsmanager/backup/config/describe.go
@@ -65,14 +65,14 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterIdDesc": "ID of the cluster.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/backup/config/list.go
+++ b/internal/cli/opsmanager/backup/config/list.go
@@ -63,14 +63,14 @@ func ListBuilder() *cobra.Command {
 		Short:   "List backup configurations for your project.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/backup/config/update.go
+++ b/internal/cli/opsmanager/backup/config/update.go
@@ -107,11 +107,11 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterIdDesc": "ID of the cluster.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.clusterID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/backup/disable.go
+++ b/internal/cli/opsmanager/backup/disable.go
@@ -71,13 +71,13 @@ func DisableBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"hostnameDesc": "Label hostname.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostname = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/backup/enable.go
+++ b/internal/cli/opsmanager/backup/enable.go
@@ -70,13 +70,13 @@ func EnableBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"hostnameDesc": "Label hostname.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostname = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/backup/restores_list.go
+++ b/internal/cli/opsmanager/backup/restores_list.go
@@ -68,14 +68,14 @@ func RestoresListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterIdDesc": "ID of the cluster.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), restoresTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := validate.ObjectID(args[0]); err != nil {
 				return err
 			}

--- a/internal/cli/opsmanager/backup/restores_start.go
+++ b/internal/cli/opsmanager/backup/restores_start.go
@@ -189,7 +189,7 @@ func RestoresStartBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/backup/snapshots/list.go
+++ b/internal/cli/opsmanager/backup/snapshots/list.go
@@ -68,14 +68,14 @@ func ListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"clusterIdDesc": "ID of the cluster.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), snapshotsTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := validate.ObjectID(args[0]); err != nil {
 				return err
 			}

--- a/internal/cli/opsmanager/backup/snapshots/schedule/describe.go
+++ b/internal/cli/opsmanager/backup/snapshots/schedule/describe.go
@@ -60,14 +60,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Describe a snapshot schedule for a cluster.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/backup/snapshots/schedule/update.go
+++ b/internal/cli/opsmanager/backup/snapshots/schedule/update.go
@@ -101,11 +101,11 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update a snapshot schedule for a cluster.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/apply.go
+++ b/internal/cli/opsmanager/clusters/apply.go
@@ -77,10 +77,10 @@ func ApplyBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply a new cluster configuration for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/create.go
+++ b/internal/cli/opsmanager/clusters/create.go
@@ -82,10 +82,10 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a MongoDB cluster.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/describe.go
+++ b/internal/cli/opsmanager/clusters/describe.go
@@ -95,7 +95,7 @@ When using an output format please provide the cluster name.`,
 		Annotations: map[string]string{
 			"id|nameDesc": "Name or ID of the cluster.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.validateArg,
@@ -103,7 +103,7 @@ When using an output format please provide the cluster name.`,
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.name = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/clusters/indexes_create.go
+++ b/internal/cli/opsmanager/clusters/indexes_create.go
@@ -174,10 +174,10 @@ func IndexesCreateBuilder() *cobra.Command {
   mongocli om clusters indexes create bedrooms_1 \
     --collectionName listings --db realestate --key bedrooms:1 \
     --rsName repl1`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				opts.name = args[0]
 			}

--- a/internal/cli/opsmanager/clusters/list.go
+++ b/internal/cli/opsmanager/clusters/list.go
@@ -78,14 +78,14 @@ func ListBuilder() *cobra.Command {
 		Long: `When listing clusters with no output format the information provided is defined by monitoring.
 When using an output format the information will be provided by automation.`,
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/reclaim_free_space.go
+++ b/internal/cli/opsmanager/clusters/reclaim_free_space.go
@@ -104,7 +104,7 @@ func ReclaimFreeSpaceBuilder() *cobra.Command {
 			opts.clusterName = args[0]
 			return opts.Confirm()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/restart.go
+++ b/internal/cli/opsmanager/clusters/restart.go
@@ -110,7 +110,7 @@ func RestartBuilder() *cobra.Command {
 			opts.clusterName = args[0]
 			return opts.Confirm()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/resync.go
+++ b/internal/cli/opsmanager/clusters/resync.go
@@ -112,7 +112,7 @@ To learn more, see: https://docs.mongodb.com/manual/tutorial/resync-replica-set-
 			opts.clusterName = args[0]
 			return opts.Confirm()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/shutdown.go
+++ b/internal/cli/opsmanager/clusters/shutdown.go
@@ -108,7 +108,7 @@ func ShutdownBuilder() *cobra.Command {
 			opts.clusterName = args[0]
 			return opts.Confirm()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/startup.go
+++ b/internal/cli/opsmanager/clusters/startup.go
@@ -109,7 +109,7 @@ func StartupBuilder() *cobra.Command {
 			opts.clusterName = args[0]
 			return opts.Confirm()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/unmanage.go
+++ b/internal/cli/opsmanager/clusters/unmanage.go
@@ -88,7 +88,7 @@ func UnmanageBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/clusters/update.go
+++ b/internal/cli/opsmanager/clusters/update.go
@@ -82,10 +82,10 @@ func UpdateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update a MongoDB cluster.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/dbusers/create.go
+++ b/internal/cli/opsmanager/dbusers/create.go
@@ -112,13 +112,13 @@ func CreateBuilder() *cobra.Command {
   # Create a user with readWriteAnyDatabase and clusterMonitor access
   mongocli om dbuser create --username <username>  --role readWriteAnyDatabase,clusterMonitor --mechanisms SCRAM-SHA-256 --projectId <projectId>`,
 		Args: require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.InitInput(cmd.InOrStdin()),
 				opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := opts.Prompt(); err != nil {
 				return err
 			}

--- a/internal/cli/opsmanager/dbusers/delete.go
+++ b/internal/cli/opsmanager/dbusers/delete.go
@@ -84,7 +84,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/dbusers/list.go
+++ b/internal/cli/opsmanager/dbusers/list.go
@@ -62,14 +62,14 @@ func ListBuilder() *cobra.Command {
 		Short:   "List Atlas database users for your project.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/diagnosearchive/diagnose_archive_download.go
+++ b/internal/cli/opsmanager/diagnosearchive/diagnose_archive_download.go
@@ -72,10 +72,10 @@ func DownloadBuilder() *cobra.Command {
 		Use:     "download",
 		Aliases: []string{"get"},
 		Short:   "Download diagnose archives.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/featurepolicies/list.go
+++ b/internal/cli/opsmanager/featurepolicies/list.go
@@ -63,14 +63,14 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List feature control policies for your project.",
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/featurepolicies/update.go
+++ b/internal/cli/opsmanager/featurepolicies/update.go
@@ -103,7 +103,7 @@ func UpdateBuilder() *cobra.Command {
   # Update policies from a JSON configuration file:
   mongocli atlas featurePolicies update --projectId <projectId> --file <path/to/file.json>
 `,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if opts.filename == "" {
 				_ = cmd.MarkFlagRequired(flag.Name)
 			}
@@ -113,7 +113,7 @@ func UpdateBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/livemigrations/link/create.go
+++ b/internal/cli/opsmanager/livemigrations/link/create.go
@@ -66,14 +66,14 @@ func CreateBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create one new organization link.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/livemigrations/link/delete.go
+++ b/internal/cli/opsmanager/livemigrations/link/delete.go
@@ -53,14 +53,14 @@ func DeleteBuilder() *cobra.Command {
 		Use:     "delete",
 		Aliases: []string{"rm"},
 		Short:   "Delete one link-token.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.Prompt,
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			opts.Entry = opts.ConfigOrgID()
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/livemigrations/link/describe.go
+++ b/internal/cli/opsmanager/livemigrations/link/describe.go
@@ -58,14 +58,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Return the status of the connection between the specified source organization and the target MongoDB Atlas organization.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/logs/decrypt.go
+++ b/internal/cli/opsmanager/logs/decrypt.go
@@ -96,10 +96,10 @@ func DecryptBuilder() *cobra.Command {
   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.bson --out /path/to/file.json
   # For audit logs in JSON format:
   mongocli ops-manager logs decrypt --localKeyFile /path/to/keyFile --file /path/to/logFile.json --out /path/to/file.json`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.initDefaultOut)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/logs/jobs_collect.go
+++ b/internal/cli/opsmanager/logs/jobs_collect.go
@@ -91,14 +91,14 @@ func JobsCollectOptsBuilder() *cobra.Command {
 			"resourceTypeDesc": "Type of resource to collect logs from.",
 			"resourceNameDesc": "Name of the resource to collect logs from.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), collectTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.resourceType = args[0]
 			opts.resourceName = args[1]
 			return opts.Run()

--- a/internal/cli/opsmanager/logs/jobs_delete.go
+++ b/internal/cli/opsmanager/logs/jobs_delete.go
@@ -64,7 +64,7 @@ func JobsDeleteOptsBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/logs/jobs_download.go
+++ b/internal/cli/opsmanager/logs/jobs_download.go
@@ -67,10 +67,10 @@ func JobsDownloadOptsBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Log job identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/logs/jobs_list.go
+++ b/internal/cli/opsmanager/logs/jobs_list.go
@@ -64,14 +64,14 @@ func JobsListOptsBuilder() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List log collection jobs for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/maintenance/create.go
+++ b/internal/cli/opsmanager/maintenance/create.go
@@ -70,14 +70,14 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create",
 		Short: "Create a maintenance window.",
 		Args:  cobra.OnlyValidArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/maintenance/delete.go
+++ b/internal/cli/opsmanager/maintenance/delete.go
@@ -64,7 +64,7 @@ func DeleteBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/maintenance/describe.go
+++ b/internal/cli/opsmanager/maintenance/describe.go
@@ -64,14 +64,14 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Maintenance window identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/maintenance/list.go
+++ b/internal/cli/opsmanager/maintenance/list.go
@@ -60,14 +60,14 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Short:   "List maintenance windows.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/maintenance/update.go
+++ b/internal/cli/opsmanager/maintenance/update.go
@@ -76,14 +76,14 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Maintenance window identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.id = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/metrics/databases_describe.go
+++ b/internal/cli/opsmanager/metrics/databases_describe.go
@@ -72,7 +72,7 @@ func DatabasesDescribeBuilder() *cobra.Command {
 			"hostIdDesc": "Process identifier. You can use mongocli ops-manager processes list to get the ID.",
 			"nameDesc":   "Database name.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.ValidatePeriodStartEnd,
@@ -80,7 +80,7 @@ func DatabasesDescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), databasesMetricTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostID = args[0]
 			opts.name = args[1]
 

--- a/internal/cli/opsmanager/metrics/databases_list.go
+++ b/internal/cli/opsmanager/metrics/databases_list.go
@@ -68,14 +68,14 @@ func DatabasesListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Process identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), databasesListTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostID = args[0]
 
 			return opts.Run()

--- a/internal/cli/opsmanager/metrics/disks_describe.go
+++ b/internal/cli/opsmanager/metrics/disks_describe.go
@@ -72,7 +72,7 @@ func DisksDescribeBuilder() *cobra.Command {
 			"hostIdDesc": "Process identifier. You can use mongocli ops-manager processes list to get the ID.",
 			"nameDesc":   "Partition name.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.ValidatePeriodStartEnd,
@@ -80,7 +80,7 @@ func DisksDescribeBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), diskMetricTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostID = args[0]
 			opts.name = args[1]
 

--- a/internal/cli/opsmanager/metrics/disks_list.go
+++ b/internal/cli/opsmanager/metrics/disks_list.go
@@ -67,14 +67,14 @@ func DisksListBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"IDDesc": "Process identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostID = args[0]
 
 			return opts.Run()

--- a/internal/cli/opsmanager/metrics/process.go
+++ b/internal/cli/opsmanager/metrics/process.go
@@ -70,7 +70,7 @@ func ProcessBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"hostIdDesc": "Process identifier. You can use mongocli ops-manager processes list to get the ID.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.ValidatePeriodStartEnd,
@@ -78,7 +78,7 @@ func ProcessBuilder() *cobra.Command {
 				opts.InitOutput(cmd.OutOrStdout(), metricTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/monitoring/disable.go
+++ b/internal/cli/opsmanager/monitoring/disable.go
@@ -71,13 +71,13 @@ func DisableBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"hostnameDesc": "Label for the hostname.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostname = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/monitoring/enable.go
+++ b/internal/cli/opsmanager/monitoring/enable.go
@@ -87,13 +87,13 @@ func EnableBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"hostnameDesc": "Label for the hostname.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostname = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/monitoring/stop.go
+++ b/internal/cli/opsmanager/monitoring/stop.go
@@ -64,7 +64,7 @@ func StopBuilder() *cobra.Command {
 			opts.Entry = args[0]
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/ops_manager.go
+++ b/internal/cli/opsmanager/ops_manager.go
@@ -52,7 +52,7 @@ func Builder() *cobra.Command {
 		Use:     "ops-manager",
 		Aliases: []string{"om"},
 		Short:   "MongoDB Ops Manager operations.",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			log.SetWriter(cmd.ErrOrStderr())
 			if debugLevel {
 				log.SetLevel(log.DebugLevel)

--- a/internal/cli/opsmanager/owner/create.go
+++ b/internal/cli/opsmanager/owner/create.go
@@ -105,7 +105,7 @@ func CreateBuilder() *cobra.Command {
 		Short: "Create the first user for Ops Manager.",
 		Long:  "Create the first user for Ops Manager. Use this command to automate Ops Manager Installations.",
 		Args:  require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), createTemplate),
@@ -115,7 +115,7 @@ func CreateBuilder() *cobra.Command {
 
 			return opts.Prompt()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/processes/describe.go
+++ b/internal/cli/opsmanager/processes/describe.go
@@ -65,14 +65,14 @@ func DescribeBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"hostIdDesc": "Process identifier.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), describeTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.hostID = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/processes/list.go
+++ b/internal/cli/opsmanager/processes/list.go
@@ -72,14 +72,14 @@ func ListBuilder() *cobra.Command {
 		Short:   "List MongoDB processes for your project.",
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/security/enable.go
+++ b/internal/cli/opsmanager/security/enable.go
@@ -77,10 +77,10 @@ func EnableBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"MONGODB-CR|SCRAM-SHA-256Desc": "Authentication mechanism.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(opts.ValidateProjectID, opts.initStore(cmd.Context()))
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.mechanisms = args
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/servers/list.go
+++ b/internal/cli/opsmanager/servers/list.go
@@ -66,14 +66,14 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    require.NoArgs,
 		Short:   "List all available servers running an automation agent for your project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/serverusage/capture.go
+++ b/internal/cli/opsmanager/serverusage/capture.go
@@ -49,10 +49,10 @@ func CaptureBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "capture",
 		Short: "Capture a snapshot of usage for the processes Ops Manager manages.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/serverusage/download.go
+++ b/internal/cli/opsmanager/serverusage/download.go
@@ -87,11 +87,11 @@ func DownloadBuilder() *cobra.Command {
 		Use:     "download",
 		Short:   "Download the server usage report.",
 		Example: `  mongocli ops-manager serverUsage download --endDate 2022-12-12 --startDate 2022-01-01`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.initDefaultOut()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/serverusage/organizations/hosts/list.go
+++ b/internal/cli/opsmanager/serverusage/organizations/hosts/list.go
@@ -73,14 +73,14 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all host assignments for one organization.",
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/describe.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/describe.go
@@ -59,14 +59,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Get the default server type for an organization.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), getTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/serverusage/organizations/servertype/set.go
+++ b/internal/cli/opsmanager/serverusage/organizations/servertype/set.go
@@ -70,13 +70,13 @@ func SetBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"typeDesc": "Server type to set.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateOrgID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.serverType = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/serverusage/projects/hosts/list.go
+++ b/internal/cli/opsmanager/serverusage/projects/hosts/list.go
@@ -73,14 +73,14 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List all host assignments for one project.",
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/serverusage/projects/servertype/describe.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/describe.go
@@ -59,14 +59,14 @@ func DescribeBuilder() *cobra.Command {
 		Use:     "describe",
 		Aliases: []string{"get"},
 		Short:   "Get the default server type for a project.",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), getTemplate),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/serverusage/projects/servertype/set.go
+++ b/internal/cli/opsmanager/serverusage/projects/servertype/set.go
@@ -70,13 +70,13 @@ func SetBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"typeDesc": "Server type to set.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 			)
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.serverType = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/opsmanager/softwarecomponents/list.go
+++ b/internal/cli/opsmanager/softwarecomponents/list.go
@@ -61,11 +61,11 @@ func ListBuilder() *cobra.Command {
 		Aliases: []string{"ls"},
 		Short:   "List versions of MongoDB Agent, MongoDB Tools, and BI Connector in your environment.",
 		Args:    require.NoArgs,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
 	}

--- a/internal/cli/opsmanager/versionmanifest/update.go
+++ b/internal/cli/opsmanager/versionmanifest/update.go
@@ -104,11 +104,11 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"versionDesc": "Manifest version.",
 		},
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			return opts.initStore(cmd.Context())()
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			opts.versionManifest = args[0]
 			return opts.Run()
 		},

--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -57,7 +57,7 @@ func (opts *OutputOpts) InitOutput(w io.Writer, t string) func() error {
 }
 
 func (*OutputOpts) AutoCompleteOutputFlag() func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "json-path", "go-template", "go-template-file"}, cobra.ShellCompDirectiveDefault
 	}
 }

--- a/internal/cli/root/atlas/builder.go
+++ b/internal/cli/root/atlas/builder.go
@@ -88,9 +88,9 @@ type Notifier struct {
 type AuthRequirements int64
 
 const (
-	// command does not require authentication.
+	// NoAuth command does not require authentication.
 	NoAuth AuthRequirements = 0
-	// command requires authentication.
+	// RequiredAuth command requires authentication.
 	RequiredAuth AuthRequirements = 1
 	// command can work with or without authentication,
 	// and if access token token is found, try to refresh it.
@@ -168,7 +168,7 @@ Use the --help flag with any command for more info on that command.`,
 
 			return nil
 		},
-		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		PersistentPostRun: func(cmd *cobra.Command, _ []string) {
 			// we don't run the release alert feature on the completion command
 			if strings.HasPrefix(cmd.CommandPath(), fmt.Sprintf("%s %s", atlas, "completion")) {
 				return
@@ -249,7 +249,7 @@ Use the --help flag with any command for more info on that command.`,
 	rootCmd.PersistentFlags().BoolVarP(&debugLevel, flag.Debug, flag.DebugShort, false, usage.Debug)
 	_ = rootCmd.PersistentFlags().MarkHidden(flag.Debug)
 
-	_ = rootCmd.RegisterFlagCompletionFunc(flag.Profile, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = rootCmd.RegisterFlagCompletionFunc(flag.Profile, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return config.List(), cobra.ShellCompDirectiveDefault
 	})
 	return rootCmd

--- a/internal/cli/root/mongocli/builder.go
+++ b/internal/cli/root/mongocli/builder.go
@@ -62,7 +62,7 @@ func Builder(profile *string, argsWithoutProg []string) *cobra.Command {
 		Annotations: map[string]string{
 			"toc": "true",
 		},
-		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		PersistentPostRun: func(cmd *cobra.Command, _ []string) {
 			// we don't run the release alert feature on the completion command
 			if strings.HasPrefix(cmd.CommandPath(), "mongocli completion") {
 				return
@@ -122,7 +122,7 @@ func Builder(profile *string, argsWithoutProg []string) *cobra.Command {
 	)
 
 	rootCmd.PersistentFlags().StringVarP(profile, flag.Profile, flag.ProfileShort, "", usage.Profile)
-	_ = rootCmd.RegisterFlagCompletionFunc(flag.Profile, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	_ = rootCmd.RegisterFlagCompletionFunc(flag.Profile, func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return config.List(), cobra.ShellCompDirectiveDefault
 	})
 	return rootCmd


### PR DESCRIPTION
Fix unused params for anonymous functions in the CLI package

The update on golangci-lint is flagging a lot of this, doing all the ones fro commands which are variations of the same 