### PR TITLE
CLOUDP-262686: In windows we can't find Compass hence cli does not launch it

### DIFF
--- a/build/ci/library_owners.json
+++ b/build/ci/library_owners.json
@@ -35,6 +35,7 @@
 	"go.mongodb.org/atlas": "mongocli",
 	"go.mongodb.org/atlas-sdk/v20240530002": "mongocli",
 	"go.mongodb.org/mongo-driver": "mongocli",
+	"golang.org/x/sys": "mongocli",
 	"golang.org/x/tools": "mongocli",
 	"google.golang.org/api": "mongocli",
 	"google.golang.org/protobuf": "mongocli",

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.mongodb.org/mongo-driver v1.16.0
 	golang.org/x/exp v0.0.0-20240318143956-a85f2c67cd81
 	golang.org/x/mod v0.19.0
+	golang.org/x/sys v0.22.0
 	golang.org/x/tools v0.23.0
 	google.golang.org/api v0.188.0
 	google.golang.org/protobuf v1.34.2
@@ -144,7 +145,6 @@ require (
 	golang.org/x/net v0.27.0 // indirect
 	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
-	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/internal/compass/compass.go
+++ b/internal/compass/compass.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 	"time"
 )
 
@@ -26,22 +25,12 @@ const waitForRunningStateDuration = 10 * time.Second
 
 var errCompassExited = errors.New("MongoDB Compass process has exited")
 
-func binPath() string {
-	if p, err := exec.LookPath(compassBin); err == nil {
-		return p
-	}
-	return ""
-}
-
 func Detect() bool {
 	return binPath() != ""
 }
 
 func Run(username, password, mongoURI string) error {
 	path := binPath()
-	if path != compassBin {
-		path += compassBin
-	}
 
 	cmd := compassCmd(path, username, password, mongoURI)
 	if err := cmd.Start(); err != nil {

--- a/internal/compass/compass_bin_darwin.go
+++ b/internal/compass/compass_bin_darwin.go
@@ -15,3 +15,7 @@
 package compass
 
 const compassBin = "/Applications/MongoDB Compass.app/Contents/MacOS/MongoDB Compass"
+
+func binPath() string {
+	return compassBin
+}

--- a/internal/compass/compass_bin_linux.go
+++ b/internal/compass/compass_bin_linux.go
@@ -15,3 +15,7 @@
 package compass
 
 const compassBin = "/usr/bin/mongodb-compass" //nolint:gosec
+
+func binPath() string {
+	return compassBin
+}


### PR DESCRIPTION
## Proposed changes
Use the windows register set by the compass installer.
If the registry value is not set, try the path too.

_Jira ticket:_ CLOUDP-262686
