### PR TITLE
CLOUDP-270956: [atlas cli/local dev] don't print local dev warning when --type atlas or no type is provided

### DIFF
--- a/internal/cli/deployments/options/deployment_opts_pre_run.go
+++ b/internal/cli/deployments/options/deployment_opts_pre_run.go
@@ -45,7 +45,7 @@ func (opts *DeploymentOpts) SelectDeployments(ctx context.Context, projectID str
 			if opts.IsLocalDeploymentType() {
 				return Deployment{}, localErr
 			}
-			_, _ = log.Warningf("Warning: failed to retrieve Local deployments because %q\n", localErr.Error())
+			_, _ = log.Debugf("Warning: failed to retrieve Local deployments because %q\n", localErr.Error())
 		}
 
 		localDeployments, localErr = opts.GetLocalDeployments(ctx)


### PR DESCRIPTION
## Proposed changes
Don't print local dev warning when --type atlas or no type is provided.
Only print when `--debug` is set.

See JIRA for more context.

_Jira ticket:_ CLOUDP-270956