### PR TITLE
task: remove unnecessary usages of fmt.Errorf

### DIFF
--- a/internal/cli/backup/compliancepolicy/enable.go
+++ b/internal/cli/backup/compliancepolicy/enable.go
@@ -66,7 +66,7 @@ func (opts *EnableOpts) enableWatcher() (any, bool, error) {
 	}
 	opts.policy = res
 	if res.GetState() == "" {
-		return nil, false, fmt.Errorf("could not access State field")
+		return nil, false, errors.New("could not access State field")
 	}
 	return nil, res.GetState() == active, nil
 }

--- a/internal/cli/deployments/options/deployment_opts_select.go
+++ b/internal/cli/deployments/options/deployment_opts_select.go
@@ -31,7 +31,7 @@ import (
 var errEmptyLocalDeployments = errors.New("currently there are no deployment in your local system")
 var errNoDeployments = errors.New("currently there are no deployments")
 var ErrDeploymentNotFound = errors.New("deployment not found")
-var errDeploymentRequiredOnPipe = fmt.Errorf("deployment name is required  when piping the output of the command")
+var errDeploymentRequiredOnPipe = errors.New("deployment name is required  when piping the output of the command")
 
 func (opts *DeploymentOpts) findMongoDContainer(ctx context.Context) (*podman.InspectContainerData, error) {
 	containers, err := opts.PodmanClient.ContainerInspect(ctx, opts.LocalMongodHostname())

--- a/internal/cli/serverless/backup/restores/create.go
+++ b/internal/cli/serverless/backup/restores/create.go
@@ -16,6 +16,7 @@ package restores
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
@@ -59,7 +60,7 @@ func (opts *CreateOpts) initStore(ctx context.Context) func() error {
 
 var createTemplate = "Restore job '{{.Id}}' successfully started\n"
 
-var ErrInvalidDeliveryType = fmt.Errorf("delivery type invalid, choose 'automated', 'download' or 'pointInTime'")
+var ErrInvalidDeliveryType = errors.New("delivery type invalid, choose 'automated', 'download' or 'pointInTime'")
 
 func (opts *CreateOpts) Run() error {
 	request := opts.newCloudProviderSnapshotRestoreJob()

--- a/internal/decryption/keyproviders/gcp.go
+++ b/internal/decryption/keyproviders/gcp.go
@@ -16,6 +16,7 @@ package keyproviders
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/crc32"
 
@@ -26,7 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-var ErrDataCorruptedInTransit = fmt.Errorf("decrypt: response corrupted in-transit")
+var ErrDataCorruptedInTransit = errors.New("decrypt: response corrupted in-transit")
 
 type GCPKeyIdentifier struct {
 	KeyStoreIdentifier

--- a/internal/kubernetes/operator/config_exporter_test.go
+++ b/internal/kubernetes/operator/config_exporter_test.go
@@ -17,7 +17,7 @@
 package operator
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -109,7 +109,7 @@ func TestProjectWithWrongOrgID(t *testing.T) {
 			projectID, "wrong-org-id",
 		)
 		_, got := ce.Run()
-		expected := fmt.Errorf("the project test-project (project-id) is not part of the " +
+		expected := errors.New("the project test-project (project-id) is not part of the " +
 			"organization \"wrong-org-id\", please confirm the arguments provided " +
 			"to the command or you are using the correct profile")
 		if diff := deep.Equal(got, expected); diff != nil {

--- a/internal/store/logs.go
+++ b/internal/store/logs.go
@@ -15,7 +15,7 @@
 package store
 
 import (
-	"fmt"
+	"errors"
 	"io"
 
 	atlasv2 "go.mongodb.org/atlas-sdk/v20231115013/admin"
@@ -34,7 +34,7 @@ func (s *Store) DownloadLog(params *atlasv2.GetHostLogsApiParams) (io.ReadCloser
 		return nil, err
 	}
 	if result == nil {
-		return nil, fmt.Errorf("returned file is empty")
+		return nil, errors.New("returned file is empty")
 	}
 	return result, nil
 }

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -594,7 +594,7 @@ func getFirstOrgUser() (string, error) {
 		return "", fmt.Errorf("%w: %s", err, string(resp))
 	}
 	if users.GetTotalCount() == 0 {
-		return "", fmt.Errorf("no users found")
+		return "", errors.New("no users found")
 	}
 
 	return users.GetResults()[0].Username, nil

--- a/tools/genevergreen/generate/publish.go
+++ b/tools/genevergreen/generate/publish.go
@@ -96,8 +96,8 @@ func newPublishTask(taskName, extension, edition, distro, taskServerVersion, not
 }
 
 func publishVariant(c *shrub.Configuration, v *shrub.Variant, sv, stableSuffix string, dependency []shrub.TaskDependency, stable bool) {
-	taskServerVersion := fmt.Sprintf("%s.0", sv)
-	notaryKey := fmt.Sprintf("server-%s", sv)
+	taskServerVersion := sv + ".0"
+	notaryKey := "server-" + sv
 	taskSv := "_" + sv
 	if !stable {
 		taskServerVersion += "-rc1"

--- a/tools/templates-checker/astparsing/astparsing.go
+++ b/tools/templates-checker/astparsing/astparsing.go
@@ -483,14 +483,14 @@ func getRelatedTemplateType(pkg *packages.Package, commandOptsStruct *ast.TypeSp
 			case *ast.Ident:
 				// Make sure the declaration is not null
 				if arg.Obj == nil || arg.Obj.Decl == nil {
-					errs = append(errs, fmt.Errorf("found ident but obj declaration is nil"))
+					errs = append(errs, errors.New("found ident but obj declaration is nil"))
 					return true
 				}
 
 				// Make sure that the declaration is assign statement
 				argAssignStmt, ok := arg.Obj.Decl.(*ast.AssignStmt)
 				if !ok {
-					errs = append(errs, fmt.Errorf("found ident but obj declaration is not of the type *ast.AssignStmt"))
+					errs = append(errs, errors.New("found ident but obj declaration is not of the type *ast.AssignStmt"))
 					return true
 				}
 


### PR DESCRIPTION
Don't use `fmt.Errorf` where `errors.New` is better and faster

Splitting from another PR where I'm linting this but getting some errors in the CI I'm trying to isolate