### PR TITLE
CLOUDP-253088: Refactor command: Pause

### DIFF
--- a/internal/cli/deployments/pause_test.go
+++ b/internal/cli/deployments/pause_test.go
@@ -57,8 +57,8 @@ func TestPause_RunLocal(t *testing.T) {
 
 	mockPodman.
 		EXPECT().
-		Exec(ctx, pauseOpts.LocalMongodHostname(), "mongod", "--shutdown").
-		Return(nil).
+		StopContainers(ctx, pauseOpts.LocalMongodHostname()).
+		Return([]byte{}, nil).
 		Times(1)
 
 	if err := pauseOpts.Run(ctx); err != nil {


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ : Refactor command: Pause

Refactored `atlas deployment pause` to the unified docker container approach.
- Call stop container instead of killing mongod inside of the container

## Testing
1. Created a local deployment
2. Paused it
3. Restarted using console and retried, everything works as expected