### PR TITLE
CLOUDP-278196: Discrepancy in "atlas deployments search indexes list" and "atlas clusters search indexes list"

### DIFF
--- a/internal/cli/deployments/options/deployment_opts.go
+++ b/internal/cli/deployments/options/deployment_opts.go
@@ -47,6 +47,7 @@ const (
 	PausedState        = "PAUSED"
 	StoppedState       = "STOPPED"
 	IdleState          = "IDLE"
+	UpdatingState      = "UPDATING"
 	DeletingState      = "DELETING"
 	RestartingState    = "RESTARTING"
 	LocalCluster       = "local"

--- a/internal/cli/deployments/search/indexes/list.go
+++ b/internal/cli/deployments/search/indexes/list.go
@@ -43,7 +43,7 @@ type ListOpts struct {
 }
 
 func (opts *ListOpts) Run(ctx context.Context) error {
-	if _, err := opts.SelectDeployments(ctx, opts.ConfigProjectID(), options.IdleState); err != nil {
+	if _, err := opts.SelectDeployments(ctx, opts.ConfigProjectID(), options.IdleState, options.UpdatingState); err != nil {
 		return err
 	}
 


### PR DESCRIPTION

<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
This PR fixes the discrepancy in `atlas deployments search indexes list` and `atlas clusters search indexes list` where the deployment command returns an error if the cluster is in the UPDATING state.
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-278196

# Testing
I was able to reproduce the issue

```bash
atlas clusters search indexes list --clusterName Cluster0 --collection listingsAndReviews --db sample_airbnb                                
ID                         NAME      DATABASE        COLLECTION           TYPE
670e63122b37bb42dc933cf7   default   sample_airbnb   listingsAndReviews   search

atlas deployments search indexes list -P dev --deploymentName Cluster0 --db sample_airbnb --collection listingsAndReviews                                
Error: deployment is in unexpected state: UPDATING
```

and I tested that the fix worked:
```bash
# Using atlascli 1.29.0 I got the error
atlas deployments search indexes list -P dev --deploymentName Cluster0 --db sample_airbnb --collection listingsAndReviews                             
Error: deployment is in unexpected state: UPDATING

# I did not get the error using the local binary with the fix
./bin/atlas deployments search indexes list -P dev --deploymentName Cluster0 --db sample_airbnb --collection listingsAndReviews                          
ID                         NAME      DATABASE        COLLECTION           STATUS   TYPE
670e63122b37bb42dc933cf7   default   sample_airbnb   listingsAndReviews   STEADY   search
```