### PR TITLE
Disabling flag parsing for plugin root commands

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -185,6 +185,8 @@ func (p *Plugin) GetCobraCommands() []*cobra.Command {
 			}
 		})
 
+		command.DisableFlagParsing = true
+
 		commands = append(commands, command)
 	}
 


### PR DESCRIPTION
## Proposed changes

Plugins are passed arguments and env from the CLI. However, the arguments the CLI forwards have already been parsed by Cobra, which means that:

* flags that the CLI supports, e.g. global flags like `--debug` are not forwarded to the plugin
* flags that only the plugin supports but that are not defined as CLI global flags are rejected by the CLI which just exits with an error.

Therefore, we should disable flag parsing plugin root commands, and just pass the raw arguments to the plugin when it is executed with `exec.Command()`.

This change does exactly that.

Admittedly, I did not look at adding tests.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
