### PR TITLE
CLOUDP-275630: [AtlasCLI] NilPointer exception when downloading datafederation logs

### DIFF
--- a/internal/cli/datafederation/logs.go
+++ b/internal/cli/datafederation/logs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +68,12 @@ func (opts *LogOpts) Run() error {
 
 // atlas dataFederation log [--projectId projectId].
 func LogBuilder() *cobra.Command {
-	opts := &LogOpts{}
+	opts := &LogOpts{
+		DownloaderOpts: cli.DownloaderOpts{
+			Fs:  afero.NewOsFs(),
+			Out: "-", // stdout
+		},
+	}
 	cmd := &cobra.Command{
 		Use:   "logs <name>",
 		Short: "Returns logs of the specified data federation database for your project.",

--- a/test/e2e/atlas/data_federation_db_test.go
+++ b/test/e2e/atlas/data_federation_db_test.go
@@ -131,6 +131,19 @@ func TestDataFederation(t *testing.T) {
 		require.NoError(t, err, string(resp))
 	})
 
+	t.Run("Download Logs", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			datafederationEntity,
+			"logs",
+			dataFederationName,
+			"--out",
+			"testLogFile")
+		cmd.Env = os.Environ()
+
+		resp, err := e2e.RunAndGetStdOut(cmd)
+		require.NoError(t, err, string(resp))
+	})
+
 	t.Run("Delete", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			datafederationEntity,


### PR DESCRIPTION
## Proposed changes
1. Reproduced the error by adding an integration test: [evergreen-run](https://spruce.mongodb.com/task/mongodb_atlas_cli_master_e2e_atlas_datafederation_atlas_datafederation_db_e2e_patch_e304af62c5de36478f8aa116ba3e0473772cd569_66f5643fad09cf00077bdeac_24_09_26_13_40_25?execution=0&sortBy=STATUS&sortDir=ASC)
2. Fixed the issue: [evergreen-run](https://spruce.mongodb.com/task/mongodb_atlas_cli_master_e2e_atlas_datafederation_atlas_datafederation_db_e2e_patch_e304af62c5de36478f8aa116ba3e0473772cd569_66f56763441a820007e28d2e_24_09_26_13_53_47?execution=0&sortBy=STATUS&sortDir=ASC)

_Jira ticket:_ CLOUDP-275630

