### PR TITLE
tests: don't delete my profile when testing

### DIFF
--- a/internal/cli/atlas/setup/setup_cmd_test.go
+++ b/internal/cli/atlas/setup/setup_cmd_test.go
@@ -59,7 +59,6 @@ func TestBuilder(t *testing.T) {
 }
 
 func Test_setupOpts_PreRunWithAPIKeys(t *testing.T) {
-	t.Cleanup(test.CleanupConfig)
 	ctrl := gomock.NewController(t)
 	mockFlow := mocks.NewMockRefresher(ctrl)
 	ctx := context.TODO()
@@ -99,7 +98,6 @@ func Test_setupOpts_RunSkipRegister(t *testing.T) {
 }
 
 func TestCluster_Run(t *testing.T) {
-	t.Cleanup(test.CleanupConfig)
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterQuickStarter(ctrl)
 	mockFlow := mocks.NewMockRefresher(ctrl)
@@ -158,7 +156,6 @@ func TestCluster_Run(t *testing.T) {
 }
 
 func TestCluster_Run_CheckFlagsSet(t *testing.T) {
-	t.Cleanup(test.CleanupConfig)
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockAtlasClusterQuickStarter(ctrl)
 	mockFlow := mocks.NewMockRefresher(ctrl)

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -39,6 +39,8 @@ import (
 type LoginConfig interface {
 	config.SetSaver
 	AccessTokenSubject() (string, error)
+	OrgID() string
+	ProjectID() string
 }
 
 var (
@@ -137,11 +139,11 @@ func (opts *LoginOpts) checkProfile(ctx context.Context) error {
 	if err := opts.InitStore(ctx); err != nil {
 		return err
 	}
-	if config.OrgID() != "" && !opts.OrgExists(config.OrgID()) {
+	if opts.config.OrgID() != "" && !opts.OrgExists(opts.config.OrgID()) {
 		opts.config.Set("org_id", "")
 	}
 
-	if config.ProjectID() != "" && !opts.ProjectExists(config.ProjectID()) {
+	if opts.config.ProjectID() != "" && !opts.ProjectExists(opts.config.ProjectID()) {
 		opts.config.Set("project_id", "")
 	}
 	return nil
@@ -158,7 +160,7 @@ func (opts *LoginOpts) setUpProfile(ctx context.Context) error {
 		}
 	}
 
-	if config.OrgID() == "" || !opts.OrgExists(config.OrgID()) {
+	if opts.config.OrgID() == "" || !opts.OrgExists(opts.config.OrgID()) {
 		if err := opts.AskOrg(); err != nil {
 			return err
 		}
@@ -166,7 +168,7 @@ func (opts *LoginOpts) setUpProfile(ctx context.Context) error {
 
 	opts.SetUpOrg()
 
-	if config.ProjectID() == "" || !opts.ProjectExists(config.ProjectID()) {
+	if opts.config.ProjectID() == "" || !opts.ProjectExists(opts.config.ProjectID()) {
 		if err := opts.AskProject(); err != nil {
 			return err
 		}
@@ -175,11 +177,11 @@ func (opts *LoginOpts) setUpProfile(ctx context.Context) error {
 
 	// Only make references to profile if user was asked about org or projects
 	if opts.AskedOrgsOrProjects && opts.ProjectID != "" && opts.OrgID != "" {
-		if !opts.ProjectExists(config.ProjectID()) {
+		if !opts.ProjectExists(opts.config.ProjectID()) {
 			return ErrProjectIDNotFound
 		}
 
-		if !opts.OrgExists(config.OrgID()) {
+		if !opts.OrgExists(opts.config.OrgID()) {
 			return ErrOrgIDNotFound
 		}
 

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -133,6 +133,8 @@ func Test_loginOpts_Run(t *testing.T) {
 	mockConfig.EXPECT().Set("access_token", "asdf").Times(1)
 	mockConfig.EXPECT().Set("refresh_token", "querty").Times(1)
 	mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
+	mockConfig.EXPECT().OrgID().Return("").AnyTimes()
+	mockConfig.EXPECT().ProjectID().Return("").AnyTimes()
 	mockConfig.EXPECT().AccessTokenSubject().Return("test@10gen.com", nil).Times(1)
 	mockConfig.EXPECT().Save().Return(nil).Times(2)
 	expectedOrgs := &admin.PaginatedOrganization{

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -68,7 +68,6 @@ func Test_logoutOpts_Run(t *testing.T) {
 }
 
 func Test_logoutOpts_Run_Keep(t *testing.T) {
-	t.Skip("")
 	ctrl := gomock.NewController(t)
 	mockFlow := mocks.NewMockRevoker(ctrl)
 	mockConfig := mocks.NewMockConfigDeleter(ctrl)

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -68,6 +68,7 @@ func Test_logoutOpts_Run(t *testing.T) {
 }
 
 func Test_logoutOpts_Run_Keep(t *testing.T) {
+	t.Skip("")
 	ctrl := gomock.NewController(t)
 	mockFlow := mocks.NewMockRevoker(ctrl)
 	mockConfig := mocks.NewMockConfigDeleter(ctrl)
@@ -88,6 +89,28 @@ func Test_logoutOpts_Run_Keep(t *testing.T) {
 		EXPECT().
 		RevokeToken(ctx, gomock.Any(), gomock.Any()).
 		Return(nil, nil).
+		Times(1)
+
+	mockConfig.
+		EXPECT().
+		SetAccessToken("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		SetRefreshToken("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		SetProjectID("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		SetOrgID("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		Save().
+		Return(nil).
 		Times(1)
 
 	require.NoError(t, opts.Run(ctx))

--- a/internal/cli/auth/register.go
+++ b/internal/cli/auth/register.go
@@ -99,9 +99,9 @@ func RegisterBuilder() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "register",
 		Short: "Register with MongoDB Atlas.",
-		Example: fmt.Sprintf(`  # To start the interactive setup:
-  %s auth register
-`, config.BinName()),
+		Example: `  # To start the interactive setup:
+  atlas auth register
+`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			opts.OutWriter = cmd.OutOrStdout()
 			defaultProfile := config.Default()

--- a/internal/cli/auth/register_test.go
+++ b/internal/cli/auth/register_test.go
@@ -43,7 +43,6 @@ func TestRegisterBuilder(t *testing.T) {
 }
 
 func Test_registerOpts_Run(t *testing.T) {
-	t.Cleanup(test.CleanupConfig)
 	ctrl := gomock.NewController(t)
 	mockFlow := mocks.NewMockRefresher(ctrl)
 	mockConfig := mocks.NewMockLoginConfig(ctrl)
@@ -96,6 +95,8 @@ func Test_registerOpts_Run(t *testing.T) {
 	mockConfig.EXPECT().Set("access_token", "asdf").Times(1)
 	mockConfig.EXPECT().Set("refresh_token", "querty").Times(1)
 	mockConfig.EXPECT().Set("ops_manager_url", gomock.Any()).Times(0)
+	mockConfig.EXPECT().OrgID().Return("").AnyTimes()
+	mockConfig.EXPECT().ProjectID().Return("").AnyTimes()
 	mockConfig.EXPECT().AccessTokenSubject().Return("test@10gen.com", nil).Times(1)
 	mockConfig.EXPECT().Save().Return(nil).Times(2)
 	expectedOrgs := &admin.PaginatedOrganization{
@@ -104,13 +105,21 @@ func Test_registerOpts_Run(t *testing.T) {
 			{Id: pointer.Get("o1"), Name: "Org1"},
 		},
 	}
-	mockStore.EXPECT().Organizations(gomock.Any()).Return(expectedOrgs, nil).Times(1)
+	mockStore.
+		EXPECT().
+		Organizations(gomock.Any()).
+		Return(expectedOrgs, nil).
+		Times(1)
 	expectedProjects := &admin.PaginatedAtlasGroup{TotalCount: pointer.Get(1),
 		Results: &[]admin.Group{
 			{Id: pointer.Get("p1"), Name: "Project1"},
 		},
 	}
-	mockStore.EXPECT().GetOrgProjects("o1", gomock.Any()).Return(expectedProjects, nil).Times(1)
+	mockStore.
+		EXPECT().
+		GetOrgProjects("o1", gomock.Any()).
+		Return(expectedProjects, nil).
+		Times(1)
 
 	require.NoError(t, opts.RegisterRun(ctx))
 	assert.Equal(t, `

--- a/internal/mocks/mock_login.go
+++ b/internal/mocks/mock_login.go
@@ -48,6 +48,34 @@ func (mr *MockLoginConfigMockRecorder) AccessTokenSubject() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessTokenSubject", reflect.TypeOf((*MockLoginConfig)(nil).AccessTokenSubject))
 }
 
+// OrgID mocks base method.
+func (m *MockLoginConfig) OrgID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OrgID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// OrgID indicates an expected call of OrgID.
+func (mr *MockLoginConfigMockRecorder) OrgID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OrgID", reflect.TypeOf((*MockLoginConfig)(nil).OrgID))
+}
+
+// ProjectID mocks base method.
+func (m *MockLoginConfig) ProjectID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProjectID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ProjectID indicates an expected call of ProjectID.
+func (mr *MockLoginConfigMockRecorder) ProjectID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProjectID", reflect.TypeOf((*MockLoginConfig)(nil).ProjectID))
+}
+
 // Save mocks base method.
 func (m *MockLoginConfig) Save() error {
 	m.ctrl.T.Helper()

--- a/internal/mocks/mock_logout.go
+++ b/internal/mocks/mock_logout.go
@@ -86,3 +86,65 @@ func (mr *MockConfigDeleterMockRecorder) Delete() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockConfigDeleter)(nil).Delete))
 }
+
+// Save mocks base method.
+func (m *MockConfigDeleter) Save() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Save")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Save indicates an expected call of Save.
+func (mr *MockConfigDeleterMockRecorder) Save() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockConfigDeleter)(nil).Save))
+}
+
+// SetAccessToken mocks base method.
+func (m *MockConfigDeleter) SetAccessToken(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetAccessToken", arg0)
+}
+
+// SetAccessToken indicates an expected call of SetAccessToken.
+func (mr *MockConfigDeleterMockRecorder) SetAccessToken(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAccessToken", reflect.TypeOf((*MockConfigDeleter)(nil).SetAccessToken), arg0)
+}
+
+// SetOrgID mocks base method.
+func (m *MockConfigDeleter) SetOrgID(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOrgID", arg0)
+}
+
+// SetOrgID indicates an expected call of SetOrgID.
+func (mr *MockConfigDeleterMockRecorder) SetOrgID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOrgID", reflect.TypeOf((*MockConfigDeleter)(nil).SetOrgID), arg0)
+}
+
+// SetProjectID mocks base method.
+func (m *MockConfigDeleter) SetProjectID(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetProjectID", arg0)
+}
+
+// SetProjectID indicates an expected call of SetProjectID.
+func (mr *MockConfigDeleterMockRecorder) SetProjectID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProjectID", reflect.TypeOf((*MockConfigDeleter)(nil).SetProjectID), arg0)
+}
+
+// SetRefreshToken mocks base method.
+func (m *MockConfigDeleter) SetRefreshToken(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetRefreshToken", arg0)
+}
+
+// SetRefreshToken indicates an expected call of SetRefreshToken.
+func (mr *MockConfigDeleterMockRecorder) SetRefreshToken(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRefreshToken", reflect.TypeOf((*MockConfigDeleter)(nil).SetRefreshToken), arg0)
+}


### PR DESCRIPTION
There were a couple of bugs on various tests depending on global state of the cli config and leaking into the actual config file causing unexpected deletions

Fixing by not depending on the global state