### PR TITLE
CLOUDP-261267: Change file permissions in cli-generator to be in line with golangci-lint recommendations

### DIFF
--- a/tools/cli-generator/generate.go
+++ b/tools/cli-generator/generate.go
@@ -237,7 +237,8 @@ func cleanupFile(filePath string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filePath, r, os.ModePerm)
+	const filePermissions = 0600
+	return os.WriteFile(filePath, r, filePermissions)
 }
 
 func goGenerate(filePath string) error {


### PR DESCRIPTION
## Proposed changes

- Decrease file permissions in cli-generator

_Jira ticket:_ CLOUDP-261267
