### PR TITLE
CLOUDP-265397: [CLI] Move random port binding to docker instead of doing in the cli

### DIFF
--- a/internal/cli/deployments/connect_test.go
+++ b/internal/cli/deployments/connect_test.go
@@ -65,10 +65,10 @@ func TestRun_ConnectLocal(t *testing.T) {
 						"version": "7.0.1",
 					},
 				},
-				HostConfig: &container.InspectDataHostConfig{
-					PortBindings: map[string][]container.InspectDataHostPort{
+				NetworkSettings: &container.NetworkSettings{
+					Ports: map[string][]container.InspectDataHostPort{
 						"27017/tcp": {
-							{
+							container.InspectDataHostPort{
 								HostIP:   "127.0.0.1",
 								HostPort: "27017",
 							},

--- a/internal/cli/deployments/options/deployment_opts_connect_string.go
+++ b/internal/cli/deployments/options/deployment_opts_connect_string.go
@@ -28,7 +28,7 @@ const deploymentTypeLocal = "local"
 func (opts *DeploymentOpts) updateFields(c *container.InspectData) {
 	opts.DeploymentType = deploymentTypeLocal
 	opts.MdbVersion = c.Config.Labels["version"]
-	portBind, ok := c.HostConfig.PortBindings["27017/tcp"]
+	portBind, ok := c.NetworkSettings.Ports["27017/tcp"]
 	if ok && len(portBind) > 0 {
 		opts.Port, _ = strconv.Atoi(portBind[0].HostPort)
 	}

--- a/internal/cli/deployments/search/indexes/create_test.go
+++ b/internal/cli/deployments/search/indexes/create_test.go
@@ -82,10 +82,10 @@ func TestCreate_RunLocal(t *testing.T) {
 						"version": "7.0.1",
 					},
 				},
-				HostConfig: &container.InspectDataHostConfig{
-					PortBindings: map[string][]container.InspectDataHostPort{
+				NetworkSettings: &container.NetworkSettings{
+					Ports: map[string][]container.InspectDataHostPort{
 						"27017/tcp": {
-							{
+							container.InspectDataHostPort{
 								HostIP:   "127.0.0.1",
 								HostPort: "27017",
 							},
@@ -198,10 +198,10 @@ func TestCreate_Duplicated(t *testing.T) {
 						"version": "7.0.1",
 					},
 				},
-				HostConfig: &container.InspectDataHostConfig{
-					PortBindings: map[string][]container.InspectDataHostPort{
+				NetworkSettings: &container.NetworkSettings{
+					Ports: map[string][]container.InspectDataHostPort{
 						"27017/tcp": {
-							{
+							container.InspectDataHostPort{
 								HostIP:   "127.0.0.1",
 								HostPort: "27017",
 							},

--- a/internal/cli/deployments/search/indexes/delete_test.go
+++ b/internal/cli/deployments/search/indexes/delete_test.go
@@ -65,10 +65,10 @@ func TestDelete_RunLocal(t *testing.T) {
 						"version": "7.0.1",
 					},
 				},
-				HostConfig: &container.InspectDataHostConfig{
-					PortBindings: map[string][]container.InspectDataHostPort{
+				NetworkSettings: &container.NetworkSettings{
+					Ports: map[string][]container.InspectDataHostPort{
 						"27017/tcp": {
-							{
+							container.InspectDataHostPort{
 								HostIP:   "127.0.0.1",
 								HostPort: "27017",
 							},

--- a/internal/cli/deployments/search/indexes/describe_test.go
+++ b/internal/cli/deployments/search/indexes/describe_test.go
@@ -72,10 +72,10 @@ func TestDescribe_RunLocal(t *testing.T) {
 						"version": "7.0.1",
 					},
 				},
-				HostConfig: &container.InspectDataHostConfig{
-					PortBindings: map[string][]container.InspectDataHostPort{
+				NetworkSettings: &container.NetworkSettings{
+					Ports: map[string][]container.InspectDataHostPort{
 						"27017/tcp": {
-							{
+							container.InspectDataHostPort{
 								HostIP:   "127.0.0.1",
 								HostPort: "27017",
 							},

--- a/internal/cli/deployments/search/indexes/list_test.go
+++ b/internal/cli/deployments/search/indexes/list_test.go
@@ -80,10 +80,10 @@ func TestList_RunLocal(t *testing.T) {
 						"version": "7.0.1",
 					},
 				},
-				HostConfig: &container.InspectDataHostConfig{
-					PortBindings: map[string][]container.InspectDataHostPort{
+				NetworkSettings: &container.NetworkSettings{
+					Ports: map[string][]container.InspectDataHostPort{
 						"27017/tcp": {
-							{
+							container.InspectDataHostPort{
 								HostIP:   "127.0.0.1",
 								HostPort: "27017",
 							},

--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -298,26 +298,6 @@ func (opts *SetupOpts) promptMdbVersion() error {
 	return telemetry.TrackAskOne(p, &opts.MdbVersion, nil)
 }
 
-func availablePort() (int, error) {
-	// prefer mongodb default's port
-	if err := checkPort(internalMongodPort); err == nil {
-		return internalMongodPort, nil
-	}
-
-	server, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		return 0, err
-	}
-	defer server.Close()
-
-	_, port, err := net.SplitHostPort(server.Addr().String())
-	if err != nil {
-		return 0, err
-	}
-
-	return strconv.Atoi(port)
-}
-
 func checkPort(p int) error {
 	server, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", p))
 	if err != nil {
@@ -447,11 +427,6 @@ func (opts *SetupOpts) setDefaultSettings() error {
 	}
 
 	if opts.Port == 0 {
-		port, err := availablePort()
-		if err != nil {
-			return err
-		}
-		opts.Port = port
 		defaultValuesSet = true
 	}
 
@@ -460,7 +435,6 @@ func (opts *SetupOpts) setDefaultSettings() error {
 [Default Settings]
 Deployment Name	{{.DeploymentName}}
 MongoDB Version	{{.MdbVersion}}
-Port	{{.Port}}
 
 `, opts); err != nil {
 			return err

--- a/internal/cli/deployments/setup_test.go
+++ b/internal/cli/deployments/setup_test.go
@@ -85,6 +85,25 @@ func TestSetupOpts_LocalDev_HappyPathClean(t *testing.T) {
 	// Container is healthy
 	deploymentTest.MockContainerEngine.EXPECT().ContainerHealthStatus(ctx, deploymentName).Return(container.DockerHealthcheckStatusHealthy, nil).Times(1)
 
+	// Because no port is specified docker inspect will happen
+	deploymentTest.MockContainerEngine.EXPECT().ContainerInspect(ctx, opts.LocalMongodHostname()).Return([]*container.InspectData{{
+		Config: &container.InspectDataConfig{
+			Labels: map[string]string{
+				"version": "7.0.12",
+			},
+		},
+		NetworkSettings: &container.NetworkSettings{
+			Ports: map[string][]container.InspectDataHostPort{
+				"27017/tcp": {
+					container.InspectDataHostPort{
+						HostIP:   "127.0.0.1",
+						HostPort: "12345",
+					},
+				},
+			},
+		},
+	}}, nil).Times(1)
+
 	// Verify
 	if err := opts.Run(ctx); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
@@ -130,6 +149,25 @@ func TestSetupOpts_LocalDev_HappyPathOfflinePull(t *testing.T) {
 
 	// Container is healthy
 	deploymentTest.MockContainerEngine.EXPECT().ContainerHealthStatus(ctx, deploymentName).Return(container.DockerHealthcheckStatusHealthy, nil).Times(1)
+
+	// Because no port is specified docker inspect will happen
+	deploymentTest.MockContainerEngine.EXPECT().ContainerInspect(ctx, opts.LocalMongodHostname()).Return([]*container.InspectData{{
+		Config: &container.InspectDataConfig{
+			Labels: map[string]string{
+				"version": "7.0.12",
+			},
+		},
+		NetworkSettings: &container.NetworkSettings{
+			Ports: map[string][]container.InspectDataHostPort{
+				"27017/tcp": {
+					container.InspectDataHostPort{
+						HostIP:   "127.0.0.1",
+						HostPort: "12345",
+					},
+				},
+			},
+		},
+	}}, nil).Times(1)
 
 	// Verify
 	if err := opts.Run(ctx); err != nil {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -109,10 +109,15 @@ type InspectDataConfig struct {
 }
 
 type InspectData struct {
-	ID         string                 `json:"Id"`
-	Name       string                 `json:"Name"`
-	Config     *InspectDataConfig     `json:"Config"`
-	HostConfig *InspectDataHostConfig `json:"HostConfig"`
+	ID              string                 `json:"Id"`
+	Name            string                 `json:"Name"`
+	Config          *InspectDataConfig     `json:"Config"`
+	HostConfig      *InspectDataHostConfig `json:"HostConfig"`
+	NetworkSettings *NetworkSettings       `json:"NetworkSettings"`
+}
+
+type NetworkSettings struct {
+	Ports map[string][]InspectDataHostPort `json:"Ports"`
 }
 
 type InspectDataHostConfig struct {

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -99,12 +99,20 @@ func splitOnceLast(s, sep string) (string, string) {
 }
 
 func portMappingFlag(pm PortMapping) string {
-	result := fmt.Sprintf("%d:%d", pm.HostPort, pm.ContainerPort)
+	result := ""
+
 	if pm.HostAddress != "" {
-		result = pm.HostAddress + ":" + result
+		result += pm.HostAddress + ":"
 	}
+
+	if pm.HostPort != 0 {
+		result += strconv.Itoa(pm.HostPort)
+	}
+
+	result += ":" + strconv.Itoa(pm.ContainerPort)
+
 	if pm.ContainerProtocol != "" {
-		result = result + "/" + pm.ContainerProtocol
+		result += "/" + pm.ContainerProtocol
 	}
 
 	return result

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -1,0 +1,81 @@
+package container
+
+import "testing"
+
+func TestPortMappingFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    PortMapping
+		expected string
+	}{
+		{
+			name: "All fields populated",
+			input: PortMapping{
+				HostAddress:       "127.0.0.1",
+				HostPort:          8080,
+				ContainerPort:     80,
+				ContainerProtocol: "tcp",
+			},
+			expected: "127.0.0.1:8080:80/tcp",
+		},
+		{
+			name: "No host address",
+			input: PortMapping{
+				HostPort:          8080,
+				ContainerPort:     80,
+				ContainerProtocol: "udp",
+			},
+			expected: "8080:80/udp",
+		},
+		{
+			name: "No host port",
+			input: PortMapping{
+				HostAddress:       "192.168.1.100",
+				ContainerPort:     443,
+				ContainerProtocol: "tcp",
+			},
+			expected: "192.168.1.100::443/tcp",
+		},
+		{
+			name: "No container protocol",
+			input: PortMapping{
+				HostAddress:   "10.0.0.1",
+				HostPort:      5000,
+				ContainerPort: 5000,
+			},
+			expected: "10.0.0.1:5000:5000",
+		},
+		{
+			name: "Only container port",
+			input: PortMapping{
+				ContainerPort: 8080,
+			},
+			expected: ":8080",
+		},
+		{
+			name: "Host port and container port only",
+			input: PortMapping{
+				HostPort:      3000,
+				ContainerPort: 3000,
+			},
+			expected: "3000:3000",
+		},
+		{
+			name: "Host address and container port only",
+			input: PortMapping{
+				HostAddress:   "localhost",
+				ContainerPort: 8080,
+			},
+			expected: "localhost::8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := portMappingFlag(tt.input)
+			if result != tt.expected {
+				t.Errorf("portMappingFlag(%+v) = %s; want %s", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -86,6 +86,7 @@ func TestPortMappingFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := portMappingFlag(tt.input)
 			if result != tt.expected {
 				t.Errorf("portMappingFlag(%+v) = %s; want %s", tt.input, result, tt.expected)

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package container
 
 import "testing"

--- a/internal/container/podman.go
+++ b/internal/container/podman.go
@@ -226,6 +226,16 @@ func (e *podmanImpl) ContainerInspect(ctx context.Context, names ...string) ([]*
 			}
 		}
 
+		publishedPorts := map[string][]InspectDataHostPort{}
+		for key, values := range data.NetworkSettings.Ports {
+			for _, value := range values {
+				publishedPorts[key] = append(publishedPorts[key], InspectDataHostPort{
+					HostIP:   value.HostIP,
+					HostPort: value.HostPort,
+				})
+			}
+		}
+
 		results = append(results, &InspectData{
 			ID:   data.ID,
 			Name: data.Name,
@@ -234,6 +244,9 @@ func (e *podmanImpl) ContainerInspect(ctx context.Context, names ...string) ([]*
 			},
 			HostConfig: &InspectDataHostConfig{
 				PortBindings: portBidings,
+			},
+			NetworkSettings: &NetworkSettings{
+				Ports: publishedPorts,
 			},
 		})
 	}

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -184,7 +184,11 @@ func (o *client) RunContainer(ctx context.Context, opts RunContainerOpts) ([]byt
 	}
 
 	for hostPort, containerPort := range opts.Ports {
-		portMapping := strconv.Itoa(hostPort) + ":" + strconv.Itoa(containerPort)
+		portMapping := ""
+		if hostPort != 0 {
+			strconv.Itoa(hostPort)
+		}
+		portMapping += ":" + strconv.Itoa(containerPort)
 		if !opts.BindIPAll {
 			portMapping = "127.0.0.1:" + portMapping
 		}

--- a/internal/podman/container_inspect.go
+++ b/internal/podman/container_inspect.go
@@ -85,6 +85,8 @@ type InspectNetworkSettings struct {
 	// container has joined.
 	// It is a map of network name to network information.
 	Networks map[string]*InspectAdditionalNetwork `json:"Networks,omitempty"`
+
+	Ports map[string][]InspectHostPort `json:"Ports"`
 }
 
 // InspectContainerData provides a detailed record of a container's configuration


### PR DESCRIPTION
## Proposed changes
- Removed logic to allocate a port in the CLI
     - Implemented logic for docker / podman
     - Wrote new tests 
- Improved `updateFields` to use actually published ports and not config (this contains the random port chosen by docker/podman)
- Fixed / updated existing tests

_Jira ticket:_ CLOUDP-265397