### PR TITLE
task: drop config file delegation

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -83,7 +83,7 @@ func shouldCopyConfig(atlasConfigPath string) bool {
 
 // createConfigFromMongoCLIConfig creates the atlasCLI config file from the mongocli config file.
 func createConfigFromMongoCLIConfig() {
-	atlasConfigHomePath, err := config.AtlasCLIConfigHome()
+	atlasConfigHomePath, err := config.CLIConfigHome()
 	if err != nil {
 		return
 	}
@@ -145,7 +145,7 @@ func mongoCLIConfigFilePath() (configPath string, err error) {
 	}
 
 	if configDir, err := config.OldMongoCLIConfigHome(); err == nil { //nolint:staticcheck // Deprecated before fully removing support in the future
-		configPath = fmt.Sprintf("%s/mongocli.toml", configDir)
+		configPath = path.Join(configDir, "mongocli.toml")
 	}
 
 	if _, err := os.Stat(configPath); err != nil {

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -734,19 +734,14 @@ func MongoCLIConfigHome() (string, error) {
 	return path.Join(home, "mongocli"), nil
 }
 
-// AtlasCLIConfigHome retrieves configHome path based used by AtlasCLI.
-func AtlasCLIConfigHome() (string, error) {
+// CLIConfigHome retrieves configHome path.
+func CLIConfigHome() (string, error) {
 	home, err := os.UserConfigDir()
 	if err != nil {
 		return "", err
 	}
 
 	return path.Join(home, "atlascli"), nil
-}
-
-// CLIConfigHome retrieves configHome path.
-func CLIConfigHome() (string, error) {
-	return AtlasCLIConfigHome()
 }
 
 func Path(f string) (string, error) {

--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -26,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfig_MongoCLIConfigHome(t *testing.T) {
+func TestMongoCLIConfigHome(t *testing.T) {
 	expHome, err := os.UserConfigDir()
 	require.NoError(t, err)
 
@@ -36,7 +37,7 @@ func TestConfig_MongoCLIConfigHome(t *testing.T) {
 	assert.Equal(t, expected, home)
 }
 
-func TestConfig_OldMongoCLIConfigHome(t *testing.T) {
+func TestOldMongoCLIConfigHome(t *testing.T) {
 	t.Run("old home with XDG_CONFIG_HOME", func(t *testing.T) {
 		const xdgHome = "my_config"
 		t.Setenv("XDG_CONFIG_HOME", xdgHome)
@@ -61,22 +62,19 @@ func TestConfig_OldMongoCLIConfigHome(t *testing.T) {
 	})
 }
 
-func TestConfig_AtlasCLIConfigHome(t *testing.T) {
-	t.Run("with env set", func(t *testing.T) {
-		expHome, err := os.UserConfigDir()
-		expected := fmt.Sprintf("%s/atlascli", expHome)
-		if err != nil {
-			t.Fatalf("os.UserConfigDir() unexpected error: %v", err)
-		}
-
-		home, err := AtlasCLIConfigHome()
-		if err != nil {
-			t.Fatalf("AtlasCLIConfigHome() unexpected error: %v", err)
-		}
-		if home != expected {
-			t.Errorf("AtlasCLIConfigHome() = %s; want '%s'", home, expected)
-		}
-	})
+func TestCLIConfigHome(t *testing.T) {
+	expHome, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("os.UserConfigDir() unexpected error: %v", err)
+	}
+	home, err := CLIConfigHome()
+	if err != nil {
+		t.Fatalf("AtlasCLIConfigHome() unexpected error: %v", err)
+	}
+	expected := path.Join(expHome, "atlascli")
+	if home != expected {
+		t.Errorf("AtlasCLIConfigHome() = %s; want '%s'", home, expected)
+	}
 }
 
 func TestConfig_IsTrue(t *testing.T) {


### PR DESCRIPTION
Remove the method delegation since this was only used when there was an `if` depending on the binary, so we can remove now that mongocli is forked