### PR TITLE
CLOUDP-270626 Fix executing "output" at <.Results>

### DIFF
--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -110,6 +110,9 @@ func (opts *OutputOpts) IsCygwinTerminal() bool {
 }
 
 func isNil(o any) bool {
+	if o == nil {
+		return true
+	}
 	ot := reflect.TypeOf(o)
 	otk := ot.Kind()
 	switch otk { //nolint:exhaustive // clearer code
@@ -122,6 +125,9 @@ func isNil(o any) bool {
 
 func isOrPtrToSliceOrArray(o any) bool {
 	ot := reflect.TypeOf(o)
+	if ot == nil {
+		return false
+	}
 	otk := ot.Kind()
 	switch otk { //nolint:exhaustive // clearer code
 	case reflect.Array, reflect.Slice:

--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -125,6 +126,10 @@ func (opts *OutputOpts) Print(o any) error {
 	}
 
 	if t != "" {
+		k := reflect.TypeOf(o).Kind()
+		if (k == reflect.Slice || k == reflect.Ptr || k == reflect.Map || k == reflect.UnsafePointer) && reflect.ValueOf(o).IsNil() {
+			o = map[string]any{}
+		}
 		return templatewriter.Print(opts.ConfigWriter(), t, o)
 	}
 	_, err = fmt.Fprintln(opts.ConfigWriter(), o)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Fix executing "output" at <.Results>
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-270626

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

the current implementation of `internal/cli/organizations/list.go`

is
```go
const listTemplate = `ID	NAME{{range valueOrEmptySlice .Results}}
{{.Id}}	{{.Name}}{{end}}
`

func (opts *ListOpts) Run() error {
	r, err := opts.store.Organizations(opts.newOrganizationListOptions())
	if err != nil {
		return err
	}
	return opts.Print(r)
}
```

if we update to something like
```go
func (opts *ListOpts) Run() error {
	r, err := opts.store.Organizations(opts.newOrganizationListOptions())
	if err != nil {
		return err
	}
        r = nil
	return opts.Print(r)
}
```

we start getting the error `Error: template: output:1:15: executing "output" at <.Results>: nil pointer evaluating *admin.PaginatedOrganization.Results` which is exactly the error we are experiencing in instruqt.

On the odd edge case scenario that our SDKs would return no error but empty response go templates wouldn't evaluate `.Results` properly as in `nil . Results` so the `valueOrEmptySlice` func does not get called.

My solution is when nil is passed to `opts.Print(o)` force it to `map[string]any{}` so all calls will always have a value that can have any keys