### PR TITLE
CLOUDP-238828: Join actions on customDbRole creation

### DIFF
--- a/internal/cli/atlas/customdbroles/create.go
+++ b/internal/cli/atlas/customdbroles/create.go
@@ -61,7 +61,7 @@ func (opts *CreateOpts) Run() error {
 }
 
 func (opts *CreateOpts) newCustomDBRole() *atlasv2.UserCustomDBRole {
-	actions := convert.BuildAtlasActions(opts.action)
+	actions := joinActions(convert.BuildAtlasActions(opts.action))
 	inheritedRoles := convert.BuildAtlasInheritedRoles(opts.inheritedRoles)
 	return &atlasv2.UserCustomDBRole{
 		RoleName:       opts.roleName,


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

[CLOUDP-238828](https://jira.mongodb.org/browse/CLOUDP-238828)

Before
```shell
❯ atlas customDbRoles create testnew2 --privilege FIND@sample_restaurants."test3",FIND@sample_restaurants."test4" -P cloud-dev --debug

2024/03/20 17:17:28
POST /api/atlas/v2/groups/5efda6aea3f2ed2e7dd6ce05/customDBRoles/roles HTTP/1.1
Host: cloud-dev.mongodb.com
User-Agent: atlascli/1.17.0 (darwin;arm64;native)
Content-Length: 250
Accept: application/vnd.atlas.2023-01-01+json
Content-Type: application/vnd.atlas.2023-01-01+json
Accept-Encoding: gzip

{"actions":[{"action":"FIND","resources":[{"cluster":false,"collection":"test3","db":"sample_restaurants"}]},{"action":"FIND","resources":[{"cluster":false,"collection":"test4","db":"sample_restaurants"}]}],"inheritedRoles":[],"roleName":"testnew2"}

2024/03/20 17:17:29
HTTP/1.1 400 Bad Request
<redacted>

{"detail":"A custom role cannot have duplicate actions.","error":400,"errorCode":"ATLAS_DUPLICATE_CUSTOM_ROLE_ACTION","parameters":[],"reason":"Bad Request"}
Error: https://cloud-dev.mongodb.com/api/atlas/v2/groups/5efda6aea3f2ed2e7dd6ce05/customDBRoles/roles POST: HTTP 400 Bad Request (Error code: "ATLAS_DUPLICATE_CUSTOM_ROLE_ACTION") Detail: A custom role cannot have duplicate actions. Reason: Bad Request. Params: []
```
After
```shell
❯ atlasdev customDbRoles create testnew2 --privilege FIND@sample_restaurants."test3",FIND@sample_restaurants."test4" -P cloud-dev --debug

2024/03/20 17:18:53
POST /api/atlas/v2/groups/5efda6aea3f2ed2e7dd6ce05/customDBRoles/roles HTTP/1.1
Host: cloud-dev.mongodb.com
User-Agent: atlascli/1.17.0-14-g1bfb719e8 (darwin;arm64;native)
Content-Length: 218
Accept: application/vnd.atlas.2023-01-01+json
Content-Type: application/vnd.atlas.2023-01-01+json
Accept-Encoding: gzip

{"actions":[{"action":"FIND","resources":[{"cluster":false,"collection":"test4","db":"sample_restaurants"},{"cluster":false,"collection":"test3","db":"sample_restaurants"}]}],"inheritedRoles":[],"roleName":"testnew2"}

2024/03/20 17:18:54
HTTP/1.1 202 Accepted
Content-Type: application/vnd.atlas.2023-01-01+json;charset=utf-8
<redacted>

{"actions":[{"action":"FIND","resources":[{"collection":"test4","db":"sample_restaurants"},{"collection":"test3","db":"sample_restaurants"}]}],"inheritedRoles":[],"roleName":"testnew2"}
Custom database role 'testnew2' successfully created.
```
## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
