### PR TITLE
CLOUDP-278912: Export without Fed Auth

### DIFF
--- a/internal/kubernetes/operator/config_exporter.go
+++ b/internal/kubernetes/operator/config_exporter.go
@@ -417,12 +417,12 @@ func (e *ConfigExporter) exportAtlasFederatedAuth(projectName string) ([]runtime
 	// Gets the FederationAuthSetting
 	federatedAuthentificationSetting, err := e.dataProvider.FederationSetting(&admin.GetFederationSettingsApiParams{OrgId: e.orgID})
 	if err != nil {
-		if isAPIError(err, "RESOURCE_NOT_FOUND") {
+		if admin.IsErrorCode(err, "RESOURCE_NOT_FOUND") {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to retrieve federation settings: %w", err)
 	}
-	// Does not have an IdenityProvider set then no need to generate
+	// Does not have an IdentityProvider set then no need to generate
 	if !federatedAuthentificationSetting.HasIdentityProviderStatus() || federatedAuthentificationSetting.GetIdentityProviderStatus() == InactiveStatus {
 		return nil, nil
 	}
@@ -445,9 +445,4 @@ func (e *ConfigExporter) exportAtlasFederatedAuth(projectName string) ([]runtime
 		return nil, fmt.Errorf("failed to export federated authentication: %w", err)
 	}
 	return append(result, federatedAuthentification), nil
-}
-
-func isAPIError(err error, errorCode string) bool {
-	oaErr, ok := err.(*admin.GenericOpenAPIError)
-	return ok && oaErr.Model().ErrorCode != nil && *oaErr.Model().ErrorCode == errorCode
 }

--- a/internal/kubernetes/operator/config_exporter.go
+++ b/internal/kubernetes/operator/config_exporter.go
@@ -417,6 +417,9 @@ func (e *ConfigExporter) exportAtlasFederatedAuth(projectName string) ([]runtime
 	// Gets the FederationAuthSetting
 	federatedAuthentificationSetting, err := e.dataProvider.FederationSetting(&admin.GetFederationSettingsApiParams{OrgId: e.orgID})
 	if err != nil {
+		if isAPIError(err, "RESOURCE_NOT_FOUND") {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to retrieve federation settings: %w", err)
 	}
 	// Does not have an IdenityProvider set then no need to generate
@@ -442,4 +445,9 @@ func (e *ConfigExporter) exportAtlasFederatedAuth(projectName string) ([]runtime
 		return nil, fmt.Errorf("failed to export federated authentication: %w", err)
 	}
 	return append(result, federatedAuthentification), nil
+}
+
+func isAPIError(err error, errorCode string) bool {
+	oaErr, ok := err.(*admin.GenericOpenAPIError)
+	return ok && oaErr.Model().ErrorCode != nil && *oaErr.Model().ErrorCode == errorCode
 }

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -131,6 +131,26 @@ func InitialSetup(t *testing.T) KubernetesConfigGenerateProjectSuite {
 	return s
 }
 
+func TestExportWorksWithoutFedAuth(t *testing.T) {
+	s := InitialSetup(t)
+	cliPath := s.cliPath
+	generator := s.generator
+	cmd := exec.Command(cliPath,
+		"kubernetes",
+		"config",
+		"generate",
+		"--projectId",
+		generator.projectID)
+	cmd.Env = os.Environ()
+	resp, err := cmd.CombinedOutput()
+	t.Log(string(resp))
+	require.NoError(t, err, string(resp))
+	var objects []runtime.Object
+	objects, err = getK8SEntities(resp)
+	require.NoError(t, err, fmt.Sprintf("should not fail on decode but got:\n%s", string(resp)))
+	require.NotEmpty(t, objects)
+}
+
 func TestFederatedAuthTest(t *testing.T) {
 	t.Run("PreRequisite Get the federation setting ID", func(t *testing.T) {
 		s := InitialSetup(t)

--- a/test/e2e/atlas/kubernetes_config_generate_test.go
+++ b/test/e2e/atlas/kubernetes_config_generate_test.go
@@ -147,7 +147,7 @@ func TestExportWorksWithoutFedAuth(t *testing.T) {
 	require.NoError(t, err, string(resp))
 	var objects []runtime.Object
 	objects, err = getK8SEntities(resp)
-	require.NoError(t, err, fmt.Sprintf("should not fail on decode but got:\n%s", string(resp)))
+	require.NoError(t, err, "should not fail on decode but got:\n"+string(resp))
 	require.NotEmpty(t, objects)
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-278912

The Atlas CLI Kubernetes config export should not fail when there is no Federated Auth configured.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [X] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
