### PR TITLE
CLOUDP-262694: Fix dockerNotFound error message.

### DIFF
--- a/internal/cli/deployments/list_test.go
+++ b/internal/cli/deployments/list_test.go
@@ -363,6 +363,8 @@ func TestListOpts_PostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentsTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
 	if err := listOpts.PostRun(); err != nil {
 		t.Fatalf("PostRun() unexpected error: %v", err)
 	}

--- a/internal/cli/deployments/options/deployment_opts_post_run.go
+++ b/internal/cli/deployments/options/deployment_opts_post_run.go
@@ -17,8 +17,8 @@ package options
 import (
 	"errors"
 
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/container"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/log"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/podman"
 )
 
 func (opts *DeploymentOpts) PostRunMessages() error {
@@ -28,8 +28,8 @@ func (opts *DeploymentOpts) PostRunMessages() error {
 		}
 	}
 
-	if err := podman.Installed(); errors.Is(err, podman.ErrPodmanNotFound) {
-		if _, err = log.Warningln("\nTo get output for both local and Atlas deployments, install Podman."); err != nil {
+	if err := opts.ContainerEngine.Ready(); errors.Is(err, container.ErrContainerEngineNotFound) {
+		if _, err = log.Warningln("\nTo get output for both local and Atlas deployments, install " + opts.ContainerEngine.Name()); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/deployments/pause_test.go
+++ b/internal/cli/deployments/pause_test.go
@@ -124,6 +124,8 @@ func TestPauseOpts_PostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
 	if err := opts.PostRun(); err != nil {
 		t.Fatalf("PostRun() unexpected error: %v", err)
 	}

--- a/internal/cli/deployments/start_test.go
+++ b/internal/cli/deployments/start_test.go
@@ -153,6 +153,8 @@ func TestStartOpts_PostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentsTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
 	require.NoError(t, opts.PostRun())
 }
 

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -16,6 +16,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -130,4 +131,8 @@ const (
 	DockerHealthcheckStatusHealthy   DockerHealthcheckStatus = "healthy"
 	DockerHealthcheckStatusUnhealthy DockerHealthcheckStatus = "unhealthy"
 	DockerHealthcheckStatusNone      DockerHealthcheckStatus = "none"
+)
+
+var (
+	ErrContainerEngineNotFound = errors.New("container engine not found")
 )

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -26,7 +26,7 @@ import (
 	"time"
 )
 
-var ErrDockerNotFound = errors.New("podman not found in your system, check requirements at https://dochub.mongodb.org/core/atlas-cli-deploy-local-reqs")
+var ErrDockerNotFound = fmt.Errorf("%w: docker not found in your system, check requirements at https://dochub.mongodb.org/core/atlas-cli-deploy-local-reqs", ErrContainerEngineNotFound)
 
 type dockerImpl struct {
 }

--- a/internal/container/podman.go
+++ b/internal/container/podman.go
@@ -19,6 +19,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -37,7 +38,16 @@ func newPodmanEngine() Engine {
 }
 
 func (e *podmanImpl) Ready() error {
-	return e.client.Ready(context.Background())
+	err := e.client.Ready(context.Background())
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, podman.ErrPodmanNotFound) {
+		err = errors.Join(err, ErrContainerEngineNotFound)
+	}
+
+	return err
 }
 
 func (e *podmanImpl) ContainerLogs(ctx context.Context, name string) ([]string, error) {


### PR DESCRIPTION
## Proposed changes
- Fixed docker error message
- Fixed post_run_opts to:
    - use container engine, get rid of reference to podman
    - show message if docker or podman is not installed, not only podman
- Fix broken tests

_Jira ticket:_ CLOUDP-262694
