### PR TITLE
CLOUDP-261265: Refactor auth command to be consistent with other commands

### DIFF
--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -1,0 +1,35 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import "github.com/spf13/cobra"
+
+func Builder() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Manage the CLI's authentication state.",
+		Annotations: map[string]string{
+			"toc": "true",
+		},
+	}
+	cmd.AddCommand(
+		LoginBuilder(),
+		WhoAmIBuilder(),
+		LogoutBuilder(),
+		RegisterBuilder(),
+	)
+
+	return cmd
+}

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -1,0 +1,30 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
+)
+
+func TestBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		Builder(),
+		4,
+		[]string{},
+	)
+}

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -315,21 +315,3 @@ func LoginBuilder() *cobra.Command {
 	_ = cmd.Flags().MarkDeprecated("skipConfig", "if you configured a profile, the command skips the config step by default.")
 	return cmd
 }
-
-func Builder() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "auth",
-		Short: "Manage the CLI's authentication state.",
-		Annotations: map[string]string{
-			"toc": "true",
-		},
-	}
-	cmd.AddCommand(
-		LoginBuilder(),
-		WhoAmIBuilder(),
-		LogoutBuilder(),
-		RegisterBuilder(),
-	)
-
-	return cmd
-}

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -34,15 +34,6 @@ import (
 	"go.mongodb.org/atlas/auth"
 )
 
-func TestBuilder(t *testing.T) {
-	test.CmdValidator(
-		t,
-		Builder(),
-		4,
-		[]string{},
-	)
-}
-
 func TestLoginBuilder(t *testing.T) {
 	test.CmdValidator(
 		t,


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

- Move auth command builder to separate file
- Move auth unit test to separate file 

_Jira ticket:_ CLOUDP-261265

