### PR TITLE
fix: update mongocli release task to use rhel90

### DIFF
--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -443,7 +443,7 @@ buildvariants:
   - name: release_mongocli_github
     display_name: "Release MongoCLI (goreleaser)"
     run_on:
-      - rhel80-small
+      - rhel90-small
     git_tag_only: true
     expansions:
       <<: *go_linux_version


### PR DESCRIPTION
Description:

The MongoCLI release is [failing](https://github.com/mongodb/mongodb-atlas-cli/blob/66cd30cf8fa3fca0a30b0cac0098c2add2850c0f/build/package/windows_notarize.sh#L29) because of the version of podman that is running on rhel80 which is 1.0.5. This PR updates the mongocli release task to use rhel90 which is running v4.8.3
