### PR TITLE
CLOUDP-272726: Deprecate datalakes pipeline commands

### DIFF
--- a/internal/cli/datalakepipelines/delete.go
+++ b/internal/cli/datalakepipelines/delete.go
@@ -53,11 +53,12 @@ func DeleteBuilder() *cobra.Command {
 		DeleteOpts: cli.NewDeleteOpts("'%s' deleted\n", "Not deleted"),
 	}
 	cmd := &cobra.Command{
-		Use:     "delete <pipelineName>",
-		Aliases: []string{"rm"},
-		Short:   "Remove the specified data lake pipeline from your project.",
-		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
-		Args:    require.ExactArgs(1),
+		Use:        "delete <pipelineName>",
+		Aliases:    []string{"rm"},
+		Short:      "Remove the specified data lake pipeline from your project.",
+		Long:       fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args:       require.ExactArgs(1),
+		Deprecated: "Data Lake Pipelines is deprecated. Please see: https://dochub.mongodb.org/core/data-lake-deprecation.",
 		Annotations: map[string]string{
 			"pipelineNameDesc": "Label that identifies the pipeline",
 			"output":           opts.SuccessMessage(),

--- a/internal/cli/datalakepipelines/list.go
+++ b/internal/cli/datalakepipelines/list.go
@@ -68,6 +68,7 @@ func ListBuilder() *cobra.Command {
 		Args:    require.NoArgs,
 		Example: `# list all pipelines:
   atlas dataLakePipelines list`,
+		Deprecated: "Data Lake Pipelines is deprecated. Please see: https://dochub.mongodb.org/core/data-lake-deprecation.",
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/datalakepipelines/pause.go
+++ b/internal/cli/datalakepipelines/pause.go
@@ -66,6 +66,7 @@ func PauseBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"pipelineNameDesc": "Label that identifies the pipeline",
 		},
+		Deprecated: "Data Lake Pipelines is deprecated. Please see: https://dochub.mongodb.org/core/data-lake-deprecation.",
 		Example: `# pause pipeline 'Pipeline1':
   atlas dataLakePipelines pause Pipeline1
 `,

--- a/internal/cli/datalakepipelines/start.go
+++ b/internal/cli/datalakepipelines/start.go
@@ -66,6 +66,7 @@ func StartBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"pipelineNameDesc": "Label that identifies the pipeline",
 		},
+		Deprecated: "Data Lake Pipelines is deprecated. Please see: https://dochub.mongodb.org/core/data-lake-deprecation.",
 		Example: `# start pipeline 'Pipeline1':
   atlas dataLakePipelines start Pipeline1
 `,

--- a/internal/cli/datalakepipelines/trigger.go
+++ b/internal/cli/datalakepipelines/trigger.go
@@ -67,6 +67,7 @@ func TriggerBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"pipelineNameDesc": "Label that identifies the pipeline",
 		},
+		Deprecated: "Data Lake Pipelines is deprecated. Please see: https://dochub.mongodb.org/core/data-lake-deprecation.",
 		Example: `# trigger pipeline 'Pipeline1':
   atlas dataLakePipelines trigger Pipeline1
 `,

--- a/internal/cli/datalakepipelines/update.go
+++ b/internal/cli/datalakepipelines/update.go
@@ -155,6 +155,7 @@ func UpdateBuilder() *cobra.Command {
 		Annotations: map[string]string{
 			"pipelineNameDesc": "Label that identifies the pipeline",
 		},
+		Deprecated: "Data Lake Pipelines is deprecated. Please see: https://dochub.mongodb.org/core/data-lake-deprecation.",
 		Example: `# update data lake pipeline:
   atlas dataLakePipelines update Pipeline1 --sinkType CPS --sinkMetadataProvider AWS --sinkMetadataRegion us-east-1 --sinkPartitionField name:0,summary:1 --sourceType PERIODIC_CPS --sourceClusterName Cluster1 --sourceDatabaseName sample_airbnb --sourceCollectionName listingsAndReviews --sourcePolicyItemId 507f1f77bcf86cd799439011 --transform EXCLUDE:space,EXCLUDE:notes`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/datalakepipelines/watch.go
+++ b/internal/cli/datalakepipelines/watch.go
@@ -76,6 +76,7 @@ func WatchBuilder() *cobra.Command {
 			"pipelineNameDesc": "Label that identifies the pipeline",
 			"output":           watchTemplate,
 		},
+		Deprecated: "Data Lake Pipelines is deprecated. Please see: https://dochub.mongodb.org/core/data-lake-deprecation.",
 		Example: `# watches the pipeline 'Pipeline1':
   atlas dataLakePipelines watch Pipeline1
 `,


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-272726

This ensures the warning also shows up for the commands:
```shell
➜  mongodb-atlas-cli git:(CLOUDP-272726) ./bin/atlas dataLakePipelines list                                   
Command "list" is deprecated, Data Lake Pipelines is deprecated. Please see: https://dochub.mongodb.org/core/data-lake-deprecation.
ID    NAME   STATE
```
## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
