### PR TITLE
CLOUDP-277610: [AtlasCLI] Clusters watch is broken when using atlas upgrade

### DIFF
--- a/internal/cli/clusters/watch_test.go
+++ b/internal/cli/clusters/watch_test.go
@@ -17,6 +17,7 @@
 package clusters
 
 import (
+	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -44,7 +45,7 @@ func TestWatch_Run(t *testing.T) {
 		Return(expected, nil).
 		Times(1)
 
-	if err := opts.Run(); err != nil {
+	if err := opts.Run(context.Background()); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
 }

--- a/internal/decryption/log_record.go
+++ b/internal/decryption/log_record.go
@@ -106,6 +106,7 @@ func (logLine *AuditLogLine) logAdditionalAuthData() []byte {
 	const AADByteSize = 8
 
 	additionalAuthData := make([]byte, AADByteSize)
+	//nolint:gosec
 	binary.LittleEndian.PutUint64(additionalAuthData, uint64(logLine.TS.UnixMilli()))
 	return additionalAuthData
 }

--- a/internal/decryption/log_record.go
+++ b/internal/decryption/log_record.go
@@ -106,7 +106,7 @@ func (logLine *AuditLogLine) logAdditionalAuthData() []byte {
 	const AADByteSize = 8
 
 	additionalAuthData := make([]byte, AADByteSize)
-	binary.LittleEndian.PutUint64(additionalAuthData, uint64(logLine.TS.UnixMilli())) //nolint:gosec
+	binary.LittleEndian.PutUint64(additionalAuthData, uint64(logLine.TS.UnixMilli()))
 	return additionalAuthData
 }
 


### PR DESCRIPTION
## Context
`atlas cluster watch` does not return a `404` after running `atlas cluster upgrade`.
However, I did encounter a `401` because the bearer token expires within the time that the cluster is done upgrading.

## Proposed changes
- removed 404 check
- added bearer token refresh logic when hitting 401

_Jira ticket:_ CLOUDP-277610
