### PR TITLE
CLOUDP-263807: process disabled flag

### DIFF
--- a/internal/convert/automation_config.go
+++ b/internal/convert/automation_config.go
@@ -48,6 +48,7 @@ func FromAutomationConfig(c *opsmngr.AutomationConfig) []*ClusterConfig {
 				p := c.Processes[k]
 				if p.Name == m.Host {
 					newRS.Processes[j] = newReplicaSetProcessConfig(&rs.Members[j], p)
+					newRS.Processes[j].Disabled = p.Disabled
 					newRS.addToMongoURI(p)
 					c.Processes = removeProcess(c.Processes, k)
 				}

--- a/internal/convert/automation_config_test.go
+++ b/internal/convert/automation_config_test.go
@@ -26,8 +26,9 @@ import (
 
 func TestFromAutomationConfig(t *testing.T) {
 	name := "cluster_1"
+	pName := name + "_0"
 	fipsMode := true
-	t.Run("replica set", func(t *testing.T) {
+	t.Run("replica set all enabled", func(t *testing.T) {
 		t.Parallel()
 		config := fixture.AutomationConfigWithOneReplicaSet(name, false)
 		expected := []*ClusterConfig{
@@ -54,7 +55,65 @@ func TestFromAutomationConfig(t *testing.T) {
 							Votes:                       pointer.Get[float64](1),
 							FeatureCompatibilityVersion: "4.2",
 							Version:                     "4.2.2",
-							Name:                        name + "_0",
+							Name:                        pName,
+							OplogSizeMB:                 pointer.Get(10),
+							TLS: &TLS{
+								CAFile:                     "CAFile",
+								CertificateKeyFile:         "CertificateKeyFile",
+								CertificateKeyFilePassword: "CertificateKeyFilePassword",
+								CertificateSelector:        "CertificateSelector",
+								ClusterCertificateSelector: "ClusterCertificateSelector",
+								ClusterFile:                "ClusterFile",
+								ClusterPassword:            "ClusterPassword",
+								CRLFile:                    "CRLFile",
+								DisabledProtocols:          "DisabledProtocols",
+								FIPSMode:                   &fipsMode,
+								Mode:                       "Mode",
+								PEMKeyFile:                 "PEMKeyFile",
+							},
+							Security: &map[string]interface{}{
+								"test": "test",
+							},
+						},
+					},
+				},
+				MongoURI: "mongodb://host0:27017",
+			},
+		}
+
+		result := FromAutomationConfig(config)
+		if diff := deep.Equal(result, expected); diff != nil {
+			t.Error(diff)
+		}
+	})
+	t.Run("replica set with disabled members", func(t *testing.T) {
+		t.Parallel()
+		config := fixture.AutomationConfigWithOneReplicaSet(name, true)
+		expected := []*ClusterConfig{
+			{
+				RSConfig: RSConfig{
+					Name: name,
+					Processes: []*ProcessConfig{
+						{
+							ArbiterOnly:                 pointer.Get(false),
+							BuildIndexes:                pointer.Get(true),
+							DBPath:                      "/data/db/",
+							Disabled:                    true,
+							Hidden:                      pointer.Get(false),
+							Hostname:                    "host0",
+							LogPath:                     "/data/db/mongodb.log",
+							LogDestination:              file,
+							AuditLogDestination:         file,
+							AuditLogPath:                "/data/db/audit.log",
+							Port:                        27017,
+							Priority:                    pointer.Get[float64](1),
+							ProcessType:                 mongod,
+							SlaveDelay:                  pointer.Get[float64](1),
+							SecondaryDelaySecs:          pointer.Get[float64](1),
+							Votes:                       pointer.Get[float64](1),
+							FeatureCompatibilityVersion: "4.2",
+							Version:                     "4.2.2",
+							Name:                        pName,
 							OplogSizeMB:                 pointer.Get(10),
 							TLS: &TLS{
 								CAFile:                     "CAFile",


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-263807](https://jira.mongodb.org/browse/CLOUDP-263807)

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [X] I have run `make fmt` and formatted my code

## Further comments

Created a replica set of 3 servers, shutdown one of them

before the change:
```{
  "name": "replSet1",
  "processes": [
    {
      "arbiterOnly": false,
      "buildIndexes": true,
      "dbPath": "/data/srv1",
      "disabled": false, <<-- HERE
      "featureCompatibilityVersion": "7.0",
      "hidden": false,
      "hostname": "ip-172-31-1-67.eu-west-1.compute.internal",
      "logDestination": "file",
      "logPath": "/data/srv1/mongodb.log",
      "name": "replSet1_5",
      "port": 28001,
      "priority": 1,
      "processType": "mongod",
      "secondaryDelaySecs": 0,
      "votes": 1,
      "version": "7.0.12"
    },
    {
      "arbiterOnly": false,
      "buildIndexes": true,
      "dbPath": "/data/srv3",
      "disabled": false, <<-- HERE
      "featureCompatibilityVersion": "7.0",
      "hidden": false,
      "hostname": "ip-172-31-1-67.eu-west-1.compute.internal",
      "logDestination": "file",
      "logPath": "/data/srv3/mongodb.log",
      "name": "replSet1_7",
      "port": 28003,
      "priority": 1,
      "processType": "mongod",
      "secondaryDelaySecs": 0,
      "votes": 1,
      "version": "7.0.12"
    }
  ],
  "mongoURI": "mongodb://ip-172-31-1-67.eu-west-1.compute.internal:28001,ip-172-31-1-67.eu-west-1.compute.internal:28002,ip-172-31-1-67.eu-west-1.compute.internal:28003"
}
```

After the change:
````{
  "name": "replSet1",
  "processes": [
    {
      "arbiterOnly": false,
      "buildIndexes": true,
      "dbPath": "/data/srv1",
      "disabled": false, <<-- HERE
      "featureCompatibilityVersion": "7.0",
      "hidden": false,
      "hostname": "ip-172-31-1-67.eu-west-1.compute.internal",
      "logDestination": "file",
      "logPath": "/data/srv1/mongodb.log",
      "name": "replSet1_5",
      "port": 28001,
      "priority": 1,
      "processType": "mongod",
      "secondaryDelaySecs": 0,
      "votes": 1,
      "version": "7.0.12"
    },
    {
      "arbiterOnly": false,
      "buildIndexes": true,
      "dbPath": "/data/srv3",
      "disabled": true, <<-- HERE
      "featureCompatibilityVersion": "7.0",
      "hidden": false,
      "hostname": "ip-172-31-1-67.eu-west-1.compute.internal",
      "logDestination": "file",
      "logPath": "/data/srv3/mongodb.log",
      "name": "replSet1_7",
      "port": 28003,
      "priority": 1,
      "processType": "mongod",
      "secondaryDelaySecs": 0,
      "votes": 1,
      "version": "7.0.12"
    }
  ],
  "mongoURI": "mongodb://ip-172-31-1-67.eu-west-1.compute.internal:28001,ip-172-31-1-67.eu-west-1.compute.internal:28002,ip-172-31-1-67.eu-west-1.compute.internal:28003"
}
```