### PR TITLE
CLOUDP-210224: More detailed message when deleting an instance

### DIFF
--- a/internal/cli/atlas/clusters/delete.go
+++ b/internal/cli/atlas/clusters/delete.go
@@ -104,7 +104,7 @@ Deleting a cluster also deletes any backup snapshots for that cluster.
 				return err
 			}
 			opts.Entry = args[0]
-			return opts.PromptWithMessage("Confirm your backup settings before terminating your cluster.\nAre you sure you want to terminate %s, this action cannot be undone?")
+			return opts.PromptWithMessage("Confirm your backup settings before terminating your cluster. This action cannot be undone.\nAre you sure you want to terminate %s?")
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()

--- a/internal/cli/atlas/clusters/delete.go
+++ b/internal/cli/atlas/clusters/delete.go
@@ -104,7 +104,7 @@ Deleting a cluster also deletes any backup snapshots for that cluster.
 				return err
 			}
 			opts.Entry = args[0]
-			return opts.Prompt()
+			return opts.PromptWithMessage("Confirm your backup settings before terminating your cluster.\nAre you sure you want to terminate %s, this action cannot be undone?")
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()

--- a/internal/cli/atlas/clusters/delete.go
+++ b/internal/cli/atlas/clusters/delete.go
@@ -104,7 +104,7 @@ Deleting a cluster also deletes any backup snapshots for that cluster.
 				return err
 			}
 			opts.Entry = args[0]
-			return opts.PromptWithMessage("Confirm your backup settings before terminating your cluster. This action cannot be undone.\nAre you sure you want to terminate %s?")
+			return opts.PromptWithMessage("This operation will delete the cluster and all of its data. Confirm your backup settings before terminating your cluster. This action cannot be undone.\nAre you sure you want to terminate %s?")
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()

--- a/internal/cli/atlas/deployments/delete.go
+++ b/internal/cli/atlas/deployments/delete.go
@@ -58,9 +58,9 @@ func (opts *DeleteOpts) Run(ctx context.Context) error {
 		return err
 	}
 	opts.Entry = opts.DeploymentName
-	message := "Confirm your backup settings before terminating your cluster.\nAre you sure you want to terminate %s, this action cannot be undone?"
+	message := "Confirm your backup settings before terminating your cluster. This action cannot be undone.\nAre you sure you want to terminate %s?"
 	if opts.IsLocalDeploymentType() {
-		message = "This operation will delete the deployment, and all of its data\nAre you sure you want to terminate %s, this action cannot be undone?"
+		message = "This operation will delete the deployment, and all of its data. This action cannot be undone\nAre you sure you want to terminate %s?"
 	}
 	if err := opts.PromptWithMessage(message); err != nil {
 		return err

--- a/internal/cli/atlas/deployments/delete.go
+++ b/internal/cli/atlas/deployments/delete.go
@@ -58,8 +58,11 @@ func (opts *DeleteOpts) Run(ctx context.Context) error {
 		return err
 	}
 	opts.Entry = opts.DeploymentName
-
-	if err := opts.PromptWithMessage("Are you sure you want to terminate %s, this action cannot be undone?"); err != nil {
+	message := "Confirm your backup settings before terminating your cluster.\nAre you sure you want to terminate %s, this action cannot be undone?"
+	if opts.IsLocalDeploymentType() {
+		message = "This operation will delete the deployment, and all of its data\nAre you sure you want to terminate %s, this action cannot be undone?"
+	}
+	if err := opts.PromptWithMessage(message); err != nil {
 		return err
 	}
 

--- a/internal/cli/atlas/deployments/delete.go
+++ b/internal/cli/atlas/deployments/delete.go
@@ -59,7 +59,7 @@ func (opts *DeleteOpts) Run(ctx context.Context) error {
 	}
 	opts.Entry = opts.DeploymentName
 
-	if err := opts.Prompt(); err != nil {
+	if err := opts.PromptWithMessage("Are you sure you want to terminate %s, this action cannot be undone?"); err != nil {
 		return err
 	}
 

--- a/internal/cli/atlas/serverless/delete.go
+++ b/internal/cli/atlas/serverless/delete.go
@@ -65,7 +65,7 @@ func DeleteBuilder() *cobra.Command {
 				return err
 			}
 			opts.Entry = args[0]
-			return opts.Prompt()
+			return opts.PromptWithMessage("This operation will delete the instance, all of its data, and any associated backups.\nAre you sure you want to terminate %s, this action cannot be undone?")
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()

--- a/internal/cli/atlas/serverless/delete.go
+++ b/internal/cli/atlas/serverless/delete.go
@@ -65,7 +65,7 @@ func DeleteBuilder() *cobra.Command {
 				return err
 			}
 			opts.Entry = args[0]
-			return opts.PromptWithMessage("This operation will delete the instance, all of its data, and any associated backups.\nAre you sure you want to terminate %s, this action cannot be undone?")
+			return opts.PromptWithMessage("This operation will delete the instance, all of its data, and any associated backups. This action cannot be undone.\nAre you sure you want to terminate %s?")
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-210224

Cluster
```bash
/bin/atlas clusters delete Cluster0 
? Confirm your backup settings before terminating your cluster.
Are you sure you want to terminate Cluster0, this action cannot be undone? (y/N) 
```

Serverless
```bash
./bin/atlas serverless delete Cluster0
? This operation will delete the instance, all of its data, and any associated backups.
Are you sure you want to terminate Cluster0, this action cannot be undone? (y/N) 
```
