### PR TITLE
CLOUDP-260149: Call root.Builder() only once in main and make execute method private

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -30,9 +30,8 @@ import (
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
+func execute(rootCmd *cobra.Command) {
 	ctx := telemetry.NewContext()
-	rootCmd := root.Builder()
 	// append here to avoid a recursive link on generated docs
 	rootCmd.Long += `
 
@@ -73,11 +72,11 @@ func createConfig() {
 	}
 }
 
-func trackInitError(e error) {
+func trackInitError(e error, rootCmd *cobra.Command) {
 	if e == nil {
 		return
 	}
-	if cmd, args, err := root.Builder().Find(os.Args[1:]); err == nil {
+	if cmd, args, err := rootCmd.Find(os.Args[1:]); err == nil {
 		if !telemetry.StartedTrackingCommand() {
 			telemetry.StartTrackingCommand(cmd, args)
 		}
@@ -88,8 +87,8 @@ func trackInitError(e error) {
 	log.Print(e)
 }
 
-func initTrack() {
-	cmd, args, _ := root.Builder().Find(os.Args[1:])
+func initTrack(rootCmd *cobra.Command) {
+	cmd, args, _ := rootCmd.Find(os.Args[1:])
 	telemetry.StartTrackingCommand(cmd, args)
 }
 
@@ -99,9 +98,11 @@ func main() {
 		core.DisableColor = true
 	}
 
-	initTrack()
+	rootCmd := root.Builder()
+	
+	initTrack(rootCmd)
 	createConfig()
-	trackInitError(loadConfig())
+	trackInitError(loadConfig(), rootCmd)
 
-	Execute()
+	execute(rootCmd)
 }

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	rootCmd := root.Builder()
-	
+
 	initTrack(rootCmd)
 	createConfig()
 	trackInitError(loadConfig(), rootCmd)


### PR DESCRIPTION
## Proposed changes
- Only call *root-Builder()* once in main and pass it to functions that previously called it
- Make execute function private

_Jira ticket:_ CLOUDP-260149
