### PR TITLE
CLOUDP-253084: Refactored delete command

### DIFF
--- a/internal/cli/deployments/delete_test.go
+++ b/internal/cli/deployments/delete_test.go
@@ -101,7 +101,6 @@ func TestDelete_Run_Local(t *testing.T) {
 		EXPECT().
 		RemoveVolumes(ctx,
 			mongodLocalData+opts.DeploymentName,
-			"mongot-local-data-"+opts.DeploymentName,
 			"mongot-local-metrics-"+opts.DeploymentName,
 		).
 		Return(nil, nil).

--- a/internal/cli/deployments/diagnostics.go
+++ b/internal/cli/deployments/diagnostics.go
@@ -57,14 +57,11 @@ func (opts *diagnosticsOpts) Run(ctx context.Context) error {
 	}
 
 	var err error
-	d.Containers, err = opts.PodmanClient.ContainerInspect(ctx, opts.LocalMongodHostname(), opts.LocalMongotHostname())
+	d.Containers, err = opts.PodmanClient.ContainerInspect(ctx, opts.LocalMongodHostname())
 	if err != nil {
 		d.Errors = append(d.Errors, err)
 	}
 
-	if d.Logs.MongoT, err = opts.PodmanClient.ContainerLogs(ctx, opts.LocalMongotHostname()); err != nil {
-		d.Errors = append(d.Errors, err)
-	}
 	if d.Logs.MongoD, err = opts.PodmanClient.ContainerLogs(ctx, opts.LocalMongodHostname()); err != nil {
 		d.Errors = append(d.Errors, err)
 	}

--- a/internal/cli/deployments/options/deployment_opts.go
+++ b/internal/cli/deployments/options/deployment_opts.go
@@ -125,16 +125,8 @@ func (opts *DeploymentOpts) LocalMongodHostname() string {
 	return fmt.Sprintf("%s-%s", MongodHostnamePrefix, opts.DeploymentName)
 }
 
-func (opts *DeploymentOpts) LocalMongotHostname() string {
-	return fmt.Sprintf("%s-%s", MongotHostnamePrefix, opts.DeploymentName)
-}
-
 func (opts *DeploymentOpts) LocalCheckHostname() string {
 	return fmt.Sprintf("%s-%s", CheckHostnamePrefix, opts.DeploymentName)
-}
-
-func (opts *DeploymentOpts) LocalMongotDataVolume() string {
-	return "mongot-local-data-" + opts.DeploymentName
 }
 
 func (opts *DeploymentOpts) LocalMongodDataVolume() string {

--- a/internal/cli/deployments/options/deployment_opts_remove.go
+++ b/internal/cli/deployments/options/deployment_opts_remove.go
@@ -16,7 +16,7 @@ package options
 import "context"
 
 func (opts *DeploymentOpts) RemoveLocal(ctx context.Context) error {
-	volumes := []string{opts.LocalMongodDataVolume(), opts.LocalMongotDataVolume(), opts.LocalMongoMetricsVolume()}
+	volumes := []string{opts.LocalMongodDataVolume(), opts.LocalMongoMetricsVolume()}
 
 	if c, _ := opts.PodmanClient.ContainerInspect(ctx, opts.LocalMongodHostname()); c != nil {
 		for _, m := range c[0].Mounts {
@@ -27,7 +27,7 @@ func (opts *DeploymentOpts) RemoveLocal(ctx context.Context) error {
 		}
 	}
 
-	if _, errRemove := opts.PodmanClient.RemoveContainers(ctx, opts.LocalMongodHostname(), opts.LocalMongotHostname()); errRemove != nil {
+	if _, errRemove := opts.PodmanClient.RemoveContainers(ctx, opts.LocalMongodHostname()); errRemove != nil {
 		return errRemove
 	}
 

--- a/internal/cli/deployments/pause.go
+++ b/internal/cli/deployments/pause.go
@@ -92,12 +92,6 @@ func (opts *PauseOpts) pauseContainer(ctx context.Context, deployment options.De
 	opts.StartSpinner()
 	defer opts.StopSpinner()
 
-	// search for a process "java ... mongot", extract the process ID, kill the process with SIGTERM (15)
-	const stopMongot = "grep -l java.*mongot /proc/*/cmdline | awk -F'/' '{print $3; exit}' | while read -r pid; do kill -15 $pid; done"
-	if err := opts.PodmanClient.Exec(ctx, opts.LocalMongotHostname(), "/bin/sh", "-c", stopMongot); err != nil {
-		return err
-	}
-
 	err := opts.PodmanClient.Exec(ctx, opts.LocalMongodHostname(), "mongod", "--shutdown")
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) && exitErr.ExitCode() == podmanContainerTerminatedExitCode {

--- a/internal/cli/deployments/pause_test.go
+++ b/internal/cli/deployments/pause_test.go
@@ -55,24 +55,11 @@ func TestPause_RunLocal(t *testing.T) {
 
 	deploymentTest.LocalMockFlow(ctx)
 
-	const stopMongot = "grep -l java.*mongot /proc/*/cmdline | awk -F'/' '{print $3; exit}' | while read -r pid; do kill -15 $pid; done"
-	mockPodman.
-		EXPECT().
-		Exec(ctx, pauseOpts.LocalMongotHostname(), "/bin/sh", "-c", stopMongot).
-		Return(nil).
-		Times(1)
-
 	mockPodman.
 		EXPECT().
 		Exec(ctx, pauseOpts.LocalMongodHostname(), "mongod", "--shutdown").
 		Return(nil).
 		Times(1)
-
-	mockPodman.
-		EXPECT().
-		StopContainers(ctx, pauseOpts.LocalMongotHostname()).
-		Return(nil, nil).
-		Times(0)
 
 	if err := pauseOpts.Run(ctx); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)

--- a/internal/cli/deployments/start.go
+++ b/internal/cli/deployments/start.go
@@ -82,7 +82,7 @@ func (opts *StartOpts) startContainer(ctx context.Context, deployment options.De
 	}
 
 	if deployment.StateName == options.StoppedState {
-		if _, err := opts.PodmanClient.StartContainers(ctx, opts.LocalMongodHostname(), opts.LocalMongotHostname()); err != nil {
+		if _, err := opts.PodmanClient.StartContainers(ctx, opts.LocalMongodHostname()); err != nil {
 			return err
 		}
 
@@ -90,7 +90,7 @@ func (opts *StartOpts) startContainer(ctx context.Context, deployment options.De
 	}
 
 	if deployment.StateName == options.PausedState {
-		if _, err := opts.PodmanClient.UnpauseContainers(ctx, opts.LocalMongodHostname(), opts.LocalMongotHostname()); err != nil {
+		if _, err := opts.PodmanClient.UnpauseContainers(ctx, opts.LocalMongodHostname()); err != nil {
 			return err
 		}
 

--- a/internal/cli/deployments/start_test.go
+++ b/internal/cli/deployments/start_test.go
@@ -58,7 +58,7 @@ func TestStart_RunLocal_PausedContainers(t *testing.T) {
 
 	mockPodman.
 		EXPECT().
-		UnpauseContainers(ctx, startOpts.LocalMongodHostname(), startOpts.LocalMongotHostname()).
+		UnpauseContainers(ctx, startOpts.LocalMongodHostname()).
 		Return(nil, nil).
 		Times(1)
 
@@ -91,7 +91,7 @@ func TestStart_RunLocal_StoppedContainers(t *testing.T) {
 
 	mockPodman.
 		EXPECT().
-		StartContainers(ctx, startOpts.LocalMongodHostname(), startOpts.LocalMongotHostname()).
+		StartContainers(ctx, startOpts.LocalMongodHostname()).
 		Return(nil, nil).
 		Times(1)
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-253084

Refactored delete command to use the new unified image.

Also, fixed collateral damage in other commands, which were impacted by removing references to MongoT and removing some networking functionality. Other commands will be fully refactored in separate PRs.

## Testing
Ran `atlas deploy setup` and then deleted the local development