### PR TITLE
CLOUDP-253943: Simplify delete logic (volumes)

### DIFF
--- a/internal/cli/deployments/delete_test.go
+++ b/internal/cli/deployments/delete_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/test/fixture"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/podman"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
 )
 
@@ -93,48 +92,6 @@ func TestDelete_Run_Local(t *testing.T) {
 		EXPECT().
 		RemoveContainers(ctx, options.MongodHostnamePrefix+"-"+opts.DeploymentName).
 		Return(nil, nil).
-		Times(1)
-
-	const mongodLocalData = "mongod-local-data-"
-	deploymentsTest.
-		MockPodman.
-		EXPECT().
-		RemoveVolumes(ctx,
-			mongodLocalData+opts.DeploymentName,
-			"mongot-local-metrics-"+opts.DeploymentName,
-		).
-		Return(nil, nil).
-		Times(1)
-
-	deploymentsTest.
-		MockPodman.
-		EXPECT().
-		ContainerInspect(ctx, options.MongodHostnamePrefix+"-"+opts.DeploymentName).
-		Return([]*podman.InspectContainerData{
-			{
-				Name: options.MongodHostnamePrefix + "-" + opts.DeploymentName,
-				Config: &podman.InspectContainerConfig{
-					Labels: map[string]string{
-						"version": "7.0.1",
-					},
-				},
-				HostConfig: &podman.InspectContainerHostConfig{
-					PortBindings: map[string][]podman.InspectHostPort{
-						"27017/tcp": {
-							{
-								HostIP:   "127.0.0.1",
-								HostPort: "27017",
-							},
-						},
-					},
-				},
-				Mounts: []podman.InspectMount{
-					{
-						Name: mongodLocalData + opts.DeploymentName,
-					},
-				},
-			},
-		}, nil).
 		Times(1)
 
 	if err := opts.Run(ctx); err != nil {

--- a/internal/cli/deployments/options/deployment_opts_remove.go
+++ b/internal/cli/deployments/options/deployment_opts_remove.go
@@ -16,22 +16,7 @@ package options
 import "context"
 
 func (opts *DeploymentOpts) RemoveLocal(ctx context.Context) error {
-	volumes := []string{opts.LocalMongodDataVolume(), opts.LocalMongoMetricsVolume()}
-
-	if c, _ := opts.PodmanClient.ContainerInspect(ctx, opts.LocalMongodHostname()); c != nil {
-		for _, m := range c[0].Mounts {
-			if m.Name != opts.LocalMongodDataVolume() {
-				volumes = append(volumes, m.Name)
-				break
-			}
-		}
-	}
-
 	if _, errRemove := opts.PodmanClient.RemoveContainers(ctx, opts.LocalMongodHostname()); errRemove != nil {
-		return errRemove
-	}
-
-	if _, errRemove := opts.PodmanClient.RemoveVolumes(ctx, volumes...); errRemove != nil {
 		return errRemove
 	}
 

--- a/internal/mocks/mock_podman.go
+++ b/internal/mocks/mock_podman.go
@@ -227,26 +227,6 @@ func (mr *MockClientMockRecorder) RemoveContainers(arg0 interface{}, arg1 ...int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveContainers", reflect.TypeOf((*MockClient)(nil).RemoveContainers), varargs...)
 }
 
-// RemoveVolumes mocks base method.
-func (m *MockClient) RemoveVolumes(arg0 context.Context, arg1 ...string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "RemoveVolumes", varargs...)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RemoveVolumes indicates an expected call of RemoveVolumes.
-func (mr *MockClientMockRecorder) RemoveVolumes(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVolumes", reflect.TypeOf((*MockClient)(nil).RemoveVolumes), varargs...)
-}
-
 // RunContainer mocks base method.
 func (m *MockClient) RunContainer(arg0 context.Context, arg1 podman.RunContainerOpts) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -131,7 +131,6 @@ type Client interface {
 	StartContainers(ctx context.Context, names ...string) ([]byte, error)
 	UnpauseContainers(ctx context.Context, names ...string) ([]byte, error)
 	RemoveContainers(ctx context.Context, names ...string) ([]byte, error)
-	RemoveVolumes(ctx context.Context, names ...string) ([]byte, error)
 	ListContainers(ctx context.Context, nameFilter string) ([]*Container, error)
 	ListImages(ctx context.Context, nameFilter string) ([]*Image, error)
 	PullImage(ctx context.Context, name string) ([]byte, error)
@@ -326,11 +325,7 @@ func (o *client) UnpauseContainers(ctx context.Context, names ...string) ([]byte
 }
 
 func (o *client) RemoveContainers(ctx context.Context, names ...string) ([]byte, error) {
-	return o.runPodman(ctx, append([]string{"rm", "-f"}, names...)...)
-}
-
-func (o *client) RemoveVolumes(ctx context.Context, names ...string) ([]byte, error) {
-	return o.runPodman(ctx, append([]string{"volume", "rm", "-f"}, names...)...)
+	return o.runPodman(ctx, append([]string{"rm", "-f", "-v"}, names...)...)
 }
 
 func (o *client) ListContainers(ctx context.Context, nameFilter string) ([]*Container, error) {


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ CLOUDP-253943

Simplified the delete deployment logic by using `rm -v` instead of manually removing volumes.