### PR TITLE
CLOUDP-268553: Add warning for docker engine/podman minimum versions

### DIFF
--- a/internal/cli/deployments/list_test.go
+++ b/internal/cli/deployments/list_test.go
@@ -122,6 +122,9 @@ func TestList_Run(t *testing.T) {
 		Return(nil).
 		Times(1)
 
+	// Verify version should always succeed
+	mockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
+
 	mockContainerEngine.
 		EXPECT().
 		ContainerList(ctx, options.ContainerFilter).
@@ -213,6 +216,9 @@ func TestList_Run_NoLocal(t *testing.T) {
 		Return(nil).
 		Times(1)
 
+	// Verify version should always succeed
+	mockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
+
 	mockContainerEngine.
 		EXPECT().
 		ContainerList(ctx, options.ContainerFilter).
@@ -301,6 +307,9 @@ func TestList_Run_NoAtlas(t *testing.T) {
 		Ready().
 		Return(nil).
 		Times(1)
+
+	// Verify version should always succeed
+	mockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
 
 	mockContainerEngine.
 		EXPECT().

--- a/internal/cli/deployments/options/deployment_opts_pre_run.go
+++ b/internal/cli/deployments/options/deployment_opts_pre_run.go
@@ -138,12 +138,16 @@ func (opts *DeploymentOpts) AtlasDeployments(projectID string) ([]Deployment, er
 	return deployments, nil
 }
 
-func (opts *DeploymentOpts) LocalDeploymentPreRun(_ context.Context) error {
+func (opts *DeploymentOpts) LocalDeploymentPreRun(ctx context.Context) error {
 	if !localDeploymentSupportedByOs() {
 		_, _ = log.Warningln("Local deployments are not supported on this OS, to see local deployments requirements visit https://www.mongodb.com/docs/atlas/cli/stable/atlas-cli-deploy-local/.")
 	}
 
-	return opts.ContainerEngine.Ready()
+	if err := opts.ContainerEngine.Ready(); err != nil {
+		return err
+	}
+
+	return opts.ContainerEngine.VerifyVersion(ctx)
 }
 
 func localDeploymentSupportedByOs() bool {

--- a/internal/cli/deployments/setup_test.go
+++ b/internal/cli/deployments/setup_test.go
@@ -68,6 +68,9 @@ func TestSetupOpts_LocalDev_HappyPathClean(t *testing.T) {
 	// Container engine is fine
 	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
 
+	// Verify version should always succeed
+	deploymentTest.MockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
+
 	// Image gets pulled
 	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageName).Return(nil).Times(1)
 
@@ -129,6 +132,9 @@ func TestSetupOpts_LocalDev_HappyPathOfflinePull(t *testing.T) {
 
 	// Container engine is fine
 	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
+	// Verify version should always succeed
+	deploymentTest.MockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
 
 	// Image gets pulled
 	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageName).Return(errors.New("image pull failed")).Times(1)
@@ -195,6 +201,9 @@ func TestSetupOpts_LocalDev_UnhappyPathOfflinePull(t *testing.T) {
 	// Container engine is fine
 	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
 
+	// Verify version should always succeed
+	deploymentTest.MockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
+
 	// Image gets pulled
 	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageName).Return(errors.New("image pull failed")).Times(1)
 
@@ -231,6 +240,9 @@ func TestSetupOpts_LocalDev_HappyPathEverythingAlreadyExists(t *testing.T) {
 	// Container engine is fine
 	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
 
+	// Verify version should always succeed
+	deploymentTest.MockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
+
 	// No local dev container exists yet
 	deploymentTest.MockContainerEngine.EXPECT().ContainerList(ctx, "mongodb-atlas-local=container").Return([]container.Container{
 		{
@@ -263,6 +275,9 @@ func TestSetupOpts_LocalDev_RemoveUnhealthyDeployment(t *testing.T) {
 
 	// Container engine is fine
 	deploymentTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
+
+	// Verify version should always succeed
+	deploymentTest.MockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
 
 	// Image gets pulled (updated)
 	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageName).Return(nil).Times(1)

--- a/internal/cli/deployments/test/fixture/deployment_local.go
+++ b/internal/cli/deployments/test/fixture/deployment_local.go
@@ -50,6 +50,11 @@ func (m *MockDeploymentOpts) LocalMockFlowWithMockContainer(ctx context.Context,
 		ContainerList(ctx, options.ContainerFilter).
 		Return(mockContainer, nil).
 		Times(1)
+	m.MockContainerEngine.
+		EXPECT().
+		VerifyVersion(ctx).
+		Return(nil).
+		Times(1)
 
 	m.MockDeploymentTelemetry.
 		EXPECT().

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -52,6 +52,7 @@ type RunFlags struct {
 type Engine interface {
 	Name() string
 	Ready() error
+	VerifyVersion(context.Context) error
 	ContainerLogs(context.Context, string) ([]string, error)
 	ContainerRun(context.Context, string, *RunFlags) (string, error)
 	ContainerList(context.Context, ...string) ([]Container, error)

--- a/internal/container/podman.go
+++ b/internal/container/podman.go
@@ -50,6 +50,10 @@ func (e *podmanImpl) Ready() error {
 	return err
 }
 
+func (p *podmanImpl) VerifyVersion(ctx context.Context) error {
+	return p.client.VerifyVersion(ctx)
+}
+
 func (e *podmanImpl) ContainerLogs(ctx context.Context, name string) ([]string, error) {
 	return e.client.ContainerLogs(ctx, name)
 }

--- a/internal/container/podman.go
+++ b/internal/container/podman.go
@@ -50,8 +50,8 @@ func (e *podmanImpl) Ready() error {
 	return err
 }
 
-func (p *podmanImpl) VerifyVersion(ctx context.Context) error {
-	return p.client.VerifyVersion(ctx)
+func (e *podmanImpl) VerifyVersion(ctx context.Context) error {
+	return e.client.VerifyVersion(ctx)
 }
 
 func (e *podmanImpl) ContainerLogs(ctx context.Context, name string) ([]string, error) {

--- a/internal/mocks/mock_container.go
+++ b/internal/mocks/mock_container.go
@@ -273,6 +273,20 @@ func (mr *MockEngineMockRecorder) Ready() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ready", reflect.TypeOf((*MockEngine)(nil).Ready))
 }
 
+// VerifyVersion mocks base method.
+func (m *MockEngine) VerifyVersion(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyVersion", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyVersion indicates an expected call of VerifyVersion.
+func (mr *MockEngineMockRecorder) VerifyVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyVersion", reflect.TypeOf((*MockEngine)(nil).VerifyVersion), arg0)
+}
+
 // Version mocks base method.
 func (m *MockEngine) Version(arg0 context.Context) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()

--- a/internal/mocks/mock_podman.go
+++ b/internal/mocks/mock_podman.go
@@ -300,6 +300,20 @@ func (mr *MockClientMockRecorder) UnpauseContainers(arg0 interface{}, arg1 ...in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpauseContainers", reflect.TypeOf((*MockClient)(nil).UnpauseContainers), varargs...)
 }
 
+// VerifyVersion mocks base method.
+func (m *MockClient) VerifyVersion(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyVersion", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyVersion indicates an expected call of VerifyVersion.
+func (mr *MockClientMockRecorder) VerifyVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyVersion", reflect.TypeOf((*MockClient)(nil).VerifyVersion), arg0)
+}
+
 // Version mocks base method.
 func (m *MockClient) Version(arg0 context.Context) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -31,7 +31,7 @@ import (
 var (
 	ErrPodmanNotFound           = errors.New("podman not found in your system, check requirements at https://dochub.mongodb.org/core/atlas-cli-deploy-local-reqs")
 	ErrDeterminingPodmanVersion = errors.New("could not determine docker version")
-	minPodmanVersion            = semver.New(5, 2, 0, "", "") //nolint:mnd
+	minPodmanVersion            = semver.New(5, 0, 0, "", "") //nolint:mnd
 )
 
 type RunContainerOpts struct {


### PR DESCRIPTION
## Proposed changes

Add warning for docker engine/podman minimum versions.

_Jira ticket:_ CLOUDP-268553

# Testing
- Tested locally
- Updated unit tests