### PR TITLE
CLOUDP-237545: Ignore tenant readonly fields for Kubernetes generation

### DIFF
--- a/internal/kubernetes/operator/deployment/deployment.go
+++ b/internal/kubernetes/operator/deployment/deployment.go
@@ -177,8 +177,8 @@ func BuildAtlasAdvancedDeployment(deploymentStore store.OperatorClusterStore, va
 }
 
 func cleanTenantFields(out *akov2.AtlasDeploymentSpec) {
-
 	isTenant := false
+
 	if out.DeploymentSpec == nil {
 		return
 	}

--- a/internal/kubernetes/operator/deployment/deployment.go
+++ b/internal/kubernetes/operator/deployment/deployment.go
@@ -171,7 +171,34 @@ func BuildAtlasAdvancedDeployment(deploymentStore store.OperatorClusterStore, va
 		advancedSpec.ManagedNamespaces = managedNamespaces
 	}
 
+	cleanTenantFields(&atlasDeployment.Spec)
+
 	return deploymentResult, nil
+}
+
+func cleanTenantFields(out *akov2.AtlasDeploymentSpec) {
+
+	isTenant := false
+	if out.DeploymentSpec == nil {
+		return
+	}
+	for _, spec := range out.DeploymentSpec.ReplicationSpecs {
+		for _, c := range spec.RegionConfigs {
+			if c.ProviderName == "TENANT" {
+				isTenant = true
+				break
+			}
+		}
+	}
+
+	if isTenant {
+		out.DeploymentSpec.BiConnector = nil
+		out.DeploymentSpec.EncryptionAtRestProvider = ""
+		out.DeploymentSpec.DiskSizeGB = nil
+		out.DeploymentSpec.MongoDBMajorVersion = ""
+		out.DeploymentSpec.PitEnabled = nil
+		out.DeploymentSpec.BackupEnabled = nil
+	}
 }
 
 func buildGlobalDeployment(atlasRepSpec []atlasv2.ReplicationSpec, globalDeploymentProvider store.GlobalClusterDescriber, projectID, clusterID string) ([]akov2.CustomZoneMapping, []akov2.ManagedNamespace, error) {

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -520,3 +520,51 @@ func TestBuildServerlessDeployments(t *testing.T) {
 		}
 	})
 }
+
+func TestCleanTenantFields(t *testing.T) {
+	spec := akov2.AtlasDeploymentSpec{
+		DeploymentSpec: &akov2.AdvancedDeploymentSpec{
+			BackupEnabled: pointer.Get(true),
+			BiConnector: &akov2.BiConnectorSpec{
+				Enabled:        pointer.Get(true),
+				ReadPreference: "SECONDARY",
+			},
+			EncryptionAtRestProvider: "AWS",
+			PitEnabled:               pointer.Get(true),
+			MongoDBMajorVersion:      "5.1",
+			ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+				{
+					RegionConfigs: []*akov2.AdvancedRegionConfig{
+						{
+							ProviderName: "TENANT",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cleanTenantFields(&spec)
+
+	expected := akov2.AtlasDeploymentSpec{
+		DeploymentSpec: &akov2.AdvancedDeploymentSpec{
+			BackupEnabled:            nil,
+			BiConnector:              nil,
+			EncryptionAtRestProvider: "",
+			PitEnabled:               nil,
+			MongoDBMajorVersion:      "",
+			ReplicationSpecs: []*akov2.AdvancedReplicationSpec{
+				{
+					RegionConfigs: []*akov2.AdvancedRegionConfig{
+						{
+							ProviderName: "TENANT",
+						},
+					},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(spec, expected) {
+		t.Fatalf("Cleaning tenant readonly fields mismatch.\r\nexpected: %v\r\ngot: %v\r\n", expected, spec)
+	}
+}

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -617,7 +617,7 @@ func TestCleanTenantFields(t *testing.T) {
 			if got := hasTenantRegionConfig(&akov2.AtlasDeployment{
 				Spec: tt.spec,
 			}); got != tt.expect {
-				t.Errorf("")
+				t.Errorf("expect hasTenantRegionConfig to be %t, got %t", tt.expect, got)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

When generating configuration/YAML for the Atlas Kubernetes Operator via the CLI, and the deployment is a shared/tenant cluster, read only fields (such as biConnector) are still exported and the operator tries to apply them. This results in an error from the Atlas API, as readonly attributes cannot be set.

This change means that when we are generating configuration for a shared cluster, we remove the readonly fields to avoid this issue; replicating the logic already used in the CLI [here](https://github.com/mongodb/mongodb-atlas-cli/blob/master/internal/cli/atlas/clusters/clusters.go#L82).

_Jira ticket:_ [CLOUDP-237545](https://jira.mongodb.org/browse/CLOUDP-237545)

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
