### PR TITLE
tests: add mising go:build unit

### DIFF
--- a/internal/cli/atlas/backup/compliancepolicy/describe_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/describe_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package compliancepolicy
 
 import (

--- a/internal/cli/atlas/backup/compliancepolicy/enable_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/enable_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package compliancepolicy
 
 import (

--- a/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/pointintimerestore_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/pointintimerestore/pointintimerestore_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package pointintimerestore
 
 import (

--- a/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/create_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/create_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package ondemand
 
 import (

--- a/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/describe_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/describe_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package ondemand
 
 import (

--- a/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/update_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/ondemand/update_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package ondemand
 
 import (

--- a/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/create_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/create_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package scheduled
 
 import (

--- a/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/describe_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/policies/scheduled/describe_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package scheduled
 
 import (

--- a/internal/cli/atlas/backup/compliancepolicy/setup_test.go
+++ b/internal/cli/atlas/backup/compliancepolicy/setup_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package compliancepolicy
 
 import (

--- a/internal/cli/atlas/backup/exports/buckets/buckets_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/buckets_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package buckets
 
 import (

--- a/internal/cli/atlas/backup/exports/buckets/create_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/create_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package buckets
 
 import (

--- a/internal/cli/atlas/backup/exports/buckets/list_test.go
+++ b/internal/cli/atlas/backup/exports/buckets/list_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package buckets
 
 import (

--- a/internal/cli/atlas/backup/exports/jobs/create_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/create_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package jobs
 
 import (

--- a/internal/cli/atlas/backup/exports/jobs/describe_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/describe_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package jobs
 
 import (

--- a/internal/cli/atlas/backup/exports/jobs/list_test.go
+++ b/internal/cli/atlas/backup/exports/jobs/list_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package jobs
 
 import (

--- a/internal/cli/atlas/backup/restores/restores_test.go
+++ b/internal/cli/atlas/backup/restores/restores_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package restores
 
 import (

--- a/internal/cli/atlas/backup/schedule/delete_test.go
+++ b/internal/cli/atlas/backup/schedule/delete_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package schedule
 
 import (

--- a/internal/cli/atlas/backup/schedule/describe_test.go
+++ b/internal/cli/atlas/backup/schedule/describe_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package schedule
 
 import (

--- a/internal/cli/atlas/backup/schedule/schedule_test.go
+++ b/internal/cli/atlas/backup/schedule/schedule_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package schedule
 
 import (

--- a/internal/cli/atlas/deployments/connect_test.go
+++ b/internal/cli/atlas/deployments/connect_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package deployments
 
 import (

--- a/internal/cli/atlas/events/events_test.go
+++ b/internal/cli/atlas/events/events_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package events
 
 import (

--- a/internal/cli/atlas/events/list_test.go
+++ b/internal/cli/atlas/events/list_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package events
 
 import (

--- a/internal/cli/atlas/events/orgs_list_test.go
+++ b/internal/cli/atlas/events/orgs_list_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package events
 
 import (

--- a/internal/cli/atlas/events/projects_list_test.go
+++ b/internal/cli/atlas/events/projects_list_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package events
 
 import (

--- a/internal/cli/atlas/kubernetes/config/apply_test.go
+++ b/internal/cli/atlas/kubernetes/config/apply_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package config
 
 import (

--- a/internal/cli/atlas/kubernetes/config/config_test.go
+++ b/internal/cli/atlas/kubernetes/config/config_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package config
 
 import (

--- a/internal/cli/atlas/kubernetes/config/generate_test.go
+++ b/internal/cli/atlas/kubernetes/config/generate_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package config
 
 import (

--- a/internal/cli/atlas/kubernetes/kubernetes_test.go
+++ b/internal/cli/atlas/kubernetes/kubernetes_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package kubernetes
 
 import (

--- a/internal/cli/atlas/kubernetes/operator/install_test.go
+++ b/internal/cli/atlas/kubernetes/operator/install_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package operator
 
 import (

--- a/internal/cli/atlas/kubernetes/operator/operator_test.go
+++ b/internal/cli/atlas/kubernetes/operator/operator_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package operator
 
 import (

--- a/internal/cli/atlas/search/nodes/delete_test.go
+++ b/internal/cli/atlas/search/nodes/delete_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package nodes
 
 import (

--- a/internal/cli/atlas/search/nodes/list_test.go
+++ b/internal/cli/atlas/search/nodes/list_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package nodes
 
 import (

--- a/internal/cli/atlas/search/nodes/nodes_test.go
+++ b/internal/cli/atlas/search/nodes/nodes_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package nodes
 
 import (

--- a/internal/cli/atlas/serverless/backup/restores/restores_test.go
+++ b/internal/cli/atlas/serverless/backup/restores/restores_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package restores
 
 import (

--- a/internal/cli/atlas/streams/connection/connection_test.go
+++ b/internal/cli/atlas/streams/connection/connection_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package connection
 
 import (

--- a/internal/cli/atlas/streams/connection/create_test.go
+++ b/internal/cli/atlas/streams/connection/create_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package connection
 
 import (

--- a/internal/cli/atlas/streams/connection/delete_test.go
+++ b/internal/cli/atlas/streams/connection/delete_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package connection
 
 import (

--- a/internal/cli/atlas/streams/connection/describe_test.go
+++ b/internal/cli/atlas/streams/connection/describe_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package connection
 
 import (

--- a/internal/cli/atlas/streams/connection/list_test.go
+++ b/internal/cli/atlas/streams/connection/list_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package connection
 
 import (

--- a/internal/cli/atlas/streams/connection/update_test.go
+++ b/internal/cli/atlas/streams/connection/update_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package connection
 
 import (

--- a/internal/cli/atlas/streams/instance/create_test.go
+++ b/internal/cli/atlas/streams/instance/create_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package instance
 
 import (

--- a/internal/cli/atlas/streams/instance/delete_test.go
+++ b/internal/cli/atlas/streams/instance/delete_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package instance
 
 import (

--- a/internal/cli/atlas/streams/instance/describe_test.go
+++ b/internal/cli/atlas/streams/instance/describe_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package instance
 
 import (

--- a/internal/cli/atlas/streams/instance/instance_test.go
+++ b/internal/cli/atlas/streams/instance/instance_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package instance
 
 import (

--- a/internal/cli/atlas/streams/instance/list_test.go
+++ b/internal/cli/atlas/streams/instance/list_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package instance
 
 import (

--- a/internal/cli/atlas/streams/instance/update_test.go
+++ b/internal/cli/atlas/streams/instance/update_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package instance
 
 import (

--- a/internal/cli/atlas/streams/streams_test.go
+++ b/internal/cli/atlas/streams/streams_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package streams
 
 import (

--- a/internal/cli/atlas/teams/rename_test.go
+++ b/internal/cli/atlas/teams/rename_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package teams
 
 import (

--- a/internal/cli/workflows/flags_test.go
+++ b/internal/cli/workflows/flags_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package workflows
 
 import (

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/templatewriter"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -41,14 +40,6 @@ func CmdValidator(t *testing.T, subject *cobra.Command, nSubCommands int, flags 
 	for _, f := range flags {
 		a.NotNilf(subject.Flags().Lookup(f), "command has no flag: %s", f)
 	}
-}
-
-func CleanupConfig() {
-	config.SetAccessToken("")
-	config.SetPublicAPIKey("")
-	config.SetPrivateAPIKey("")
-	config.SetOrgID("")
-	config.SetProjectID("")
 }
 
 // VerifyOutputTemplate validates that the given template string is valid.


### PR DESCRIPTION
Spotted while trying to spot the tests deleting the profile we were missing some unit build tags

This PR only adds `//go:build unit` to tests that were missing it