### PR TITLE
CLOUDP-274948: Atlas CLI's plugin system does not support passing flags to plugins

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -185,6 +185,8 @@ func (p *Plugin) GetCobraCommands() []*cobra.Command {
 			}
 		})
 
+		command.DisableFlagParsing = true
+
 		commands = append(commands, command)
 	}
 

--- a/test/e2e/atlas/plugin_run_test.go
+++ b/test/e2e/atlas/plugin_run_test.go
@@ -56,7 +56,7 @@ func TestPluginRun(t *testing.T) {
 	})
 
 	t.Run("Echo", func(t *testing.T) {
-		echoString := "this string will be the output of the echo command"
+		echoString := "lorem ipsum dolor sit amet --test=true --debug --profile nunc nunc vel urna"
 		cmd := exec.Command(cliPath,
 			"example",
 			"echo",
@@ -65,8 +65,9 @@ func TestPluginRun(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
-		if !strings.Contains(string(resp), echoString) {
-			t.Errorf("expected %q to contain %q\n", string(resp), echoString)
+		actual := strings.TrimSpace(string(resp))
+		if actual != echoString {
+			t.Errorf("expected \"%q\" to contain %q\n", actual, echoString)
 		}
 	})
 


### PR DESCRIPTION
## Proposed changes
- Disable flag parsing for plugin commands.
- Additional integration tests
    - Updated the example plugin to support arbitrary flags: https://github.com/mongodb/atlas-cli-plugin-example/pull/15

PR by @mmarcon #3269 + some additional integration tests.
I could have managed to push my changes to the original PR, hence the new PR.

_Jira ticket:_ [CLOUDP-274948](https://jira.mongodb.org/browse/CLOUDP-274948)