### PR TITLE
CLOUDP-261264: remove podman as a recommondation on debian based distros

### DIFF
--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -110,11 +110,13 @@ nfpms:
   overrides:
     deb:
       dependencies:
-        - docker
+        - docker-ce
+        - docker-ce-cli
     rpm:
       recommends:
         - podman
-        - docker
+        - docker-ce
+        - docker-ce-cli
 checksum:
   name_template: checksums.txt
   extra_files:

--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -106,9 +106,15 @@ nfpms:
   dependencies:
     - mongodb-atlas-cli
     - mongodb-mongosh
-  recommends:
-    - podman
   meta: true
+  overrides:
+    deb:
+      dependencies:
+        - docker
+    rpm:
+      recommends:
+        - podman
+        - docker
 checksum:
   name_template: checksums.txt
   extra_files:

--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -109,11 +109,11 @@ nfpms:
   meta: true
   overrides:
     deb:
-      recommends:
+      suggests:
         - docker-ce
         - docker-ce-cli
     rpm:
-      recommends:
+      suggests:
         - podman
         - docker-ce
         - docker-ce-cli

--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -109,7 +109,7 @@ nfpms:
   meta: true
   overrides:
     deb:
-      dependencies:
+      recommends:
         - docker-ce
         - docker-ce-cli
     rpm:


### PR DESCRIPTION
## Proposed changes
- Make docker a debendency on debian based systems.
- Add docker to the suggestions on fedora based systems.

_Jira ticket:_ CLOUDP-261264
