### PR TITLE
task: split kube test into two tasks

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -312,7 +312,7 @@ tasks:
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,clusters,m0
-  - name: atlas_kubernetes_e2e
+  - name: atlas_kubernetes_generate_e2e
     tags: ["e2e","atlas","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas"]
     must_have_test_results: true
     depends_on:
@@ -330,7 +330,26 @@ tasks:
           MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,cluster,kubernetes
+          E2E_TAGS: atlas,cluster,kubernetes,generate
+  - name: atlas_kubernetes_apply_e2e
+    tags: [ "e2e","atlas","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas" ]
+    must_have_test_results: true
+    depends_on:
+      - name: atlas_clusters_flags_e2e
+        variant: "e2e_atlas_clusters"
+        patch_optional: true
+    commands:
+      - func: "install gotestsum"
+      - func: "setup operator"
+      - func: "e2e test"
+        vars:
+          MCLI_ORG_ID: ${atlas_org_id}
+          MCLI_PROJECT_ID: ${atlas_project_id}
+          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MCLI_SERVICE: cloud
+          E2E_TAGS: atlas,cluster,kubernetes,apply
   - name: atlas_clusters_upgrade_e2e
     tags: ["e2e","clusters","atlas"]
     must_have_test_results: true

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -477,7 +477,7 @@ func (g *atlasE2ETestGenerator) getProcesses() ([]atlasv2.ApiHostViewAtlas, erro
 	return processes.GetResults(), nil
 }
 
-// runCommand runs a command on mongocli tool.
+// runCommand runs a command on atlascli.
 func (g *atlasE2ETestGenerator) runCommand(args ...string) ([]byte, error) {
 	g.t.Helper()
 

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -29,7 +29,6 @@ import (
 	akov2common "github.com/mongodb/mongodb-atlas-kubernetes/v2/pkg/api/v1/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,12 +39,16 @@ func TestKubernetesConfigApply(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("should failed to apply resources when namespace doesn't exist", func(t *testing.T) {
+		g := newAtlasE2ETestGenerator(t)
+		g.generateProject("k8sConfigApplyWrongNs")
 		cmd := exec.Command(cliPath,
 			"kubernetes",
 			"config",
 			"apply",
-			"--targetNamespace", "a-wrong-namespace",
-			"--projectId", primitive.NewObjectID().Hex())
+			"--targetNamespace",
+			"a-wrong-namespace",
+			"--projectId",
+			g.projectID)
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.Error(t, err, string(resp))

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -71,7 +71,6 @@ func TestKubernetesConfigApply(t *testing.T) {
 				Name: "e2e-autodetect-parameters",
 			},
 		}
-		t.Logf("adding namespace %s", e2eNamespace)
 		require.NoError(t, operator.createK8sObject(e2eNamespace))
 		g.t.Cleanup(func() {
 			require.NoError(t, operator.deleteK8sObject(e2eNamespace))
@@ -105,7 +104,6 @@ func TestKubernetesConfigApply(t *testing.T) {
 				Name: "e2e-autodetect-operator-version",
 			},
 		}
-		t.Logf("adding namespace %s", e2eNamespace)
 		require.NoError(t, operator.createK8sObject(e2eNamespace))
 		g.t.Cleanup(func() {
 			require.NoError(t, operator.deleteK8sObject(e2eNamespace))
@@ -139,7 +137,6 @@ func TestKubernetesConfigApply(t *testing.T) {
 				Name: "e2e-export-atlas-resource",
 			},
 		}
-		t.Logf("adding namespace %s", e2eNamespace)
 		require.NoError(t, operator.createK8sObject(e2eNamespace))
 		g.t.Cleanup(func() {
 			require.NoError(t, operator.deleteK8sObject(e2eNamespace))
@@ -160,24 +157,28 @@ func TestKubernetesConfigApply(t *testing.T) {
 		})
 
 		akoProject := akov2.AtlasProject{}
-		err = operator.getK8sObject(
-			client.ObjectKey{Name: prepareK8sName(g.projectName), Namespace: e2eNamespace.Name},
-			&akoProject,
-			true,
+		require.NoError(
+			t,
+			operator.getK8sObject(
+				client.ObjectKey{Name: prepareK8sName(g.projectName), Namespace: e2eNamespace.Name},
+				&akoProject,
+				true,
+			),
 		)
-		require.NoError(t, err)
 		assert.NotEmpty(t, akoProject.Spec.AlertConfigurations)
 		akoProject.Spec.AlertConfigurations = nil
 		assert.Equal(t, referenceExportedProject(g.projectName, g.teamName, &akoProject).Spec, akoProject.Spec)
 
 		// Assert Database User
 		akoDBUser := akov2.AtlasDatabaseUser{}
-		err = operator.getK8sObject(
-			client.ObjectKey{Name: prepareK8sName(fmt.Sprintf("%s-%s", g.projectName, g.dbUser)), Namespace: e2eNamespace.Name},
-			&akoDBUser,
-			true,
+		require.NoError(
+			t,
+			operator.getK8sObject(
+				client.ObjectKey{Name: prepareK8sName(fmt.Sprintf("%s-%s", g.projectName, g.dbUser)), Namespace: e2eNamespace.Name},
+				&akoDBUser,
+				true,
+			),
 		)
-		require.NoError(t, err)
 		assert.Equal(t, referenceExportedDBUser(g.projectName, g.dbUser, e2eNamespace.Name).Spec, akoDBUser.Spec)
 
 		// Assert Team
@@ -206,12 +207,14 @@ func TestKubernetesConfigApply(t *testing.T) {
 
 		// Assert Backup Schedule
 		akoBkpSchedule := akov2.AtlasBackupSchedule{}
-		err = operator.getK8sObject(
-			client.ObjectKey{Name: prepareK8sName(fmt.Sprintf("%s-%s-backupschedule", g.projectName, g.clusterName)), Namespace: e2eNamespace.Name},
-			&akoBkpSchedule,
-			true,
+		require.NoError(
+			t,
+			operator.getK8sObject(
+				client.ObjectKey{Name: prepareK8sName(fmt.Sprintf("%s-%s-backupschedule", g.projectName, g.clusterName)), Namespace: e2eNamespace.Name},
+				&akoBkpSchedule,
+				true,
+			),
 		)
-		require.NoError(t, err)
 		assert.Equal(
 			t,
 			referenceExportedBackupSchedule(g.projectName, g.clusterName, e2eNamespace.Name, akoBkpSchedule.Spec.ReferenceHourOfDay, akoBkpSchedule.Spec.ReferenceMinuteOfHour).Spec,

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -45,7 +45,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 			"config",
 			"apply",
 			"--targetNamespace", "a-wrong-namespace",
-			"--projectId", primitive.NewObjectID().String())
+			"--projectId", primitive.NewObjectID().Hex())
 		cmd.Env = os.Environ()
 		resp, err := cmd.CombinedOutput()
 		require.Error(t, err, string(resp))

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || (atlas && cluster && kubernetes)
+//go:build e2e || (atlas && cluster && kubernetes && apply)
 
 package atlas_test
 
@@ -37,9 +37,7 @@ import (
 func TestKubernetesConfigApply(t *testing.T) {
 	a := assert.New(t)
 	req := require.New(t)
-
 	cliPath, err := e2e.AtlasCLIBin()
-	t.Log(cliPath)
 	req.NoError(err)
 
 	t.Run("should failed to apply resources when namespace doesn't exist", func(t *testing.T) {

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -38,7 +38,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 	cliPath, err := e2e.AtlasCLIBin()
 	require.NoError(t, err)
 
-	t.Run("should failed to apply resources when namespace doesn't exist", func(t *testing.T) {
+	t.Run("should fail to apply resources when namespace do not exist", func(t *testing.T) {
 		g := newAtlasE2ETestGenerator(t)
 		g.generateProject("k8sConfigApplyWrongNs")
 		cmd := exec.Command(cliPath,
@@ -55,7 +55,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 		assert.Equal(t, "Error: namespaces \"a-wrong-namespace\" not found\n", string(resp))
 	})
 
-	t.Run("should failed to apply resources when unable to autodetect parameters", func(t *testing.T) {
+	t.Run("should fail to apply resources when unable to autodetect parameters", func(t *testing.T) {
 		g := newAtlasE2ETestGenerator(t)
 		g.generateProject("k8sConfigApplyNoAutoDetect")
 
@@ -88,7 +88,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 		assert.Equal(t, "Error: unable to auto detect params: couldn't find an operator installed in any accessible namespace\n", string(resp))
 	})
 
-	t.Run("should failed to apply resources when unable to autodetect operator version", func(t *testing.T) {
+	t.Run("should fail to apply resources when unable to autodetect operator version", func(t *testing.T) {
 		g := newAtlasE2ETestGenerator(t)
 		g.generateProject("k8sConfigApplyFailVersion")
 

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -88,12 +88,14 @@ type KubernetesConfigGenerateProjectSuite struct {
 	cliPath         string
 }
 
+const projectPrefix = "Kubernetes-"
+
 func InitialSetupWithTeam(t *testing.T) KubernetesConfigGenerateProjectSuite {
 	t.Helper()
 	s := KubernetesConfigGenerateProjectSuite{}
 	s.generator = newAtlasE2ETestGenerator(t)
 	s.generator.generateTeam("Kubernetes")
-	s.generator.generateEmptyProject(fmt.Sprintf("Kubernetes-%s", s.generator.projectName))
+	s.generator.generateEmptyProject(projectPrefix + s.generator.projectName)
 	s.expectedProject = referenceProject(s.generator.projectName, targetNamespace, expectedLabels)
 
 	cliPath, err := e2e.AtlasCLIBin()
@@ -109,7 +111,7 @@ func InitialSetup(t *testing.T) KubernetesConfigGenerateProjectSuite {
 	t.Helper()
 	s := KubernetesConfigGenerateProjectSuite{}
 	s.generator = newAtlasE2ETestGenerator(t)
-	s.generator.generateEmptyProject(fmt.Sprintf("Kubernetes-%s", s.generator.projectName))
+	s.generator.generateEmptyProject(projectPrefix + s.generator.projectName)
 	s.expectedProject = referenceProject(s.generator.projectName, targetNamespace, expectedLabels)
 
 	cliPath, err := e2e.AtlasCLIBin()
@@ -219,23 +221,23 @@ func TestProjectWithNonDefaultAlertConf(t *testing.T) {
 				SMSEnabled:   pointer.Get(false),
 				EmailEnabled: pointer.Get(true),
 				APITokenRef: akov2common.ResourceRefNamespaced{
-					Name:      resources.NormalizeAtlasName(fmt.Sprintf("%s-api-token-0", expectedProject.Name), dictionary),
+					Name:      resources.NormalizeAtlasName(expectedProject.Name+"-api-token-0", dictionary),
 					Namespace: targetNamespace,
 				},
 				DatadogAPIKeyRef: akov2common.ResourceRefNamespaced{
-					Name:      resources.NormalizeAtlasName(fmt.Sprintf("%s-datadog-api-key-0", expectedProject.Name), dictionary),
+					Name:      resources.NormalizeAtlasName(expectedProject.Name+"-datadog-api-key-0", dictionary),
 					Namespace: targetNamespace,
 				},
 				OpsGenieAPIKeyRef: akov2common.ResourceRefNamespaced{
-					Name:      resources.NormalizeAtlasName(fmt.Sprintf("%s-ops-genie-api-key-0", expectedProject.Name), dictionary),
+					Name:      resources.NormalizeAtlasName(expectedProject.Name+"-ops-genie-api-key-0", dictionary),
 					Namespace: targetNamespace,
 				},
 				ServiceKeyRef: akov2common.ResourceRefNamespaced{
-					Name:      resources.NormalizeAtlasName(fmt.Sprintf("%s-service-key-0", expectedProject.Name), dictionary),
+					Name:      resources.NormalizeAtlasName(expectedProject.Name+"%s-service-key-0", dictionary),
 					Namespace: targetNamespace,
 				},
 				VictorOpsSecretRef: akov2common.ResourceRefNamespaced{
-					Name:      resources.NormalizeAtlasName(fmt.Sprintf("%s-victor-ops-credentials-0", expectedProject.Name), dictionary),
+					Name:      resources.NormalizeAtlasName(expectedProject.Name+"-victor-ops-credentials-0", dictionary),
 					Namespace: targetNamespace,
 				},
 			},
@@ -321,7 +323,8 @@ func TestProjectWithAccessList(t *testing.T) {
 			accessListEntity,
 			"create",
 			newIPAccess.IPAddress,
-			fmt.Sprintf("--comment=%s", newIPAccess.Comment),
+			"--comment",
+			newIPAccess.Comment,
 			"--projectId",
 			generator.projectID,
 			"--type",
@@ -863,7 +866,7 @@ func referenceProject(name, namespace string, labels map[string]string) *akov2.A
 		Spec: akov2.AtlasProjectSpec{
 			Name: name,
 			ConnectionSecret: &akov2common.ResourceRefNamespaced{
-				Name: resources.NormalizeAtlasName(fmt.Sprintf("%s-credentials", name), dictionary),
+				Name: resources.NormalizeAtlasName(name+"-credentials", dictionary),
 			},
 			Settings: &akov2.ProjectSettings{
 				IsCollectDatabaseSpecificsStatisticsEnabled: pointer.Get(true),
@@ -881,21 +884,21 @@ func referenceProject(name, namespace string, labels map[string]string) *akov2.A
 					Enabled: pointer.Get(false),
 					Valid:   pointer.Get(false),
 					SecretRef: akov2common.ResourceRefNamespaced{
-						Name:      resources.NormalizeAtlasName(fmt.Sprintf("%s-aws-credentials", name), dictionary),
+						Name:      resources.NormalizeAtlasName(name+"-aws-credentials", dictionary),
 						Namespace: namespace,
 					},
 				},
 				AzureKeyVault: akov2.AzureKeyVault{
 					Enabled: pointer.Get(false),
 					SecretRef: akov2common.ResourceRefNamespaced{
-						Name:      resources.NormalizeAtlasName(fmt.Sprintf("%s-azure-credentials", name), dictionary),
+						Name:      resources.NormalizeAtlasName(name+"-azure-credentials", dictionary),
 						Namespace: namespace,
 					},
 				},
 				GoogleCloudKms: akov2.GoogleCloudKms{
 					Enabled: pointer.Get(false),
 					SecretRef: akov2common.ResourceRefNamespaced{
-						Name:      resources.NormalizeAtlasName(fmt.Sprintf("%s-gcp-credentials", name), dictionary),
+						Name:      resources.NormalizeAtlasName(name+"-gcp-credentials", dictionary),
 						Namespace: namespace,
 					},
 				},
@@ -1553,7 +1556,9 @@ func TestKubernetesConfigGenerate_DataFederation(t *testing.T) {
 			"--projectId",
 			g.projectID,
 			"--dataFederationName",
-			fmt.Sprintf("%s,%s", storeNames[0], storeNames[1]),
+			storeNames[0],
+			"--dataFederationName",
+			storeNames[1],
 			"--targetNamespace",
 			targetNamespace)
 		cmd.Env = os.Environ()

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -150,22 +150,9 @@ func TestEmptyProject(t *testing.T) {
 		require.NotEmpty(t, objects)
 
 		checkProject(t, objects, expectedProject)
-		t.Run("Connection Secret present with non-empty credentials", func(t *testing.T) {
-			found := false
-			var secret *corev1.Secret
-			var ok bool
-			for i := range objects {
-				secret, ok = objects[i].(*corev1.Secret)
-				if ok {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Fatal("Secret is not found in results")
-			}
-			assert.Equal(t, targetNamespace, secret.Namespace)
-		})
+		secret, found := findSecret(objects)
+		require.True(t, found, "Secret is not found in results")
+		assert.Equal(t, targetNamespace, secret.Namespace)
 	})
 }
 
@@ -584,12 +571,9 @@ func TestProjectWithMaintenanceWindow(t *testing.T) {
 		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
-		t.Run("Output can be decoded", func(t *testing.T) {
-			objects, err = getK8SEntities(resp)
-			require.NoError(t, err, "should not fail on decode")
-			require.NotEmpty(t, objects)
-		})
-
+		objects, err = getK8SEntities(resp)
+		require.NoError(t, err, "should not fail on decode")
+		require.NotEmpty(t, objects)
 		checkProject(t, objects, expectedProject)
 	})
 }
@@ -652,12 +636,9 @@ func TestProjectWithNetworkPeering(t *testing.T) {
 		require.NoError(t, err, string(resp))
 
 		var objects []runtime.Object
-		t.Run("Output can be decoded", func(t *testing.T) {
-			objects, err = getK8SEntities(resp)
-			require.NoError(t, err, "should not fail on decode")
-			require.NotEmpty(t, objects)
-		})
-
+		objects, err = getK8SEntities(resp)
+		require.NoError(t, err, "should not fail on decode")
+		require.NotEmpty(t, objects)
 		checkProject(t, objects, expectedProject)
 	})
 }
@@ -1367,9 +1348,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 		require.NoError(t, err, "should not fail on decode")
 		require.NotEmpty(t, objects)
 		p, found := findAtlasProject(objects)
-		if !found {
-			t.Fatal("AtlasProject is not found in results")
-		}
+		require.True(t, found, "AtlasProject is not found in results")
 		assert.Equal(t, targetNamespace, p.Namespace)
 		ds := atlasDeployments(objects)
 		checkClustersData(t, ds, []string{g.clusterName, g.serverlessName}, g.clusterRegion, targetNamespace, g.projectName)

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -47,7 +47,6 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	req := require.New(t)
 
 	cliPath, err := e2e.AtlasCLIBin()
-	t.Log(cliPath)
 	req.NoError(err)
 
 	t.Run("should failed to install old and not supported version of the operator", func(t *testing.T) {

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -48,7 +48,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 
 	cliPath, err := e2e.AtlasCLIBin()
 	req.NoError(err)
-
+	const contextPrefix = "kind-"
 	t.Run("should failed to install old and not supported version of the operator", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			"kubernetes",
@@ -88,7 +88,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	t.Run("should install operator with default options", func(t *testing.T) {
 		clusterName := "install-default"
 		operator := setupCluster(t, clusterName)
-		context := fmt.Sprintf("kind-%s", clusterName)
+		context := contextPrefix + clusterName
 
 		cmd := exec.Command(cliPath,
 			"kubernetes",
@@ -106,7 +106,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	t.Run("should install latest major version of operator in its own namespace with cluster-wide config", func(t *testing.T) {
 		clusterName := "install-clusterwide"
 		operator := setupCluster(t, clusterName, operatorNamespace)
-		context := fmt.Sprintf("kind-%s", clusterName)
+		context := contextPrefix + clusterName
 
 		cmd := exec.Command(cliPath,
 			"kubernetes",
@@ -128,7 +128,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 		operatorWatch1 := "atlas-watch1"
 		operatorWatch2 := "atlas-watch2"
 		operator := setupCluster(t, clusterName, operatorNamespace, operatorWatch1, operatorWatch2)
-		context := fmt.Sprintf("kind-%s", clusterName)
+		context := contextPrefix + clusterName
 
 		cmd := exec.Command(cliPath,
 			"kubernetes",
@@ -136,7 +136,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"install",
 			"--operatorVersion", features.LatestOperatorMajorVersion,
 			"--targetNamespace", operatorNamespace,
-			"--watchNamespace", fmt.Sprintf("%s,%s", operatorWatch1, operatorWatch2),
+			"--watchNamespace", operatorWatch1,
+			"--watchNamespace", operatorWatch2,
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
 		resp, inErr := cmd.CombinedOutput()
@@ -148,7 +149,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	t.Run("should install latest major version of operator in a single namespaced config", func(t *testing.T) {
 		clusterName := "install-namespaced"
 		operator := setupCluster(t, clusterName, operatorNamespace)
-		context := fmt.Sprintf("kind-%s", clusterName)
+		context := contextPrefix + clusterName
 
 		cmd := exec.Command(cliPath,
 			"kubernetes",
@@ -169,7 +170,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 	t.Run("should install operator starting a new project", func(t *testing.T) {
 		clusterName := "install-new-project"
 		operator := setupCluster(t, clusterName, operatorNamespace)
-		context := fmt.Sprintf("kind-%s", clusterName)
+		context := contextPrefix + clusterName
 		projectName := "MyK8sProject"
 
 		cmd := exec.Command(cliPath,
@@ -245,7 +246,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 
 		clusterName := "install-import"
 		operator := setupCluster(t, clusterName, operatorNamespace)
-		context := fmt.Sprintf("kind-%s", clusterName)
+		context := contextPrefix + clusterName
 
 		cmd := exec.Command(cliPath,
 			"kubernetes",
@@ -275,7 +276,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 
 		clusterName := "install-import-without-dp"
 		operator := setupCluster(t, clusterName, operatorNamespace)
-		context := fmt.Sprintf("kind-%s", clusterName)
+		context := contextPrefix + clusterName
 
 		cmd := exec.Command(cliPath,
 			"kubernetes",


### PR DESCRIPTION
Try to improve kube tests times by splitting into two tasks

Before 1 task ~30 min
Now 2 tasks in parallel where the slowest takes ~18min