### PR TITLE
CLOUDP-256305: SETUP: Wait for container to become healthy

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -57,6 +57,7 @@ type Engine interface {
 	ContainerStop(context.Context, ...string) error
 	ContainerUnpause(context.Context, ...string) error
 	ContainerInspect(context.Context, ...string) ([]*InspectData, error)
+	ContainerHealthStatus(context.Context, string) (DockerHealthcheckStatus, error)
 	ImageList(context.Context, ...string) ([]Image, error)
 	ImagePull(context.Context, string) error
 	ImageHealthCheck(context.Context, string) (*ImageHealthCheck, error)
@@ -119,6 +120,15 @@ type InspectDataHostPort struct {
 	HostIP   string `json:"HostIp"`
 	HostPort string `json:"HostPort"`
 }
+
+type DockerHealthcheckStatus string
+
+const (
+	DockerHealthcheckStatusStarting  DockerHealthcheckStatus = "starting"
+	DockerHealthcheckStatusHealthy   DockerHealthcheckStatus = "healthy"
+	DockerHealthcheckStatusUnhealthy DockerHealthcheckStatus = "unhealthy"
+	DockerHealthcheckStatusNone      DockerHealthcheckStatus = "none"
+)
 
 func New() Engine {
 	return newPodmanEngine()

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -16,6 +16,7 @@ package container
 
 import (
 	"context"
+	"time"
 )
 
 type PortMapping struct {
@@ -24,18 +25,23 @@ type PortMapping struct {
 }
 
 type RunFlags struct {
-	Name       *string
-	Detach     *bool
-	Remove     *bool
-	Hostname   *string
-	Ports      []PortMapping
-	Env        map[string]string
-	Cmd        *string
-	Args       []string
-	Network    *string
-	IP         *string
-	Entrypoint *string
-	BindIPAll  *bool
+	Name              *string
+	Detach            *bool
+	Remove            *bool
+	Hostname          *string
+	Ports             []PortMapping
+	Env               map[string]string
+	Cmd               *string
+	Args              []string
+	Network           *string
+	IP                *string
+	Entrypoint        *string
+	BindIPAll         *bool
+	HealthCmd         *[]string
+	HealthInterval    *time.Duration
+	HealthTimeout     *time.Duration
+	HealthStartPeriod *time.Duration
+	HealthRetries     *int
 }
 
 //go:generate mockgen -destination=../mocks/mock_container.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/container Engine
@@ -53,6 +59,7 @@ type Engine interface {
 	ContainerInspect(context.Context, ...string) ([]*InspectData, error)
 	ImageList(context.Context, ...string) ([]Image, error)
 	ImagePull(context.Context, string) error
+	ImageHealthCheck(context.Context, string) (*ImageHealthCheck, error)
 	Version(context.Context) (map[string]any, error)
 }
 
@@ -74,6 +81,14 @@ type Image struct {
 	}
 	Containers int
 	Names      []string
+}
+
+type ImageHealthCheck struct {
+	Test        []string
+	Interval    *time.Duration
+	Timeout     *time.Duration
+	StartPeriod *time.Duration
+	Retries     *int
 }
 
 type Container struct {

--- a/internal/container/podman.go
+++ b/internal/container/podman.go
@@ -16,6 +16,7 @@ package container
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/podman"
@@ -224,6 +225,26 @@ func (e *podmanImpl) ContainerInspect(ctx context.Context, names ...string) ([]*
 	}
 
 	return results, nil
+}
+
+func (e *podmanImpl) ContainerHealthStatus(ctx context.Context, name string) (DockerHealthcheckStatus, error) {
+	stringStatus, err := e.client.ContainerHealthStatus(ctx, name)
+	if err != nil {
+		return DockerHealthcheckStatusNone, err
+	}
+
+	switch stringStatus {
+	case "starting":
+		return DockerHealthcheckStatusStarting, nil
+	case "healthy":
+		return DockerHealthcheckStatusHealthy, nil
+	case "unhealthy":
+		return DockerHealthcheckStatusUnhealthy, nil
+	case "none":
+		return DockerHealthcheckStatusNone, nil
+	default:
+		return DockerHealthcheckStatusNone, fmt.Errorf("unknown health status: %s", stringStatus)
+	}
 }
 
 func (e *podmanImpl) Version(ctx context.Context) (map[string]any, error) {

--- a/internal/container/podman.go
+++ b/internal/container/podman.go
@@ -39,6 +39,7 @@ func (e *podmanImpl) ContainerLogs(ctx context.Context, name string) ([]string, 
 	return e.client.ContainerLogs(ctx, name)
 }
 
+//nolint:gocyclo
 func (e *podmanImpl) ContainerRun(ctx context.Context, image string, flags *RunFlags) (string, error) {
 	podmanOpts := podman.RunContainerOpts{
 		Image: image,
@@ -76,6 +77,21 @@ func (e *podmanImpl) ContainerRun(ctx context.Context, image string, flags *RunF
 			for _, entry := range flags.Ports {
 				podmanOpts.Ports[entry.HostPort] = entry.ContainerPort
 			}
+		}
+		if flags.HealthCmd != nil {
+			podmanOpts.HealthCmd = flags.HealthCmd
+		}
+		if flags.HealthInterval != nil {
+			podmanOpts.HealthInterval = flags.HealthInterval
+		}
+		if flags.HealthTimeout != nil {
+			podmanOpts.HealthTimeout = flags.HealthTimeout
+		}
+		if flags.HealthStartPeriod != nil {
+			podmanOpts.HealthStartPeriod = flags.HealthStartPeriod
+		}
+		if flags.HealthRetries != nil {
+			podmanOpts.HealthRetries = flags.HealthRetries
 		}
 		podmanOpts.Args = flags.Args
 		podmanOpts.EnvVars = flags.Env
@@ -138,6 +154,22 @@ func (e *podmanImpl) ImageList(ctx context.Context, nameFilter ...string) ([]Ima
 func (e *podmanImpl) ImagePull(ctx context.Context, name string) error {
 	_, err := e.client.PullImage(ctx, name)
 	return err
+}
+
+func (e *podmanImpl) ImageHealthCheck(ctx context.Context, name string) (*ImageHealthCheck, error) {
+	healthCheck, err := e.client.ImageHealthCheck(ctx, name)
+	if healthCheck == nil {
+		return nil, nil
+	}
+
+	imageHealthCheck := &ImageHealthCheck{
+		Test:        healthCheck.Test,
+		Interval:    &healthCheck.Interval,
+		Timeout:     &healthCheck.Timeout,
+		StartPeriod: &healthCheck.StartPeriod,
+		Retries:     &healthCheck.Retries,
+	}
+	return imageHealthCheck, err
 }
 
 func (e *podmanImpl) ContainerRm(ctx context.Context, names ...string) error {

--- a/internal/mocks/mock_container.go
+++ b/internal/mocks/mock_container.go
@@ -181,6 +181,21 @@ func (mr *MockEngineMockRecorder) ContainerUnpause(arg0 interface{}, arg1 ...int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerUnpause", reflect.TypeOf((*MockEngine)(nil).ContainerUnpause), varargs...)
 }
 
+// ImageHealthCheck mocks base method.
+func (m *MockEngine) ImageHealthCheck(arg0 context.Context, arg1 string) (*container.ImageHealthCheck, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImageHealthCheck", arg0, arg1)
+	ret0, _ := ret[0].(*container.ImageHealthCheck)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImageHealthCheck indicates an expected call of ImageHealthCheck.
+func (mr *MockEngineMockRecorder) ImageHealthCheck(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageHealthCheck", reflect.TypeOf((*MockEngine)(nil).ImageHealthCheck), arg0, arg1)
+}
+
 // ImageList mocks base method.
 func (m *MockEngine) ImageList(arg0 context.Context, arg1 ...string) ([]container.Image, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/mock_container.go
+++ b/internal/mocks/mock_container.go
@@ -35,6 +35,21 @@ func (m *MockEngine) EXPECT() *MockEngineMockRecorder {
 	return m.recorder
 }
 
+// ContainerHealthStatus mocks base method.
+func (m *MockEngine) ContainerHealthStatus(arg0 context.Context, arg1 string) (container.DockerHealthcheckStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainerHealthStatus", arg0, arg1)
+	ret0, _ := ret[0].(container.DockerHealthcheckStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainerHealthStatus indicates an expected call of ContainerHealthStatus.
+func (mr *MockEngineMockRecorder) ContainerHealthStatus(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerHealthStatus", reflect.TypeOf((*MockEngine)(nil).ContainerHealthStatus), arg0, arg1)
+}
+
 // ContainerInspect mocks base method.
 func (m *MockEngine) ContainerInspect(arg0 context.Context, arg1 ...string) ([]*container.InspectData, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/mock_podman.go
+++ b/internal/mocks/mock_podman.go
@@ -70,6 +70,21 @@ func (mr *MockClientMockRecorder) ContainerLogs(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerLogs", reflect.TypeOf((*MockClient)(nil).ContainerLogs), arg0, arg1)
 }
 
+// ImageHealthCheck mocks base method.
+func (m *MockClient) ImageHealthCheck(arg0 context.Context, arg1 string) (*podman.Schema2HealthConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImageHealthCheck", arg0, arg1)
+	ret0, _ := ret[0].(*podman.Schema2HealthConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImageHealthCheck indicates an expected call of ImageHealthCheck.
+func (mr *MockClientMockRecorder) ImageHealthCheck(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageHealthCheck", reflect.TypeOf((*MockClient)(nil).ImageHealthCheck), arg0, arg1)
+}
+
 // ListContainers mocks base method.
 func (m *MockClient) ListContainers(arg0 context.Context, arg1 string) ([]*podman.Container, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/mock_podman.go
+++ b/internal/mocks/mock_podman.go
@@ -35,6 +35,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// ContainerHealthStatus mocks base method.
+func (m *MockClient) ContainerHealthStatus(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainerHealthStatus", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ContainerHealthStatus indicates an expected call of ContainerHealthStatus.
+func (mr *MockClientMockRecorder) ContainerHealthStatus(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerHealthStatus", reflect.TypeOf((*MockClient)(nil).ContainerHealthStatus), arg0, arg1)
+}
+
 // ContainerInspect mocks base method.
 func (m *MockClient) ContainerInspect(arg0 context.Context, arg1 ...string) ([]*podman.InspectContainerData, error) {
 	m.ctrl.T.Helper()

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -101,6 +101,7 @@ type Client interface {
 	ListImages(ctx context.Context, nameFilter string) ([]*Image, error)
 	PullImage(ctx context.Context, name string) ([]byte, error)
 	ImageHealthCheck(ctx context.Context, name string) (*Schema2HealthConfig, error)
+	ContainerHealthStatus(ctx context.Context, name string) (string, error)
 	Logs(ctx context.Context) (map[string]interface{}, []error)
 	ContainerLogs(ctx context.Context, name string) ([]string, error)
 }
@@ -155,6 +156,15 @@ func (o *client) ContainerInspect(ctx context.Context, names ...string) ([]*Insp
 	var containers []*InspectContainerData
 	err = json.Unmarshal(buf, &containers)
 	return containers, err
+}
+
+func (o *client) ContainerHealthStatus(ctx context.Context, name string) (string, error) {
+	buf, err := o.runPodman(ctx, "inspect", "--format", "{{.State.Health.Status}}", name)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(buf)), nil
 }
 
 //nolint:gocyclo

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/log"
 )
@@ -32,22 +33,25 @@ var (
 )
 
 type RunContainerOpts struct {
-	Detach   bool
-	Remove   bool
-	Image    string
-	Name     string
-	Hostname string
-	// map[hostVolume, pathInContainer]
-	Volumes map[string]string
-	// map[hostPort, containerPort]
-	Ports      map[int]int
-	BindIPAll  bool
-	Network    string
-	EnvVars    map[string]string
-	Args       []string
-	Entrypoint string
-	Cmd        string
-	IP         string
+	Detach            bool
+	Remove            bool
+	Image             string
+	Name              string
+	Hostname          string
+	Volumes           map[string]string
+	Ports             map[int]int
+	BindIPAll         bool
+	Network           string
+	EnvVars           map[string]string
+	Args              []string
+	Entrypoint        string
+	Cmd               string
+	IP                string
+	HealthCmd         *[]string
+	HealthInterval    *time.Duration
+	HealthTimeout     *time.Duration
+	HealthStartPeriod *time.Duration
+	HealthRetries     *int
 }
 
 type Container struct {
@@ -96,6 +100,7 @@ type Client interface {
 	ListContainers(ctx context.Context, nameFilter string) ([]*Container, error)
 	ListImages(ctx context.Context, nameFilter string) ([]*Image, error)
 	PullImage(ctx context.Context, name string) ([]byte, error)
+	ImageHealthCheck(ctx context.Context, name string) (*Schema2HealthConfig, error)
 	Logs(ctx context.Context) (map[string]interface{}, []error)
 	ContainerLogs(ctx context.Context, name string) ([]string, error)
 }
@@ -152,6 +157,7 @@ func (o *client) ContainerInspect(ctx context.Context, names ...string) ([]*Insp
 	return containers, err
 }
 
+//nolint:gocyclo
 func (o *client) RunContainer(ctx context.Context, opts RunContainerOpts) ([]byte, error) {
 	arg := []string{"run",
 		"--name", opts.Name,
@@ -191,6 +197,31 @@ func (o *client) RunContainer(ctx context.Context, opts RunContainerOpts) ([]byt
 		arg = append(arg, "--entrypoint", opts.Entrypoint)
 	}
 
+	if opts.HealthCmd != nil && len(*opts.HealthCmd) > 0 {
+		cmd := ""
+		for i, c := range *opts.HealthCmd {
+			if i != 0 {
+				cmd += ","
+			}
+
+			cmd = cmd + "\"" + c + "\""
+		}
+
+		arg = append(arg, fmt.Sprintf("--health-cmd=[%s]", cmd))
+	}
+	if opts.HealthInterval != nil {
+		arg = append(arg, "--health-interval", toMsString(*opts.HealthInterval))
+	}
+	if opts.HealthTimeout != nil {
+		arg = append(arg, "--health-timeout", toMsString(*opts.HealthTimeout))
+	}
+	if opts.HealthStartPeriod != nil {
+		arg = append(arg, "--health-start-period", toMsString(*opts.HealthStartPeriod))
+	}
+	if opts.HealthRetries != nil {
+		arg = append(arg, "--health-startup-retries", strconv.Itoa(*opts.HealthRetries))
+	}
+
 	arg = append(arg, opts.Image)
 
 	if opts.Cmd != "" {
@@ -200,6 +231,10 @@ func (o *client) RunContainer(ctx context.Context, opts RunContainerOpts) ([]byt
 	arg = append(arg, opts.Args...)
 
 	return o.runPodman(ctx, arg...)
+}
+
+func toMsString(duration time.Duration) string {
+	return strconv.FormatInt(duration.Milliseconds(), 10) + "ms"
 }
 
 func (o *client) StopContainers(ctx context.Context, names ...string) ([]byte, error) {
@@ -259,6 +294,32 @@ func (o *client) ListImages(ctx context.Context, nameFilter string) ([]*Image, e
 
 func (o *client) PullImage(ctx context.Context, name string) ([]byte, error) {
 	return o.runPodman(ctx, "pull", name)
+}
+
+func (o *client) ImageHealthCheck(ctx context.Context, name string) (*Schema2HealthConfig, error) {
+	bytes, err := o.runPodman(ctx, "image", "inspect", "--format", "json", name)
+	if err != nil {
+		return nil, err
+	}
+
+	type PartialImageInspectConfig struct {
+		Healthcheck *Schema2HealthConfig
+	}
+
+	type PartialImageInspect struct {
+		Config PartialImageInspectConfig
+	}
+
+	var inspectOutput []PartialImageInspect
+	if err := json.Unmarshal(bytes, &inspectOutput); err != nil {
+		return nil, err
+	}
+
+	if len(inspectOutput) != 1 {
+		return nil, fmt.Errorf("expected 1 output, got %v", len(inspectOutput))
+	}
+
+	return inspectOutput[0].Config.Healthcheck, nil
 }
 
 func (o *client) Version(ctx context.Context) (map[string]any, error) {


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ CLOUDP-256305

- Fix the issue where podman ignores the healthcheck defined in our unified docker image
- Wait for the healthcheck to be ready when running the setup command (this is the same behavior like we have in the master branch right now)