### PR TITLE
task: use the recommended slice initialization

### DIFF
--- a/internal/cli/atlas/datalakepipelines/create.go
+++ b/internal/cli/atlas/datalakepipelines/create.go
@@ -114,13 +114,13 @@ func (opts *CreateOpts) newCreateRequest() (*atlasv2.DataLakeIngestionPipeline, 
 		},
 	}
 
-	partitionFields := []atlasv2.DataLakePipelinesPartitionField{}
+	partitionFields := make([]atlasv2.DataLakePipelinesPartitionField, len(opts.sinkPartitionField))
 	for i, fieldName := range opts.sinkPartitionField {
-		partitionFields = append(partitionFields, *atlasv2.NewDataLakePipelinesPartitionField(fieldName, i))
+		partitionFields[i] = *atlasv2.NewDataLakePipelinesPartitionField(fieldName, i)
 	}
 	pipeline.Sink.SetPartitionFields(partitionFields)
 
-	transformations := []atlasv2.FieldTransformation{}
+	var transformations []atlasv2.FieldTransformation
 	for _, entry := range opts.transform {
 		entries := strings.Split(entry, ":")
 		transformType := entries[0]

--- a/internal/cli/atlas/datalakepipelines/update.go
+++ b/internal/cli/atlas/datalakepipelines/update.go
@@ -108,13 +108,13 @@ func (opts *UpdateOpts) newUpdateRequest() (*atlasv2.DataLakeIngestionPipeline, 
 		},
 	}
 
-	partitionFields := []atlasv2.DataLakePipelinesPartitionField{}
+	partitionFields := make([]atlasv2.DataLakePipelinesPartitionField, len(opts.sinkPartitionField))
 	for i, fieldName := range opts.sinkPartitionField {
-		partitionFields = append(partitionFields, *atlasv2.NewDataLakePipelinesPartitionField(fieldName, i))
+		partitionFields[i] = *atlasv2.NewDataLakePipelinesPartitionField(fieldName, i)
 	}
 	pipeline.Sink.SetPartitionFields(partitionFields)
 
-	transformations := []atlasv2.FieldTransformation{}
+	var transformations []atlasv2.FieldTransformation
 	for _, entry := range opts.transform {
 		entries := strings.Split(entry, ":")
 		transformType := entries[0]

--- a/internal/cli/atlas/security/ldap/save.go
+++ b/internal/cli/atlas/security/ldap/save.go
@@ -97,7 +97,7 @@ func (opts *SaveOpts) validate() error {
 }
 
 func (opts *SaveOpts) newLDAPConfiguration() *atlasv2.UserSecurity {
-	userToDNMapping := []atlasv2.UserToDNMapping{}
+	var userToDNMapping []atlasv2.UserToDNMapping
 	if opts.mappingMatch != "" {
 		mapping := atlasv2.UserToDNMapping{Match: opts.mappingMatch}
 		if opts.mappingLdapQuery != "" {

--- a/internal/cli/atlas/serverless/create.go
+++ b/internal/cli/atlas/serverless/create.go
@@ -73,7 +73,7 @@ func (opts *CreateOpts) newServerlessCreateRequestParams() *atlasv2.ServerlessIn
 	}
 
 	if len(opts.tag) > 0 {
-		tags := []atlasv2.ResourceTag{}
+		var tags []atlasv2.ResourceTag
 		for k, v := range opts.tag {
 			if k != "" && v != "" {
 				tags = append(tags, atlasv2.ResourceTag{Key: k, Value: v})

--- a/internal/cli/atlas/serverless/update.go
+++ b/internal/cli/atlas/serverless/update.go
@@ -71,7 +71,7 @@ func (opts *UpdateOpts) newServerlessUpdateRequestParams() *atlasv2.ServerlessIn
 	}
 
 	if len(opts.tag) > 0 {
-		tags := []atlasv2.ResourceTag{}
+		var tags []atlasv2.ResourceTag
 		for k, v := range opts.tag {
 			if k != "" && v != "" {
 				tags = append(tags, atlasv2.ResourceTag{Key: k, Value: v})

--- a/internal/cli/atlas/setup/cluster_setup.go
+++ b/internal/cli/atlas/setup/cluster_setup.go
@@ -107,7 +107,7 @@ func (opts *Opts) newCluster() *atlasv2.AdvancedClusterDescription {
 	}
 
 	if len(opts.Tag) > 0 {
-		tags := []atlasv2.ResourceTag{}
+		var tags []atlasv2.ResourceTag
 		for k, v := range opts.Tag {
 			if k != "" && v != "" {
 				tags = append(tags, atlasv2.ResourceTag{Key: k, Value: v})

--- a/internal/kubernetes/operator/project/project.go
+++ b/internal/kubernetes/operator/project/project.go
@@ -817,7 +817,7 @@ func buildAlertConfigurations(acProvider store.AlertConfigurationLister, project
 		return akoNotifications, akoSecrets
 	}
 
-	secretResults := []*corev1.Secret{}
+	var secretResults []*corev1.Secret
 	results := make([]akov2.AlertConfiguration, 0, len(data.GetResults()))
 	for _, alertConfig := range data.GetResults() {
 		notifications, notificationSecrets := convertNotifications(alertConfig.GetNotifications())

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -482,8 +482,7 @@ func (o *client) Version(ctx context.Context) (version *Version, err error) {
 
 func (o *client) Logs(ctx context.Context) (map[string]interface{}, []error) {
 	l := map[string]interface{}{}
-	errs := []error{}
-
+	var errs []error
 	output, err := o.runPodman(ctx, "ps", "--all", "--format", "json", "--filter", "name=mongo")
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
Ran some IDEA code inspection tools and found these as recommended fixes 
prefer `var mySlice []string` over `mySlice := []string{}`, it also helped linting flag usages where we could pre-allocate the size of the slice 