### PR TITLE
CLOUDP-230973: Addressed issues with stringToString

### DIFF
--- a/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
+++ b/docs/atlascli/command/atlas-backups-exports-jobs-create.txt
@@ -46,9 +46,9 @@ Options
      - true
      - Name of the cluster.
    * - --customData
-     - stringToString
+     - key=value
      - false
-     - Custom data to include in the metadata file named .complete that Atlas uploads to the bucket when the export job finishes. Custom data can be specified as key and value pairs. This value defaults to [].
+     - Custom data to include in the metadata file named .complete that Atlas uploads to the bucket when the export job finishes. Custom data can be specified as key and value pairs.
    * - -h, --help
      - 
      - false

--- a/docs/atlascli/command/atlas-clusters-create.txt
+++ b/docs/atlascli/command/atlas-clusters-create.txt
@@ -125,11 +125,11 @@ Options
 
        Mutually exclusive with --file. This value defaults to 1.
    * - --tag
-     - stringToString
+     - key=value
      - false
      - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster.
 
-       Mutually exclusive with --file. This value defaults to [].
+       Mutually exclusive with --file.
    * - --tier
      - string
      - false

--- a/docs/atlascli/command/atlas-clusters-update.txt
+++ b/docs/atlascli/command/atlas-clusters-update.txt
@@ -99,11 +99,11 @@ Options
      - false
      - Hexadecimal string that identifies the project to use. This option overrides the settings in the configuration file or environment variable.
    * - --tag
-     - stringToString
+     - key=value
      - false
      - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. Passing this flag replaces preexisting data.
 
-       Mutually exclusive with --file. This value defaults to [].
+       Mutually exclusive with --file.
    * - --tier
      - string
      - false

--- a/docs/atlascli/command/atlas-clusters-upgrade.txt
+++ b/docs/atlascli/command/atlas-clusters-upgrade.txt
@@ -98,11 +98,11 @@ Options
      - false
      - Hexadecimal string that identifies the project to use. This option overrides the settings in the configuration file or environment variable.
    * - --tag
-     - stringToString
+     - key=value
      - false
      - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. Passing this flag replaces preexisting data.
 
-       Mutually exclusive with --file. This value defaults to [].
+       Mutually exclusive with --file.
    * - --tier
      - string
      - false

--- a/docs/atlascli/command/atlas-deployments-setup.txt
+++ b/docs/atlascli/command/atlas-deployments-setup.txt
@@ -116,9 +116,9 @@ Options
      - false
      - Flag that indicates whether to skip loading sample data into your MongoDB deployment.
    * - --tag
-     - stringToString
+     - key=value
      - false
-     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the deployment. This value defaults to [].
+     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the deployment.
    * - --tier
      - string
      - false

--- a/docs/atlascli/command/atlas-projects-create.txt
+++ b/docs/atlascli/command/atlas-projects-create.txt
@@ -76,9 +76,9 @@ Options
      - false
      - Unique 24-digit string that identifies the Atlas user to be granted the Project Owner role on the specified project. If unspecified, this value defaults to the user ID of the oldest Organization Owner.
    * - --tag
-     - stringToString
+     - key=value
      - false
-     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the project. This value defaults to [].
+     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the project.
    * - --withoutDefaultAlertSettings
      - 
      - false

--- a/docs/atlascli/command/atlas-serverless-create.txt
+++ b/docs/atlascli/command/atlas-serverless-create.txt
@@ -74,9 +74,9 @@ Options
      - true
      - Human-readable label that identifies the physical location of your MongoDB serverless instance. The region you choose can affect network latency for clients accessing your databases.
    * - --tag
-     - stringToString
+     - key=value
      - false
-     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the serverless instance. This value defaults to [].
+     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the serverless instance.
 
 Inherited Options
 -----------------

--- a/docs/atlascli/command/atlas-serverless-update.txt
+++ b/docs/atlascli/command/atlas-serverless-update.txt
@@ -90,9 +90,9 @@ Options
      - false
      - Hexadecimal string that identifies the project to use. This option overrides the settings in the configuration file or environment variable.
    * - --tag
-     - stringToString
+     - key=value
      - false
-     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the serverless instance. Passing this flag replaces preexisting data. This value defaults to [].
+     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the serverless instance. Passing this flag replaces preexisting data.
 
 Inherited Options
 -----------------

--- a/docs/atlascli/command/atlas-setup.txt
+++ b/docs/atlascli/command/atlas-setup.txt
@@ -98,9 +98,9 @@ Options
      - false
      - Flag that indicates whether to skip loading sample data into your MongoDB cluster.
    * - --tag
-     - stringToString
+     - key=value
      - false
-     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster. This value defaults to [].
+     - List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster.
    * - --tier
      - string
      - false

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/klauspost/compress v1.17.6
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mongodb-forks/digest v1.0.5
-	github.com/mongodb-labs/cobra2snooty v0.18.0
+	github.com/mongodb-labs/cobra2snooty v0.18.1
 	github.com/mongodb/mongodb-atlas-kubernetes/v2 v2.1.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -292,8 +292,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mongodb-forks/digest v1.0.5 h1:EJu3wtLZcA0HCvsZpX5yuD193/sW9tHiNvrEM5apXMk=
 github.com/mongodb-forks/digest v1.0.5/go.mod h1:rb+EX8zotClD5Dj4NdgxnJXG9nwrlx3NWKJ8xttz1Dg=
-github.com/mongodb-labs/cobra2snooty v0.18.0 h1:phyPCrDMTpJxKRXSSbzOH+JQ7cNGzKrq3MDvmsJf4wg=
-github.com/mongodb-labs/cobra2snooty v0.18.0/go.mod h1:WnzqCFmx4f72Yj9dL/ulBUqcatfURGdKFf8DLT4h7zQ=
+github.com/mongodb-labs/cobra2snooty v0.18.1 h1:0HWXJofuKPR+yu1P+0gr4z/uGXWqhu/ec2CvbMqnxYs=
+github.com/mongodb-labs/cobra2snooty v0.18.1/go.mod h1:WnzqCFmx4f72Yj9dL/ulBUqcatfURGdKFf8DLT4h7zQ=
 github.com/mongodb/mongodb-atlas-kubernetes/v2 v2.1.0 h1:7VUkK0LjKCi80A4CFcImiUgAtKWfLDVJKF1QqBtJsBQ=
 github.com/mongodb/mongodb-atlas-kubernetes/v2 v2.1.0/go.mod h1:9+sTPWCBcivshJX+FLIJ/Mv91sWqIlL+i+fosvWKdao=
 github.com/montanaflynn/stats v0.7.0 h1:r3y12KyNxj/Sb/iOE46ws+3mS1+MZca1wlHQFPsY/JU=


### PR DESCRIPTION
## Proposed changes
This PR addresses the issues the docs team had with the documentation generated for flags of the type `stringToString`.

1. Fixed the issues in [cobra2snooty@0.18.1](https://github.com/mongodb-labs/cobra2snooty/releases/tag/v0.18.1)
2. Upgraded cobra2snooty
3. Ran 'make gen-docs'

_Jira ticket:_ CLOUDP-230973
