### PR TITLE
task: go back to rhel80 for since we don't run podman tests anymore

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1178,7 +1178,7 @@ buildvariants:
   - name: e2e_required
     display_name: "E2E Tests Required"
     run_on:
-      - rhel8.9-small
+      - rhel80-small
     expansions:
       <<: *go_linux_version
     tasks:


### PR DESCRIPTION
EVG is stuck on the 8.9 hosts and we can go back to 80 since we don't need podman 