### PR TITLE
CLOUDP-266174: kubernetes config generate to export mongodb major version

### DIFF
--- a/internal/kubernetes/operator/deployment/deployment.go
+++ b/internal/kubernetes/operator/deployment/deployment.go
@@ -108,7 +108,7 @@ func BuildAtlasAdvancedDeployment(deploymentStore store.OperatorClusterStore, va
 		RootCertType:             deployment.GetRootCertType(),
 		VersionReleaseSystem:     deployment.GetVersionReleaseSystem(),
 		Tags:                     convertTags(deployment.GetTags()),
-		MongoDBMajorVersion:      pointer.GetOrZero[string](deployment.MongoDBMajorVersion),
+		MongoDBMajorVersion:      deployment.GetMongoDBMajorVersion(),
 	}
 
 	atlasDeployment := &akov2.AtlasDeployment{

--- a/internal/kubernetes/operator/deployment/deployment.go
+++ b/internal/kubernetes/operator/deployment/deployment.go
@@ -108,6 +108,7 @@ func BuildAtlasAdvancedDeployment(deploymentStore store.OperatorClusterStore, va
 		RootCertType:             deployment.GetRootCertType(),
 		VersionReleaseSystem:     deployment.GetVersionReleaseSystem(),
 		Tags:                     convertTags(deployment.GetTags()),
+		MongoDBMajorVersion:      pointer.GetOrZero[string](deployment.MongoDBMajorVersion),
 	}
 
 	atlasDeployment := &akov2.AtlasDeployment{

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -223,7 +223,8 @@ func TestBuildAtlasAdvancedDeployment(t *testing.T) {
 					Namespace: targetNamespace,
 				},
 				DeploymentSpec: &akov2.AdvancedDeploymentSpec{
-					BackupEnabled: cluster.BackupEnabled,
+					MongoDBMajorVersion: "5.0",
+					BackupEnabled:       cluster.BackupEnabled,
 					CustomZoneMapping: []akov2.CustomZoneMapping{
 						{
 							Location: firstLocation,

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -228,6 +228,8 @@ func TestKubernetesConfigApply(t *testing.T) {
 				true,
 			),
 		)
+		assert.NotEmpty(t, akoDeployment.Spec.DeploymentSpec.MongoDBMajorVersion)
+		akoDeployment.Spec.DeploymentSpec.MongoDBMajorVersion = ""
 		assert.Equal(t, referenceExportedDeployment(g.projectName, g.clusterName, e2eNamespace.Name).Spec, akoDeployment.Spec)
 	})
 }

--- a/test/e2e/atlas/kubernetes_config_apply_test.go
+++ b/test/e2e/atlas/kubernetes_config_apply_test.go
@@ -228,9 +228,7 @@ func TestKubernetesConfigApply(t *testing.T) {
 				true,
 			),
 		)
-		assert.NotEmpty(t, akoDeployment.Spec.DeploymentSpec.MongoDBMajorVersion)
-		akoDeployment.Spec.DeploymentSpec.MongoDBMajorVersion = ""
-		assert.Equal(t, referenceExportedDeployment(g.projectName, g.clusterName, e2eNamespace.Name).Spec, akoDeployment.Spec)
+		assert.Equal(t, referenceExportedDeployment(g.projectName, g.clusterName, e2eNamespace.Name, g.mDBVer).Spec, akoDeployment.Spec)
 	})
 }
 
@@ -414,7 +412,7 @@ func referenceExportedBackupPolicy() *akov2.AtlasBackupPolicy {
 	}
 }
 
-func referenceExportedDeployment(projectName, clusterName, namespace string) *akov2.AtlasDeployment {
+func referenceExportedDeployment(projectName, clusterName, namespace, mdbVersion string) *akov2.AtlasDeployment {
 	return &akov2.AtlasDeployment{
 		Spec: akov2.AtlasDeploymentSpec{
 			Project: akov2common.ResourceRefNamespaced{
@@ -432,6 +430,7 @@ func referenceExportedDeployment(projectName, clusterName, namespace string) *ak
 					Enabled:        pointer.Get(false),
 					ReadPreference: "secondary",
 				},
+				MongoDBMajorVersion:      mdbVersion,
 				ClusterType:              "REPLICASET",
 				EncryptionAtRestProvider: "NONE",
 				Paused:                   pointer.Get(false),

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -1580,7 +1580,7 @@ func checkClustersData(t *testing.T, deployments []*akov2.AtlasDeployment, clust
 			if ok := slices.Contains(clusterNames, deployment.Spec.DeploymentSpec.Name); ok {
 				name := deployment.Spec.DeploymentSpec.Name
 				expectedDeployment := referenceAdvancedCluster(name, region, namespace, projectName, expectedLabels)
-				assert.NotEmpty(t, akoDeployment.Spec.DeploymentSpec.MongoDBMajorVersion)
+				assert.NotEmpty(t, deployment.Spec.DeploymentSpec.MongoDBMajorVersion)
 				deployment.Spec.DeploymentSpec.MongoDBMajorVersion = ""
 				assert.Equal(t, expectedDeployment, deployment)
 				entries = append(entries, name)
@@ -1668,7 +1668,7 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 			}
 		}
 		require.True(t, found, "AtlasDeployment is not found in results")
-		assert.NotEmpty(t, akoDeployment.Spec.DeploymentSpec.MongoDBMajorVersion)
+		assert.NotEmpty(t, deployment.Spec.DeploymentSpec.MongoDBMajorVersion)
 		deployment.Spec.DeploymentSpec.MongoDBMajorVersion = ""
 		assert.Equal(t, expectedDeployment, deployment)
 

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -1417,8 +1417,8 @@ func referenceServerless(name, region, namespace, projectName string, labels map
 	}
 }
 
-func referenceSharedCluster(name, region, namespace, projectName string, labels map[string]string, mdbVersion string) *akov2.AtlasDeployment {
-	cluster := referenceAdvancedCluster(name, region, namespace, projectName, labels, mdbVersion)
+func referenceSharedCluster(name, region, namespace, projectName string, labels map[string]string) *akov2.AtlasDeployment {
+	cluster := referenceAdvancedCluster(name, region, namespace, projectName, labels, "")
 	cluster.Spec.DeploymentSpec.ReplicationSpecs[0].RegionConfigs[0].ElectableSpecs = &akov2.Specs{
 		DiskIOPS:     nil,
 		InstanceSize: e2eSharedClusterTier,
@@ -1764,7 +1764,7 @@ func TestKubernetesConfigGenerateSharedCluster(t *testing.T) {
 	g.tier = e2eSharedClusterTier
 	g.generateCluster()
 
-	expectedDeployment := referenceSharedCluster(g.clusterName, g.clusterRegion, targetNamespace, g.projectName, expectedLabels, g.mDBVer)
+	expectedDeployment := referenceSharedCluster(g.clusterName, g.clusterRegion, targetNamespace, g.projectName, expectedLabels)
 
 	cliPath, err := e2e.AtlasCLIBin()
 	require.NoError(t, err)

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -1580,6 +1580,8 @@ func checkClustersData(t *testing.T, deployments []*akov2.AtlasDeployment, clust
 			if ok := slices.Contains(clusterNames, deployment.Spec.DeploymentSpec.Name); ok {
 				name := deployment.Spec.DeploymentSpec.Name
 				expectedDeployment := referenceAdvancedCluster(name, region, namespace, projectName, expectedLabels)
+				assert.NotEmpty(t, akoDeployment.Spec.DeploymentSpec.MongoDBMajorVersion)
+				deployment.Spec.DeploymentSpec.MongoDBMajorVersion = ""
 				assert.Equal(t, expectedDeployment, deployment)
 				entries = append(entries, name)
 			}
@@ -1666,6 +1668,8 @@ func TestKubernetesConfigGenerate_ClustersWithBackup(t *testing.T) {
 			}
 		}
 		require.True(t, found, "AtlasDeployment is not found in results")
+		assert.NotEmpty(t, akoDeployment.Spec.DeploymentSpec.MongoDBMajorVersion)
+		deployment.Spec.DeploymentSpec.MongoDBMajorVersion = ""
 		assert.Equal(t, expectedDeployment, deployment)
 
 		secret, found := findSecret(objects)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

`atlas kubernetes config generate` now exports mongodb major version for AtlasDeployments

blocked by: https://github.com/mongodb/mongodb-atlas-cli/pull/3168 

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
