### PR TITLE
fix: use Executable instead of Args[0]

### DIFF
--- a/internal/telemetry/installer_windows.go
+++ b/internal/telemetry/installer_windows.go
@@ -22,7 +22,7 @@ import (
 )
 
 func readInstaller() *string {
-	if b, err := os.ReadFile(path.Join(path.Base(os.Args[0]), "installer")); err == nil {
+	if b, err := os.ReadFile(path.Join(path.Base(os.Executable()), "installer")); err == nil {
 		s := string(b)
 		return &s
 	}


### PR DESCRIPTION
## Proposed changes

Small modernization of the code to use a simpler approach to get the executable name 
