### PR TITLE
Call CreateAtlasSearchDeployment in CreateSearchNodes

### DIFF
--- a/internal/store/search_nodes.go
+++ b/internal/store/search_nodes.go
@@ -51,7 +51,7 @@ func (s *Store) SearchNodes(projectID, clusterName string) (*atlasv2.ApiSearchDe
 func (s *Store) CreateSearchNodes(projectID, clusterName string, spec *atlasv2.ApiSearchDeploymentRequest) (*atlasv2.ApiSearchDeploymentResponse, error) {
 	switch s.service {
 	case config.CloudService, config.CloudGovService:
-		result, _, err := s.clientv2.AtlasSearchApi.UpdateAtlasSearchDeployment(s.ctx, projectID, clusterName, spec).Execute()
+		result, _, err := s.clientv2.AtlasSearchApi.CreateAtlasSearchDeployment(s.ctx, projectID, clusterName, spec).Execute()
 		return result, err
 	default:
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)


### PR DESCRIPTION
Found a small issue caused by a merge:
`CreateSearchNodes` was calling `UpdateAtlasSearchDeployment` instead of `CreateAtlasSearchDeployment`