### PR TITLE
CLOUDP-200390: [ML3] atlas deployments setup unit test

### DIFF
--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -59,6 +59,7 @@ const (
 
 var (
 	errCancel                   = errors.New("the setup was cancelled")
+	ErrDeploymentExists         = errors.New("deployment already exists")
 	errMustBeInt                = errors.New("you must specify an integer")
 	errPortOutOfRange           = errors.New("you must specify a port within the range 1..65535")
 	errPortNotAvailable         = errors.New("the port is unavailable")
@@ -278,7 +279,7 @@ func (opts *SetupOpts) validateLocalDeploymentsSettings(containers []container.C
 	for _, c := range containers {
 		for _, n := range c.Names {
 			if n == mongodContainerName {
-				return fmt.Errorf("\"%s\" deployment already exists and is currently in \"%s\" state", opts.DeploymentName, c.State)
+				return fmt.Errorf("%w: \"%s\", state:\"%s\"", ErrDeploymentExists, opts.DeploymentName, c.State)
 			}
 		}
 	}
@@ -599,7 +600,7 @@ func (opts *SetupOpts) runLocal(ctx context.Context) error {
 
 	if err := opts.createLocalDeployment(ctx); err != nil {
 		// in case the deployment already exists we shouldn't delete it
-		if !strings.Contains(err.Error(), "deployment already exists and is currently in") {
+		if !errors.Is(err, ErrDeploymentExists) {
 			_ = opts.RemoveLocal(ctx)
 		}
 		return err

--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -598,7 +598,10 @@ func (opts *SetupOpts) runLocal(ctx context.Context) error {
 	}
 
 	if err := opts.createLocalDeployment(ctx); err != nil {
-		_ = opts.RemoveLocal(ctx)
+		// in case the deployment already exists we shouldn't delete it
+		if !strings.Contains(err.Error(), "deployment already exists and is currently in") {
+			_ = opts.RemoveLocal(ctx)
+		}
 		return err
 	}
 

--- a/internal/cli/deployments/setup_test.go
+++ b/internal/cli/deployments/setup_test.go
@@ -18,11 +18,13 @@ package deployments
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/test/fixture"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/container"
 )
 
 func TestSetupOpts_PostRun(t *testing.T) {
@@ -43,4 +45,181 @@ func TestSetupOpts_PostRun(t *testing.T) {
 		Times(1)
 
 	opts.PostRun()
+}
+
+// Happy path, nothing is downloaded yet. No containers exist.
+func TestSetupOpts_LocalDev_HappyPathClean(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := context.Background()
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+	buf := new(bytes.Buffer)
+
+	opts := &SetupOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+		OutputOpts: cli.OutputOpts{
+			OutWriter: buf,
+		},
+		force: true,
+	}
+
+	const dockerImageName = "docker.io/mongodb/mongodb-atlas-local:7.0"
+
+	// Container engine is fine
+	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
+	// Image does not exist
+	deploymentTest.MockContainerEngine.EXPECT().ImageList(ctx, dockerImageName).Return([]container.Image{}, nil).AnyTimes()
+
+	// Image gets pulled
+	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageName).Return(nil).Times(1)
+
+	// No local dev container exists yet
+	deploymentTest.MockContainerEngine.EXPECT().ContainerList(ctx, "mongodb-atlas-local=container").Return([]container.Container{}, nil).Times(1)
+
+	// Container run succeeds
+	deploymentTest.MockContainerEngine.EXPECT().ContainerRun(ctx, gomock.Any(), gomock.Any()).Return(deploymentName, nil).Times(1)
+
+	// Image contains a health check
+	deploymentTest.MockContainerEngine.EXPECT().ImageHealthCheck(ctx, dockerImageName).Return(&container.ImageHealthCheck{
+		Test: []string{"/bin/some-path"},
+	}, nil).Times(1)
+
+	// Container is healthy
+	deploymentTest.MockContainerEngine.EXPECT().ContainerHealthStatus(ctx, deploymentName).Return(container.DockerHealthcheckStatusHealthy, nil).Times(1)
+
+	// Verify
+	if err := opts.Run(ctx); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}
+
+// Happy path, image is already downloaded. No containers exist.
+func TestSetupOpts_LocalDev_HappyPathImageDownloaded(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := context.Background()
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+	buf := new(bytes.Buffer)
+
+	opts := &SetupOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+		OutputOpts: cli.OutputOpts{
+			OutWriter: buf,
+		},
+		force: true,
+	}
+
+	const dockerImageName = "docker.io/mongodb/mongodb-atlas-local:7.0"
+
+	// Container engine is fine
+	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
+	// Image exists
+	deploymentTest.MockContainerEngine.EXPECT().ImageList(ctx, dockerImageName).Return([]container.Image{{
+		ID: dockerImageName,
+	}}, nil).Times(1)
+
+	// No local dev container exists yet
+	deploymentTest.MockContainerEngine.EXPECT().ContainerList(ctx, "mongodb-atlas-local=container").Return([]container.Container{}, nil).Times(1)
+
+	// Container run succeeds
+	deploymentTest.MockContainerEngine.EXPECT().ContainerRun(ctx, gomock.Any(), gomock.Any()).Return(deploymentName, nil).Times(1)
+
+	// Image contains a health check
+	deploymentTest.MockContainerEngine.EXPECT().ImageHealthCheck(ctx, dockerImageName).Return(&container.ImageHealthCheck{
+		Test: []string{"/bin/some-path"},
+	}, nil).Times(1)
+
+	// Container is healthy
+	deploymentTest.MockContainerEngine.EXPECT().ContainerHealthStatus(ctx, deploymentName).Return(container.DockerHealthcheckStatusHealthy, nil).Times(1)
+
+	// Verify
+	if err := opts.Run(ctx); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+}
+
+// Happy path, image is already downloaded. Containers exist.
+func TestSetupOpts_LocalDev_HappyPathEverythingAlreadyExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := context.Background()
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+	buf := new(bytes.Buffer)
+
+	opts := &SetupOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+		OutputOpts: cli.OutputOpts{
+			OutWriter: buf,
+		},
+		force: true,
+	}
+
+	const dockerImageName = "docker.io/mongodb/mongodb-atlas-local:7.0"
+
+	// Container engine is fine
+	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
+	// Image exists
+	deploymentTest.MockContainerEngine.EXPECT().ImageList(ctx, dockerImageName).Return([]container.Image{{
+		ID: dockerImageName,
+	}}, nil).Times(1)
+
+	// No local dev container exists yet
+	deploymentTest.MockContainerEngine.EXPECT().ContainerList(ctx, "mongodb-atlas-local=container").Return([]container.Container{
+		{
+			ID:    "random-container-id",
+			Names: []string{deploymentName},
+		},
+	}, nil).Times(1)
+
+	// Verify
+	if err := opts.Run(ctx); err == nil {
+		t.Fatal("Run() unexpected success, should fail")
+	}
+}
+
+func TestSetupOpts_LocalDev_RemoveUnhealthyDeployment(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := context.Background()
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+	buf := new(bytes.Buffer)
+
+	opts := &SetupOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+		OutputOpts: cli.OutputOpts{
+			OutWriter: buf,
+		},
+		force: true,
+	}
+
+	const dockerImageName = "docker.io/mongodb/mongodb-atlas-local:7.0"
+
+	// Container engine is fine
+	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
+	// Image exists
+	deploymentTest.MockContainerEngine.EXPECT().ImageList(ctx, dockerImageName).Return([]container.Image{{
+		ID: dockerImageName,
+	}}, nil).Times(1)
+
+	// No local dev container exists yet
+	deploymentTest.MockContainerEngine.EXPECT().ContainerList(ctx, "mongodb-atlas-local=container").Return([]container.Container{}, nil).Times(1)
+
+	// Container run succeeds
+	deploymentTest.MockContainerEngine.EXPECT().ContainerRun(ctx, gomock.Any(), gomock.Any()).Return(deploymentName, nil).Times(1)
+
+	// Image contains a health check
+	deploymentTest.MockContainerEngine.EXPECT().ImageHealthCheck(ctx, dockerImageName).Return(&container.ImageHealthCheck{
+		Test: []string{"/bin/some-path"},
+	}, nil).Times(1)
+
+	// Container is unhealthy
+	deploymentTest.MockContainerEngine.EXPECT().ContainerHealthStatus(ctx, deploymentName).Return(container.DockerHealthcheckStatusUnhealthy, nil).Times(1)
+
+	// Container is removed
+	deploymentTest.MockContainerEngine.EXPECT().ContainerRm(ctx, deploymentName).Return(nil).Times(1)
+
+	// Verify
+	if err := opts.Run(ctx); err == nil {
+		t.Fatal("Run() unexpected success, should fail")
+	}
 }


### PR DESCRIPTION
## Proposed changes
- Added unit tests for `atlas deployment setup`
- Fixed an issue I've discovered while implementing the unit tests. When a deployment already exists we print "deployment already exists" and then delete the deployment we found and exit.

_Jira ticket:_ CLOUDP-200390
