### PR TITLE
CLOUDP-257881-map: Skip some of the publishing in some versions

### DIFF
--- a/tools/genevergreen/generate/generate.go
+++ b/tools/genevergreen/generate/generate.go
@@ -16,7 +16,6 @@ package generate
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/evergreen-ci/shrub"
@@ -97,9 +96,6 @@ func RepoTasks(c *shrub.Configuration) {
 		entrypoint := "atlas"
 
 		for _, os := range oses {
-			if slices.Contains(unsupportedOsByVersion[serverVersion], os) {
-				continue
-			}
 			for _, repo := range repos {
 				mongoRepo := "https://repo.mongodb.com"
 				if repo == "org" {

--- a/tools/genevergreen/generate/generate.go
+++ b/tools/genevergreen/generate/generate.go
@@ -35,7 +35,7 @@ var (
 	}
 
 	unsupportedOsByVersion = map[string][]string{
-		"8.0": {"debian11", "rhel70"},
+		"8.0": {"debian11", "rhel70", "amazon2"},
 	}
 
 	oses = []string{

--- a/tools/genevergreen/generate/generate.go
+++ b/tools/genevergreen/generate/generate.go
@@ -16,6 +16,7 @@ package generate
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/evergreen-ci/shrub"
@@ -32,6 +33,11 @@ var (
 		"7.0",
 		"8.0",
 	}
+
+	unsupportedOsByVersion = map[string][]string{
+		"8.0": {"debian11", "rhel70"},
+	}
+
 	oses = []string{
 		"amazonlinux2",
 		"centos7",
@@ -91,6 +97,9 @@ func RepoTasks(c *shrub.Configuration) {
 		entrypoint := "atlas"
 
 		for _, os := range oses {
+			if slices.Contains(unsupportedOsByVersion[serverVersion], os) {
+				continue
+			}
 			for _, repo := range repos {
 				mongoRepo := "https://repo.mongodb.com"
 				if repo == "org" {

--- a/tools/genevergreen/generate/generate_test.go
+++ b/tools/genevergreen/generate/generate_test.go
@@ -34,5 +34,5 @@ func TestPublishStableTasks(t *testing.T) {
 	c := &shrub.Configuration{}
 	PublishStableTasks(c)
 	assert.Len(t, c.Variants, 4)
-	assert.Len(t, c.Tasks, 130)
+	assert.Len(t, c.Tasks, 126)
 }

--- a/tools/genevergreen/generate/generate_test.go
+++ b/tools/genevergreen/generate/generate_test.go
@@ -34,5 +34,5 @@ func TestPublishStableTasks(t *testing.T) {
 	c := &shrub.Configuration{}
 	PublishStableTasks(c)
 	assert.Len(t, c.Variants, 4)
-	assert.Len(t, c.Tasks, 136)
+	assert.Len(t, c.Tasks, 130)
 }

--- a/tools/genevergreen/generate/publish.go
+++ b/tools/genevergreen/generate/publish.go
@@ -16,6 +16,7 @@ package generate
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/evergreen-ci/shrub"
@@ -110,6 +111,9 @@ func publishVariant(c *shrub.Configuration, v *shrub.Variant, sv, stableSuffix s
 	}
 	for _, r := range repos {
 		for k, d := range distros {
+			if slices.Contains(unsupportedOsByVersion[sv], k) {
+				continue
+			}
 			for _, a := range d.architectures {
 				taskName := fmt.Sprintf("push_atlascli_%s_%s_%s%s%s", k, r, a, strings.ReplaceAll(taskSv, ".", ""), stableSuffix)
 				t := newPublishTask(taskName, d.extension, r, k, taskServerVersion, notaryKey, a, stable, dependency)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-257881

Removes publishing of debian11, amazon2 and rhel70 from the 8.0 repository as they [fail](https://spruce.mongodb.com/version/mongodb_atlas_cli_master_atlascli_v1.24.0_66744fd1eb66df000792d29d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and won't be supported. 


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
