### PR TITLE
CLOUDP-229266: Failed Test: mongodb-atlas-cli-master-github.com_mongodb_mongodb-atlas-cli_test_e2e_atlas.TestClustersFlags_Fail_Delete_for_Termination_Protection_enabled/atlas_clusters_flags_e2e/e2e_atlas_clusters

### DIFF
--- a/test/e2e/atlas/clusters_flags_test.go
+++ b/test/e2e/atlas/clusters_flags_test.go
@@ -198,7 +198,7 @@ func TestClustersFlags(t *testing.T) {
 
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
-		require.NoError(t, err, string(resp))
+		require.Error(t, err, string(resp))
 	})
 
 	t.Run("Update", func(t *testing.T) {


### PR DESCRIPTION
CLOUDP-229266: revert accidental change from `require.Error` to `require.NoError`