### PR TITLE
CLOUDP-240399 Checksum for the Atlas CLI is missing .msi for Windows (#2836)

### DIFF
--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -90,6 +90,8 @@ nfpms:
   formats: [deb,rpm]
 checksum:
   name_template: checksums.txt
+  extra_files:
+    - glob: ./bin/*.msi
 snapshot:
   name_template: "{{ .Env.VERSION_GIT }}-next"
 changelog:


### PR DESCRIPTION
Backport #2836 into [mongocli-master](https://github.com/mongodb/mongodb-atlas-cli/tree/mongocli-master)