### PR TITLE
CLOUDP-264040: local dev: stop printing could not refresh access token when using type local

### DIFF
--- a/internal/cli/root/builder.go
+++ b/internal/cli/root/builder.go
@@ -152,9 +152,9 @@ Use the --help flag with any command for more info on that command.`,
 					func() error {
 						if err := opts.RefreshAccessToken(cmd.Context()); err != nil {
 							if authReq == RequiredAuth {
+								_, _ = log.Warningf("Could not refresh access token: %s\n", err.Error())
 								return err
 							}
-							_, _ = log.Warningf("Could not refresh access token: %s\n", err.Error())
 						}
 						return nil
 					},


### PR DESCRIPTION
## Proposed changes
When running commands like the command below you get the error that we couldn't refresh the refresh token, even though the command doesn't need authorization.

```
atlas deployments list --type LOCAL
```

Only print the messages for commands that need authorization.

_Jira ticket:_ CLOUDP-264040