### PR TITLE
tas: go back to rhel80 for mongocli

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -478,7 +478,7 @@ buildvariants:
   - name: e2e_required
     display_name: "E2E Tests Required"
     run_on:
-      - rhel8.9-small
+      - rhel80-small
     expansions:
       <<: *go_linux_version
     tasks:


### PR DESCRIPTION
This branch doesn't run podman or docker so we can move back to the more available host