### PR TITLE
(DOCSP-41063) Adds missing TOC entries for orphan pages

### DIFF
--- a/docs/command/atlas-security-ldap-verify-status.txt
+++ b/docs/command/atlas-security-ldap-verify-status.txt
@@ -98,3 +98,9 @@ Related Commands
 
 * :ref:`atlas-security-ldap-verify-status-watch` - Watch for an LDAP configuration request to complete.
 
+
+.. toctree::
+   :titlesonly:
+
+   watch </command/atlas-security-ldap-verify-status-watch>
+

--- a/docs/command/atlas-security-ldap-verify.txt
+++ b/docs/command/atlas-security-ldap-verify.txt
@@ -114,3 +114,9 @@ Related Commands
 
 * :ref:`atlas-security-ldap-verify-status` - Get the status of an LDAP configuration request.
 
+
+.. toctree::
+   :titlesonly:
+
+   status </command/atlas-security-ldap-verify-status>
+

--- a/internal/cli/security/ldap/status.go
+++ b/internal/cli/security/ldap/status.go
@@ -66,6 +66,7 @@ func StatusBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"requestIdDesc": "ID of the request to verify an LDAP configuration.",
 			"output":        verifyStatusTemplate,
+			"toc":           "true",
 		},
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(

--- a/internal/cli/security/ldap/verify.go
+++ b/internal/cli/security/ldap/verify.go
@@ -109,6 +109,7 @@ func VerifyBuilder() *cobra.Command {
 		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Annotations: map[string]string{
 			"output": verifyTemplate,
+			"toc":    "true",
 		},
 		Example: `  # Request the JSON-formatted verification of the LDAP configuration for the atlas-ldaps-01.ldap.myteam.com host in the project with the ID 5e2211c17a3e5a48f5497de3:
   atlas security ldap verify --hostname atlas-ldaps-01.ldap.myteam.com --bindUsername "CN=Administrator,CN=Users,DC=atlas-ldaps-01,DC=myteam,DC=com" --bindPassword changeMe --projectId 5e2211c17a3e5a48f5497de3 --output json


### PR DESCRIPTION
## Proposed changes

Adds missing docs TOC entries for two commands that are currently orphan pages in the docs

_Jira ticket:_ 

https://jira.mongodb.org/browse/DOCSP-41063

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
