### PR TITLE
CLOUDP-240596: fix search index create watcher for Atlas deployments

### DIFF
--- a/internal/cli/deployments/search/indexes/create.go
+++ b/internal/cli/deployments/search/indexes/create.go
@@ -43,7 +43,6 @@ const (
 )
 
 var ErrSearchIndexDuplicated = errors.New("search index is duplicated")
-var ErrWatchNotAvailable = errors.New("watch is not available for Atlas resources")
 
 type CreateOpts struct {
 	cli.WatchOpts
@@ -263,10 +262,6 @@ func CreateBuilder() *cobra.Command {
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
 			opts.WatchOpts.OutWriter = w
-
-			if opts.DeploymentType == "atlas" && opts.EnableWatch {
-				return ErrWatchNotAvailable
-			}
 
 			if opts.Filename != "" && (opts.DBName != "" || opts.Collection != "") {
 				return errors.New("the '-file' flag cannot be used in conjunction with the 'db' and 'collection' flags, please choose either 'file' or 'db' and '-collection', but not both")

--- a/internal/cli/deployments/search/indexes/create.go
+++ b/internal/cli/deployments/search/indexes/create.go
@@ -26,7 +26,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mongodbclient"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
@@ -178,7 +177,7 @@ func (opts *CreateOpts) watchAtlas(_ context.Context) (any, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	if pointer.GetOrZero(index.Status) == "STEADY" {
+	if index.GetStatus() == "STEADY" {
 		return index, true, nil
 	}
 	return nil, false, nil

--- a/internal/mocks/mock_search.go
+++ b/internal/mocks/mock_search.go
@@ -87,6 +87,21 @@ func (mr *MockSearchIndexCreatorMockRecorder) CreateSearchIndexes(arg0, arg1, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSearchIndexes", reflect.TypeOf((*MockSearchIndexCreator)(nil).CreateSearchIndexes), arg0, arg1, arg2)
 }
 
+// SearchIndex mocks base method.
+func (m *MockSearchIndexCreator) SearchIndex(arg0, arg1, arg2 string) (*admin.ClusterSearchIndex, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchIndex", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*admin.ClusterSearchIndex)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchIndex indicates an expected call of SearchIndex.
+func (mr *MockSearchIndexCreatorMockRecorder) SearchIndex(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchIndex", reflect.TypeOf((*MockSearchIndexCreator)(nil).SearchIndex), arg0, arg1, arg2)
+}
+
 // MockSearchIndexDescriber is a mock of SearchIndexDescriber interface.
 type MockSearchIndexDescriber struct {
 	ctrl     *gomock.Controller

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -26,6 +26,7 @@ type SearchIndexLister interface {
 
 type SearchIndexCreator interface {
 	CreateSearchIndexes(string, string, *atlasv2.ClusterSearchIndex) (*atlasv2.ClusterSearchIndex, error)
+	SearchIndex(string, string, string) (*atlasv2.ClusterSearchIndex, error)
 }
 
 type SearchIndexDescriber interface {

--- a/test/e2e/atlas/deployments_atlas_test.go
+++ b/test/e2e/atlas/deployments_atlas_test.go
@@ -144,7 +144,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 	})
 	require.NoError(t, watchCluster(g.projectID, clusterName))
 
-	t.Run("Create Index", func(t *testing.T) {
+	t.Run("Create Search Index", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			deploymentEntity,
 			searchEntity,
@@ -159,6 +159,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 			databaseNameAtlas,
 			"--collection",
 			collectionNameAtlas,
+			"--watch",
 		)
 		cmd.Env = os.Environ()
 


### PR DESCRIPTION
## Proposed changes
fix search index create watcher for Atlas deployments


_Jira ticket:_ CLOUDP-240596

Testing:
* Atlas deployment: https://spruce.mongodb.com/task/mongodb_atlas_cli_master_e2e_atlas_deployments_atlas_deployments_atlas_clusters_e2e_patch_07319bbad7ef2b9d622be191947b63f4efc256fd_660c07c0bd7dd000079b2ccc_24_04_02_13_27_29/logs?execution=0
* Local deployment: https://spruce.mongodb.com/task/mongodb_atlas_cli_master_e2e_local_deployments_atlas_deployments_local_noauth_e2e_patch_07319bbad7ef2b9d622be191947b63f4efc256fd_660c07c0bd7dd000079b2ccc_24_04_02_13_27_29/logs?execution=0