### PR TITLE
fix: Add MDB 8.0

### DIFF
--- a/tools/genevergreen/generate/generate.go
+++ b/tools/genevergreen/generate/generate.go
@@ -30,6 +30,7 @@ var (
 		"5.0",
 		"6.0",
 		"7.0",
+		"8.0",
 	}
 	oses = []string{
 		"amazonlinux2",

--- a/tools/genevergreen/generate/generate.go
+++ b/tools/genevergreen/generate/generate.go
@@ -216,7 +216,7 @@ func PublishSnapshotTasks(c *shrub.Configuration) {
 	publishVariant(
 		c,
 		v,
-		"5.0",
+		"8.0",
 		"",
 		dependency,
 		false,

--- a/tools/genevergreen/generate/generate_test.go
+++ b/tools/genevergreen/generate/generate_test.go
@@ -33,6 +33,6 @@ func TestPublishSnapshotTasks(t *testing.T) {
 func TestPublishStableTasks(t *testing.T) {
 	c := &shrub.Configuration{}
 	PublishStableTasks(c)
-	assert.Len(t, c.Variants, 3)
-	assert.Len(t, c.Tasks, 126)
+	assert.Len(t, c.Variants, 4)
+	assert.Len(t, c.Tasks, 168)
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_  CLOUDP-252044

- Curator fails because the new ubuntu image is under MDB 8.0
- This PR adds MDB 8.0 for test generation and tries to start using MDB 8.0 for the publishing tasks, we can't test as this is non-patcheable. But here is a [patch](https://spruce.mongodb.com/version/666973d90d7f250008d96fdc/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with packaging/post-packaging tasks. I believe the patch would only succeed after the publishing.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
