### PR TITLE
CLOUDP-222791: expose "include total" on paginated commands - Part 1

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1280,13 +1280,14 @@ buildvariants:
       <<: *go_linux_version
     tasks:
       - name: ".e2e .deployments .atlas"
-  - name: e2e_local_deployments
-    display_name: "E2E Local Deployments Tests"
-    run_on:
-      - rhel80-small
-    expansions:
-      <<: *go_linux_version
-    tasks:
-      - name: ".e2e .deployments .local"
+# This variant will be enabled in CLOUDP-237038
+#  - name: e2e_local_deployments
+#    display_name: "E2E Local Deployments Tests"
+#    run_on:
+#      - rhel80-small
+#    expansions:
+#      <<: *go_linux_version
+#    tasks:
+#      - name: ".e2e .deployments .local"
 include:
   - filename: build/ci/release.yml

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1280,14 +1280,13 @@ buildvariants:
       <<: *go_linux_version
     tasks:
       - name: ".e2e .deployments .atlas"
-# This variant will be enabled in CLOUDP-237038
-#  - name: e2e_local_deployments
-#    display_name: "E2E Local Deployments Tests"
-#    run_on:
-#      - rhel80-small
-#    expansions:
-#      <<: *go_linux_version
-#    tasks:
-#      - name: ".e2e .deployments .local"
+  - name: e2e_local_deployments
+    display_name: "E2E Local Deployments Tests"
+    run_on:
+      - rhel80-small
+    expansions:
+      <<: *go_linux_version
+    tasks:
+      - name: ".e2e .deployments .local"
 include:
   - filename: build/ci/release.yml

--- a/docs/command/atlas-accessLists-list.txt
+++ b/docs/command/atlas-accessLists-list.txt
@@ -45,6 +45,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-alerts-list.txt
+++ b/docs/command/atlas-alerts-list.txt
@@ -45,6 +45,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-backups-exports-buckets-list.txt
+++ b/docs/command/atlas-backups-exports-buckets-list.txt
@@ -45,6 +45,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-backups-exports-jobs-list.txt
+++ b/docs/command/atlas-backups-exports-jobs-list.txt
@@ -61,6 +61,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-backups-restores-list.txt
+++ b/docs/command/atlas-backups-restores-list.txt
@@ -61,6 +61,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-backups-snapshots-list.txt
+++ b/docs/command/atlas-backups-snapshots-list.txt
@@ -61,6 +61,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-clusters-list.txt
+++ b/docs/command/atlas-clusters-list.txt
@@ -45,6 +45,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-clusters-onlineArchives-list.txt
+++ b/docs/command/atlas-clusters-onlineArchives-list.txt
@@ -49,6 +49,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-dataLakePipelines-availableSnapshots-list.txt
+++ b/docs/command/atlas-dataLakePipelines-availableSnapshots-list.txt
@@ -49,6 +49,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-dbusers-list.txt
+++ b/docs/command/atlas-dbusers-list.txt
@@ -49,6 +49,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-metrics-databases-list.txt
+++ b/docs/command/atlas-metrics-databases-list.txt
@@ -64,6 +64,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-metrics-disks-list.txt
+++ b/docs/command/atlas-metrics-disks-list.txt
@@ -64,6 +64,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-networking-containers-list.txt
+++ b/docs/command/atlas-networking-containers-list.txt
@@ -45,6 +45,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/docs/command/atlas-networking-peering-list.txt
+++ b/docs/command/atlas-networking-peering-list.txt
@@ -45,6 +45,10 @@ Options
      - int
      - false
      - Number of items per results page, up to a maximum of 500. If you have more than 500 results, specify the --page option to change the results page. This value defaults to 100.
+   * - --omitCount
+     - 
+     - false
+     - Flag that indicates whether the JSON response returns the total number of items (totalCount) in the JSON response.
    * - -o, --output
      - string
      - false

--- a/internal/cli/atlas/accesslists/list.go
+++ b/internal/cli/atlas/accesslists/list.go
@@ -82,6 +82,7 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/accesslists/list_test.go
+++ b/internal/cli/atlas/accesslists/list_test.go
@@ -82,6 +82,6 @@ func TestListBuilder(t *testing.T) {
 		t,
 		ListBuilder(),
 		0,
-		[]string{flag.ProjectID, flag.Output, flag.Page, flag.Limit},
+		[]string{flag.ProjectID, flag.Output, flag.Page, flag.Limit, flag.OmitCount},
 	)
 }

--- a/internal/cli/atlas/alerts/list.go
+++ b/internal/cli/atlas/alerts/list.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/require"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
 	"github.com/spf13/cobra"
@@ -54,6 +55,11 @@ func (opts *ListOpts) Run() error {
 		ItemsPerPage: &opts.ItemsPerPage,
 		PageNum:      &opts.PageNum,
 	}
+
+	if opts.OmitCount {
+		params.IncludeCount = pointer.Get(false)
+	}
+
 	if opts.status != "" {
 		params.Status = &opts.status
 	}
@@ -94,6 +100,8 @@ func ListBuilder() *cobra.Command {
 	}
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
+
 	cmd.Flags().StringVar(&opts.status, flag.Status, "", usage.Status)
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/alerts/list_test.go
+++ b/internal/cli/atlas/alerts/list_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
@@ -74,4 +75,13 @@ func TestList_Run(t *testing.T) {
 
 	t.Log(buf.String())
 	test.VerifyOutputTemplate(t, listTemplate, expected)
+}
+
+func TestListBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		ListBuilder(),
+		0,
+		[]string{flag.ProjectID, flag.Output, flag.Page, flag.Limit, flag.OmitCount, flag.Status},
+	)
 }

--- a/internal/cli/atlas/backup/exports/buckets/list.go
+++ b/internal/cli/atlas/backup/exports/buckets/list.go
@@ -84,6 +84,7 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/backup/exports/buckets/list_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/list_test.go
@@ -72,6 +72,7 @@ func TestListBuilder(t *testing.T) {
 			flag.Limit,
 			flag.ProjectID,
 			flag.Output,
+			flag.OmitCount,
 		},
 	)
 }

--- a/internal/cli/atlas/backup/exports/jobs/list.go
+++ b/internal/cli/atlas/backup/exports/jobs/list.go
@@ -88,6 +88,7 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/backup/exports/jobs/list_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/list_test.go
@@ -57,6 +57,7 @@ func TestListBuilder(t *testing.T) {
 			flag.Limit,
 			flag.ProjectID,
 			flag.Output,
+			flag.OmitCount,
 		},
 	)
 }

--- a/internal/cli/atlas/backup/restores/list.go
+++ b/internal/cli/atlas/backup/restores/list.go
@@ -88,6 +88,7 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/backup/restores/list_test.go
+++ b/internal/cli/atlas/backup/restores/list_test.go
@@ -60,6 +60,7 @@ func TestListBuilder(t *testing.T) {
 			flag.Limit,
 			flag.ProjectID,
 			flag.Output,
+			flag.OmitCount,
 		},
 	)
 }

--- a/internal/cli/atlas/backup/snapshots/list.go
+++ b/internal/cli/atlas/backup/snapshots/list.go
@@ -88,6 +88,7 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/backup/snapshots/list_test.go
+++ b/internal/cli/atlas/backup/snapshots/list_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
@@ -62,4 +63,19 @@ func TestList_Run(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 	test.VerifyOutputTemplate(t, listTemplate, expected)
+}
+
+func TestListBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		ListBuilder(),
+		0,
+		[]string{
+			flag.Page,
+			flag.Limit,
+			flag.OmitCount,
+			flag.ProjectID,
+			flag.Output,
+		},
+	)
 }

--- a/internal/cli/atlas/clusters/list.go
+++ b/internal/cli/atlas/clusters/list.go
@@ -84,6 +84,7 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/clusters/list_test.go
+++ b/internal/cli/atlas/clusters/list_test.go
@@ -64,6 +64,6 @@ func TestListBuilder(t *testing.T) {
 		t,
 		ListBuilder(),
 		0,
-		[]string{flag.Limit, flag.Page, flag.Output, flag.ProjectID},
+		[]string{flag.Limit, flag.Page, flag.Output, flag.ProjectID, flag.OmitCount},
 	)
 }

--- a/internal/cli/atlas/clusters/onlinearchive/list.go
+++ b/internal/cli/atlas/clusters/onlinearchive/list.go
@@ -83,10 +83,11 @@ func ListBuilder() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.clusterName, flag.ClusterName, "", usage.ClusterName)
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
+	cmd.Flags().StringVar(&opts.clusterName, flag.ClusterName, "", usage.ClusterName)
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())

--- a/internal/cli/atlas/clusters/onlinearchive/list_test.go
+++ b/internal/cli/atlas/clusters/onlinearchive/list_test.go
@@ -38,6 +38,7 @@ func TestListBuilder(t *testing.T) {
 			flag.Limit,
 			flag.Output,
 			flag.ProjectID,
+			flag.OmitCount,
 		},
 	)
 }

--- a/internal/cli/atlas/datalakepipelines/availablesnapshots/list.go
+++ b/internal/cli/atlas/datalakepipelines/availablesnapshots/list.go
@@ -111,6 +111,7 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/datalakepipelines/availablesnapshots/list_test.go
+++ b/internal/cli/atlas/datalakepipelines/availablesnapshots/list_test.go
@@ -88,6 +88,6 @@ func TestListBuilder(t *testing.T) {
 		t,
 		ListBuilder(),
 		0,
-		[]string{flag.ProjectID, flag.Output},
+		[]string{flag.ProjectID, flag.Output, flag.OmitCount, flag.Page, flag.Limit, flag.CompletedAfter, flag.Pipeline},
 	)
 }

--- a/internal/cli/atlas/dbusers/list.go
+++ b/internal/cli/atlas/dbusers/list.go
@@ -86,6 +86,7 @@ func ListBuilder() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/dbusers/list_test.go
+++ b/internal/cli/atlas/dbusers/list_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20231115007/admin"
@@ -51,4 +52,13 @@ func TestDBUserList_Run(t *testing.T) {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 	test.VerifyOutputTemplate(t, listTemplate, expected)
+}
+
+func TestListBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		ListBuilder(),
+		0,
+		[]string{flag.ProjectID, flag.Output, flag.OmitCount, flag.Page, flag.Limit, flag.CompactResponse},
+	)
 }

--- a/internal/cli/atlas/metrics/databases/list.go
+++ b/internal/cli/atlas/metrics/databases/list.go
@@ -96,6 +96,8 @@ atlas processes list
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
+
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())

--- a/internal/cli/atlas/metrics/databases/list_test.go
+++ b/internal/cli/atlas/metrics/databases/list_test.go
@@ -62,6 +62,6 @@ func TestListBuilder(t *testing.T) {
 		t,
 		ListBuilder(),
 		0,
-		[]string{flag.Page, flag.Limit, flag.ProjectID, flag.Output},
+		[]string{flag.Page, flag.Limit, flag.OmitCount, flag.ProjectID, flag.Output},
 	)
 }

--- a/internal/cli/atlas/metrics/disks/list.go
+++ b/internal/cli/atlas/metrics/disks/list.go
@@ -97,6 +97,8 @@ $ atlas processes list
 
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
+
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)
 	_ = cmd.RegisterFlagCompletionFunc(flag.Output, opts.AutoCompleteOutputFlag())

--- a/internal/cli/atlas/metrics/disks/list_test.go
+++ b/internal/cli/atlas/metrics/disks/list_test.go
@@ -62,6 +62,6 @@ func TestListBuilder(t *testing.T) {
 		t,
 		ListBuilder(),
 		0,
-		[]string{flag.Page, flag.Limit, flag.ProjectID, flag.Output},
+		[]string{flag.Page, flag.Limit, flag.OmitCount, flag.ProjectID, flag.Output},
 	)
 }

--- a/internal/cli/atlas/networking/containers/list.go
+++ b/internal/cli/atlas/networking/containers/list.go
@@ -97,6 +97,7 @@ func ListBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.provider, flag.Provider, "", usage.Provider)
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/networking/containers/list_test.go
+++ b/internal/cli/atlas/networking/containers/list_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
@@ -79,4 +80,13 @@ func TestList_Run(t *testing.T) {
 			t.Fatalf("Run() unexpected error: %v", err)
 		}
 	})
+}
+
+func TestListBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		ListBuilder(),
+		0,
+		[]string{flag.Page, flag.Limit, flag.OmitCount, flag.ProjectID, flag.Output, flag.Provider},
+	)
 }

--- a/internal/cli/atlas/networking/peering/list.go
+++ b/internal/cli/atlas/networking/peering/list.go
@@ -89,6 +89,7 @@ func ListBuilder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.provider, flag.Provider, "AWS", usage.Provider)
 	cmd.Flags().IntVar(&opts.PageNum, flag.Page, cli.DefaultPage, usage.Page)
 	cmd.Flags().IntVar(&opts.ItemsPerPage, flag.Limit, cli.DefaultPageLimit, usage.Limit)
+	cmd.Flags().BoolVar(&opts.OmitCount, flag.OmitCount, false, usage.OmitCount)
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 	cmd.Flags().StringVarP(&opts.Output, flag.Output, flag.OutputShort, "", usage.FormatOut)

--- a/internal/cli/atlas/networking/peering/list_test.go
+++ b/internal/cli/atlas/networking/peering/list_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
@@ -62,4 +63,13 @@ func TestList_Run(t *testing.T) {
 		t.Log(buf.String())
 		test.VerifyOutputTemplate(t, listTemplate, expected)
 	})
+}
+
+func TestListBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		ListBuilder(),
+		0,
+		[]string{flag.Page, flag.Limit, flag.OmitCount, flag.ProjectID, flag.Output, flag.Provider},
+	)
 }

--- a/internal/cli/list_opts.go
+++ b/internal/cli/list_opts.go
@@ -34,6 +34,7 @@ func (opts *ListOpts) NewListOptions() *mongodbatlas.ListOptions {
 	return &mongodbatlas.ListOptions{
 		PageNum:      opts.PageNum,
 		ItemsPerPage: opts.ItemsPerPage,
+		IncludeCount: !opts.OmitCount,
 	}
 }
 
@@ -41,5 +42,6 @@ func (opts *ListOpts) NewAtlasListOptions() *store.ListOptions {
 	return &store.ListOptions{
 		PageNum:      opts.PageNum,
 		ItemsPerPage: opts.ItemsPerPage,
+		IncludeCount: !opts.OmitCount,
 	}
 }

--- a/internal/store/cloud_provider_backup.go
+++ b/internal/store/cloud_provider_backup.go
@@ -94,7 +94,7 @@ type ScheduleDeleter interface {
 func (s *Store) RestoreJobs(projectID, clusterName string, opts *atlas.ListOptions) (*atlasv2.PaginatedCloudBackupRestoreJob, error) {
 	res := s.clientv2.CloudBackupsApi.ListBackupRestoreJobs(s.ctx, projectID, clusterName)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err
@@ -122,7 +122,7 @@ func (s *Store) CreateSnapshot(projectID, clusterName string, request *atlasv2.D
 func (s *Store) Snapshots(projectID, clusterName string, opts *atlas.ListOptions) (*atlasv2.PaginatedCloudBackupReplicaSet, error) {
 	res := s.clientv2.CloudBackupsApi.ListReplicaSetBackups(s.ctx, projectID, clusterName)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err
@@ -166,7 +166,7 @@ func (s *Store) CreateExportJob(projectID, clusterName string, job *atlasv2.Disk
 func (s *Store) ExportBuckets(projectID string, opts *atlas.ListOptions) (*atlasv2.PaginatedBackupSnapshotExportBucket, error) {
 	res := s.clientv2.CloudBackupsApi.ListExportBuckets(s.ctx, projectID)
 	if opts != nil {
-		res = res.ItemsPerPage(opts.ItemsPerPage).PageNum(opts.PageNum)
+		res = res.ItemsPerPage(opts.ItemsPerPage).PageNum(opts.PageNum).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -163,7 +163,7 @@ func (s *Store) UpgradeCluster(projectID string, cluster *atlas.Cluster) (*atlas
 func (s *Store) ProjectClusters(projectID string, opts *ListOptions) (*admin.PaginatedAdvancedClusterDescription, error) {
 	res := s.clientv2.ClustersApi.ListClusters(s.ctx, projectID)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err

--- a/internal/store/data_lake_pipelines.go
+++ b/internal/store/data_lake_pipelines.go
@@ -108,8 +108,7 @@ func (s *Store) PipelineAvailableSnapshots(projectID, pipelineName string, compl
 		request = request.CompletedAfter(*completedAfter)
 	}
 	if listOps != nil {
-		request = request.ItemsPerPage(listOps.ItemsPerPage)
-		request = request.PageNum(listOps.PageNum)
+		request = request.ItemsPerPage(listOps.ItemsPerPage).PageNum(listOps.PageNum).IncludeCount(listOps.IncludeCount)
 	}
 	result, _, err := request.Execute()
 	return result, err

--- a/internal/store/database_users.go
+++ b/internal/store/database_users.go
@@ -64,7 +64,7 @@ func (s *Store) DeleteDatabaseUser(authDB, groupID, username string) error {
 func (s *Store) DatabaseUsers(projectID string, opts *ListOptions) (*atlasv2.PaginatedApiAtlasDatabaseUser, error) {
 	res := s.clientv2.DatabaseUsersApi.ListDatabaseUsers(s.ctx, projectID)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err

--- a/internal/store/online_archives.go
+++ b/internal/store/online_archives.go
@@ -50,7 +50,7 @@ func (s *Store) OnlineArchives(projectID, clusterName string, lstOpt *atlas.List
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
 	}
 	result, _, err := s.clientv2.OnlineArchiveApi.ListOnlineArchives(s.ctx, projectID, clusterName).
-		PageNum(lstOpt.PageNum).ItemsPerPage(lstOpt.ItemsPerPage).Execute()
+		PageNum(lstOpt.PageNum).ItemsPerPage(lstOpt.ItemsPerPage).IncludeCount(lstOpt.IncludeCount).Execute()
 	return result, err
 }
 

--- a/internal/store/operator.go
+++ b/internal/store/operator.go
@@ -27,6 +27,7 @@ import (
 type ListOptions struct {
 	PageNum      int
 	ItemsPerPage int
+	IncludeCount bool
 }
 
 type ContainersListOptions struct {

--- a/internal/store/peering_connections.go
+++ b/internal/store/peering_connections.go
@@ -96,7 +96,7 @@ func (s *Store) CreatePeeringConnection(projectID string, peer *atlasv2.BaseNetw
 func (s *Store) ContainersByProvider(projectID string, opts *atlas.ContainersListOptions) ([]atlasv2.CloudProviderContainer, error) {
 	res := s.clientv2.NetworkPeeringApi.ListPeeringContainerByCloudProvider(s.ctx, projectID)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).ProviderName(opts.ProviderName)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount).ProviderName(opts.ProviderName)
 	}
 	result, _, err := res.Execute()
 	if err != nil {

--- a/internal/store/process_databases.go
+++ b/internal/store/process_databases.go
@@ -31,6 +31,6 @@ type ProcessDatabaseLister interface {
 func (s *Store) ProcessDatabases(groupID, host string, port int, opts *atlas.ListOptions) (*atlasv2.PaginatedDatabase, error) {
 	process := host + ":" + strconv.Itoa(port)
 	result, _, err := s.clientv2.MonitoringAndLogsApi.ListDatabases(s.ctx, groupID, process).
-		PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).Execute()
+		PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount).Execute()
 	return result, err
 }

--- a/internal/store/process_disks.go
+++ b/internal/store/process_disks.go
@@ -31,6 +31,6 @@ type ProcessDisksLister interface {
 func (s *Store) ProcessDisks(groupID, host string, port int, opts *atlas.ListOptions) (*atlasv2.PaginatedDiskPartition, error) {
 	processID := host + ":" + strconv.Itoa(port)
 	result, _, err := s.clientv2.MonitoringAndLogsApi.ListDiskPartitions(s.ctx, groupID, processID).
-		ItemsPerPage(opts.ItemsPerPage).PageNum(opts.PageNum).Execute()
+		ItemsPerPage(opts.ItemsPerPage).PageNum(opts.PageNum).IncludeCount(opts.IncludeCount).Execute()
 	return result, err
 }

--- a/internal/store/project_ip_access_lists.go
+++ b/internal/store/project_ip_access_lists.go
@@ -62,7 +62,7 @@ func (s *Store) DeleteProjectIPAccessList(projectID, entry string) error {
 func (s *Store) ProjectIPAccessLists(projectID string, opts *ListOptions) (*atlasv2.PaginatedNetworkAccess, error) {
 	res := s.clientv2.ProjectIPAccessListApi.ListProjectIpAccessLists(s.ctx, projectID)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-222791


This is the first part of two where we are introducing the `omitCount` for all the AtlasCLI list commands.

<!--
What MongoDB CLI issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
