### PR TITLE
CLOUDP-219248: Support --tier in Atlas Stream Instance Create command

### DIFF
--- a/docs/command/atlas-streams-instances-create.txt
+++ b/docs/command/atlas-streams-instances-create.txt
@@ -73,6 +73,10 @@ Options
      - string
      - true
      - Human-readable label that identifies the physical location of your Atlas Stream Processing instance. The region can affect network latency and performance if it is far from your source or sink.
+   * - --tier
+     - string
+     - false
+     - Tier for your Stream Instance. This value defaults to "SP30".
 
 Inherited Options
 -----------------
@@ -106,4 +110,4 @@ Examples
 .. code-block::
 
    # Deploy an Atlas Stream Processing instance called myProcessor for the project with the ID 5e2211c17a3e5a48f5497de3:
-   atlas streams instance create myProcessor --projectId 5e2211c17a3e5a48f5497de3 --provider AWS --region VIRGINIA_USA
+   atlas streams instance create myProcessor --projectId 5e2211c17a3e5a48f5497de3 --provider AWS --region VIRGINIA_USA --tier SP30

--- a/internal/cli/streams/instance/create.go
+++ b/internal/cli/streams/instance/create.go
@@ -41,6 +41,7 @@ type CreateOpts struct {
 
 const (
 	createTemplate = "Atlas Streams Processor Instance '{{.Name}}' successfully created.\n"
+	defaultTier    = "SP30"
 )
 
 func (opts *CreateOpts) Run() error {
@@ -48,11 +49,14 @@ func (opts *CreateOpts) Run() error {
 	streamProcessor.Name = &opts.name
 	streamProcessor.GroupId = &opts.ProjectID
 	streamProcessor.DataProcessRegion = atlasv2.NewStreamsDataProcessRegion(opts.provider, opts.region)
+
+	tierOrDefault := defaultTier
 	if opts.tier != "" {
-		streamConfig := streamProcessor.GetStreamConfig()
-		streamConfig.Tier = &opts.tier
-		streamProcessor.StreamConfig = &streamConfig
+		tierOrDefault = opts.tier
 	}
+	streamConfig := streamProcessor.GetStreamConfig()
+	streamConfig.Tier = &tierOrDefault
+	streamProcessor.StreamConfig = &streamConfig
 
 	r, err := opts.store.CreateStream(opts.ProjectID, streamProcessor)
 

--- a/internal/cli/streams/instance/create_test.go
+++ b/internal/cli/streams/instance/create_test.go
@@ -27,32 +27,71 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20231115008/admin"
 )
 
+const (
+	testProjectID = "create-project-id"
+)
+
 func TestCreateOpts_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockStreamsCreator(ctrl)
 
-	buf := new(bytes.Buffer)
-	opts := &CreateOpts{
-		store:    mockStore,
-		name:     "ExampleStream",
-		provider: "AWS",
-		region:   "VIRGINIA_USA",
-	}
-	opts.ProjectID = "create-project-id"
+	t.Run("stream instances create", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		opts := &CreateOpts{
+			store:    mockStore,
+			name:     "ExampleStream",
+			provider: "AWS",
+			region:   "VIRGINIA_USA",
+		}
+		opts.ProjectID = testProjectID
 
-	expected := &atlasv2.StreamsTenant{Name: &opts.name, GroupId: &opts.ProjectID, DataProcessRegion: &atlasv2.StreamsDataProcessRegion{CloudProvider: "AWS", Region: "VIRGINIA_USA"}}
+		expected := &atlasv2.StreamsTenant{Name: &opts.name, GroupId: &opts.ProjectID, DataProcessRegion: &atlasv2.StreamsDataProcessRegion{CloudProvider: "AWS", Region: "VIRGINIA_USA"}}
 
-	mockStore.
-		EXPECT().
-		CreateStream(opts.ProjectID, expected).
-		Return(expected, nil).
-		Times(1)
+		mockStore.
+			EXPECT().
+			CreateStream(opts.ProjectID, expected).
+			Return(expected, nil).
+			Times(1)
 
-	if err := opts.Run(); err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
-	}
-	t.Log(buf.String())
-	test.VerifyOutputTemplate(t, createTemplate, expected)
+		if err := opts.Run(); err != nil {
+			t.Fatalf("Run() unexpected error: %v", err)
+		}
+		t.Log(buf.String())
+		test.VerifyOutputTemplate(t, createTemplate, expected)
+	})
+
+	t.Run("stream instances create --tier", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		opts := &CreateOpts{
+			store:    mockStore,
+			name:     "ExampleStream",
+			provider: "AWS",
+			region:   "VIRGINIA_USA",
+			tier:     "SP30",
+		}
+		opts.ProjectID = testProjectID
+
+		expected := &atlasv2.StreamsTenant{
+			Name:              &opts.name,
+			GroupId:           &opts.ProjectID,
+			DataProcessRegion: &atlasv2.StreamsDataProcessRegion{CloudProvider: "AWS", Region: "VIRGINIA_USA"},
+			StreamConfig: &atlasv2.StreamConfig{
+				Tier: &opts.tier,
+			},
+		}
+
+		mockStore.
+			EXPECT().
+			CreateStream(opts.ProjectID, expected).
+			Return(expected, nil).
+			Times(1)
+
+		if err := opts.Run(); err != nil {
+			t.Fatalf("Run() unexpected error: %v", err)
+		}
+		t.Log(buf.String())
+		test.VerifyOutputTemplate(t, createTemplate, expected)
+	})
 }
 
 func TestCreateBuilder(t *testing.T) {
@@ -61,5 +100,14 @@ func TestCreateBuilder(t *testing.T) {
 		CreateBuilder(),
 		0,
 		[]string{flag.Provider, flag.Region},
+	)
+}
+
+func TestCreateBuilderWithTier(t *testing.T) {
+	test.CmdValidator(
+		t,
+		CreateBuilder(),
+		0,
+		[]string{flag.Provider, flag.Region, flag.Tier},
 	)
 }

--- a/internal/cli/streams/instance/create_test.go
+++ b/internal/cli/streams/instance/create_test.go
@@ -107,15 +107,6 @@ func TestCreateBuilder(t *testing.T) {
 		t,
 		CreateBuilder(),
 		0,
-		[]string{flag.Provider, flag.Region},
-	)
-}
-
-func TestCreateBuilderWithTier(t *testing.T) {
-	test.CmdValidator(
-		t,
-		CreateBuilder(),
-		0,
 		[]string{flag.Provider, flag.Region, flag.Tier},
 	)
 }

--- a/internal/cli/streams/instance/create_test.go
+++ b/internal/cli/streams/instance/create_test.go
@@ -44,8 +44,16 @@ func TestCreateOpts_Run(t *testing.T) {
 			region:   "VIRGINIA_USA",
 		}
 		opts.ProjectID = testProjectID
+		defaultTier := "SP30"
 
-		expected := &atlasv2.StreamsTenant{Name: &opts.name, GroupId: &opts.ProjectID, DataProcessRegion: &atlasv2.StreamsDataProcessRegion{CloudProvider: "AWS", Region: "VIRGINIA_USA"}}
+		expected := &atlasv2.StreamsTenant{
+			Name:              &opts.name,
+			GroupId:           &opts.ProjectID,
+			DataProcessRegion: &atlasv2.StreamsDataProcessRegion{CloudProvider: "AWS", Region: "VIRGINIA_USA"},
+			StreamConfig: &atlasv2.StreamConfig{
+				Tier: &defaultTier,
+			},
+		}
 
 		mockStore.
 			EXPECT().
@@ -67,7 +75,7 @@ func TestCreateOpts_Run(t *testing.T) {
 			name:     "ExampleStream",
 			provider: "AWS",
 			region:   "VIRGINIA_USA",
-			tier:     "SP30",
+			tier:     "SP10", // Test non default case
 		}
 		opts.ProjectID = testProjectID
 

--- a/internal/cli/streams/instance/create_test.go
+++ b/internal/cli/streams/instance/create_test.go
@@ -42,16 +42,16 @@ func TestCreateOpts_Run(t *testing.T) {
 			name:     "ExampleStream",
 			provider: "AWS",
 			region:   "VIRGINIA_USA",
+			tier:     "SP30", // Test non default case
 		}
 		opts.ProjectID = testProjectID
-		defaultTier := "SP30"
 
 		expected := &atlasv2.StreamsTenant{
 			Name:              &opts.name,
 			GroupId:           &opts.ProjectID,
 			DataProcessRegion: &atlasv2.StreamsDataProcessRegion{CloudProvider: "AWS", Region: "VIRGINIA_USA"},
 			StreamConfig: &atlasv2.StreamConfig{
-				Tier: &defaultTier,
+				Tier: &opts.tier,
 			},
 		}
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -233,6 +233,7 @@ dbName and collection are required only for built-in roles.`
 	StreamsProvider                           = "Cloud service provider that applies to the provisioned Atlas Stream Processing instance."
 	StreamsInstance                           = "Name of your Atlas Stream Processing instance."
 	StreamsConnectionFilename                 = "Path to a JSON configuration file that defines an Atlas Stream Processing connection."
+	StreamsInstanceTier                       = "Tier for your Stream Instance."
 	WithoutDefaultAlertSettings               = "Flag that creates the new project without the default alert settings enabled. This flag defaults to false. This option is useful if you create projects programmatically and want to create your own alerts instead of using the default alert settings."
 	FormatOut                                 = "Output format. Valid values are json, json-path, go-template, or go-template-file. To see the full output, use the -o json option."
 	TargetClusterName                         = "Name of the target cluster. For use only with automated restore jobs. You must specify a targetClusterName for automated restores."

--- a/test/e2e/atlas/streams_test.go
+++ b/test/e2e/atlas/streams_test.go
@@ -78,6 +78,8 @@ func TestStreams(t *testing.T) {
 			"AWS",
 			"-r",
 			"VIRGINIA_USA",
+			"--tier",
+			"SP30",
 			instanceName,
 			"-o=json",
 			"--projectId",


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

- Introduce a new optional flag, `--tier` for the Atlas Stream Processing create instance command.
- This value defaults to `SP30`, in the coming months we will support `SP10` as well.
  - Note, the public API already supports receiving this value. 

```
To get started quickly, specify a name, a cloud provider, and a region to configure an Atlas Stream Processing instance.To use this command, you must authenticate with a user account or an API key with the Project Owner role.

Usage:
  atlas streams instances create <name> [flags]

Examples:
  # Deploy an Atlas Stream Processing instance called myProcessor for the project with the ID 5e2211c17a3e5a48f5497de3:
  atlas streams instance create myProcessor --projectId 5e2211c17a3e5a48f5497de3 --provider AWS --region VIRGINIA_USA --tier SP30

Flags:
  -h, --help               help for create
  -o, --output string      Output format. Valid values are json, json-path, go-template, or go-template-file. To see the full output, use the -o json option.
      --projectId string   Hexadecimal string that identifies the project to use. This option overrides the settings in the configuration file or environment variable.
      --provider string    Cloud service provider that applies to the provisioned Atlas Stream Processing instance. (default "AWS")
  -r, --region string      Human-readable label that identifies the physical location of your Atlas Stream Processing instance. The region can affect network latency and performance if it is far from your source or sink.
      --tier string        Tier for your Stream Instance. (default "SP30")

Global Flags:
  -P, --profile string   Name of the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings.
```

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-219248

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [✅] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [✅] I have added tests that prove my fix is effective or that my feature works
- [✅] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [N/A] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [N/A] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [✅] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
