### PR TITLE
CLOUDP-249261: improve AKO backward compatibility for CI

### DIFF
--- a/docs/command/atlas-kubernetes-config-generate.txt
+++ b/docs/command/atlas-kubernetes-config-generate.txt
@@ -56,7 +56,7 @@ Options
    * - --operatorVersion
      - string
      - false
-     - Version of Atlas Kubernetes Operator to generate resources for. This value defaults to "2.3.0".
+     - Version of Atlas Kubernetes Operator to generate resources for. This value defaults to "2.2.0".
    * - --orgId
      - string
      - false

--- a/internal/kubernetes/operator/config_exporter.go
+++ b/internal/kubernetes/operator/config_exporter.go
@@ -351,6 +351,11 @@ func (e *ConfigExporter) fetchDataFederationNames() ([]string, error) {
 }
 
 func (e *ConfigExporter) exportAtlasStreamProcessing(projectName string) ([]runtime.Object, error) {
+	if !e.featureValidator.IsResourceSupported(features.ResourceAtlasStreamInstance) ||
+		!e.featureValidator.IsResourceSupported(features.ResourceAtlasStreamConnection) {
+		return nil, nil
+	}
+
 	instancesList, err := e.dataProvider.ProjectStreams(&admin.ListStreamInstancesApiParams{GroupId: e.projectID})
 	if err != nil {
 		return nil, err

--- a/internal/kubernetes/operator/features/crds.go
+++ b/internal/kubernetes/operator/features/crds.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	LatestOperatorMajorVersion    = "2.3.0"
+	LatestOperatorMajorVersion    = "2.2.0"
 	maxDepth                      = 100
 	ResourceVersion               = "mongodb.com/atlas-resource-version"
 	ResourceAtlasProject          = "atlasprojects"

--- a/internal/kubernetes/operator/features/crds.go
+++ b/internal/kubernetes/operator/features/crds.go
@@ -187,6 +187,12 @@ func NewAtlasCRDs(crdProvider crds.AtlasOperatorCRDProvider, version string) (*A
 	return result, nil
 }
 
+func (a *AtlasCRDs) IsResourceSupported(resourceName string) bool {
+	_, ok := a.resources[resourceName]
+
+	return ok
+}
+
 // FeatureExist
 // resourceName: one of SupportedResources
 // featurePath: dot-separated string - path in CRD spec to check.

--- a/internal/kubernetes/operator/features/validator.go
+++ b/internal/kubernetes/operator/features/validator.go
@@ -17,5 +17,6 @@ package features
 //go:generate mockgen -destination=../../../mocks/mock_atlas_operator_feature_validator.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/kubernetes/operator/features FeatureValidator
 
 type FeatureValidator interface {
+	IsResourceSupported(resourceName string) bool
 	FeatureExist(resourceName, version string) bool
 }

--- a/internal/mocks/mock_atlas_operator_feature_validator.go
+++ b/internal/mocks/mock_atlas_operator_feature_validator.go
@@ -46,3 +46,17 @@ func (mr *MockFeatureValidatorMockRecorder) FeatureExist(arg0, arg1 interface{})
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FeatureExist", reflect.TypeOf((*MockFeatureValidator)(nil).FeatureExist), arg0, arg1)
 }
+
+// IsResourceSupported mocks base method.
+func (m *MockFeatureValidator) IsResourceSupported(arg0 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsResourceSupported", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsResourceSupported indicates an expected call of IsResourceSupported.
+func (mr *MockFeatureValidatorMockRecorder) IsResourceSupported(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsResourceSupported", reflect.TypeOf((*MockFeatureValidator)(nil).IsResourceSupported), arg0)
+}

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -41,7 +41,8 @@ func TestKubernetesConfigApply(t *testing.T) {
 
 	t.Run("should fail to apply resources when namespace do not exist", func(t *testing.T) {
 		operator := setupCluster(t, "k8s-config-apply-wrong-ns", defaultOperatorNamespace)
-		operator.installOperator(defaultOperatorNamespace, features.LatestOperatorMajorVersion)
+		err = operator.installOperator(defaultOperatorNamespace, features.LatestOperatorMajorVersion)
+		require.NoError(t, err)
 
 		g := newAtlasE2ETestGenerator(t)
 		g.generateProject("k8sConfigApplyWrongNs")
@@ -83,7 +84,9 @@ func TestKubernetesConfigApply(t *testing.T) {
 		g := newAtlasE2ETestGenerator(t)
 
 		operator := setupCluster(t, "k8s-config-apply-fail-version", defaultOperatorNamespace)
-		operator.installOperator(defaultOperatorNamespace, features.LatestOperatorMajorVersion)
+		err = operator.installOperator(defaultOperatorNamespace, features.LatestOperatorMajorVersion)
+		require.NoError(t, err)
+
 		operator.emulateCertifiedOperator()
 		g.t.Cleanup(func() {
 			operator.restoreOperatorImage()
@@ -115,7 +118,9 @@ func TestKubernetesConfigApply(t *testing.T) {
 
 	t.Run("export and apply atlas resource to kubernetes cluster", func(t *testing.T) {
 		operator := setupCluster(t, "k8s-config-apply", defaultOperatorNamespace)
-		operator.installOperator(defaultOperatorNamespace, features.LatestOperatorMajorVersion)
+		err = operator.installOperator(defaultOperatorNamespace, features.LatestOperatorMajorVersion)
+		require.NoError(t, err)
+
 		// we don't want the operator to do reconcile and avoid conflict with cli actions
 		operator.stopOperator()
 		t.Cleanup(func() {

--- a/test/e2e/atlas/operator_helper_test.go
+++ b/test/e2e/atlas/operator_helper_test.go
@@ -206,9 +206,8 @@ func (oh *operatorHelper) installOperator(namespace, version string) error {
 		"--targetNamespace", namespace,
 	)
 	cmd.Env = os.Environ()
-	out, err := cmd.CombinedOutput()
+	_, err = cmd.CombinedOutput()
 	if err != nil {
-		fmt.Println(string(out))
 		return fmt.Errorf("unable install the operator: %w", err)
 	}
 


### PR DESCRIPTION
## Proposed changes

This change improves how Kubernetes operator tests behave when a new version is released.
Now is possible to bump the operator version, add any new changes/fixes and rely on the supported version, avoiding
breaking CI pipeline

_Jira ticket:_ CLOUDP-249261

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code