### PR TITLE
CLOUDP-250877: E2E tests fail when error level is set to debug

### DIFF
--- a/test/e2e/atlas/access_lists_test.go
+++ b/test/e2e/atlas/access_lists_test.go
@@ -53,7 +53,7 @@ func TestAccessList(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err)
 
 		var entries *atlasv2.PaginatedNetworkAccess
@@ -78,7 +78,7 @@ func TestAccessList(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var entries *atlasv2.PaginatedNetworkAccess
 		require.NoError(t, json.Unmarshal(resp, &entries))
@@ -93,7 +93,7 @@ func TestAccessList(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var entry *atlasv2.NetworkPermissionEntry
 		require.NoError(t, json.Unmarshal(resp, &entry))
@@ -108,7 +108,7 @@ func TestAccessList(t *testing.T) {
 			g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Project access list entry '%s' deleted\n", entry)
@@ -126,7 +126,7 @@ func TestAccessList(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var entries *atlasv2.PaginatedNetworkAccess
@@ -151,7 +151,7 @@ func TestAccessList(t *testing.T) {
 			g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Project access list entry '%s' deleted\n", entry)
@@ -168,7 +168,7 @@ func TestAccessList(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var entries *atlasv2.PaginatedNetworkAccess
@@ -190,7 +190,7 @@ func TestAccessList(t *testing.T) {
 			g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Project access list entry '%s' deleted\n", currentIPEntry)

--- a/test/e2e/atlas/access_logs_test.go
+++ b/test/e2e/atlas/access_logs_test.go
@@ -46,7 +46,7 @@ func TestAccessLogs(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var entries *atlasv2.MongoDBAccessLogsList
 		require.NoError(t, json.Unmarshal(resp, &entries))
@@ -60,7 +60,7 @@ func TestAccessLogs(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var entries *atlasv2.MongoDBAccessLogsList
 		require.NoError(t, json.Unmarshal(resp, &entries))

--- a/test/e2e/atlas/access_roles_test.go
+++ b/test/e2e/atlas/access_roles_test.go
@@ -46,7 +46,7 @@ func TestAccessRoles(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var iamRole atlasv2.CloudProviderAccessRole
@@ -63,7 +63,7 @@ func TestAccessRoles(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var roles atlasv2.CloudProviderAccessRoles
 		require.NoError(t, json.Unmarshal(resp, &roles))

--- a/test/e2e/atlas/alert_settings_test.go
+++ b/test/e2e/atlas/alert_settings_test.go
@@ -54,7 +54,7 @@ func TestAlertConfig(t *testing.T) {
 			"--notificationEmailEnabled=true",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var alert admin.GroupAlertsConfig
 		require.NoError(t, json.Unmarshal(resp, &alert))
@@ -79,7 +79,7 @@ func TestAlertConfig(t *testing.T) {
 			alertID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var config admin.GroupAlertsConfig
 		require.NoError(t, json.Unmarshal(resp, &config))
@@ -93,7 +93,7 @@ func TestAlertConfig(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var config admin.PaginatedAlertConfig
 		require.NoError(t, json.Unmarshal(resp, &config))
@@ -108,7 +108,7 @@ func TestAlertConfig(t *testing.T) {
 			"-c",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var config []admin.GroupAlertsConfig
 		require.NoError(t, json.Unmarshal(resp, &config))
@@ -133,7 +133,7 @@ func TestAlertConfig(t *testing.T) {
 			"--notificationEmailEnabled=true",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -175,7 +175,7 @@ func TestAlertConfig(t *testing.T) {
 			"--file", fileName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -190,7 +190,7 @@ func TestAlertConfig(t *testing.T) {
 	t.Run("Delete", func(t *testing.T) {
 		cmd := exec.Command(cliPath, alertsEntity, configEntity, "delete", alertID, "--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -202,7 +202,7 @@ func TestAlertConfig(t *testing.T) {
 			"type",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var fields []string

--- a/test/e2e/atlas/alerts_test.go
+++ b/test/e2e/atlas/alerts_test.go
@@ -47,7 +47,7 @@ func TestAlerts(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var alerts atlasv2.PaginatedAlert
 		require.NoError(t, json.Unmarshal(resp, &alerts))
@@ -66,7 +66,7 @@ func TestAlerts(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -78,7 +78,7 @@ func TestAlerts(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -94,7 +94,7 @@ func TestAlerts(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 		var alert atlasv2.AlertViewForNdsGroup
@@ -116,7 +116,7 @@ func TestAlerts(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var alert atlasv2.AlertViewForNdsGroup
 		require.NoError(t, json.Unmarshal(resp, &alert))
@@ -135,7 +135,7 @@ func TestAlerts(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var alert atlasv2.AlertViewForNdsGroup
 		require.NoError(t, json.Unmarshal(resp, &alert))
@@ -153,7 +153,7 @@ func TestAlerts(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 		var alert atlasv2.AlertViewForNdsGroup

--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -261,7 +261,7 @@ func deleteOrgInvitations(t *testing.T, cliPath string) {
 		"ls",
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	t.Logf("%s\n", resp)
 	require.NoError(t, err, string(resp))
 	var invitations []atlasv2.OrganizationInvitation
@@ -279,7 +279,7 @@ func deleteOrgTeams(t *testing.T, cliPath string) {
 		"ls",
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	t.Logf("%s\n", resp)
 	require.NoError(t, err, string(resp))
 	var teams atlasv2.PaginatedTeam
@@ -298,7 +298,7 @@ func deleteOrgInvitation(t *testing.T, cliPath string, id string) {
 		id,
 		"--force")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 }
 
@@ -544,5 +544,5 @@ func (g *atlasE2ETestGenerator) runCommand(args ...string) ([]byte, error) {
 	cmd := exec.Command(cliPath, args...)
 
 	cmd.Env = os.Environ()
-	return cmd.CombinedOutput()
+	return e2e.RunAndGetStdOut(cmd)
 }

--- a/test/e2e/atlas/auditing_test.go
+++ b/test/e2e/atlas/auditing_test.go
@@ -40,7 +40,7 @@ func TestAuditing(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var setting *atlasv2.AuditLog
 		require.NoError(t, json.Unmarshal(resp, &setting), string(resp))

--- a/test/e2e/atlas/backup_compliancepolicy_copyprotection_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_copyprotection_test.go
@@ -50,7 +50,7 @@ func TestBackupCompliancePolicyCopyProtection(t *testing.T) {
 			"--watch", // avoiding HTTP 400 Bad Request "CANNOT_UPDATE_BACKUP_COMPLIANCE_POLICY_SETTINGS_WITH_PENDING_ACTION".
 		)
 		cmd.Env = os.Environ()
-		resp, outputErr := cmd.CombinedOutput()
+		resp, outputErr := e2e.RunAndGetStdOut(cmd)
 		r.NoError(outputErr, string(resp))
 
 		trimmedResponse := removeDotsFromWatching(resp)
@@ -73,7 +73,7 @@ func TestBackupCompliancePolicyCopyProtection(t *testing.T) {
 			g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, outputErr := cmd.CombinedOutput()
+		resp, outputErr := e2e.RunAndGetStdOut(cmd)
 		r.NoError(outputErr, string(resp))
 
 		var compliancepolicy atlasv2.DataProtectionSettings20231001

--- a/test/e2e/atlas/backup_compliancepolicy_describe_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_describe_test.go
@@ -45,7 +45,7 @@ func TestBackupCompliancePolicyDescribe(t *testing.T) {
 		g.projectID,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, outputErr := cmd.CombinedOutput()
+	resp, outputErr := e2e.RunAndGetStdOut(cmd)
 
 	r.NoError(outputErr, string(resp))
 

--- a/test/e2e/atlas/backup_compliancepolicy_enable_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_enable_test.go
@@ -52,7 +52,7 @@ func TestBackupCompliancePolicyEnable(t *testing.T) {
 		"--force",
 	)
 	cmd.Env = os.Environ()
-	resp, outputErr := cmd.CombinedOutput()
+	resp, outputErr := e2e.RunAndGetStdOut(cmd)
 	r.NoError(outputErr, string(resp))
 	var result atlasv2.DataProtectionSettings20231001
 	r.NoError(json.Unmarshal(resp, &result), string(resp))

--- a/test/e2e/atlas/backup_compliancepolicy_pitrestore_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_pitrestore_test.go
@@ -63,7 +63,7 @@ func TestBackupCompliancePolicyPointInTimeRestore(t *testing.T) {
 			"1",
 		)
 		cmd.Env = os.Environ()
-		resp, outputErr := cmd.CombinedOutput()
+		resp, outputErr := e2e.RunAndGetStdOut(cmd)
 		r.NoError(outputErr, string(resp))
 
 		var compliancepolicy atlasv2.DataProtectionSettings20231001

--- a/test/e2e/atlas/backup_compliancepolicy_policies_describe_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_policies_describe_test.go
@@ -46,7 +46,7 @@ func TestBackupCompliancePolicyPoliciesDescribe(t *testing.T) {
 		g.projectID,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, outputErr := cmd.CombinedOutput()
+	resp, outputErr := e2e.RunAndGetStdOut(cmd)
 
 	r.NoError(outputErr, string(resp))
 

--- a/test/e2e/atlas/backup_compliancepolicy_setup_test.go
+++ b/test/e2e/atlas/backup_compliancepolicy_setup_test.go
@@ -66,7 +66,7 @@ func TestBackupCompliancePolicySetup(t *testing.T) {
 	)
 
 	cmd.Env = os.Environ()
-	resp, outputErr := cmd.CombinedOutput()
+	resp, outputErr := e2e.RunAndGetStdOut(cmd)
 
 	r.NoError(outputErr, string(resp))
 

--- a/test/e2e/atlas/backup_export_buckets_test.go
+++ b/test/e2e/atlas/backup_export_buckets_test.go
@@ -52,7 +52,7 @@ func TestExportBuckets(t *testing.T) {
 			iamRoleID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		r.NoError(err, string(resp))
 
@@ -70,7 +70,7 @@ func TestExportBuckets(t *testing.T) {
 			"list",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 		var buckets atlasv2.PaginatedBackupSnapshotExportBucket
 		r.NoError(json.Unmarshal(resp, &buckets))
@@ -87,7 +87,7 @@ func TestExportBuckets(t *testing.T) {
 			bucketID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 		var exportBucket atlasv2.DiskBackupSnapshotAWSExportBucket
 		r.NoError(json.Unmarshal(resp, &exportBucket))
@@ -104,7 +104,7 @@ func TestExportBuckets(t *testing.T) {
 			bucketID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 	})

--- a/test/e2e/atlas/backup_export_jobs_test.go
+++ b/test/e2e/atlas/backup_export_jobs_test.go
@@ -62,7 +62,7 @@ func TestExportJobs(t *testing.T) {
 			"--mdbVersion", mdbVersion,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 
 		var cluster *atlasv2.AdvancedClusterDescription
@@ -87,7 +87,7 @@ func TestExportJobs(t *testing.T) {
 			iamRoleID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 		var exportBucket atlasv2.DiskBackupSnapshotAWSExportBucket
 		r.NoError(json.Unmarshal(resp, &exportBucket))
@@ -105,7 +105,7 @@ func TestExportJobs(t *testing.T) {
 			"test-snapshot",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		r.NoError(err, string(resp))
 
@@ -125,7 +125,7 @@ func TestExportJobs(t *testing.T) {
 			"--clusterName",
 			clusterName)
 		cmd.Env = os.Environ()
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 
@@ -143,7 +143,7 @@ func TestExportJobs(t *testing.T) {
 			snapshotID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		r.NoError(err, string(resp))
 		var job atlasv2.DiskBackupExportJob
@@ -162,7 +162,7 @@ func TestExportJobs(t *testing.T) {
 			"--clusterName",
 			clusterName)
 		cmd.Env = os.Environ()
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 
@@ -178,7 +178,7 @@ func TestExportJobs(t *testing.T) {
 			exportJobID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		r.NoError(err, string(resp))
 
@@ -196,7 +196,7 @@ func TestExportJobs(t *testing.T) {
 			clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 
 		var jobs atlasv2.PaginatedApiAtlasDiskBackupExportJob
@@ -214,7 +214,7 @@ func TestExportJobs(t *testing.T) {
 			clusterName,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -227,7 +227,7 @@ func TestExportJobs(t *testing.T) {
 			"--clusterName",
 			clusterName)
 		cmd.Env = os.Environ()
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 }

--- a/test/e2e/atlas/backup_restores_test.go
+++ b/test/e2e/atlas/backup_restores_test.go
@@ -54,7 +54,7 @@ func TestRestores(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 
@@ -75,7 +75,7 @@ func TestRestores(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 
@@ -97,7 +97,7 @@ func TestRestores(t *testing.T) {
 			g2.clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 		var result atlasv2.DiskBackupSnapshotRestoreJob
@@ -117,7 +117,7 @@ func TestRestores(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 	})
@@ -132,7 +132,7 @@ func TestRestores(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 		var result atlasv2.PaginatedCloudBackupRestoreJob
@@ -152,7 +152,7 @@ func TestRestores(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 
@@ -173,7 +173,7 @@ func TestRestores(t *testing.T) {
 			g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -188,7 +188,7 @@ func TestRestores(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 }

--- a/test/e2e/atlas/backup_schedule_test.go
+++ b/test/e2e/atlas/backup_schedule_test.go
@@ -49,7 +49,7 @@ func TestSchedule(t *testing.T) {
 			"-o=json",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err)
 		require.NoError(t, json.Unmarshal(resp, &policy))
 
@@ -69,7 +69,7 @@ func TestSchedule(t *testing.T) {
 			"-o=json",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -84,7 +84,7 @@ func TestSchedule(t *testing.T) {
 			"--force",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/atlas/backup_serverless_test.go
+++ b/test/e2e/atlas/backup_serverless_test.go
@@ -49,7 +49,7 @@ func TestServerlessBackup(t *testing.T) {
 			clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var r atlasv2.PaginatedApiAtlasServerlessBackupSnapshot
@@ -72,7 +72,7 @@ func TestServerlessBackup(t *testing.T) {
 			clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 		var result atlasv2.ServerlessBackupSnapshot
@@ -100,7 +100,7 @@ func TestServerlessBackup(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 		var result atlasv2.ServerlessBackupRestoreJob
@@ -122,7 +122,7 @@ func TestServerlessBackup(t *testing.T) {
 			clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 	})
@@ -136,7 +136,7 @@ func TestServerlessBackup(t *testing.T) {
 			clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var result atlasv2.PaginatedApiAtlasServerlessBackupRestoreJob
@@ -156,7 +156,7 @@ func TestServerlessBackup(t *testing.T) {
 			clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var result atlasv2.ServerlessBackupRestoreJob
 		require.NoError(t, json.Unmarshal(resp, &result))

--- a/test/e2e/atlas/backup_snapshot_test.go
+++ b/test/e2e/atlas/backup_snapshot_test.go
@@ -52,7 +52,7 @@ func TestSnapshots(t *testing.T) {
 			"--mdbVersion", mdbVersion,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var cluster *atlasv2.AdvancedClusterDescription
@@ -74,7 +74,7 @@ func TestSnapshots(t *testing.T) {
 			"test-snapshot",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 
@@ -93,7 +93,7 @@ func TestSnapshots(t *testing.T) {
 			"--clusterName",
 			clusterName)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -105,7 +105,7 @@ func TestSnapshots(t *testing.T) {
 			clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 		var backups atlasv2.PaginatedCloudBackupReplicaSet
@@ -123,7 +123,7 @@ func TestSnapshots(t *testing.T) {
 			clusterName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 
@@ -142,7 +142,7 @@ func TestSnapshots(t *testing.T) {
 			clusterName,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -155,7 +155,7 @@ func TestSnapshots(t *testing.T) {
 			"--clusterName",
 			clusterName)
 		cmd.Env = os.Environ()
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 }

--- a/test/e2e/atlas/cleanup_test.go
+++ b/test/e2e/atlas/cleanup_test.go
@@ -50,7 +50,7 @@ func TestCleanup(t *testing.T) {
 	}
 	cmd := exec.Command(cliPath, args...)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	req.NoError(err, string(resp))
 	var projects admin.PaginatedAtlasGroup
 	req.NoError(json.Unmarshal(resp, &projects), string(resp))

--- a/test/e2e/atlas/clusters_file_test.go
+++ b/test/e2e/atlas/clusters_file_test.go
@@ -61,7 +61,7 @@ func TestClustersFile(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
@@ -78,7 +78,7 @@ func TestClustersFile(t *testing.T) {
 			clusterFileName,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 		assert.Contains(t, string(resp), "Cluster available")
 	})
@@ -93,7 +93,7 @@ func TestClustersFile(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -107,7 +107,7 @@ func TestClustersFile(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -121,7 +121,7 @@ func TestClustersFile(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -135,7 +135,7 @@ func TestClustersFile(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
@@ -154,7 +154,7 @@ func TestClustersFile(t *testing.T) {
 			"--projectId", g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("Deleting cluster '%s'", clusterFileName)
@@ -171,7 +171,7 @@ func TestClustersFile(t *testing.T) {
 		cmd.Env = os.Environ()
 		// this command will fail with 404 once the cluster is deleted
 		// we just need to wait for this to close the project
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 }

--- a/test/e2e/atlas/clusters_flags_test.go
+++ b/test/e2e/atlas/clusters_flags_test.go
@@ -68,7 +68,7 @@ func TestClustersFlags(t *testing.T) {
 			"--tag", "env=test", "-w",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var cluster *atlasv2.AdvancedClusterDescription
@@ -86,7 +86,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var job *atlasv2.SampleDatasetStatus
@@ -101,7 +101,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var clusters atlasv2.PaginatedAdvancedClusterDescription
@@ -117,7 +117,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
@@ -134,7 +134,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var connectionString atlasv2.ClusterConnectionStrings
@@ -156,7 +156,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -169,7 +169,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var config atlasv2.ClusterDescriptionProcessArgs
@@ -192,7 +192,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -205,7 +205,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.Error(t, err, string(resp))
 	})
 
@@ -220,7 +220,7 @@ func TestClustersFlags(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
@@ -232,7 +232,7 @@ func TestClustersFlags(t *testing.T) {
 	t.Run("Delete", func(t *testing.T) {
 		cmd := exec.Command(cliPath, clustersEntity, "delete", clusterName, "--projectId", g.projectID, "--force", "-w")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		expected := "Cluster deleted"

--- a/test/e2e/atlas/clusters_m0_test.go
+++ b/test/e2e/atlas/clusters_m0_test.go
@@ -54,7 +54,7 @@ func TestClustersM0Flags(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var cluster *atlasv2.AdvancedClusterDescription
@@ -72,7 +72,7 @@ func TestClustersM0Flags(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		a := assert.New(t)
@@ -88,7 +88,7 @@ func TestClustersM0Flags(t *testing.T) {
 			"-o=json",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
@@ -108,7 +108,7 @@ func TestClustersM0Flags(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("Deleting cluster '%s'", clusterName)
@@ -126,7 +126,7 @@ func TestClustersM0Flags(t *testing.T) {
 		cmd.Env = os.Environ()
 		// this command will fail with 404 once the cluster is deleted
 		// we just need to wait for this to close the project
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 }

--- a/test/e2e/atlas/clusters_sharded_test.go
+++ b/test/e2e/atlas/clusters_sharded_test.go
@@ -63,7 +63,7 @@ func TestShardedCluster(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription
@@ -75,7 +75,7 @@ func TestShardedCluster(t *testing.T) {
 	t.Run("Delete sharded cluster", func(t *testing.T) {
 		cmd := exec.Command(cliPath, clustersEntity, "delete", shardedClusterName, "--projectId", g.projectID, "--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("Deleting cluster '%s'", shardedClusterName)
@@ -92,7 +92,7 @@ func TestShardedCluster(t *testing.T) {
 		cmd.Env = os.Environ()
 		// this command will fail with 404 once the cluster is deleted
 		// we just need to wait for this to close the project
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 }

--- a/test/e2e/atlas/clusters_upgrade_test.go
+++ b/test/e2e/atlas/clusters_upgrade_test.go
@@ -46,7 +46,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 			"--tag", "env=e2e",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		require.NoError(t, watchCluster(g.projectID, g.clusterName))
 		cluster := fetchCluster(t, cliPath, g.projectID, g.clusterName)
@@ -65,7 +65,7 @@ func TestSharedClusterUpgrade(t *testing.T) {
 			"--tag", "env=e2e",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		require.NoError(t, watchCluster(g.projectID, g.clusterName))
 		cluster := fetchCluster(t, cliPath, g.projectID, g.clusterName)
@@ -84,7 +84,7 @@ func fetchCluster(t *testing.T, cliPath, projectID, clusterName string) *atlasv2
 		"--projectId", projectID,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	req := require.New(t)
 	req.NoError(err, string(resp))
 	var c *atlasv2.AdvancedClusterDescription

--- a/test/e2e/atlas/custom_db_roles_test.go
+++ b/test/e2e/atlas/custom_db_roles_test.go
@@ -56,7 +56,7 @@ func TestDBRoles(t *testing.T) {
 			"-o=json",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var role atlasv2.UserCustomDBRole
@@ -76,7 +76,7 @@ func TestDBRoles(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var roles []atlasv2.UserCustomDBRole
@@ -92,7 +92,7 @@ func TestDBRoles(t *testing.T) {
 			roleName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var role atlasv2.UserCustomDBRole
@@ -117,7 +117,7 @@ func TestDBRoles(t *testing.T) {
 			"--append",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var role atlasv2.UserCustomDBRole
@@ -143,7 +143,7 @@ func TestDBRoles(t *testing.T) {
 			"--privilege", updatePrivilege,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var role atlasv2.UserCustomDBRole
@@ -164,7 +164,7 @@ func TestDBRoles(t *testing.T) {
 			roleName,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)

--- a/test/e2e/atlas/custom_dns_test.go
+++ b/test/e2e/atlas/custom_dns_test.go
@@ -43,7 +43,7 @@ func TestCustomDNS(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -62,7 +62,7 @@ func TestCustomDNS(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -81,7 +81,7 @@ func TestCustomDNS(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))

--- a/test/e2e/atlas/data_federation_db_test.go
+++ b/test/e2e/atlas/data_federation_db_test.go
@@ -57,7 +57,7 @@ func TestDataFederation(t *testing.T) {
 			testBucket,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		r.NoError(err, string(resp))
 
@@ -73,7 +73,7 @@ func TestDataFederation(t *testing.T) {
 			dataFederationName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		r.NoError(err, string(resp))
 		var dataLake atlasv2.DataLakeTenant
@@ -87,7 +87,7 @@ func TestDataFederation(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 
 		var r []atlasv2.DataLakeTenant
@@ -105,7 +105,7 @@ func TestDataFederation(t *testing.T) {
 			updateRegion,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 
 		var dataLake atlasv2.DataLakeTenant
@@ -127,7 +127,7 @@ func TestDataFederation(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -139,7 +139,7 @@ func TestDataFederation(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("'%s' deleted\n", dataFederationName)

--- a/test/e2e/atlas/data_federation_private_endpoint_test.go
+++ b/test/e2e/atlas/data_federation_private_endpoint_test.go
@@ -53,7 +53,7 @@ func TestDataFederationPrivateEndpointsAWS(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		a := assert.New(t)
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.PaginatedPrivateNetworkEndpointIdEntry
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -71,7 +71,7 @@ func TestDataFederationPrivateEndpointsAWS(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var r atlasv2.PrivateNetworkEndpointIdEntry
@@ -88,7 +88,7 @@ func TestDataFederationPrivateEndpointsAWS(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -108,7 +108,7 @@ func TestDataFederationPrivateEndpointsAWS(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("'%s' deleted\n", vpcID)

--- a/test/e2e/atlas/data_federation_query_limit_test.go
+++ b/test/e2e/atlas/data_federation_query_limit_test.go
@@ -54,7 +54,7 @@ func TestDataFederationQueryLimit(t *testing.T) {
 			testBucket,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		r.NoError(err, string(resp))
 
@@ -80,7 +80,7 @@ func TestDataFederationQueryLimit(t *testing.T) {
 		cmd.Env = os.Environ()
 
 		a := assert.New(t)
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.DataFederationTenantQueryLimit
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -97,7 +97,7 @@ func TestDataFederationQueryLimit(t *testing.T) {
 			dataFederationName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var r atlasv2.DataFederationTenantQueryLimit
@@ -114,7 +114,7 @@ func TestDataFederationQueryLimit(t *testing.T) {
 			dataFederationName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -134,7 +134,7 @@ func TestDataFederationQueryLimit(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("'%s' deleted\n", limitName)
@@ -149,7 +149,7 @@ func TestDataFederationQueryLimit(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		r.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("'%s' deleted\n", dataFederationName)

--- a/test/e2e/atlas/data_lake_pipelines_test.go
+++ b/test/e2e/atlas/data_lake_pipelines_test.go
@@ -46,7 +46,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var sampleDatasetJob *atlasv2.SampleDatasetStatus
@@ -63,7 +63,7 @@ func TestDataLakePipelines(t *testing.T) {
 			sampleDatasetJob.GetId(),
 			"--projectId", g.projectID)
 		cmd.Env = os.Environ()
-		resp, err = cmd.CombinedOutput()
+		resp, err = e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 		t.Log(string(resp))
 	})
@@ -78,7 +78,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var snapshot *atlasv2.BackupSnapshot
@@ -94,7 +94,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--clusterName", g.clusterName,
 			"--projectId", g.projectID)
 		cmd.Env = os.Environ()
-		resp, err = cmd.CombinedOutput()
+		resp, err = e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 		t.Log(string(resp))
 	})
@@ -118,7 +118,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		req.NoError(err, string(resp))
 
@@ -135,7 +135,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"watch", pipelineName,
 			"--projectId", g.projectID)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 		t.Log(string(resp))
 	})
@@ -147,7 +147,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		a := assert.New(t)
@@ -163,7 +163,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var r []atlasv2.DataLakeIngestionPipeline
@@ -182,7 +182,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		req.NoError(err, string(resp))
 
@@ -200,7 +200,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		req.NoError(err, string(resp))
 
@@ -218,7 +218,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		req.NoError(err, string(resp))
 
@@ -235,7 +235,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		req.NoError(err, string(resp))
 
@@ -254,7 +254,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var r *atlasv2.PaginatedPipelineRun
@@ -272,7 +272,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		a := assert.New(t)
@@ -290,7 +290,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--pipeline", pipelineName,
 			"--projectId", g.projectID)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 		t.Log(string(resp))
 	})
@@ -304,7 +304,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 		t.Log(string(resp))
 	})
@@ -318,7 +318,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var r []atlasv2.DiskBackupApiPolicyItem
@@ -336,7 +336,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var r *atlasv2.PaginatedBackupSnapshot
@@ -352,7 +352,7 @@ func TestDataLakePipelines(t *testing.T) {
 			"--projectId", g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("'%s' deleted\n", pipelineName)

--- a/test/e2e/atlas/dbusers_certs_test.go
+++ b/test/e2e/atlas/dbusers_certs_test.go
@@ -47,7 +47,7 @@ func TestDBUserCerts(t *testing.T) {
 			dbusers.X509TypeManaged,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var user atlasv2.CloudDatabaseUser
 		require.NoError(t, json.Unmarshal(resp, &user), string(resp))
@@ -62,7 +62,7 @@ func TestDBUserCerts(t *testing.T) {
 			"--username", username,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -74,7 +74,7 @@ func TestDBUserCerts(t *testing.T) {
 			username,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var users atlasv2.PaginatedUserCert
@@ -91,7 +91,7 @@ func TestDBUserCerts(t *testing.T) {
 			"--authDB",
 			"$external")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("DB user '%s' deleted\n", username)

--- a/test/e2e/atlas/dbusers_test.go
+++ b/test/e2e/atlas/dbusers_test.go
@@ -71,7 +71,7 @@ func TestDBUserWithFlags(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var users atlasv2.PaginatedApiAtlasDatabaseUser
@@ -89,7 +89,7 @@ func TestDBUserWithFlags(t *testing.T) {
 			"-c",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var users []atlasv2.CloudDatabaseUser
@@ -205,7 +205,7 @@ func testCreateUserCmd(t *testing.T, cmd *exec.Cmd, username string) {
 
 	cmd.Env = os.Environ()
 
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 
 	var user atlasv2.CloudDatabaseUser
@@ -230,7 +230,7 @@ func testDescribeUser(t *testing.T, cliPath, username string) {
 		username,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 
 	var user atlasv2.CloudDatabaseUser
@@ -244,7 +244,7 @@ func testUpdateUserCmd(t *testing.T, cmd *exec.Cmd, username string) {
 	t.Helper()
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 
 	var user atlasv2.CloudDatabaseUser
@@ -273,7 +273,7 @@ func testDeleteUser(t *testing.T, cliPath, dbusersEntity, username string) {
 		"--authDB",
 		"admin")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 
 	expected := fmt.Sprintf("DB user '%s' deleted\n", username)

--- a/test/e2e/atlas/decryption_aws_test.go
+++ b/test/e2e/atlas/decryption_aws_test.go
@@ -54,7 +54,7 @@ func TestDecryptWithAWS(t *testing.T) {
 	)
 	cmd.Env = os.Environ()
 
-	gotContents, err := cmd.CombinedOutput()
+	gotContents, err := e2e.RunAndGetStdOut(cmd)
 	req.NoError(err, string(gotContents))
 	decryption.LogsAreEqual(t, expectedContents, gotContents)
 }

--- a/test/e2e/atlas/decryption_azure_test.go
+++ b/test/e2e/atlas/decryption_azure_test.go
@@ -54,7 +54,7 @@ func TestDecryptWithAzure(t *testing.T) {
 	)
 	cmd.Env = os.Environ()
 
-	gotContents, err := cmd.CombinedOutput()
+	gotContents, err := e2e.RunAndGetStdOut(cmd)
 	req.NoError(err, string(gotContents))
 	decryption.LogsAreEqual(t, expectedContents, gotContents)
 }

--- a/test/e2e/atlas/decryption_gcp_test.go
+++ b/test/e2e/atlas/decryption_gcp_test.go
@@ -64,7 +64,7 @@ func TestDecryptWithGCP(t *testing.T) {
 	)
 	cmd.Env = os.Environ()
 
-	gotContents, err := cmd.CombinedOutput()
+	gotContents, err := e2e.RunAndGetStdOut(cmd)
 	req.NoError(err, string(gotContents))
 
 	decryption.LogsAreEqual(t, expectedContents, gotContents)

--- a/test/e2e/atlas/decryption_localkey_test.go
+++ b/test/e2e/atlas/decryption_localkey_test.go
@@ -54,7 +54,7 @@ func TestDecryptWithLocalKey(t *testing.T) {
 	)
 	cmd.Env = os.Environ()
 
-	gotContents, err := cmd.CombinedOutput()
+	gotContents, err := e2e.RunAndGetStdOut(cmd)
 	req.NoError(err, string(gotContents))
 
 	decryption.LogsAreEqual(t, expectedContents, gotContents)

--- a/test/e2e/atlas/deployments_atlas_test.go
+++ b/test/e2e/atlas/deployments_atlas_test.go
@@ -93,7 +93,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(r))
 
 		connectionString := strings.TrimSpace(string(r))
@@ -137,7 +137,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		assert.Contains(t, string(resp), fmt.Sprintf("Starting deployment '%s'", clusterName))
 	})
@@ -162,7 +162,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		out := string(r)
 		require.NoError(t, err, out)
 		assert.Contains(t, out, "Search index created")
@@ -181,7 +181,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		expected := "Deployment '" + clusterName + "' deleted\n<nil>\n"

--- a/test/e2e/atlas/deployments_local_auth_test.go
+++ b/test/e2e/atlas/deployments_local_auth_test.go
@@ -53,7 +53,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 
 			cmd.Env = os.Environ()
 
-			r, errDiag := cmd.CombinedOutput()
+			r, errDiag := e2e.RunAndGetStdOut(cmd)
 			t.Log("Diagnostics")
 			t.Log(errDiag, string(r))
 		})
@@ -74,7 +74,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, setupErr := cmd.CombinedOutput()
+		r, setupErr := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, setupErr, string(r))
 	})
 
@@ -90,7 +90,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, delErr := cmd.CombinedOutput()
+		r, delErr := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, delErr, string(r))
 	})
 
@@ -139,7 +139,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(r))
 
 		connectionString := strings.TrimSpace(string(r))
@@ -191,7 +191,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		out := string(r)
 		req.NoError(err, out)
 		assert.Contains(t, out, "Search index created with ID:")
@@ -248,7 +248,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(r))
 	})
 

--- a/test/e2e/atlas/deployments_local_noauth_test.go
+++ b/test/e2e/atlas/deployments_local_noauth_test.go
@@ -51,7 +51,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 			cmd.Env = os.Environ()
 
-			r, errDiag := cmd.CombinedOutput()
+			r, errDiag := e2e.RunAndGetStdOut(cmd)
 			t.Log("Diagnostics")
 			t.Log(errDiag, string(r))
 		}(t)
@@ -67,7 +67,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, setupErr := cmd.CombinedOutput()
+		r, setupErr := e2e.RunAndGetStdOut(cmd)
 		req.NoError(setupErr, string(r))
 	})
 
@@ -83,7 +83,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, delErr := cmd.CombinedOutput()
+		r, delErr := e2e.RunAndGetStdOut(cmd)
 		req.NoError(delErr, string(r))
 	})
 
@@ -128,7 +128,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(r))
 
 		connectionString := strings.TrimSpace(string(r))
@@ -185,7 +185,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		out := string(r)
 		require.NoError(t, err, out)
 		assert.Contains(t, out, "Search index created with ID:")
@@ -235,7 +235,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(r))
 	})
 
@@ -298,7 +298,7 @@ func TestDeploymentsLocal(t *testing.T) {
 
 		cmd.Env = os.Environ()
 
-		r, err := cmd.CombinedOutput()
+		r, err := e2e.RunAndGetStdOut(cmd)
 		out := string(r)
 		require.NoError(t, err, out)
 		assert.Contains(t, out, "Search index created with ID:")

--- a/test/e2e/atlas/events_test.go
+++ b/test/e2e/atlas/events_test.go
@@ -41,7 +41,7 @@ func TestEvents(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var events admin.GroupPaginatedEvent
 		require.NoError(t, json.Unmarshal(resp, &events))
@@ -59,7 +59,7 @@ func TestEvents(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var events admin.OrgPaginatedEvent
 		require.NoError(t, json.Unmarshal(resp, &events))

--- a/test/e2e/atlas/federation_settings_test.go
+++ b/test/e2e/atlas/federation_settings_test.go
@@ -47,7 +47,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var settings atlasv2.OrgFederationSettings
@@ -90,7 +90,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var provider atlasv2.FederationIdentityProvider
@@ -114,7 +114,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var config atlasv2.ConnectedOrgConfig
@@ -160,7 +160,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var provider atlasv2.FederationIdentityProvider
@@ -183,7 +183,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var provider atlasv2.FederationIdentityProvider
@@ -206,7 +206,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var config atlasv2.ConnectedOrgConfig
@@ -228,7 +228,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var config atlasv2.ConnectedOrgConfig
@@ -252,7 +252,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var config atlasv2.ConnectedOrgConfig
@@ -275,7 +275,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var config atlasv2.ConnectedOrgConfig
@@ -298,7 +298,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var config atlasv2.ConnectedOrgConfig
@@ -321,7 +321,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var config atlasv2.ConnectedOrgConfig
@@ -346,7 +346,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var provider atlasv2.FederationIdentityProvider
@@ -369,7 +369,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var provider atlasv2.FederationIdentityProvider
@@ -390,7 +390,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var provider atlasv2.FederationIdentityProvider
@@ -409,7 +409,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var config atlasv2.PaginatedConnectedOrgConfigs
@@ -434,7 +434,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var provider atlasv2.FederationIdentityProvider
@@ -455,7 +455,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 	})
 
@@ -473,7 +473,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 	})
 
@@ -490,7 +490,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 	})
 
@@ -508,7 +508,7 @@ func TestIdentityProviders(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 	})
 }

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -188,7 +188,7 @@ func deployServerlessInstanceForProject(projectID string) (string, error) {
 	}
 	create := exec.Command(cliPath, args...)
 	create.Env = os.Environ()
-	if resp, err := create.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(create); err != nil {
 		return "", fmt.Errorf("error creating serverless instance %w: %s", err, string(resp))
 	}
 
@@ -202,7 +202,7 @@ func deployServerlessInstanceForProject(projectID string) (string, error) {
 	}
 	watch := exec.Command(cliPath, watchArgs...)
 	watch.Env = os.Environ()
-	if resp, err := watch.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(watch); err != nil {
 		return "", fmt.Errorf("error watching serverless instance %w: %s", err, string(resp))
 	}
 	return clusterName, nil
@@ -224,7 +224,7 @@ func watchServerlessInstanceForProject(projectID, clusterName string) error {
 	}
 	watchCmd := exec.Command(cliPath, watchArgs...)
 	watchCmd.Env = os.Environ()
-	if resp, err := watchCmd.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(watchCmd); err != nil {
 		return fmt.Errorf("error watching serverless instance %w: %s", err, string(resp))
 	}
 	return nil
@@ -244,7 +244,7 @@ func deleteServerlessInstanceForProject(t *testing.T, cliPath, projectID, cluste
 	}
 	deleteCmd := exec.Command(cliPath, args...)
 	deleteCmd.Env = os.Environ()
-	resp, err := deleteCmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(deleteCmd)
 	require.NoError(t, err, string(resp))
 
 	_ = watchServerlessInstanceForProject(projectID, clusterName)
@@ -281,7 +281,7 @@ func deployClusterForProject(projectID, tier, mDBVersion string, enableBackup bo
 	}
 	create := exec.Command(cliPath, args...)
 	create.Env = os.Environ()
-	if resp, err := create.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(create); err != nil {
 		return "", "", fmt.Errorf("error creating cluster %w: %s", err, string(resp))
 	}
 
@@ -295,7 +295,7 @@ func deployClusterForProject(projectID, tier, mDBVersion string, enableBackup bo
 	}
 	watch := exec.Command(cliPath, watchArgs...)
 	watch.Env = os.Environ()
-	if resp, err := watch.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(watch); err != nil {
 		return "", "", fmt.Errorf("error watching cluster %w: %s", err, string(resp))
 	}
 	return clusterName, region, nil
@@ -325,7 +325,7 @@ func internalDeleteClusterForProject(projectID, clusterName string) error {
 	}
 	deleteCmd := exec.Command(cliPath, args...)
 	deleteCmd.Env = os.Environ()
-	if resp, err := deleteCmd.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(deleteCmd); err != nil {
 		return fmt.Errorf("error deleting cluster %w: %s", err, string(resp))
 	}
 
@@ -350,7 +350,7 @@ func watchCluster(projectID, clusterName string) error {
 	}
 	watchCmd := exec.Command(cliPath, watchArgs...)
 	watchCmd.Env = os.Environ()
-	if resp, err := watchCmd.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(watchCmd); err != nil {
 		return fmt.Errorf("error waiting for cluster %w: %s", err, string(resp))
 	}
 	return nil
@@ -372,7 +372,7 @@ func removeTerminationProtectionFromCluster(projectID, clusterName string) error
 	}
 	updateCmd := exec.Command(cliPath, args...)
 	updateCmd.Env = os.Environ()
-	if resp, err := updateCmd.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(updateCmd); err != nil {
 		return fmt.Errorf("error updating cluster %w: %s", err, string(resp))
 	}
 
@@ -405,7 +405,7 @@ func deleteDatalakeForProject(cliPath, projectID, id string) error {
 	}
 	deleteCmd := exec.Command(cliPath, args...)
 	deleteCmd.Env = os.Environ()
-	if resp, err := deleteCmd.CombinedOutput(); err != nil {
+	if resp, err := e2e.RunAndGetStdOut(deleteCmd); err != nil {
 		return fmt.Errorf("error deleting datalake %w: %s", err, string(resp))
 	}
 	return nil
@@ -431,7 +431,7 @@ func newAvailableRegion(projectID, tier, provider string) (string, error) {
 	}
 	cmd := exec.Command(cliPath, args...)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 
 	if err != nil {
 		return "", fmt.Errorf("error getting regions %w: %s", err, string(resp))
@@ -585,7 +585,7 @@ func getFirstOrgUser() (string, error) {
 	}
 	cmd := exec.Command(cliPath, args...)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -616,7 +616,7 @@ func createTeam(teamName, userName string) (string, error) {
 	}
 	cmd := exec.Command(cliPath, args...)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -645,7 +645,7 @@ func createProject(projectName string) (string, error) {
 	}
 	cmd := exec.Command(cliPath, args...)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -675,7 +675,7 @@ func createProjectWithoutAlertSettings(projectName string) (string, error) {
 	}
 	cmd := exec.Command(cliPath, args...)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -696,7 +696,7 @@ func listClustersForProject(t *testing.T, cliPath, projectID string) atlasv2.Pag
 		"--projectId", projectID,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	t.Log(string(resp))
 	require.NoError(t, err, string(resp))
 	var clusters atlasv2.PaginatedAdvancedClusterDescription
@@ -729,7 +729,7 @@ func deleteDatapipelinesForProject(t *testing.T, cliPath, projectID string) {
 		"--projectId", projectID,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	t.Log(string(resp))
 	require.NoError(t, err, string(resp))
 	var pipelines []atlasv2.DataLakeIngestionPipeline
@@ -752,7 +752,7 @@ func deleteAllNetworkPeers(t *testing.T, cliPath, projectID, provider string) {
 		"-o=json",
 	)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	t.Log("available network peers", string(resp))
 	require.NoError(t, err, string(resp))
 	var networkPeers []atlasv2.BaseNetworkPeeringConnectionSettings
@@ -770,7 +770,7 @@ func deleteAllNetworkPeers(t *testing.T, cliPath, projectID, provider string) {
 			"--force",
 		)
 		cmd.Env = os.Environ()
-		resp, err = cmd.CombinedOutput()
+		resp, err = e2e.RunAndGetStdOut(cmd)
 		assert.NoError(t, err, string(resp))
 	}
 }
@@ -810,7 +810,7 @@ func listPrivateEndpointsByProject(t *testing.T, cliPath, projectID, provider st
 		"-o=json",
 	)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	t.Log(string(resp))
 	require.NoError(t, err, string(resp))
 	var privateEndpoints []atlasv2.EndpointService
@@ -832,7 +832,7 @@ func deletePrivateEndpoint(t *testing.T, cliPath, projectID, provider, endpointI
 		"--force",
 	)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 }
 
@@ -847,7 +847,7 @@ func deleteTeam(teamID string) error {
 		teamID,
 		"--force")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -865,7 +865,7 @@ func deleteProject(projectID string) error {
 		projectID,
 		"--force")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -886,7 +886,7 @@ func createDBUserWithCert(projectID, username string) error {
 		"--x509Type", "MANAGED",
 		"--projectId", projectID)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -913,7 +913,7 @@ func createDataFederationForProject(projectID string) (string, error) {
 		"--projectId", projectID,
 		"--region", "DUBLIN_IRL")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -930,7 +930,7 @@ func listDataFederationsByProject(t *testing.T, cliPath, projectID string) []atl
 		"--projectId", projectID,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	t.Log("available datafederations", string(resp))
 	require.NoError(t, err, string(resp))
 
@@ -950,7 +950,7 @@ func listServerlessByProject(t *testing.T, cliPath, projectID string) *atlasv2.P
 		"--projectId", projectID,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 
 	var serverlessInstances *atlasv2.PaginatedServerlessInstanceDescription
@@ -1000,7 +1000,7 @@ func deleteDataFederationForProject(t *testing.T, cliPath, projectID, dataFedNam
 		"--projectId", projectID,
 		"--force")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 }
 
@@ -1070,7 +1070,7 @@ func enableCompliancePolicy(projectID string) error {
 		"--watch", // avoiding HTTP 400 Bad Request "CANNOT_UPDATE_BACKUP_COMPLIANCE_POLICY_SETTINGS_WITH_PENDING_ACTION".
 	)
 	cmd.Env = os.Environ()
-	output, outputErr := cmd.CombinedOutput()
+	output, outputErr := e2e.RunAndGetStdOut(cmd)
 	if outputErr != nil {
 		return fmt.Errorf("%w\n %s", outputErr, string(output))
 	}
@@ -1109,7 +1109,7 @@ func setupCompliancePolicy(t *testing.T, projectID string, compliancePolicy *atl
 	)
 
 	cmd.Env = os.Environ()
-	resp, outputErr := cmd.CombinedOutput()
+	resp, outputErr := e2e.RunAndGetStdOut(cmd)
 	if outputErr != nil {
 		return nil, fmt.Errorf("%w\n %s", outputErr, string(resp))
 	}
@@ -1153,7 +1153,7 @@ func createStreamsInstance(t *testing.T, projectID, name string) (string, error)
 		"--region", "VIRGINIA_USA",
 	)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -1179,7 +1179,7 @@ func deleteStreamsInstance(t *testing.T, projectID, name string) error {
 		"--force",
 	)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -1212,7 +1212,7 @@ func createStreamsConnection(t *testing.T, projectID, instanceName, name string)
 		"--projectId", projectID,
 	)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%s (%w)", string(resp), err)
 	}
@@ -1239,7 +1239,7 @@ func deleteStreamsConnection(t *testing.T, projectID, instanceName, name string)
 		"--force",
 	)
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return fmt.Errorf("%s (%w)", string(resp), err)
 	}

--- a/test/e2e/atlas/integrations_test.go
+++ b/test/e2e/atlas/integrations_test.go
@@ -56,7 +56,7 @@ func TestIntegrations(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -79,7 +79,7 @@ func TestIntegrations(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -103,7 +103,7 @@ func TestIntegrations(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -129,7 +129,7 @@ func TestIntegrations(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -152,7 +152,7 @@ func TestIntegrations(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -170,7 +170,7 @@ func TestIntegrations(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -188,7 +188,7 @@ func TestIntegrations(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -206,7 +206,7 @@ func TestIntegrations(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -144,7 +144,7 @@ func TestEmptyProject(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -177,7 +177,7 @@ func TestProjectWithNonDefaultSettings(t *testing.T) {
 			"--projectId",
 			generator.projectID)
 		cmd.Env = os.Environ()
-		settingsResp, err := cmd.CombinedOutput()
+		settingsResp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(settingsResp))
 
 		cmd = exec.Command(cliPath,
@@ -191,7 +191,7 @@ func TestProjectWithNonDefaultSettings(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -282,7 +282,7 @@ func TestProjectWithNonDefaultAlertConf(t *testing.T) {
 			newAlertConfig.Matchers[0].Value,
 			"-o=json")
 		cmd.Env = os.Environ()
-		alertConfigResp, err := cmd.CombinedOutput()
+		alertConfigResp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(alertConfigResp))
 
 		cmd = exec.Command(cliPath,
@@ -296,7 +296,7 @@ func TestProjectWithNonDefaultAlertConf(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -336,7 +336,7 @@ func TestProjectWithAccessList(t *testing.T) {
 			"ipAddress",
 			"-o=json")
 		cmd.Env = os.Environ()
-		accessListResp, err := cmd.CombinedOutput()
+		accessListResp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(accessListResp))
 
 		cmd = exec.Command(cliPath,
@@ -350,7 +350,7 @@ func TestProjectWithAccessList(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -385,7 +385,7 @@ func TestProjectWithAccessRole(t *testing.T) {
 			generator.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		accessRoleResp, err := cmd.CombinedOutput()
+		accessRoleResp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(accessRoleResp))
 
 		cmd = exec.Command(cliPath,
@@ -399,7 +399,7 @@ func TestProjectWithAccessRole(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -447,7 +447,7 @@ func TestProjectWithCustomRole(t *testing.T) {
 			generator.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		dbRoleResp, err := cmd.CombinedOutput()
+		dbRoleResp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(dbRoleResp))
 
 		cmd = exec.Command(cliPath,
@@ -461,7 +461,7 @@ func TestProjectWithCustomRole(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -503,7 +503,7 @@ func TestProjectWithIntegration(t *testing.T) {
 			generator.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		_, err := cmd.CombinedOutput()
+		_, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err)
 
 		cmd = exec.Command(cliPath,
@@ -517,7 +517,7 @@ func TestProjectWithIntegration(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -560,7 +560,7 @@ func TestProjectWithMaintenanceWindow(t *testing.T) {
 			generator.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		_, err := cmd.CombinedOutput()
+		_, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err)
 
 		cmd = exec.Command(cliPath,
@@ -574,7 +574,7 @@ func TestProjectWithMaintenanceWindow(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -618,7 +618,7 @@ func TestProjectWithNetworkPeering(t *testing.T) {
 			generator.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		t.Cleanup(func() {
 			deleteAllNetworkPeers(t, cliPath, generator.projectID, gcpEntity)
@@ -639,7 +639,7 @@ func TestProjectWithNetworkPeering(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err = cmd.CombinedOutput()
+		resp, err = e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -677,7 +677,7 @@ func TestProjectWithPrivateEndpoint_Azure(t *testing.T) {
 			generator.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err)
 		t.Cleanup(func() {
 			deleteAllPrivateEndpoints(t, cliPath, generator.projectID, azureEntity)
@@ -693,7 +693,7 @@ func TestProjectWithPrivateEndpoint_Azure(t *testing.T) {
 			createdNetworkPeer.GetId(),
 			"--projectId", generator.projectID)
 		cmd.Env = os.Environ()
-		_, err = cmd.CombinedOutput()
+		_, err = e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err)
 
 		cmd = exec.Command(cliPath,
@@ -707,7 +707,7 @@ func TestProjectWithPrivateEndpoint_Azure(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err = cmd.CombinedOutput()
+		resp, err = e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -755,7 +755,7 @@ func TestProjectAndTeams(t *testing.T) {
 			generator.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		cmd = exec.Command(cliPath,
@@ -769,7 +769,7 @@ func TestProjectAndTeams(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err = cmd.CombinedOutput()
+		resp, err = e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -808,7 +808,7 @@ func TestProjectWithStreamsProcessing(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -1401,7 +1401,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 			"--clusterName",
 			g.clusterName)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -1419,7 +1419,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -1472,7 +1472,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -1504,7 +1504,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 			"--includeSecrets")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -1559,7 +1559,7 @@ func TestKubernetesConfigGenerateSharedCluster(t *testing.T) {
 		"--includeSecrets")
 	cmd.Env = os.Environ()
 
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	t.Log(string(resp))
 	require.NoError(t, err, string(resp))
 	var objects []runtime.Object
@@ -1683,7 +1683,7 @@ func TestKubernetesConfigGenerate_DataFederation(t *testing.T) {
 			targetNamespace)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 
 		require.NoError(t, err, string(resp))
@@ -1725,7 +1725,7 @@ func TestKubernetesConfigGenerate_DataFederation(t *testing.T) {
 			targetNamespace)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 
@@ -1752,7 +1752,7 @@ func TestKubernetesConfigGenerate_DataFederation(t *testing.T) {
 			targetNamespace)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 		require.NoError(t, err, string(resp))
 

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -55,7 +55,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"install",
 			"--operatorVersion", "1.1.0")
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		require.Error(t, inErr, string(resp))
 		assert.Equal(t, "Error: version 1.1.0 is not supported\n", string(resp))
 	})
@@ -67,7 +67,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"install",
 			"--operatorVersion", "100.0.0")
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		require.Error(t, inErr, string(resp))
 		assert.Equal(t, "Error: version 100.0.0 is not supported\n", string(resp))
 	})
@@ -79,7 +79,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"install",
 			"--kubeconfig", "/path/to/non/existing/config")
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		require.Error(t, inErr, string(resp))
 		assert.Equal(t, "Error: unable to prepare client configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable\n", string(resp))
 	})
@@ -95,7 +95,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"install",
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, inErr, string(resp))
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
@@ -115,7 +115,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--targetNamespace", operatorNamespace,
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, inErr, string(resp))
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
@@ -139,7 +139,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--watchNamespace", operatorWatch2,
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		req.NoError(inErr, string(resp))
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 		checkDeployment(t, operator, operatorNamespace)
@@ -159,7 +159,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--watchNamespace", operatorNamespace,
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		req.NoError(inErr, string(resp))
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
@@ -181,7 +181,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--import",
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, inErr, string(resp))
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
@@ -256,7 +256,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--import",
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		req.NoError(inErr, string(resp))
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
@@ -286,7 +286,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--targetNamespace", operatorNamespace,
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
-		resp, inErr := cmd.CombinedOutput()
+		resp, inErr := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, inErr, string(resp))
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
@@ -450,7 +450,7 @@ func cleanUpKeys(t *testing.T, operator *operatorHelper, namespace string, cliPa
 		"ls",
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 
 	var keys atlasv2.PaginatedApiApiUser
@@ -469,7 +469,7 @@ func cleanUpKeys(t *testing.T, operator *operatorHelper, namespace string, cliPa
 				keyID,
 				"--force")
 			cmd.Env = os.Environ()
-			_, err = cmd.CombinedOutput()
+			_, err = e2e.RunAndGetStdOut(cmd)
 			require.NoError(t, err)
 		}
 	}

--- a/test/e2e/atlas/ldap_test.go
+++ b/test/e2e/atlas/ldap_test.go
@@ -76,7 +76,7 @@ func TestLDAPWithFlags(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		assert.Contains(t, string(resp), "LDAP Configuration request completed.")
 	})
@@ -93,7 +93,7 @@ func TestLDAPWithFlags(t *testing.T) {
 			"json",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)
@@ -136,7 +136,7 @@ func TestLDAPWithFlags(t *testing.T) {
 			"-o",
 			"json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)
@@ -223,7 +223,7 @@ func testLDAPDelete(t *testing.T, cliPath, projectID string) {
 		"--projectId", projectID,
 		"--force")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 	assert.Contains(t, string(resp), "LDAP configuration userToDNMapping deleted")
 }
@@ -232,7 +232,7 @@ func testLDAPVerifyCmd(t *testing.T, cmd *exec.Cmd) string {
 	t.Helper()
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 
 	a := assert.New(t)
@@ -246,7 +246,7 @@ func testLDAPSaveCmd(t *testing.T, cmd *exec.Cmd) {
 	t.Helper()
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 
 	a := assert.New(t)

--- a/test/e2e/atlas/live_migrations_test.go
+++ b/test/e2e/atlas/live_migrations_test.go
@@ -50,7 +50,7 @@ func TestLinkToken(t *testing.T) {
 			"--accessListIp",
 			"1.2.3.4,5.6.7.8")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 	})
@@ -62,7 +62,7 @@ func TestLinkToken(t *testing.T) {
 			"delete",
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 	})

--- a/test/e2e/atlas/maintenance_test.go
+++ b/test/e2e/atlas/maintenance_test.go
@@ -45,7 +45,7 @@ func TestMaintenanceWindows(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := "Maintenance window updated.\n"
 		assert.Equal(t, expected, string(resp))
@@ -60,7 +60,7 @@ func TestMaintenanceWindows(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var maintenanceWindow atlasv2.GroupMaintenanceWindow
@@ -78,7 +78,7 @@ func TestMaintenanceWindows(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := "Maintenance window removed.\n"
 		assert.Equal(t, expected, string(resp))

--- a/test/e2e/atlas/metrics_test.go
+++ b/test/e2e/atlas/metrics_test.go
@@ -67,7 +67,7 @@ func process(t *testing.T, cliPath, hostname, projectID string) {
 		"-o=json")
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 	var metrics *atlasv2.ApiMeasurementsGeneralViewAtlas
 	require.NoError(t, json.Unmarshal(resp, &metrics), string(resp))
@@ -87,7 +87,7 @@ func processWithType(t *testing.T, cliPath, hostname, projectID string) {
 		"-o=json")
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 	var metrics *atlasv2.ApiMeasurementsGeneralViewAtlas
 	require.NoError(t, json.Unmarshal(resp, &metrics), string(resp))
@@ -106,7 +106,7 @@ func databases(t *testing.T, cliPath, hostname, projectID string) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var db atlasv2.PaginatedDatabase
 		require.NoError(t, json.Unmarshal(resp, &db), string(resp))
@@ -126,7 +126,7 @@ func databases(t *testing.T, cliPath, hostname, projectID string) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var metrics atlasv2.ApiMeasurementsGeneralViewAtlas
 		require.NoError(t, json.Unmarshal(resp, &metrics), string(resp))
@@ -146,7 +146,7 @@ func disks(t *testing.T, cliPath, hostname, projectID string) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var d atlasv2.PaginatedDiskPartition
 		require.NoError(t, json.Unmarshal(resp, &d), string(resp))
@@ -166,7 +166,7 @@ func disks(t *testing.T, cliPath, hostname, projectID string) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var metrics atlasv2.ApiMeasurementsGeneralViewAtlas
 		require.NoError(t, json.Unmarshal(resp, &metrics), string(resp))

--- a/test/e2e/atlas/online_archives_test.go
+++ b/test/e2e/atlas/online_archives_test.go
@@ -90,7 +90,7 @@ func deleteOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveI
 		"--force")
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 	expected := fmt.Sprintf("Archive '%s' deleted\n", archiveID)
 	assert.Equal(t, expected, string(resp))
@@ -165,7 +165,7 @@ func updateOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiveI
 		"-o=json")
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 	}
@@ -188,7 +188,7 @@ func describeOnlineArchive(t *testing.T, cliPath, projectID, clusterName, archiv
 		"-o=json")
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 	}
@@ -211,7 +211,7 @@ func listOnlineArchives(t *testing.T, cliPath, projectID, clusterName string) {
 		"-o=json")
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 	}
@@ -239,7 +239,7 @@ func createOnlineArchive(t *testing.T, cliPath, projectID, clusterName string) s
 		"-o=json")
 
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 	}

--- a/test/e2e/atlas/operator_helper_test.go
+++ b/test/e2e/atlas/operator_helper_test.go
@@ -206,7 +206,7 @@ func (oh *operatorHelper) installOperator(namespace, version string) error {
 		"--targetNamespace", namespace,
 	)
 	cmd.Env = os.Environ()
-	_, err = cmd.CombinedOutput()
+	_, err = e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return fmt.Errorf("unable install the operator: %w", err)
 	}

--- a/test/e2e/atlas/performance_advisor_test.go
+++ b/test/e2e/atlas/performance_advisor_test.go
@@ -45,7 +45,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -60,7 +60,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -75,7 +75,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -88,7 +88,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -101,7 +101,7 @@ func TestPerformanceAdvisor(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/atlas/private_endpoint_test.go
+++ b/test/e2e/atlas/private_endpoint_test.go
@@ -62,7 +62,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -80,7 +80,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 			g.projectID)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -94,7 +94,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -110,7 +110,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r []atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -128,7 +128,7 @@ func TestPrivateEndpointsAWS(t *testing.T) {
 			"--force")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Private endpoint '%s' deleted\n", id)
 		assert.Equal(t, expected, string(resp))
@@ -183,7 +183,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -202,7 +202,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			"--projectId",
 			g.projectID)
 		cmd.Env = os.Environ()
-		_, err := cmd.CombinedOutput()
+		_, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err)
 	})
 
@@ -216,7 +216,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -232,7 +232,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r []atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -250,7 +250,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 			g.projectID)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Private endpoint '%s' deleted\n", id)
 		assert.Equal(t, expected, string(resp))
@@ -310,7 +310,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -328,7 +328,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 			g.projectID)
 		cmd.Env = os.Environ()
 
-		_, err := cmd.CombinedOutput()
+		_, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err)
 	})
 
@@ -342,7 +342,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -358,7 +358,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r []atlasv2.EndpointService
 		require.NoError(t, json.Unmarshal(resp, &r))
@@ -376,7 +376,7 @@ func TestPrivateEndpointsGCP(t *testing.T) {
 			g.projectID)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Private endpoint '%s' deleted\n", id)
 		assert.Equal(t, expected, string(resp))
@@ -415,7 +415,7 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 			g.projectID)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		assert.Equal(t, "Regionalized private endpoint setting enabled.\n", string(resp))
 	})
@@ -429,7 +429,7 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 			g.projectID)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		assert.Equal(t, "Regionalized private endpoint setting disabled.\n", string(resp))
 	})
@@ -444,7 +444,7 @@ func TestRegionalizedPrivateEndpointsSettings(t *testing.T) {
 			"-o=json")
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var r atlasv2.ProjectSettingItem
 		require.NoError(t, json.Unmarshal(resp, &r))

--- a/test/e2e/atlas/processes_test.go
+++ b/test/e2e/atlas/processes_test.go
@@ -44,7 +44,7 @@ func TestProcesses(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		require.NoError(t, json.Unmarshal(resp, &processes))
 		require.NotEmpty(t, processes.Results)
@@ -59,7 +59,7 @@ func TestProcesses(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var hostViewsCompact []atlasv2.ApiHostViewAtlas
 		require.NoError(t, json.Unmarshal(resp, &hostViewsCompact))
@@ -75,7 +75,7 @@ func TestProcesses(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var p *atlasv2.ApiHostViewAtlas
 		require.NoError(t, json.Unmarshal(resp, &p))

--- a/test/e2e/atlas/profile_test.go
+++ b/test/e2e/atlas/profile_test.go
@@ -36,7 +36,7 @@ func validateProfile(t *testing.T, cliPath string, profile string, profileValid 
 	cmd.Env = os.Environ()
 
 	// Execute the command
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 
 	// We only care about errors that happened due to something other than a non-zero exit code
 	if err != nil {

--- a/test/e2e/atlas/project_settings_test.go
+++ b/test/e2e/atlas/project_settings_test.go
@@ -52,7 +52,7 @@ func TestProjectSettings(t *testing.T) {
 			"get",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var settings map[string]interface{}
 		if err := json.Unmarshal(resp, &settings); err != nil {
@@ -74,7 +74,7 @@ func TestProjectSettings(t *testing.T) {
 			"--disableCollectDatabaseSpecificsStatistics",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var settings atlasv2.GroupSettings
 		require.NoError(t, json.Unmarshal(resp, &settings))

--- a/test/e2e/atlas/search_nodes_test.go
+++ b/test/e2e/atlas/search_nodes_test.go
@@ -76,7 +76,7 @@ func TestSearchNodes(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		resp = bytes.TrimLeft(resp, ".")
 
 		require.NoError(t, err, resp)
@@ -104,7 +104,7 @@ func TestSearchNodes(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		resp = bytes.TrimLeft(resp, ".")
 
 		require.NoError(t, err, resp)
@@ -134,7 +134,7 @@ func TestSearchNodes(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		resp = bytes.TrimLeft(resp, ".")
 
 		require.NoError(t, err, resp)
@@ -162,7 +162,7 @@ func TestSearchNodes(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		resp = bytes.TrimLeft(resp, ".")
 
 		require.NoError(t, err, resp)
@@ -192,7 +192,7 @@ func TestSearchNodes(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		respStr := strings.TrimLeft(string(resp), ".")
 
 		require.NoError(t, err, respStr)

--- a/test/e2e/atlas/search_test.go
+++ b/test/e2e/atlas/search_test.go
@@ -91,7 +91,7 @@ func TestSearch(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
 		require.NoError(t, json.Unmarshal(resp, &index))
@@ -110,7 +110,7 @@ func TestSearch(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
 		require.NoError(t, json.Unmarshal(resp, &index))
@@ -156,7 +156,7 @@ func TestSearch(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
 		require.NoError(t, json.Unmarshal(resp, &index))
@@ -176,7 +176,7 @@ func TestSearch(t *testing.T) {
 			"--projectId", g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Index '%s' deleted\n", indexID)
 		assert.Equal(t, expected, string(resp))
@@ -239,7 +239,7 @@ func TestSearch(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
 		require.NoError(t, json.Unmarshal(resp, &index))
@@ -342,7 +342,7 @@ func TestSearch(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
 		require.NoError(t, json.Unmarshal(resp, &index))
@@ -398,7 +398,7 @@ func TestSearch(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var index atlasv2.ClusterSearchIndex
 		require.NoError(t, json.Unmarshal(resp, &index))
@@ -418,7 +418,7 @@ func TestSearch(t *testing.T) {
 			"-o=json")
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var indexes []atlasv2.ClusterSearchIndex

--- a/test/e2e/atlas/serverless_test.go
+++ b/test/e2e/atlas/serverless_test.go
@@ -50,7 +50,7 @@ func TestServerless(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var cluster atlasv2.ServerlessInstanceDescription
@@ -69,7 +69,7 @@ func TestServerless(t *testing.T) {
 			clusterName,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		a := assert.New(t)
@@ -86,7 +86,7 @@ func TestServerless(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var cluster atlasv2.ServerlessInstanceDescription
@@ -104,7 +104,7 @@ func TestServerless(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var clusters atlasv2.PaginatedServerlessInstanceDescription
@@ -123,7 +123,7 @@ func TestServerless(t *testing.T) {
 			"--projectId", g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var cluster atlasv2.ServerlessInstanceDescription
@@ -143,7 +143,7 @@ func TestServerless(t *testing.T) {
 			"--projectId", g.projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		expected := fmt.Sprintf("Serverless instance '%s' deleted\n", clusterName)
@@ -161,7 +161,7 @@ func TestServerless(t *testing.T) {
 		cmd.Env = os.Environ()
 		// this command will fail with 404 once the cluster is deleted
 		// we just need to wait for this to close the project
-		resp, _ := cmd.CombinedOutput()
+		resp, _ := e2e.RunAndGetStdOut(cmd)
 		t.Log(string(resp))
 	})
 }

--- a/test/e2e/atlas/setup_force_test.go
+++ b/test/e2e/atlas/setup_force_test.go
@@ -57,7 +57,7 @@ func TestSetup(t *testing.T) {
 			"--accessListIp", arbitraryAccessListIP,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		assert.Contains(t, string(resp), "Cluster created.", string(resp))
 	})
@@ -72,7 +72,7 @@ func TestSetup(t *testing.T) {
 			g.projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var entries *atlasv2.PaginatedNetworkAccess
@@ -93,7 +93,7 @@ func TestSetup(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var user atlasv2.CloudDatabaseUser
@@ -110,7 +110,7 @@ func TestSetup(t *testing.T) {
 			"--projectId", g.projectID,
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var cluster atlasv2.AdvancedClusterDescription

--- a/test/e2e/atlas/streams_test.go
+++ b/test/e2e/atlas/streams_test.go
@@ -59,7 +59,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var instances atlasv2.PaginatedApiStreamsTenant
@@ -87,7 +87,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var instance atlasv2.StreamsTenant
@@ -114,7 +114,7 @@ func TestStreams(t *testing.T) {
 		)
 		cmd.Env = os.Environ()
 
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -129,7 +129,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var instances atlasv2.PaginatedApiStreamsTenant
@@ -154,7 +154,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var instance atlasv2.StreamsTenant
@@ -183,7 +183,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var instance atlasv2.StreamsTenant
@@ -212,7 +212,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var connection atlasv2.StreamsConnection
@@ -235,7 +235,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var connection atlasv2.StreamsConnection
@@ -260,7 +260,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var response atlasv2.PaginatedApiStreamsConnection
@@ -290,7 +290,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var connection atlasv2.StreamsConnection
@@ -314,7 +314,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Atlas Stream Processing connection '%s' deleted\n", connectionName)
@@ -335,7 +335,7 @@ func TestStreams(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		expected := fmt.Sprintf("Atlas Streams processor instance '%s' deleted\n", instanceName)

--- a/test/e2e/atlas/streams_with_clusters_test.go
+++ b/test/e2e/atlas/streams_with_clusters_test.go
@@ -64,7 +64,7 @@ func TestStreamsWithClusters(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		req.NoError(err, string(resp))
 
 		var instance atlasv2.StreamsTenant
@@ -94,7 +94,7 @@ func TestStreamsWithClusters(t *testing.T) {
 		)
 
 		streamsCmd.Env = os.Environ()
-		streamsResp, streamsErr := streamsCmd.CombinedOutput()
+		streamsResp, streamsErr := e2e.RunAndGetStdOut(streamsCmd)
 		req.NoError(streamsErr, string(streamsResp))
 
 		var connection atlasv2.StreamsConnection

--- a/test/e2e/brew/brew_test.go
+++ b/test/e2e/brew/brew_test.go
@@ -40,7 +40,7 @@ func TestAtlasCLIConfig(t *testing.T) {
 	t.Run("config ls", func(t *testing.T) {
 		cmd := exec.Command(cliPath, "config", "ls")
 		cmd.Env = append(os.Environ(), tempDirEnv)
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
@@ -59,9 +59,9 @@ func TestAtlasCLIConfig(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error, resp: %v", string(resp))
 		}
-		got := strings.TrimSpace(string(resp))
+		got := string(resp)
 
-		if !strings.HasPrefix(got, errorMessage) {
+		if !strings.Contains(got, errorMessage) {
 			t.Errorf("want %q; got %q\n", errorMessage, got)
 		}
 	})
@@ -69,7 +69,7 @@ func TestAtlasCLIConfig(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		cmd := exec.Command(cliPath, "help")
 		cmd.Env = append(os.Environ(), tempDirEnv)
-		if resp, err := cmd.CombinedOutput(); err != nil {
+		if resp, err := e2e.RunAndGetStdOut(cmd); err != nil {
 			t.Fatalf("unexpected error, resp: %v", string(resp))
 		}
 	})

--- a/test/e2e/config/autocomplete_test.go
+++ b/test/e2e/config/autocomplete_test.go
@@ -35,7 +35,7 @@ func TestAtlasCLIAutocomplete(t *testing.T) {
 		t.Run(option, func(t *testing.T) {
 			cmd := exec.Command(cliPath, completionEntity, option)
 			cmd.Env = os.Environ()
-			if resp, err := cmd.CombinedOutput(); err != nil {
+			if resp, err := e2e.RunAndGetStdOut(cmd); err != nil {
 				t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 			}
 		})

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -120,7 +120,7 @@ func TestConfig(t *testing.T) {
 	t.Run("List", func(t *testing.T) {
 		cmd := exec.Command(cliPath, configEntity, "ls")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
@@ -138,7 +138,7 @@ func TestConfig(t *testing.T) {
 			"-o=json",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
@@ -162,7 +162,7 @@ func TestConfig(t *testing.T) {
 			"renamed",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
@@ -174,7 +174,7 @@ func TestConfig(t *testing.T) {
 	t.Run("Delete", func(t *testing.T) {
 		cmd := exec.Command(cliPath, configEntity, "delete", "renamed", "--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -40,7 +41,7 @@ func CreateProject(projectName string) (string, error) {
 		projectName,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%w: %s", err, string(resp))
 	}
@@ -89,4 +90,19 @@ func DeleteProjectWithRetry(t *testing.T, projectID string) {
 	if !deleted {
 		t.Errorf("we could not delete the project %q", projectID)
 	}
+}
+
+func RunAndGetStdOut(cmd *exec.Cmd) ([]byte, error) {
+	cmd.Stderr = os.Stderr
+	var b bytes.Buffer
+	cmd.Stdout = &b
+
+	err := cmd.Run()
+	resp := b.Bytes()
+
+	if err != nil {
+		return nil, fmt.Errorf("%s (%w)", string(resp), err)
+	}
+
+	return resp, nil
 }

--- a/test/e2e/iam/atlas_org_api_key_access_list_test.go
+++ b/test/e2e/iam/atlas_org_api_key_access_list_test.go
@@ -57,7 +57,7 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 			entry,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var key atlasv2.PaginatedApiUserAccessListResponse
 		require.NoError(t, json.Unmarshal(resp, &key))
@@ -73,7 +73,7 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 			apiKeyID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var key atlasv2.PaginatedApiUserAccessListResponse
 		require.NoError(t, json.Unmarshal(resp, &key))
@@ -95,7 +95,7 @@ func TestAtlasOrgAPIKeyAccessList(t *testing.T) {
 			"--currentIp",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var key atlasv2.PaginatedApiUserAccessListResponse
 		require.NoError(t, json.Unmarshal(resp, &key))
@@ -120,7 +120,7 @@ func deleteAtlasAccessListEntry(t *testing.T, cliPath, entry, apiKeyID string) {
 		apiKeyID,
 		"--force")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
 	expected := fmt.Sprintf("Access list entry '%s' deleted\n", entry)
 	assert.Equal(t, expected, string(resp))

--- a/test/e2e/iam/atlas_org_api_keys_test.go
+++ b/test/e2e/iam/atlas_org_api_keys_test.go
@@ -48,7 +48,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			"--role=ORG_READ_ONLY",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var key atlasv2.ApiKeyUserDetails
 		require.NoError(t, json.Unmarshal(resp, &key))
@@ -64,7 +64,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var keys atlasv2.PaginatedApiApiUser
 		require.NoError(t, json.Unmarshal(resp, &keys))
@@ -79,7 +79,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			"-c",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var keys []atlasv2.ApiKeyUserDetails
@@ -99,7 +99,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			"--role=ORG_READ_ONLY",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var key atlasv2.ApiKeyUserDetails
 		require.NoError(t, json.Unmarshal(resp, &key))
@@ -114,7 +114,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			ID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var key atlasv2.ApiKeyUserDetails
 		require.NoError(t, json.Unmarshal(resp, &key))
@@ -129,7 +129,7 @@ func TestAtlasOrgAPIKeys(t *testing.T) {
 			ID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
 		assert.Equal(t, expected, string(resp))

--- a/test/e2e/iam/atlas_org_invitations_test.go
+++ b/test/e2e/iam/atlas_org_invitations_test.go
@@ -48,7 +48,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 			"ORG_MEMBER",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 
@@ -66,7 +66,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)
@@ -84,7 +84,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 			orgInvitationID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)
@@ -106,7 +106,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 			roleNameOrg,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)
@@ -127,7 +127,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 			roleNameOrg,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)
@@ -145,7 +145,7 @@ func TestAtlasOrgInvitations(t *testing.T) {
 			orgInvitationID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Invitation '%s' deleted\n", orgInvitationID)

--- a/test/e2e/iam/atlas_orgs_test.go
+++ b/test/e2e/iam/atlas_orgs_test.go
@@ -41,7 +41,7 @@ func TestAtlasOrgs(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err2 := cmd.CombinedOutput()
+		resp, err2 := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err2, string(resp))
 		var orgs admin.PaginatedOrganization
 		err = json.Unmarshal(resp, &orgs)
@@ -58,7 +58,7 @@ func TestAtlasOrgs(t *testing.T) {
 			orgID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err2 := cmd.CombinedOutput()
+		resp, err2 := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err2, string(resp))
 	})
 
@@ -72,7 +72,7 @@ func TestAtlasOrgs(t *testing.T) {
 			orgID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err2 := cmd.CombinedOutput()
+		resp, err2 := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err2, string(resp))
 		var users admin.PaginatedApiAppUser
 		require.NoError(t, json.Unmarshal(resp, &users), string(resp))
@@ -102,7 +102,7 @@ func TestAtlasOrgs(t *testing.T) {
 			"test",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var org admin.CreateOrganizationResponse
 		require.NoError(t, json.Unmarshal(resp, &org), string(resp))
@@ -128,7 +128,7 @@ func TestAtlasOrgs(t *testing.T) {
 			"--force",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 }

--- a/test/e2e/iam/atlas_project_api_keys_test.go
+++ b/test/e2e/iam/atlas_project_api_keys_test.go
@@ -49,7 +49,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 			"--role=GROUP_READ_ONLY",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 		var key atlasv2.ApiKeyUserDetails
@@ -74,7 +74,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 			"--role=GROUP_DATA_ACCESS_READ_ONLY",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -85,7 +85,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
@@ -105,7 +105,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 			"-c",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
@@ -125,7 +125,7 @@ func TestAtlasProjectAPIKeys(t *testing.T) {
 			ID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("API Key '%s' deleted\n", ID)
 		assert.Equal(t, expected, string(resp))

--- a/test/e2e/iam/atlas_project_invitations_test.go
+++ b/test/e2e/iam/atlas_project_invitations_test.go
@@ -58,7 +58,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 
@@ -78,7 +78,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 
@@ -97,7 +97,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 
@@ -122,7 +122,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 
@@ -146,7 +146,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 
@@ -166,7 +166,7 @@ func TestAtlasProjectInvitations(t *testing.T) {
 			"--projectId",
 			projectID)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Invitation '%s' deleted\n", invitationID)

--- a/test/e2e/iam/atlas_project_teams_test.go
+++ b/test/e2e/iam/atlas_project_teams_test.go
@@ -63,7 +63,7 @@ func TestAtlasProjectTeams(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 
@@ -93,7 +93,7 @@ func TestAtlasProjectTeams(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 
@@ -116,7 +116,7 @@ func TestAtlasProjectTeams(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 
@@ -135,7 +135,7 @@ func TestAtlasProjectTeams(t *testing.T) {
 			"--projectId",
 			projectID)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Team '%s' deleted\n", teamID)

--- a/test/e2e/iam/atlas_projects_test.go
+++ b/test/e2e/iam/atlas_projects_test.go
@@ -53,7 +53,7 @@ func TestAtlasProjects(t *testing.T) {
 			"--tag", "prod=false",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 
@@ -71,7 +71,7 @@ func TestAtlasProjects(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 	})
@@ -83,7 +83,7 @@ func TestAtlasProjects(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 	})
@@ -95,7 +95,7 @@ func TestAtlasProjects(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var project admin.Group
 		if err := json.Unmarshal(resp, &project); err != nil {
@@ -153,7 +153,7 @@ func TestAtlasProjects(t *testing.T) {
 				filename,
 				"-o=json")
 			cmd.Env = os.Environ()
-			resp, err := cmd.CombinedOutput()
+			resp, err := e2e.RunAndGetStdOut(cmd)
 			require.NoError(t, err, string(resp))
 
 			cmd = exec.Command(cliPath,
@@ -162,7 +162,7 @@ func TestAtlasProjects(t *testing.T) {
 				projectID,
 				"-o=json")
 			cmd.Env = os.Environ()
-			resp, err = cmd.CombinedOutput()
+			resp, err = e2e.RunAndGetStdOut(cmd)
 			require.NoError(t, err, string(resp))
 			var project admin.Group
 			if err := json.Unmarshal(resp, &project); err != nil {
@@ -184,7 +184,7 @@ func TestAtlasProjects(t *testing.T) {
 			projectID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 	})
 
@@ -195,7 +195,7 @@ func TestAtlasProjects(t *testing.T) {
 			projectID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		require.NoError(t, err, string(resp))
 

--- a/test/e2e/iam/atlas_team_users_test.go
+++ b/test/e2e/iam/atlas_team_users_test.go
@@ -59,7 +59,7 @@ func TestAtlasTeamUsers(t *testing.T) {
 			"-o=json",
 		)
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 
@@ -84,7 +84,7 @@ func TestAtlasTeamUsers(t *testing.T) {
 			teamID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var teams atlasv2.PaginatedApiAppUser
@@ -102,7 +102,7 @@ func TestAtlasTeamUsers(t *testing.T) {
 			teamID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		a := assert.New(t)
 		var teams []atlasv2.CloudAppUser
@@ -120,7 +120,7 @@ func TestAtlasTeamUsers(t *testing.T) {
 			teamID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		a := assert.New(t)

--- a/test/e2e/iam/atlas_teams_test.go
+++ b/test/e2e/iam/atlas_teams_test.go
@@ -57,7 +57,7 @@ func TestAtlasTeams(t *testing.T) {
 			username,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 
 		a := assert.New(t)
 		require.NoError(t, err, string(resp))
@@ -77,7 +77,7 @@ func TestAtlasTeams(t *testing.T) {
 			teamID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var team atlasv2.TeamResponse
@@ -93,7 +93,7 @@ func TestAtlasTeams(t *testing.T) {
 			teamName,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		var team atlasv2.TeamResponse
 		require.NoError(t, json.Unmarshal(resp, &team))
@@ -110,7 +110,7 @@ func TestAtlasTeams(t *testing.T) {
 			teamID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var team atlasv2.TeamResponse
@@ -125,7 +125,7 @@ func TestAtlasTeams(t *testing.T) {
 			"ls",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var teams atlasv2.PaginatedTeam
@@ -140,7 +140,7 @@ func TestAtlasTeams(t *testing.T) {
 			"-c",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var teams []atlasv2.TeamResponse
@@ -155,7 +155,7 @@ func TestAtlasTeams(t *testing.T) {
 			teamID,
 			"--force")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 		expected := fmt.Sprintf("Team '%s' deleted\n", teamID)
 		assert.Equal(t, expected, string(resp))

--- a/test/e2e/iam/atlas_users_test.go
+++ b/test/e2e/iam/atlas_users_test.go
@@ -45,7 +45,7 @@ func TestAtlasUsers(t *testing.T) {
 			"list",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var users atlasv2.PaginatedApiAppUser
@@ -63,7 +63,7 @@ func TestAtlasUsers(t *testing.T) {
 			username,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var user atlasv2.CloudAppUser
@@ -86,7 +86,7 @@ func TestAtlasUsers(t *testing.T) {
 			userID,
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var user atlasv2.CloudAppUser
@@ -114,7 +114,7 @@ func TestAtlasUsers(t *testing.T) {
 			"--orgRole", orgID+":ORG_READ_ONLY",
 			"-o=json")
 		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
+		resp, err := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, err, string(resp))
 
 		var user atlasv2.CloudAppUser

--- a/test/e2e/iam/helper_test.go
+++ b/test/e2e/iam/helper_test.go
@@ -59,7 +59,7 @@ func createOrgAPIKey() (string, error) {
 		"--role=ORG_READ_ONLY",
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 
 	if err != nil {
 		return "", fmt.Errorf("%w: %s", err, string(resp))
@@ -110,7 +110,7 @@ func createTeam(teamName string) (string, error) {
 		username,
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", fmt.Errorf("%w: %s", err, string(resp))
 	}
@@ -155,7 +155,7 @@ func OrgNUser(n int) (username, userID string, err error) {
 		strconv.Itoa(n+1),
 		"-o=json")
 	cmd.Env = os.Environ()
-	resp, err := cmd.CombinedOutput()
+	resp, err := e2e.RunAndGetStdOut(cmd)
 	if err != nil {
 		return "", "", fmt.Errorf("error loading org users: %w (%s)", err, string(resp))
 	}


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ CLOUDP-250877

Fixed e2e tests when you change the default log level from `WarningLevel` to `DebugLevel` on line 109:
https://github.com/mongodb/mongodb-atlas-cli/blob/3ba0033fe8392dbdb692f31a78ba40169f907d47/internal/log/log.go#L109

What I've changed:
I've added a helper method called `e2e.RunAndGetStdOut` which does exactly the same as `cmd.CombinedOutput()` (copy pasted most of the code), except that it writes `stderr` output to `stderr` and only captures `stdout`.

I've tested this here:
https://spruce.mongodb.com/version/66630cc3c73c360007999b6f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

As you can see some tests under kubernetes and backup fail.
These e2e tests also fail in our master branch: https://spruce.mongodb.com/version/6662dd9b46b7c80007caf13c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
I've opened a slack threat in the apix2 channel to follow up on the failing e2e tests on master.