### PR TITLE
task: reduce usages of the old atlas client

### DIFF
--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/oauth"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 type logoutOpts struct {
@@ -44,7 +44,7 @@ type ConfigDeleter interface {
 }
 
 type Revoker interface {
-	RevokeToken(context.Context, string, string) (*atlas.Response, error)
+	RevokeToken(context.Context, string, string) (*opsmngr.Response, error)
 }
 
 func (opts *logoutOpts) initFlow() error {

--- a/internal/cli/default_setter_opts.go
+++ b/internal/cli/default_setter_opts.go
@@ -26,7 +26,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/prompt"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/validate"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -87,14 +86,14 @@ func (opts *DefaultSetterOpts) projects() (ids, names []string, err error) {
 
 	var projects *opsmngr.Projects
 	if opts.OrgID == "" {
-		projects, err = opts.Store.Projects(&atlas.ListOptions{ItemsPerPage: resultsLimit})
+		projects, err = opts.Store.Projects(&opsmngr.ListOptions{ItemsPerPage: resultsLimit})
 	} else {
-		list := &atlas.ProjectsListOptions{}
+		list := &opsmngr.ProjectsListOptions{}
 		list.ItemsPerPage = resultsLimit
 		projects, err = opts.Store.GetOrgProjects(opts.OrgID, list)
 	}
 	if err != nil {
-		var atlasErr *atlas.ErrorResponse
+		var atlasErr *opsmngr.ErrorResponse
 		if errors.As(err, &atlasErr) && atlasErr.HTTPCode == 404 {
 			return nil, nil, errNoResults
 		}
@@ -116,11 +115,11 @@ func (opts *DefaultSetterOpts) orgs(filter string) (organizations []*opsmngr.Org
 	spin.Start()
 	defer spin.Stop()
 	includeDeleted := false
-	pagination := &atlas.OrganizationsListOptions{IncludeDeletedOrgs: &includeDeleted, Name: filter}
+	pagination := &opsmngr.OrganizationsListOptions{IncludeDeletedOrgs: &includeDeleted, Name: filter}
 	pagination.ItemsPerPage = resultsLimit
 	orgs, err := opts.Store.Organizations(pagination)
 	if err != nil {
-		var atlasErr *atlas.ErrorResponse
+		var atlasErr *opsmngr.ErrorResponse
 		if errors.As(err, &atlasErr) && atlasErr.HTTPCode == 404 {
 			return nil, errNoResults
 		}
@@ -150,7 +149,7 @@ func (opts *DefaultSetterOpts) ProjectExists(id string) bool {
 func (opts *DefaultSetterOpts) AskProject() error {
 	ids, names, err := opts.projects()
 	if err != nil {
-		var target *atlas.ErrorResponse
+		var target *opsmngr.ErrorResponse
 		switch {
 		case errors.Is(err, errNoResults):
 			_, _ = fmt.Fprintln(opts.OutWriter, "You don't seem to have access to any project")
@@ -212,7 +211,7 @@ func (opts *DefaultSetterOpts) askOrgWithFilter(filter string) error {
 	orgs, err := opts.orgs(filter)
 	if err != nil {
 		applyFilter := false
-		var target *atlas.ErrorResponse
+		var target *opsmngr.ErrorResponse
 		switch {
 		case errors.Is(err, errNoResults):
 			if filter == "" {
@@ -271,7 +270,7 @@ func (opts *DefaultSetterOpts) manualOrgID() error {
 	return nil
 }
 
-func (opts *DefaultSetterOpts) selectOnPremOrg(orgs []*atlas.Organization) error {
+func (opts *DefaultSetterOpts) selectOnPremOrg(orgs []*opsmngr.Organization) error {
 	if len(orgs) == 1 {
 		opts.OrgID = orgs[0].ID
 		return nil

--- a/internal/cli/iam/organizations/apikeys/accesslists/create.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/create.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const createTemplate = "Created new access list entry(s).\n"
@@ -46,20 +46,20 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-func (opts *CreateOpts) newAccessListAPIKeysReq() ([]*atlas.AccessListAPIKeysReq, error) {
-	req := make([]*atlas.AccessListAPIKeysReq, 0, len(opts.ips)+len(opts.cidrs))
+func (opts *CreateOpts) newAccessListAPIKeysReq() ([]*opsmngr.AccessListAPIKeysReq, error) {
+	req := make([]*opsmngr.AccessListAPIKeysReq, 0, len(opts.ips)+len(opts.cidrs))
 	if len(opts.ips) == 0 && len(opts.cidrs) == 0 {
 		return nil, fmt.Errorf("either --%s, --%s must be set", flag.IP, flag.CIDR)
 	}
 	for _, v := range opts.ips {
-		entry := &atlas.AccessListAPIKeysReq{
+		entry := &opsmngr.AccessListAPIKeysReq{
 			IPAddress: v,
 		}
 		req = append(req, entry)
 	}
 
 	for _, v := range opts.cidrs {
-		entry := &atlas.AccessListAPIKeysReq{
+		entry := &opsmngr.AccessListAPIKeysReq{
 			CidrBlock: v,
 		}
 		req = append(req, entry)
@@ -74,7 +74,7 @@ func (opts *CreateOpts) Run() error {
 		return err
 	}
 
-	var result *atlas.AccessListAPIKeys
+	var result *opsmngr.AccessListAPIKeys
 
 	result, err = opts.store.CreateOrganizationAPIKeyAccessList(opts.ConfigOrgID(), opts.apyKey, req)
 	if err != nil {

--- a/internal/cli/iam/organizations/apikeys/accesslists/create_test.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/create_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/test"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestCreate_Run(t *testing.T) {
@@ -44,7 +44,7 @@ func TestCreate_Run(t *testing.T) {
 	mockStore.
 		EXPECT().
 		CreateOrganizationAPIKeyAccessList(createOpts.OrgID, createOpts.apyKey, r).
-		Return(&atlas.AccessListAPIKeys{}, nil).
+		Return(&opsmngr.AccessListAPIKeys{}, nil).
 		Times(1)
 
 	if err = createOpts.Run(); err != nil {

--- a/internal/cli/iam/organizations/apikeys/accesslists/list_test.go
+++ b/internal/cli/iam/organizations/apikeys/accesslists/list_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/test"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestListOpts_Run(t *testing.T) {
@@ -37,8 +37,8 @@ func TestListOpts_Run(t *testing.T) {
 	mockStore.
 		EXPECT().
 		OrganizationAPIKeyAccessLists(opts.OrgID, opts.id, opts.NewListOptions()).
-		Return(&atlas.AccessListAPIKeys{
-			Results: []*atlas.AccessListAPIKey{},
+		Return(&opsmngr.AccessListAPIKeys{
+			Results: []*opsmngr.AccessListAPIKey{},
 		}, nil).
 		Times(1)
 

--- a/internal/cli/iam/organizations/apikeys/create.go
+++ b/internal/cli/iam/organizations/apikeys/create.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const createTemplate = `API Key '{{.ID}}' created.
@@ -49,8 +49,8 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-func (opts *CreateOpts) newAPIKeyInput() *atlas.APIKeyInput {
-	return &atlas.APIKeyInput{
+func (opts *CreateOpts) newAPIKeyInput() *opsmngr.APIKeyInput {
+	return &opsmngr.APIKeyInput{
 		Desc:  opts.desc,
 		Roles: opts.roles,
 	}

--- a/internal/cli/iam/organizations/apikeys/create_test.go
+++ b/internal/cli/iam/organizations/apikeys/create_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestCreate_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyCreator(ctrl)
 
-	expected := &mongodbatlas.APIKey{
+	expected := &opsmngr.APIKey{
 		ID: "1",
 	}
 

--- a/internal/cli/iam/organizations/apikeys/describe_test.go
+++ b/internal/cli/iam/organizations/apikeys/describe_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDescribeOpts_Run(t *testing.T) {
@@ -36,7 +36,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 	mockStore.
 		EXPECT().
 		OrganizationAPIKey(opts.OrgID, opts.id).
-		Return(&mongodbatlas.APIKey{}, nil).
+		Return(&opsmngr.APIKey{}, nil).
 		Times(1)
 
 	if err := opts.Run(); err != nil {

--- a/internal/cli/iam/organizations/apikeys/list_test.go
+++ b/internal/cli/iam/organizations/apikeys/list_test.go
@@ -22,14 +22,14 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyLister(ctrl)
 
-	var expected []mongodbatlas.APIKey
+	var expected []opsmngr.APIKey
 
 	opts := &ListOpts{
 		store: mockStore,

--- a/internal/cli/iam/organizations/apikeys/update.go
+++ b/internal/cli/iam/organizations/apikeys/update.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 type UpdateOpts struct {
@@ -45,8 +45,8 @@ func (opts *UpdateOpts) initStore(ctx context.Context) func() error {
 	}
 }
 
-func (opts *UpdateOpts) newAPIKeyInput() *atlas.APIKeyInput {
-	return &atlas.APIKeyInput{
+func (opts *UpdateOpts) newAPIKeyInput() *opsmngr.APIKeyInput {
+	return &opsmngr.APIKeyInput{
 		Desc:  opts.desc,
 		Roles: opts.roles,
 	}

--- a/internal/cli/iam/organizations/apikeys/update_test.go
+++ b/internal/cli/iam/organizations/apikeys/update_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestUpdateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockOrganizationAPIKeyUpdater(ctrl)
 
-	expected := &mongodbatlas.APIKey{
+	expected := &opsmngr.APIKey{
 		ID: "1",
 	}
 

--- a/internal/cli/iam/organizations/list.go
+++ b/internal/cli/iam/organizations/list.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -59,7 +58,7 @@ func (opts *ListOpts) Run() error {
 }
 
 func (opts *ListOpts) newOrganizationListOptions() *opsmngr.OrganizationsListOptions {
-	return &atlas.OrganizationsListOptions{
+	return &opsmngr.OrganizationsListOptions{
 		Name:               opts.name,
 		IncludeDeletedOrgs: &opts.includeDeletedOrgs,
 		ListOptions:        *opts.NewListOptions(),

--- a/internal/cli/iam/organizations/users/list_test.go
+++ b/internal/cli/iam/organizations/users/list_test.go
@@ -24,14 +24,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockUserLister(ctrl)
 
-	expected := &mongodbatlas.AtlasUsersResponse{}
+	expected := &opsmngr.UsersResponse{}
 
 	listOpts := &ListOpts{
 		GlobalOpts: cli.GlobalOpts{

--- a/internal/cli/iam/projects/apikeys/create.go
+++ b/internal/cli/iam/projects/apikeys/create.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 var createTemplate = `API Key '{{.ID}}' created.
@@ -50,7 +50,7 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *CreateOpts) Run() error {
-	apiKeyInput := &mongodbatlas.APIKeyInput{
+	apiKeyInput := &opsmngr.APIKeyInput{
 		Desc:  opts.description,
 		Roles: opts.roles,
 	}

--- a/internal/cli/iam/projects/apikeys/create_test.go
+++ b/internal/cli/iam/projects/apikeys/create_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestCreate_Run(t *testing.T) {
@@ -36,11 +36,11 @@ func TestCreate_Run(t *testing.T) {
 
 	createOpts.ProjectID = "5a0a1e7e0f2912c554080adc"
 
-	apiKey := &mongodbatlas.APIKeyInput{
+	apiKey := &opsmngr.APIKeyInput{
 		Desc:  createOpts.description,
 		Roles: []string{},
 	}
-	expected := &mongodbatlas.APIKey{}
+	expected := &opsmngr.APIKey{}
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/iam/projects/apikeys/list_test.go
+++ b/internal/cli/iam/projects/apikeys/list_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectAPIKeyLister(ctrl)
 
-	var expected []mongodbatlas.APIKey
+	var expected []opsmngr.APIKey
 
 	listOpts := &ListOpts{
 		store: mockStore,

--- a/internal/cli/iam/projects/create.go
+++ b/internal/cli/iam/projects/create.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	atlasCreateTemplate = "Project '{{.ID}}' created.\n"
-	govRegionOnly       = "GOV_REGIONS_ONLY"
 )
 
 type CreateOpts struct {

--- a/internal/cli/iam/projects/list.go
+++ b/internal/cli/iam/projects/list.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const listTemplate = `ID	NAME{{range valueOrEmptySlice .Results}}
@@ -52,7 +52,7 @@ func (opts *ListOpts) Run() error {
 	var err error
 	listOptions := opts.NewListOptions()
 	if opts.ConfigOrgID() != "" && config.Service() == config.OpsManagerService {
-		l := &mongodbatlas.ProjectsListOptions{ListOptions: *listOptions}
+		l := &opsmngr.ProjectsListOptions{ListOptions: *listOptions}
 		r, err = opts.store.GetOrgProjects(opts.ConfigOrgID(), l)
 	} else {
 		r, err = opts.store.Projects(listOptions)

--- a/internal/cli/iam/users/describe_test.go
+++ b/internal/cli/iam/users/describe_test.go
@@ -20,14 +20,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDescribe_Run_ByID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockUserDescriber(ctrl)
 
-	var expected mongodbatlas.AtlasUser
+	var expected *opsmngr.User
 
 	descOpts := &DescribeOpts{
 		store: mockStore,
@@ -49,7 +49,7 @@ func TestDescribe_Run_ByName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockUserDescriber(ctrl)
 
-	var expected mongodbatlas.AtlasUser
+	var expected *opsmngr.User
 
 	descOpts := &DescribeOpts{
 		store:    mockStore,

--- a/internal/cli/list_opts.go
+++ b/internal/cli/list_opts.go
@@ -15,7 +15,7 @@
 package cli
 
 import (
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const (
@@ -28,8 +28,8 @@ type ListOpts struct {
 	ItemsPerPage int
 }
 
-func (opts *ListOpts) NewListOptions() *mongodbatlas.ListOptions {
-	return &mongodbatlas.ListOptions{
+func (opts *ListOpts) NewListOptions() *opsmngr.ListOptions {
+	return &opsmngr.ListOptions{
 		PageNum:      opts.PageNum,
 		ItemsPerPage: opts.ItemsPerPage,
 	}

--- a/internal/cli/metrics_opt.go
+++ b/internal/cli/metrics_opt.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/flag"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 type MetricsOpts struct {
@@ -32,8 +32,8 @@ type MetricsOpts struct {
 	MeasurementType []string
 }
 
-func (opts *MetricsOpts) NewProcessMetricsListOptions() *atlas.ProcessMeasurementListOptions {
-	o := &atlas.ProcessMeasurementListOptions{
+func (opts *MetricsOpts) NewProcessMetricsListOptions() *opsmngr.ProcessMeasurementListOptions {
+	o := &opsmngr.ProcessMeasurementListOptions{
 		ListOptions: opts.NewListOptions(),
 	}
 	o.Granularity = opts.Granularity

--- a/internal/cli/mongocli/alerts/acknowledge.go
+++ b/internal/cli/mongocli/alerts/acknowledge.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 type AcknowledgeOpts struct {
@@ -59,14 +59,14 @@ func (opts *AcknowledgeOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *AcknowledgeOpts) newAcknowledgeRequest() *atlas.AcknowledgeRequest {
+func (opts *AcknowledgeOpts) newAcknowledgeRequest() *opsmngr.AcknowledgeRequest {
 	if opts.forever {
 		// To acknowledge an alert “forever”, set the field value to 100 years in the future.
 		const years = 100
 		opts.until = time.Now().AddDate(years, 1, 1).Format(time.RFC3339)
 	}
 
-	return &atlas.AcknowledgeRequest{
+	return &opsmngr.AcknowledgeRequest{
 		AcknowledgedUntil:      &opts.until,
 		AcknowledgementComment: opts.comment,
 	}

--- a/internal/cli/mongocli/alerts/acknowledge_test.go
+++ b/internal/cli/mongocli/alerts/acknowledge_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/test"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestAcknowledgeBuilder(t *testing.T) {
@@ -95,7 +95,7 @@ func TestAcknowledgeOpts_Run(t *testing.T) {
 					Times(1)
 				require.Error(t, opts.Run())
 			} else {
-				expected := &mongodbatlas.Alert{}
+				expected := &opsmngr.Alert{}
 				mockStore.
 					EXPECT().
 					AcknowledgeAlert(opts.ProjectID, opts.alertID, ackReq).

--- a/internal/cli/mongocli/alerts/describe_test.go
+++ b/internal/cli/mongocli/alerts/describe_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestDescribeBuilder(t *testing.T) {
@@ -47,7 +47,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertDescriber(ctrl)
 
-	expected := &mongodbatlas.Alert{
+	expected := &opsmngr.Alert{
 		ID:            "test",
 		EventTypeName: "test",
 		Status:        "test",

--- a/internal/cli/mongocli/alerts/global_list.go
+++ b/internal/cli/mongocli/alerts/global_list.go
@@ -24,7 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 type GlobalListOpts struct {
@@ -52,8 +52,8 @@ func (opts *GlobalListOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *GlobalListOpts) newAlertsListOptions() *atlas.AlertsListOptions {
-	return &atlas.AlertsListOptions{
+func (opts *GlobalListOpts) newAlertsListOptions() *opsmngr.AlertsListOptions {
+	return &opsmngr.AlertsListOptions{
 		Status:      opts.status,
 		ListOptions: *opts.NewListOptions(),
 	}

--- a/internal/cli/mongocli/alerts/list.go
+++ b/internal/cli/mongocli/alerts/list.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 type ListOpts struct {
@@ -59,8 +59,8 @@ func (opts *ListOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *ListOpts) newAlertsListOptions() *atlas.AlertsListOptions {
-	o := &atlas.AlertsListOptions{
+func (opts *ListOpts) newAlertsListOptions() *opsmngr.AlertsListOptions {
+	o := &opsmngr.AlertsListOptions{
 		Status:      opts.status,
 		ListOptions: *opts.NewListOptions(),
 	}

--- a/internal/cli/mongocli/alerts/list_test.go
+++ b/internal/cli/mongocli/alerts/list_test.go
@@ -24,16 +24,16 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestList_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertLister(ctrl)
 
-	expected := &mongodbatlas.AlertsResponse{
+	expected := &opsmngr.AlertsResponse{
 		Links: nil,
-		Results: []mongodbatlas.Alert{
+		Results: []opsmngr.Alert{
 			{
 				ID:            "test",
 				EventTypeName: "test",

--- a/internal/cli/mongocli/alerts/unacknowledge.go
+++ b/internal/cli/mongocli/alerts/unacknowledge.go
@@ -25,7 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 type UnacknowledgeOpts struct {
@@ -56,8 +56,8 @@ func (opts *UnacknowledgeOpts) Run() error {
 	return opts.Print(r)
 }
 
-func (opts *UnacknowledgeOpts) newAcknowledgeRequest() *atlas.AcknowledgeRequest {
-	return &atlas.AcknowledgeRequest{
+func (opts *UnacknowledgeOpts) newAcknowledgeRequest() *opsmngr.AcknowledgeRequest {
+	return &opsmngr.AcknowledgeRequest{
 		AcknowledgedUntil:      nil,
 		AcknowledgementComment: opts.comment,
 	}

--- a/internal/cli/mongocli/alerts/unacknowledge_test.go
+++ b/internal/cli/mongocli/alerts/unacknowledge_test.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestUnacknowledge_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAlertAcknowledger(ctrl)
 
-	expected := &mongodbatlas.Alert{}
+	expected := &opsmngr.Alert{}
 
 	acknowledgeOpts := &UnacknowledgeOpts{
 		alertID: "533dc40ae4b00835ff81eaee",

--- a/internal/cli/mongocli/events/projects_list_test.go
+++ b/internal/cli/mongocli/events/projects_list_test.go
@@ -21,14 +21,14 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/test"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func Test_projectListOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockProjectEventLister(ctrl)
 
-	expected := &mongodbatlas.EventResponse{}
+	expected := &opsmngr.EventResponse{}
 	listOpts := &projectListOpts{
 		store: mockStore,
 	}

--- a/internal/cli/opsmanager/clusters/indexes_create.go
+++ b/internal/cli/opsmanager/clusters/indexes_create.go
@@ -26,7 +26,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/usage"
 	"github.com/spf13/cobra"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/atmcfg"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
@@ -111,8 +110,8 @@ func (opts *IndexesCreateOpts) newIndexOptions() *opsmngr.IndexOptions {
 	}
 }
 
-func (opts *IndexesCreateOpts) newCollationOptions() *atlas.CollationOptions {
-	return &atlas.CollationOptions{
+func (opts *IndexesCreateOpts) newCollationOptions() *opsmngr.CollationOptions {
+	return &opsmngr.CollationOptions{
 		Locale:          opts.locale,
 		CaseLevel:       opts.caseLevel,
 		CaseFirst:       opts.caseFirst,

--- a/internal/cli/refresher_opts.go
+++ b/internal/cli/refresher_opts.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/oauth"
 	atlasauth "go.mongodb.org/atlas/auth"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 var TokenRefreshed bool
@@ -33,10 +33,10 @@ type RefresherOpts struct {
 
 //go:generate mockgen -destination=../mocks/mock_refresher.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/cli Refresher
 type Refresher interface {
-	RequestCode(context.Context) (*atlasauth.DeviceCode, *atlas.Response, error)
-	PollToken(context.Context, *atlasauth.DeviceCode) (*atlasauth.Token, *atlas.Response, error)
-	RefreshToken(context.Context, string) (*atlasauth.Token, *atlas.Response, error)
-	RegistrationConfig(ctx context.Context) (*atlasauth.RegistrationConfig, *atlas.Response, error)
+	RequestCode(context.Context) (*atlasauth.DeviceCode, *opsmngr.Response, error)
+	PollToken(context.Context, *atlasauth.DeviceCode) (*atlasauth.Token, *opsmngr.Response, error)
+	RefreshToken(context.Context, string) (*atlasauth.Token, *opsmngr.Response, error)
+	RegistrationConfig(ctx context.Context) (*atlasauth.RegistrationConfig, *opsmngr.Response, error)
 }
 
 func (opts *RefresherOpts) InitFlow(c oauth.ServiceGetter) func() error {
@@ -65,7 +65,7 @@ func (opts *RefresherOpts) RefreshAccessToken(ctx context.Context) error {
 	}
 	t, _, err := opts.flow.RefreshToken(ctx, config.RefreshToken())
 	if err != nil {
-		var target *atlas.ErrorResponse
+		var target *opsmngr.ErrorResponse
 		if errors.As(err, &target) && target.ErrorCode == "INVALID_REFRESH_TOKEN" {
 			return fmt.Errorf(
 				"%w\n\nTo login, run: %s auth login",
@@ -83,14 +83,14 @@ func (opts *RefresherOpts) RefreshAccessToken(ctx context.Context) error {
 	return nil
 }
 
-func (opts *RefresherOpts) PollToken(c context.Context, d *atlasauth.DeviceCode) (*atlasauth.Token, *atlas.Response, error) {
+func (opts *RefresherOpts) PollToken(c context.Context, d *atlasauth.DeviceCode) (*atlasauth.Token, *opsmngr.Response, error) {
 	return opts.flow.PollToken(c, d)
 }
 
-func (opts *RefresherOpts) RequestCode(c context.Context) (*atlasauth.DeviceCode, *atlas.Response, error) {
+func (opts *RefresherOpts) RequestCode(c context.Context) (*atlasauth.DeviceCode, *opsmngr.Response, error) {
 	return opts.flow.RequestCode(c)
 }
 
-func (opts *RefresherOpts) RegistrationConfig(c context.Context) (*atlasauth.RegistrationConfig, *atlas.Response, error) {
+func (opts *RefresherOpts) RegistrationConfig(c context.Context) (*atlasauth.RegistrationConfig, *opsmngr.Response, error) {
 	return opts.flow.RegistrationConfig(c)
 }

--- a/internal/mocks/mock_users.go
+++ b/internal/mocks/mock_users.go
@@ -36,10 +36,10 @@ func (m *MockUserCreator) EXPECT() *MockUserCreatorMockRecorder {
 }
 
 // CreateUser mocks base method.
-func (m *MockUserCreator) CreateUser(arg0 *opsmngr.User) (interface{}, error) {
+func (m *MockUserCreator) CreateUser(arg0 *opsmngr.User) (*opsmngr.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUser", arg0)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(*opsmngr.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -74,10 +74,10 @@ func (m *MockUserDescriber) EXPECT() *MockUserDescriberMockRecorder {
 }
 
 // UserByID mocks base method.
-func (m *MockUserDescriber) UserByID(arg0 string) (interface{}, error) {
+func (m *MockUserDescriber) UserByID(arg0 string) (*opsmngr.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UserByID", arg0)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(*opsmngr.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -89,10 +89,10 @@ func (mr *MockUserDescriberMockRecorder) UserByID(arg0 interface{}) *gomock.Call
 }
 
 // UserByName mocks base method.
-func (m *MockUserDescriber) UserByName(arg0 string) (interface{}, error) {
+func (m *MockUserDescriber) UserByName(arg0 string) (*opsmngr.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UserByName", arg0)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(*opsmngr.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -164,10 +164,10 @@ func (m *MockUserLister) EXPECT() *MockUserListerMockRecorder {
 }
 
 // OrganizationUsers mocks base method.
-func (m *MockUserLister) OrganizationUsers(arg0 string, arg1 *mongodbatlas.ListOptions) (interface{}, error) {
+func (m *MockUserLister) OrganizationUsers(arg0 string, arg1 *mongodbatlas.ListOptions) (*opsmngr.UsersResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OrganizationUsers", arg0, arg1)
-	ret0, _ := ret[0].(interface{})
+	ret0, _ := ret[0].(*opsmngr.UsersResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/prompt/config.go
+++ b/internal/prompt/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/validate"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func NewOMURLInput() survey.Prompt {
@@ -109,7 +109,7 @@ func NewProfileReplaceConfirm(entry string) survey.Prompt {
 }
 
 // NewOnPremOrgSelect create a prompt to choice the organization.
-func NewOnPremOrgSelect(options []*atlas.Organization) survey.Prompt {
+func NewOnPremOrgSelect(options []*opsmngr.Organization) survey.Prompt {
 	opt := make([]string, len(options))
 	for i, o := range options {
 		opt[i] = o.ID

--- a/internal/store/alert_configuration.go
+++ b/internal/store/alert_configuration.go
@@ -19,18 +19,17 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/pointer"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_alert_configuration.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store AlertConfigurationLister,AlertConfigurationCreator,AlertConfigurationDeleter,AlertConfigurationUpdater,MatcherFieldsLister,AlertConfigurationEnabler,AlertConfigurationDisabler
 
 type AlertConfigurationLister interface {
-	AlertConfigurations(string, *opsmngr.ListOptions) ([]atlas.AlertConfiguration, error)
+	AlertConfigurations(string, *opsmngr.ListOptions) ([]opsmngr.AlertConfiguration, error)
 }
 
 type AlertConfigurationCreator interface {
-	CreateAlertConfiguration(*atlas.AlertConfiguration) (*atlas.AlertConfiguration, error)
+	CreateAlertConfiguration(*opsmngr.AlertConfiguration) (*opsmngr.AlertConfiguration, error)
 }
 
 type AlertConfigurationDeleter interface {
@@ -38,7 +37,7 @@ type AlertConfigurationDeleter interface {
 }
 
 type AlertConfigurationUpdater interface {
-	UpdateAlertConfiguration(*atlas.AlertConfiguration) (*atlas.AlertConfiguration, error)
+	UpdateAlertConfiguration(*opsmngr.AlertConfiguration) (*opsmngr.AlertConfiguration, error)
 }
 
 type MatcherFieldsLister interface {
@@ -46,15 +45,15 @@ type MatcherFieldsLister interface {
 }
 
 type AlertConfigurationEnabler interface {
-	EnableAlertConfiguration(string, string) (*atlas.AlertConfiguration, error)
+	EnableAlertConfiguration(string, string) (*opsmngr.AlertConfiguration, error)
 }
 
 type AlertConfigurationDisabler interface {
-	DisableAlertConfiguration(string, string) (*atlas.AlertConfiguration, error)
+	DisableAlertConfiguration(string, string) (*opsmngr.AlertConfiguration, error)
 }
 
 // AlertConfigurations encapsulate the logic to manage different cloud providers.
-func (s *Store) AlertConfigurations(projectID string, opts *atlas.ListOptions) ([]atlas.AlertConfiguration, error) {
+func (s *Store) AlertConfigurations(projectID string, opts *opsmngr.ListOptions) ([]opsmngr.AlertConfiguration, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.AlertConfigurations.List(s.ctx, projectID, opts)
@@ -65,7 +64,7 @@ func (s *Store) AlertConfigurations(projectID string, opts *atlas.ListOptions) (
 }
 
 // CreateAlertConfiguration encapsulate the logic to manage different cloud providers.
-func (s *Store) CreateAlertConfiguration(alertConfig *atlas.AlertConfiguration) (*atlas.AlertConfiguration, error) {
+func (s *Store) CreateAlertConfiguration(alertConfig *opsmngr.AlertConfiguration) (*opsmngr.AlertConfiguration, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.AlertConfigurations.Create(s.ctx, alertConfig.GroupID, alertConfig)
@@ -97,7 +96,7 @@ func (s *Store) MatcherFields() ([]string, error) {
 	}
 }
 
-func (s *Store) UpdateAlertConfiguration(alertConfig *atlas.AlertConfiguration) (*atlas.AlertConfiguration, error) {
+func (s *Store) UpdateAlertConfiguration(alertConfig *opsmngr.AlertConfiguration) (*opsmngr.AlertConfiguration, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.AlertConfigurations.Update(s.ctx, alertConfig.GroupID, alertConfig.ID, alertConfig)
@@ -108,7 +107,7 @@ func (s *Store) UpdateAlertConfiguration(alertConfig *atlas.AlertConfiguration) 
 }
 
 // EnableAlertConfiguration encapsulate the logic to manage different cloud providers.
-func (s *Store) EnableAlertConfiguration(projectID, id string) (*atlas.AlertConfiguration, error) {
+func (s *Store) EnableAlertConfiguration(projectID, id string) (*opsmngr.AlertConfiguration, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.AlertConfigurations.EnableAnAlertConfig(s.ctx, projectID, id, pointer.Get(true))
@@ -119,7 +118,7 @@ func (s *Store) EnableAlertConfiguration(projectID, id string) (*atlas.AlertConf
 }
 
 // DisableAlertConfiguration encapsulate the logic to manage different cloud providers.
-func (s *Store) DisableAlertConfiguration(projectID, id string) (*atlas.AlertConfiguration, error) {
+func (s *Store) DisableAlertConfiguration(projectID, id string) (*opsmngr.AlertConfiguration, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.AlertConfigurations.EnableAnAlertConfig(s.ctx, projectID, id, pointer.Get(false))

--- a/internal/store/alerts.go
+++ b/internal/store/alerts.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -29,15 +28,15 @@ type AlertDescriber interface {
 }
 
 type AlertLister interface {
-	Alerts(string, *opsmngr.AlertsListOptions) (*atlas.AlertsResponse, error)
+	Alerts(string, *opsmngr.AlertsListOptions) (*opsmngr.AlertsResponse, error)
 }
 
 type AlertAcknowledger interface {
-	AcknowledgeAlert(string, string, *opsmngr.AcknowledgeRequest) (*atlas.Alert, error)
+	AcknowledgeAlert(string, string, *opsmngr.AcknowledgeRequest) (*opsmngr.Alert, error)
 }
 
 // Alert encapsulate the logic to manage different cloud providers.
-func (s *Store) Alert(projectID, alertID string) (*atlas.Alert, error) {
+func (s *Store) Alert(projectID, alertID string) (*opsmngr.Alert, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Alerts.Get(s.ctx, projectID, alertID)
@@ -59,7 +58,7 @@ func (s *Store) Alerts(projectID string, opts *opsmngr.AlertsListOptions) (*opsm
 }
 
 // AcknowledgeAlert encapsulate the logic to manage different cloud providers.
-func (s *Store) AcknowledgeAlert(projectID, alertID string, body *opsmngr.AcknowledgeRequest) (*atlas.Alert, error) {
+func (s *Store) AcknowledgeAlert(projectID, alertID string, body *opsmngr.AcknowledgeRequest) (*opsmngr.Alert, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Alerts.Acknowledge(s.ctx, projectID, alertID, body)

--- a/internal/store/api_keys.go
+++ b/internal/store/api_keys.go
@@ -19,16 +19,17 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_api_keys.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store ProjectAPIKeyLister,ProjectAPIKeyCreator,OrganizationAPIKeyLister,OrganizationAPIKeyDescriber,OrganizationAPIKeyUpdater,OrganizationAPIKeyCreator,OrganizationAPIKeyDeleter,ProjectAPIKeyDeleter,ProjectAPIKeyAssigner
 
 type ProjectAPIKeyLister interface {
-	ProjectAPIKeys(string, *atlas.ListOptions) ([]atlas.APIKey, error)
+	ProjectAPIKeys(string, *opsmngr.ListOptions) ([]opsmngr.APIKey, error)
 }
 
 type ProjectAPIKeyCreator interface {
-	CreateProjectAPIKey(string, *atlas.APIKeyInput) (*atlas.APIKey, error)
+	CreateProjectAPIKey(string, *opsmngr.APIKeyInput) (*opsmngr.APIKey, error)
 }
 
 type ProjectAPIKeyDeleter interface {
@@ -40,19 +41,19 @@ type ProjectAPIKeyAssigner interface {
 }
 
 type OrganizationAPIKeyLister interface {
-	OrganizationAPIKeys(string, *atlas.ListOptions) ([]atlas.APIKey, error)
+	OrganizationAPIKeys(string, *opsmngr.ListOptions) ([]opsmngr.APIKey, error)
 }
 
 type OrganizationAPIKeyDescriber interface {
-	OrganizationAPIKey(string, string) (*atlas.APIKey, error)
+	OrganizationAPIKey(string, string) (*opsmngr.APIKey, error)
 }
 
 type OrganizationAPIKeyUpdater interface {
-	UpdateOrganizationAPIKey(string, string, *atlas.APIKeyInput) (*atlas.APIKey, error)
+	UpdateOrganizationAPIKey(string, string, *opsmngr.APIKeyInput) (*opsmngr.APIKey, error)
 }
 
 type OrganizationAPIKeyCreator interface {
-	CreateOrganizationAPIKey(string, *atlas.APIKeyInput) (*atlas.APIKey, error)
+	CreateOrganizationAPIKey(string, *opsmngr.APIKeyInput) (*opsmngr.APIKey, error)
 }
 
 type OrganizationAPIKeyDeleter interface {
@@ -60,7 +61,7 @@ type OrganizationAPIKeyDeleter interface {
 }
 
 // OrganizationAPIKeys encapsulates the logic to manage different cloud providers.
-func (s *Store) OrganizationAPIKeys(orgID string, opts *atlas.ListOptions) ([]atlas.APIKey, error) {
+func (s *Store) OrganizationAPIKeys(orgID string, opts *opsmngr.ListOptions) ([]opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.OrganizationAPIKeys.List(s.ctx, orgID, opts)
@@ -71,7 +72,7 @@ func (s *Store) OrganizationAPIKeys(orgID string, opts *atlas.ListOptions) ([]at
 }
 
 // OrganizationAPIKey encapsulates the logic to manage different cloud providers.
-func (s *Store) OrganizationAPIKey(orgID, apiKeyID string) (*atlas.APIKey, error) {
+func (s *Store) OrganizationAPIKey(orgID, apiKeyID string) (*opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.OrganizationAPIKeys.Get(s.ctx, orgID, apiKeyID)
@@ -82,7 +83,7 @@ func (s *Store) OrganizationAPIKey(orgID, apiKeyID string) (*atlas.APIKey, error
 }
 
 // UpdateOrganizationAPIKey encapsulates the logic to manage different cloud providers.
-func (s *Store) UpdateOrganizationAPIKey(orgID, apiKeyID string, input *atlas.APIKeyInput) (*atlas.APIKey, error) {
+func (s *Store) UpdateOrganizationAPIKey(orgID, apiKeyID string, input *opsmngr.APIKeyInput) (*opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.OrganizationAPIKeys.Update(s.ctx, orgID, apiKeyID, input)
@@ -93,7 +94,7 @@ func (s *Store) UpdateOrganizationAPIKey(orgID, apiKeyID string, input *atlas.AP
 }
 
 // CreateOrganizationAPIKey encapsulates the logic to manage different cloud providers.
-func (s *Store) CreateOrganizationAPIKey(orgID string, input *atlas.APIKeyInput) (*atlas.APIKey, error) {
+func (s *Store) CreateOrganizationAPIKey(orgID string, input *opsmngr.APIKeyInput) (*opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.OrganizationAPIKeys.Create(s.ctx, orgID, input)
@@ -115,7 +116,7 @@ func (s *Store) DeleteOrganizationAPIKey(orgID, id string) error {
 }
 
 // ProjectAPIKeys returns the API Keys for a specific project.
-func (s *Store) ProjectAPIKeys(projectID string, opts *atlas.ListOptions) ([]atlas.APIKey, error) {
+func (s *Store) ProjectAPIKeys(projectID string, opts *opsmngr.ListOptions) ([]opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.ProjectAPIKeys.List(s.ctx, projectID, opts)
@@ -126,7 +127,7 @@ func (s *Store) ProjectAPIKeys(projectID string, opts *atlas.ListOptions) ([]atl
 }
 
 // CreateProjectAPIKey creates an API Keys for a project.
-func (s *Store) CreateProjectAPIKey(projectID string, apiKeyInput *atlas.APIKeyInput) (*atlas.APIKey, error) {
+func (s *Store) CreateProjectAPIKey(projectID string, apiKeyInput *opsmngr.APIKeyInput) (*opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.ProjectAPIKeys.Create(s.ctx, projectID, apiKeyInput)

--- a/internal/store/api_keys_access_list.go
+++ b/internal/store/api_keys_access_list.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_api_keys_access_list.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store OrganizationAPIKeyAccessListCreator,OrganizationAPIKeyAccessListDeleter,OrganizationAPIKeyAccessListLister
 
 type OrganizationAPIKeyAccessListLister interface {
-	OrganizationAPIKeyAccessLists(string, string, *opsmngr.ListOptions) (*atlas.AccessListAPIKeys, error)
+	OrganizationAPIKeyAccessLists(string, string, *opsmngr.ListOptions) (*opsmngr.AccessListAPIKeys, error)
 }
 
 type OrganizationAPIKeyAccessListDeleter interface {
@@ -33,11 +32,11 @@ type OrganizationAPIKeyAccessListDeleter interface {
 }
 
 type OrganizationAPIKeyAccessListCreator interface {
-	CreateOrganizationAPIKeyAccessList(string, string, []*atlas.AccessListAPIKeysReq) (*atlas.AccessListAPIKeys, error)
+	CreateOrganizationAPIKeyAccessList(string, string, []*opsmngr.AccessListAPIKeysReq) (*opsmngr.AccessListAPIKeys, error)
 }
 
 // CreateOrganizationAPIKeyAccessList encapsulates the logic to manage different cloud providers.
-func (s *Store) CreateOrganizationAPIKeyAccessList(orgID, apiKeyID string, opts []*atlas.AccessListAPIKeysReq) (*atlas.AccessListAPIKeys, error) {
+func (s *Store) CreateOrganizationAPIKeyAccessList(orgID, apiKeyID string, opts []*opsmngr.AccessListAPIKeysReq) (*opsmngr.AccessListAPIKeys, error) {
 	switch s.service {
 	case config.CloudManagerService, config.OpsManagerService:
 		result, _, err := s.client.AccessListAPIKeys.Create(s.ctx, orgID, apiKeyID, opts)
@@ -59,7 +58,7 @@ func (s *Store) DeleteOrganizationAPIKeyAccessList(orgID, apiKeyID, ipAddress st
 }
 
 // OrganizationAPIKeyAccessLists encapsulates the logic to manage different cloud providers.
-func (s *Store) OrganizationAPIKeyAccessLists(orgID, apiKeyID string, opts *atlas.ListOptions) (*atlas.AccessListAPIKeys, error) {
+func (s *Store) OrganizationAPIKeyAccessLists(orgID, apiKeyID string, opts *opsmngr.ListOptions) (*opsmngr.AccessListAPIKeys, error) {
 	switch s.service {
 	case config.CloudManagerService, config.OpsManagerService:
 		result, _, err := s.client.AccessListAPIKeys.List(s.ctx, orgID, apiKeyID, opts)

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -18,26 +18,21 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_clusters.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store ClusterLister,OpsManagerClusterDescriber
 
 type ClusterLister interface {
-	ProjectClusters(string, *atlas.ListOptions) (*opsmngr.Clusters, error)
+	ProjectClusters(string, *opsmngr.ListOptions) (*opsmngr.Clusters, error)
 }
 
 type OpsManagerClusterDescriber interface {
 	OpsManagerCluster(string, string) (*opsmngr.Cluster, error)
 }
 
-type AtlasSharedClusterDescriber interface {
-	AtlasSharedCluster(string, string) (*atlas.Cluster, error)
-}
-
 // ProjectClusters encapsulate the logic to manage different cloud providers.
-func (s *Store) ProjectClusters(projectID string, opts *atlas.ListOptions) (*opsmngr.Clusters, error) {
+func (s *Store) ProjectClusters(projectID string, opts *opsmngr.ListOptions) (*opsmngr.Clusters, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Clusters.List(s.ctx, projectID, opts)

--- a/internal/store/continuous_backup.go
+++ b/internal/store/continuous_backup.go
@@ -18,29 +18,29 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_continuous_backup.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store CheckpointsLister,ContinuousJobLister,ContinuousJobCreator,ContinuousSnapshotsLister
 
 type CheckpointsLister interface {
-	Checkpoints(string, string, *atlas.ListOptions) (*atlas.Checkpoints, error)
+	Checkpoints(string, string, *opsmngr.ListOptions) (*opsmngr.Checkpoints, error)
 }
 
 type ContinuousJobLister interface {
-	ContinuousRestoreJobs(string, string, *atlas.ListOptions) (*atlas.ContinuousJobs, error)
+	ContinuousRestoreJobs(string, string, *opsmngr.ListOptions) (*opsmngr.ContinuousJobs, error)
 }
 
 type ContinuousJobCreator interface {
-	CreateContinuousRestoreJob(string, string, *atlas.ContinuousJobRequest) (*atlas.ContinuousJobs, error)
+	CreateContinuousRestoreJob(string, string, *opsmngr.ContinuousJobRequest) (*opsmngr.ContinuousJobs, error)
 }
 
 type ContinuousSnapshotsLister interface {
-	ContinuousSnapshots(string, string, *atlas.ListOptions) (*atlas.ContinuousSnapshots, error)
+	ContinuousSnapshots(string, string, *opsmngr.ListOptions) (*opsmngr.ContinuousSnapshots, error)
 }
 
 // Checkpoints encapsulate the logic to manage different cloud providers.
-func (s *Store) Checkpoints(projectID, clusterID string, opts *atlas.ListOptions) (*atlas.Checkpoints, error) {
+func (s *Store) Checkpoints(projectID, clusterID string, opts *opsmngr.ListOptions) (*opsmngr.Checkpoints, error) {
 	switch s.service {
 	case config.CloudManagerService, config.OpsManagerService:
 		result, _, err := s.client.Checkpoints.List(s.ctx, projectID, clusterID, opts)
@@ -51,7 +51,7 @@ func (s *Store) Checkpoints(projectID, clusterID string, opts *atlas.ListOptions
 }
 
 // ContinuousRestoreJobs encapsulate the logic to manage different cloud providers.
-func (s *Store) ContinuousRestoreJobs(projectID, clusterID string, opts *atlas.ListOptions) (*atlas.ContinuousJobs, error) {
+func (s *Store) ContinuousRestoreJobs(projectID, clusterID string, opts *opsmngr.ListOptions) (*opsmngr.ContinuousJobs, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.ContinuousRestoreJobs.List(s.ctx, projectID, clusterID, opts)
@@ -62,7 +62,7 @@ func (s *Store) ContinuousRestoreJobs(projectID, clusterID string, opts *atlas.L
 }
 
 // CreateContinuousRestoreJob encapsulate the logic to manage different cloud providers.
-func (s *Store) CreateContinuousRestoreJob(projectID, clusterID string, request *atlas.ContinuousJobRequest) (*atlas.ContinuousJobs, error) {
+func (s *Store) CreateContinuousRestoreJob(projectID, clusterID string, request *opsmngr.ContinuousJobRequest) (*opsmngr.ContinuousJobs, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.ContinuousRestoreJobs.Create(s.ctx, projectID, clusterID, request)
@@ -73,7 +73,7 @@ func (s *Store) CreateContinuousRestoreJob(projectID, clusterID string, request 
 }
 
 // ContinuousSnapshots encapsulate the logic to manage different cloud providers.
-func (s *Store) ContinuousSnapshots(projectID, clusterID string, opts *atlas.ListOptions) (*atlas.ContinuousSnapshots, error) {
+func (s *Store) ContinuousSnapshots(projectID, clusterID string, opts *opsmngr.ListOptions) (*opsmngr.ContinuousSnapshots, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.ContinuousSnapshots.List(s.ctx, projectID, clusterID, opts)

--- a/internal/store/deployments.go
+++ b/internal/store/deployments.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -36,15 +35,15 @@ type HostByHostnameDescriber interface {
 }
 
 type HostDatabaseLister interface {
-	HostDatabases(string, string, *atlas.ListOptions) (*atlas.ProcessDatabasesResponse, error)
+	HostDatabases(string, string, *opsmngr.ListOptions) (*opsmngr.ProcessDatabasesResponse, error)
 }
 
 type HostDisksLister interface {
-	HostDisks(string, string, *atlas.ListOptions) (*atlas.ProcessDisksResponse, error)
+	HostDisks(string, string, *opsmngr.ListOptions) (*opsmngr.ProcessDisksResponse, error)
 }
 
 // HostDatabases encapsulate the logic to manage different cloud providers.
-func (s *Store) HostDatabases(groupID, hostID string, opts *atlas.ListOptions) (*atlas.ProcessDatabasesResponse, error) {
+func (s *Store) HostDatabases(groupID, hostID string, opts *opsmngr.ListOptions) (*opsmngr.ProcessDatabasesResponse, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Deployments.ListDatabases(s.ctx, groupID, hostID, opts)
@@ -55,7 +54,7 @@ func (s *Store) HostDatabases(groupID, hostID string, opts *atlas.ListOptions) (
 }
 
 // HostDisks encapsulate the logic to manage different cloud providers.
-func (s *Store) HostDisks(groupID, hostID string, opts *atlas.ListOptions) (*atlas.ProcessDisksResponse, error) {
+func (s *Store) HostDisks(groupID, hostID string, opts *opsmngr.ListOptions) (*opsmngr.ProcessDisksResponse, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Deployments.ListPartitions(s.ctx, groupID, hostID, opts)

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -18,17 +18,17 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_events.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store OrganizationEventLister,ProjectEventLister,EventLister
 
 type OrganizationEventLister interface {
-	OrganizationEvents(string, *atlas.EventListOptions) (*atlas.EventResponse, error)
+	OrganizationEvents(string, *opsmngr.EventListOptions) (*opsmngr.EventResponse, error)
 }
 
 type ProjectEventLister interface {
-	ProjectEvents(string, *atlas.EventListOptions) (*atlas.EventResponse, error)
+	ProjectEvents(string, *opsmngr.EventListOptions) (*opsmngr.EventResponse, error)
 }
 
 type EventLister interface {
@@ -37,7 +37,7 @@ type EventLister interface {
 }
 
 // ProjectEvents encapsulate the logic to manage different cloud providers.
-func (s *Store) ProjectEvents(projectID string, opts *atlas.EventListOptions) (*atlas.EventResponse, error) {
+func (s *Store) ProjectEvents(projectID string, opts *opsmngr.EventListOptions) (*opsmngr.EventResponse, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Events.ListProjectEvents(s.ctx, projectID, opts)
@@ -48,7 +48,7 @@ func (s *Store) ProjectEvents(projectID string, opts *atlas.EventListOptions) (*
 }
 
 // OrganizationEvents encapsulate the logic to manage different cloud providers.
-func (s *Store) OrganizationEvents(orgID string, opts *atlas.EventListOptions) (*atlas.EventResponse, error) {
+func (s *Store) OrganizationEvents(orgID string, opts *opsmngr.EventListOptions) (*opsmngr.EventResponse, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Events.ListOrganizationEvents(s.ctx, orgID, opts)

--- a/internal/store/global_alerts.go
+++ b/internal/store/global_alerts.go
@@ -18,18 +18,17 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen  -destination=../mocks/mock_global_alerts.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store GlobalAlertLister
 
 type GlobalAlertLister interface {
-	GlobalAlerts(*atlas.AlertsListOptions) (*opsmngr.GlobalAlerts, error)
+	GlobalAlerts(*opsmngr.AlertsListOptions) (*opsmngr.GlobalAlerts, error)
 }
 
 // GlobalAlerts encapsulate the logic to manage different cloud providers.
-func (s *Store) GlobalAlerts(opts *atlas.AlertsListOptions) (*opsmngr.GlobalAlerts, error) {
+func (s *Store) GlobalAlerts(opts *opsmngr.AlertsListOptions) (*opsmngr.GlobalAlerts, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.GlobalAlerts.List(s.ctx, opts)

--- a/internal/store/global_api_keys.go
+++ b/internal/store/global_api_keys.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -67,7 +66,7 @@ func (s *Store) GlobalAPIKey(apiKeyID string) (*opsmngr.APIKey, error) {
 }
 
 // UpdateGlobalAPIKey encapsulates the logic to manage different cloud providers.
-func (s *Store) UpdateGlobalAPIKey(apiKeyID string, input *atlas.APIKeyInput) (*opsmngr.APIKey, error) {
+func (s *Store) UpdateGlobalAPIKey(apiKeyID string, input *opsmngr.APIKeyInput) (*opsmngr.APIKey, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.GlobalAPIKeys.Update(s.ctx, apiKeyID, input)

--- a/internal/store/global_api_keys_whitelist.go
+++ b/internal/store/global_api_keys_whitelist.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_global_api_keys_access_list.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store GlobalAPIKeyWhitelistLister,GlobalAPIKeyWhitelistDescriber,GlobalAPIKeyWhitelistCreator,GlobalAPIKeyWhitelistDeleter
 
 type GlobalAPIKeyWhitelistLister interface {
-	GlobalAPIKeyWhitelists(*atlas.ListOptions) (*opsmngr.GlobalWhitelistAPIKeys, error)
+	GlobalAPIKeyWhitelists(*opsmngr.ListOptions) (*opsmngr.GlobalWhitelistAPIKeys, error)
 }
 
 type GlobalAPIKeyWhitelistDescriber interface {
@@ -41,7 +40,7 @@ type GlobalAPIKeyWhitelistDeleter interface {
 }
 
 // GlobalAPIKeyWhitelists encapsulates the logic to manage different cloud providers.
-func (s *Store) GlobalAPIKeyWhitelists(opts *atlas.ListOptions) (*opsmngr.GlobalWhitelistAPIKeys, error) {
+func (s *Store) GlobalAPIKeyWhitelists(opts *opsmngr.ListOptions) (*opsmngr.GlobalWhitelistAPIKeys, error) {
 	switch s.service {
 	case config.OpsManagerService:
 		result, _, err := s.client.GlobalAPIKeysWhitelist.List(s.ctx, opts)

--- a/internal/store/live_migration_orgs_connection.go
+++ b/internal/store/live_migration_orgs_connection.go
@@ -18,22 +18,21 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_live_migration_orgs_connection.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store OrganizationsConnector,OrganizationsDescriber
 
 type OrganizationsConnector interface {
-	ConnectOrganizations(string, *atlas.LinkToken) (*opsmngr.ConnectionStatus, error)
+	ConnectOrganizations(string, *opsmngr.LinkToken) (*opsmngr.ConnectionStatus, error)
 }
 
 type OrganizationsDescriber interface {
 	OrganizationConnectionStatus(string) (*opsmngr.ConnectionStatus, error)
 }
 
-// CreateLinkConnection encapsulate the logic to manage different cloud providers.
-func (s *Store) ConnectOrganizations(orgID string, linkToken *atlas.LinkToken) (*opsmngr.ConnectionStatus, error) {
+// ConnectOrganizations encapsulate the logic to manage different cloud providers.
+func (s *Store) ConnectOrganizations(orgID string, linkToken *opsmngr.LinkToken) (*opsmngr.ConnectionStatus, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.LiveMigration.ConnectOrganizations(s.ctx, orgID, linkToken)

--- a/internal/store/measurements.go
+++ b/internal/store/measurements.go
@@ -18,25 +18,25 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_measurements.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store HostMeasurementLister,HostDiskMeasurementsLister,HostDatabaseMeasurementsLister
 
 type HostMeasurementLister interface {
-	HostMeasurements(string, string, *atlas.ProcessMeasurementListOptions) (*atlas.ProcessMeasurements, error)
+	HostMeasurements(string, string, *opsmngr.ProcessMeasurementListOptions) (*opsmngr.ProcessMeasurements, error)
 }
 
 type HostDiskMeasurementsLister interface {
-	HostDiskMeasurements(string, string, string, *atlas.ProcessMeasurementListOptions) (*atlas.ProcessDiskMeasurements, error)
+	HostDiskMeasurements(string, string, string, *opsmngr.ProcessMeasurementListOptions) (*opsmngr.ProcessDiskMeasurements, error)
 }
 
 type HostDatabaseMeasurementsLister interface {
-	HostDatabaseMeasurements(string, string, string, *atlas.ProcessMeasurementListOptions) (*atlas.ProcessDatabaseMeasurements, error)
+	HostDatabaseMeasurements(string, string, string, *opsmngr.ProcessMeasurementListOptions) (*opsmngr.ProcessDatabaseMeasurements, error)
 }
 
 // HostMeasurements encapsulate the logic to manage different cloud providers.
-func (s *Store) HostMeasurements(groupID, host string, opts *atlas.ProcessMeasurementListOptions) (*atlas.ProcessMeasurements, error) {
+func (s *Store) HostMeasurements(groupID, host string, opts *opsmngr.ProcessMeasurementListOptions) (*opsmngr.ProcessMeasurements, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Measurements.Host(s.ctx, groupID, host, opts)
@@ -47,7 +47,7 @@ func (s *Store) HostMeasurements(groupID, host string, opts *atlas.ProcessMeasur
 }
 
 // HostDiskMeasurements encapsulates the logic to manage different cloud providers.
-func (s *Store) HostDiskMeasurements(groupID, hostID, partitionName string, opts *atlas.ProcessMeasurementListOptions) (*atlas.ProcessDiskMeasurements, error) {
+func (s *Store) HostDiskMeasurements(groupID, hostID, partitionName string, opts *opsmngr.ProcessMeasurementListOptions) (*opsmngr.ProcessDiskMeasurements, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Measurements.Disk(s.ctx, groupID, hostID, partitionName, opts)
@@ -58,7 +58,7 @@ func (s *Store) HostDiskMeasurements(groupID, hostID, partitionName string, opts
 }
 
 // HostDatabaseMeasurements encapsulate the logic to manage different cloud providers.
-func (s *Store) HostDatabaseMeasurements(groupID, hostID, databaseName string, opts *atlas.ProcessMeasurementListOptions) (*atlas.ProcessDatabaseMeasurements, error) {
+func (s *Store) HostDatabaseMeasurements(groupID, hostID, databaseName string, opts *opsmngr.ProcessMeasurementListOptions) (*opsmngr.ProcessDatabaseMeasurements, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Measurements.Database(s.ctx, groupID, hostID, databaseName, opts)

--- a/internal/store/organizations.go
+++ b/internal/store/organizations.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -41,7 +40,7 @@ type OrganizationDeleter interface {
 }
 
 // Organizations encapsulate the logic to manage different cloud providers.
-func (s *Store) Organizations(opts *atlas.OrganizationsListOptions) (*opsmngr.Organizations, error) {
+func (s *Store) Organizations(opts *opsmngr.OrganizationsListOptions) (*opsmngr.Organizations, error) {
 	switch s.service {
 	case config.CloudManagerService, config.OpsManagerService:
 		result, _, err := s.client.Organizations.List(s.ctx, opts)
@@ -63,10 +62,10 @@ func (s *Store) Organization(id string) (*opsmngr.Organization, error) {
 }
 
 // CreateOrganization encapsulate the logic to manage different cloud providers.
-func (s *Store) CreateOrganization(name string) (*atlas.Organization, error) {
+func (s *Store) CreateOrganization(name string) (*opsmngr.Organization, error) {
 	switch s.service {
 	case config.CloudManagerService, config.OpsManagerService:
-		org := &atlas.Organization{Name: name}
+		org := &opsmngr.Organization{Name: name}
 		result, _, err := s.client.Organizations.Create(s.ctx, org)
 		return result, err
 	default:

--- a/internal/store/service_version.go
+++ b/internal/store/service_version.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -29,7 +28,7 @@ type ServiceVersionDescriber interface {
 }
 
 // ServiceVersion encapsulates the logic to manage different cloud providers.
-func (s *Store) ServiceVersion() (*atlas.ServiceVersion, error) {
+func (s *Store) ServiceVersion() (*opsmngr.ServiceVersion, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.ServiceVersion.Get(s.ctx)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,7 +32,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/log"
 	atlasauth "go.mongodb.org/atlas/auth"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
@@ -282,7 +281,7 @@ func (s *Store) setOpsManagerClient(client *http.Client) error {
 		return err
 	}
 
-	c.OnResponseProcessed(func(resp *atlas.Response) {
+	c.OnResponseProcessed(func(resp *opsmngr.Response) {
 		respHeaders := ""
 		for key, value := range resp.Header {
 			respHeaders += fmt.Sprintf("%v: %v\n", key, strings.Join(value, " "))

--- a/internal/store/teams.go
+++ b/internal/store/teams.go
@@ -25,7 +25,7 @@ import (
 //go:generate mockgen -destination=../mocks/mock_teams.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store TeamLister,TeamDescriber,TeamCreator,TeamDeleter,TeamAdder,TeamUserRemover,TeamRolesUpdater
 
 type TeamLister interface {
-	Teams(string, *atlas.ListOptions) ([]atlas.Team, error)
+	Teams(string, *opsmngr.ListOptions) ([]atlas.Team, error)
 }
 
 type TeamDescriber interface {

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/config"
-	atlas "go.mongodb.org/atlas/mongodbatlas"
 	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 //go:generate mockgen -destination=../mocks/mock_users.go -package=mocks github.com/mongodb/mongodb-atlas-cli/mongocli/v2/internal/store UserCreator,UserDescriber,UserDeleter,UserLister,TeamUserLister
 
 type UserCreator interface {
-	CreateUser(*opsmngr.User) (interface{}, error)
+	CreateUser(*opsmngr.User) (*opsmngr.User, error)
 }
 
 type UserDeleter interface {
@@ -33,7 +32,7 @@ type UserDeleter interface {
 }
 
 type UserLister interface {
-	OrganizationUsers(string, *atlas.ListOptions) (interface{}, error)
+	OrganizationUsers(string, *opsmngr.ListOptions) (*opsmngr.UsersResponse, error)
 }
 
 type TeamUserLister interface {
@@ -41,12 +40,12 @@ type TeamUserLister interface {
 }
 
 type UserDescriber interface {
-	UserByID(string) (interface{}, error)
-	UserByName(string) (interface{}, error)
+	UserByID(string) (*opsmngr.User, error)
+	UserByName(string) (*opsmngr.User, error)
 }
 
 // CreateUser encapsulates the logic to manage different cloud providers.
-func (s *Store) CreateUser(user *opsmngr.User) (interface{}, error) {
+func (s *Store) CreateUser(user *opsmngr.User) (*opsmngr.User, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Users.Create(s.ctx, user)
@@ -57,7 +56,7 @@ func (s *Store) CreateUser(user *opsmngr.User) (interface{}, error) {
 }
 
 // UserByID encapsulates the logic to manage different cloud providers.
-func (s *Store) UserByID(userID string) (interface{}, error) {
+func (s *Store) UserByID(userID string) (*opsmngr.User, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Users.Get(s.ctx, userID)
@@ -68,7 +67,7 @@ func (s *Store) UserByID(userID string) (interface{}, error) {
 }
 
 // UserByName encapsulates the logic to manage different cloud providers.
-func (s *Store) UserByName(username string) (interface{}, error) {
+func (s *Store) UserByName(username string) (*opsmngr.User, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Users.GetByName(s.ctx, username)
@@ -90,7 +89,7 @@ func (s *Store) DeleteUser(userID string) error {
 }
 
 // OrganizationUsers encapsulates the logic to manage different cloud providers.
-func (s *Store) OrganizationUsers(organizationID string, opts *atlas.ListOptions) (interface{}, error) {
+func (s *Store) OrganizationUsers(organizationID string, opts *opsmngr.ListOptions) (*opsmngr.UsersResponse, error) {
 	switch s.service {
 	case config.OpsManagerService, config.CloudManagerService:
 		result, _, err := s.client.Organizations.ListUsers(s.ctx, organizationID, opts)

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const (
@@ -47,7 +47,7 @@ func CreateProject(projectName string) (string, error) {
 		return "", fmt.Errorf("%w: %s", err, string(resp))
 	}
 
-	var project mongodbatlas.Project
+	var project opsmngr.Project
 	if err := json.Unmarshal(resp, &project); err != nil {
 		return "", fmt.Errorf("%w: %s", err, resp)
 	}

--- a/test/e2e/iam/helper_test.go
+++ b/test/e2e/iam/helper_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/test/e2e"
 	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 const (
@@ -66,7 +67,7 @@ func createOrgAPIKey() (string, error) {
 		return "", fmt.Errorf("%w: %s", err, string(resp))
 	}
 
-	var key mongodbatlas.APIKey
+	var key opsmngr.APIKey
 	if err := json.Unmarshal(resp, &key); err != nil {
 		return "", err
 	}

--- a/test/e2e/iam/org_api_key_access_list_test.go
+++ b/test/e2e/iam/org_api_key_access_list_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestOrgAPIKeyAccessList(t *testing.T) {
@@ -58,7 +58,7 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var key mongodbatlas.AccessListAPIKeys
+		var key opsmngr.AccessListAPIKeys
 		require.NoError(t, json.Unmarshal(resp, &key))
 		assert.NotEmpty(t, key.Results)
 	})
@@ -74,34 +74,13 @@ func TestOrgAPIKeyAccessList(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var key mongodbatlas.AccessListAPIKeys
+		var key opsmngr.AccessListAPIKeys
 		require.NoError(t, json.Unmarshal(resp, &key))
 		assert.NotEmpty(t, key.Results)
 	})
 
 	t.Run("Delete", func(t *testing.T) {
 		deleteAccessListEntry(t, cliPath, entry, apiKeyID)
-	})
-
-	t.Run("Create Current IP", func(t *testing.T) {
-		t.Skip("400 (request \"CANNOT_REMOVE_CALLER_FROM_ACCESS_LIST\") Cannot remove caller's IP address from access list")
-		cmd := exec.Command(cliPath, iamEntity,
-			orgEntity,
-			apiKeysEntity,
-			apiKeyAccessListEntity,
-			"create",
-			"--apiKey",
-			apiKeyID,
-			"--currentIp",
-			"-o=json")
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		a := assert.New(t)
-		require.NoError(t, err, string(resp))
-		var key mongodbatlas.AccessListAPIKeys
-		require.NoError(t, json.Unmarshal(resp, &key))
-		a.NotEmpty(key.Results)
-		entry = key.Results[0].IPAddress
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/test/e2e/iam/org_api_keys_test.go
+++ b/test/e2e/iam/org_api_keys_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestOrgAPIKeys(t *testing.T) {
@@ -51,7 +52,7 @@ func TestOrgAPIKeys(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
-		var key mongodbatlas.APIKey
+		var key opsmngr.APIKey
 		require.NoError(t, json.Unmarshal(resp, &key))
 		a.Equal(desc, key.Desc)
 		ID = key.ID

--- a/test/e2e/iam/project_api_keys_test.go
+++ b/test/e2e/iam/project_api_keys_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestProjectAPIKeys(t *testing.T) {
@@ -50,7 +50,7 @@ func TestProjectAPIKeys(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
-		var key mongodbatlas.APIKey
+		var key opsmngr.APIKey
 		require.NoError(t, json.Unmarshal(resp, &key))
 		a.Equal(desc, key.Desc)
 		ID = key.ID
@@ -89,7 +89,7 @@ func TestProjectAPIKeys(t *testing.T) {
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
-		var keys []mongodbatlas.APIKey
+		var keys []opsmngr.APIKey
 		require.NoError(t, json.Unmarshal(resp, &keys))
 		assert.NotEmpty(t, keys)
 	})

--- a/test/e2e/iam/projects_test.go
+++ b/test/e2e/iam/projects_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/test/e2e"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestProjects(t *testing.T) {
@@ -54,7 +54,7 @@ func TestProjects(t *testing.T) {
 
 		require.NoError(t, err, string(resp))
 
-		var project mongodbatlas.Project
+		var project opsmngr.Project
 		if err = json.Unmarshal(resp, &project); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/test/e2e/iam/team_users_test.go
+++ b/test/e2e/iam/team_users_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/mongocli/v2/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/ops-manager/opsmngr"
 )
 
 func TestTeamUsers(t *testing.T) {
@@ -64,7 +64,7 @@ func TestTeamUsers(t *testing.T) {
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 
-		var users []mongodbatlas.AtlasUser
+		var users []opsmngr.User
 		require.NoError(t, json.Unmarshal(resp, &users))
 		found := false
 		for _, user := range users {
@@ -89,7 +89,7 @@ func TestTeamUsers(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
-		var teams []mongodbatlas.AtlasUser
+		var teams []opsmngr.User
 		require.NoError(t, json.Unmarshal(resp, &teams))
 		a.NotEmpty(teams)
 	})


### PR DESCRIPTION
Reduce as much as possible references to the Atlas SDK, there are some references missing pending https://github.com/mongodb/go-client-mongodb-ops-manager/pull/225