### PR TITLE
task: remove the unused output format for SDK migration

### DIFF
--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -15,14 +15,12 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/PaesslerAG/jsonpath"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/jsonpathwriter"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/jsonwriter"
@@ -129,48 +127,6 @@ func (opts *OutputOpts) Print(o interface{}) error {
 	}
 	_, err = fmt.Fprintln(opts.ConfigWriter(), o)
 	return err
-}
-
-func (opts *OutputOpts) PrintForCompactResultsResponse(o interface{}) error {
-	if opts.ConfigOutput() == jsonFormat {
-		compactResponse, err := mapReduceResults(o)
-		if err == nil {
-			return jsonwriter.Print(opts.ConfigWriter(), compactResponse)
-		}
-	}
-
-	outputType, val := opts.outputTypeAndValue()
-	if outputType == jsonPath {
-		compactResponse, err := mapReduceResults(o)
-		if err == nil {
-			return jsonpathwriter.Print(opts.ConfigWriter(), val, compactResponse)
-		}
-	}
-
-	t, err := template(outputType, val)
-	if err != nil {
-		return err
-	}
-
-	if t != "" {
-		return templatewriter.Print(opts.ConfigWriter(), t, o)
-	}
-	_, err = fmt.Fprintln(opts.ConfigWriter(), o)
-	return err
-}
-
-func mapReduceResults(o interface{}) (interface{}, error) {
-	jsonString, err := json.Marshal(o)
-	if err != nil {
-		return nil, err
-	}
-
-	var val interface{}
-	if e := json.Unmarshal(jsonString, &val); e != nil {
-		return nil, e
-	}
-
-	return jsonpath.Get("results", val)
 }
 
 // outputTypeAndValue returns the output type and the associated value

--- a/internal/cli/output_opts_test.go
+++ b/internal/cli/output_opts_test.go
@@ -18,11 +18,7 @@ package cli
 
 import (
 	"io"
-	"reflect"
 	"testing"
-
-	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/pointer"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20231115007/admin"
 )
 
 func TestOutputOpts_outputTypeAndValue(t *testing.T) {
@@ -67,34 +63,4 @@ func TestOutputOpts_outputTypeAndValue(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestOutputOpts_mapReduceResults(t *testing.T) {
-	t.Run("when results present", func(t *testing.T) {
-		input := *atlasv2.NewPaginatedTeam()
-		wantID := "123"
-		wantName := "Team A"
-		input.Results = &[]atlasv2.TeamResponse{
-			{
-				Id:   pointer.Get(wantID),
-				Name: pointer.Get(wantName),
-			},
-		}
-
-		compactResults, err := mapReduceResults(input)
-		if err != nil {
-			t.Fatalf("mapReduceResults() unexpected error: %v", err)
-		}
-
-		mapArrayResponse := reflect.ValueOf(compactResults).Interface().([]interface{})
-		mapResponse := mapArrayResponse[0].(map[string]interface{})
-		gotID := mapResponse["id"]
-		gotName := mapResponse["name"]
-		if gotID != wantID {
-			t.Errorf("mapReduceResults() got = %v, want %v", gotID, wantID)
-		}
-		if gotName != wantName {
-			t.Errorf("mapReduceResults() got = %v, want %v", gotName, wantName)
-		}
-	})
 }


### PR DESCRIPTION
Remove the unused transformation output needed when we migrated to the auto generated SDK, this is not needed for mongocli