### PR TITLE
CLOUDP-278461: Kubernetes Operator - Fixed Serverless PE export for GCP provider

### DIFF
--- a/internal/kubernetes/operator/config_exporter.go
+++ b/internal/kubernetes/operator/config_exporter.go
@@ -62,6 +62,7 @@ type Patcher interface {
 }
 
 var (
+	ErrServerless             = errors.New("serverless instance error")
 	ErrClusterNotFound        = errors.New("cluster not found")
 	ErrNoCloudManagerClusters = errors.New("can not get 'advanced clusters' object")
 )
@@ -282,13 +283,14 @@ func (e *ConfigExporter) exportDeployments(projectName string) ([]runtime.Object
 		}
 
 		// Try serverless cluster next
-		if serverlessCluster, err := deployment.BuildServerlessDeployments(e.dataProvider, e.featureValidator, e.projectID, projectName, deploymentName, e.targetNamespace, e.dictionaryForAtlasNames, e.operatorVersion); err == nil {
+		serverlessCluster, err := deployment.BuildServerlessDeployments(e.dataProvider, e.featureValidator, e.projectID, projectName, deploymentName, e.targetNamespace, e.dictionaryForAtlasNames, e.operatorVersion)
+		if err == nil {
 			if serverlessCluster != nil {
 				result = append(result, serverlessCluster)
 			}
 			continue
 		}
-		return nil, fmt.Errorf("%w: %s(%s)", ErrClusterNotFound, deploymentName, e.projectID)
+		return nil, fmt.Errorf("%w: %s(%s), e: %s", ErrServerless, deploymentName, e.projectID, err)
 	}
 	return result, nil
 }

--- a/internal/kubernetes/operator/config_exporter.go
+++ b/internal/kubernetes/operator/config_exporter.go
@@ -290,7 +290,7 @@ func (e *ConfigExporter) exportDeployments(projectName string) ([]runtime.Object
 			}
 			continue
 		}
-		return nil, fmt.Errorf("%w: %s(%s), e: %s", ErrServerless, deploymentName, e.projectID, err)
+		return nil, fmt.Errorf("%w: %s(%s), e: %w", ErrServerless, deploymentName, e.projectID, err)
 	}
 	return result, nil
 }

--- a/internal/kubernetes/operator/deployment/deployment.go
+++ b/internal/kubernetes/operator/deployment/deployment.go
@@ -506,11 +506,13 @@ func BuildServerlessDeployments(deploymentStore store.OperatorClusterStore, vali
 	}
 
 	if validator.FeatureExist(features.ResourceAtlasDeployment, featureServerlessPrivateEndpoints) {
-		privateEndpoints, err := buildServerlessPrivateEndpoints(deploymentStore, projectID, deployment.GetName())
-		if err != nil {
-			return nil, err
+		if deployment.ProviderSettings.BackingProviderName != "GCP" {
+			privateEndpoints, err := buildServerlessPrivateEndpoints(deploymentStore, projectID, deployment.GetName())
+			if err != nil {
+				return nil, err
+			}
+			atlasDeployment.Spec.ServerlessSpec.PrivateEndpoints = privateEndpoints
 		}
-		atlasDeployment.Spec.ServerlessSpec.PrivateEndpoints = privateEndpoints
 	}
 
 	return atlasDeployment, nil

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -17,6 +17,7 @@
 package deployment
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -411,6 +412,9 @@ func TestBuildAtlasAdvancedDeployment(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(expected, got) {
+			expJs, _ := json.MarshalIndent(expected, "", " ")
+			gotJs, _ := json.MarshalIndent(got, "", " ")
+			fmt.Printf("E:%s\r\n; G:%s\r\n", expJs, gotJs)
 			t.Fatalf("Advanced deployment mismatch.\r\nexpected: %v\r\ngot: %v\r\n", expected, got)
 		}
 	})

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -17,7 +17,6 @@
 package deployment
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -520,9 +519,9 @@ func TestBuildServerlessDeployments(t *testing.T) {
 }
 
 func TestBuildServerlessDeploymentsWithGCP(t *testing.T) {
-	const projectName = "testProject-2"
-	const clusterName = "testCluster-2"
-	const targetNamespace = "test-namespace-2"
+	const projectName = "testProject-2-1"
+	const clusterName = "testCluster-2-1"
+	const targetNamespace = "test-namespace-2-1"
 
 	ctl := gomock.NewController(t)
 	clusterStore := mocks.NewMockOperatorClusterStore(ctl)
@@ -531,9 +530,9 @@ func TestBuildServerlessDeploymentsWithGCP(t *testing.T) {
 	featureValidator := mocks.NewMockFeatureValidator(ctl)
 
 	t.Run("Can import Serverless deployment", func(t *testing.T) {
-		speID := "TestPEId"
-		speCloudProviderEndpointID := "TestCloudProviderID"
-		speComment := "TestPEName"
+		speID := "TestPEId-1"
+		speCloudProviderEndpointID := "TestCloudProviderID-1"
+		speComment := "TestPEName-1"
 		spePrivateEndpointIPAddress := ""
 
 		spe := []atlasClustersPinned.ServerlessTenantEndpoint{
@@ -609,10 +608,6 @@ func TestBuildServerlessDeploymentsWithGCP(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(expected, got) {
-			je, _ := json.MarshalIndent(expected, "", " ")
-			fmt.Println("Expected", string(je))
-			jg, _ := json.MarshalIndent(expected, "", " ")
-			fmt.Println("Got", string(jg))
 			t.Fatalf("Serverless deployment mismatch.\r\nexp: %v\r\ngot: %v\r\n", expected, got)
 		}
 	})

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -412,9 +412,6 @@ func TestBuildAtlasAdvancedDeployment(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(expected, got) {
-			expJs, _ := json.MarshalIndent(expected, "", " ")
-			gotJs, _ := json.MarshalIndent(got, "", " ")
-			fmt.Printf("E:%s\r\n; G:%s\r\n", expJs, gotJs)
 			t.Fatalf("Advanced deployment mismatch.\r\nexpected: %v\r\ngot: %v\r\n", expected, got)
 		}
 	})
@@ -518,6 +515,105 @@ func TestBuildServerlessDeployments(t *testing.T) {
 
 		if !reflect.DeepEqual(expected, got) {
 			t.Fatalf("Serverless deployment mismatch.\r\nexpected: %v\r\ngot: %v\r\n", expected, got)
+		}
+	})
+}
+
+func TestBuildServerlessDeploymentsWithGCP(t *testing.T) {
+	const projectName = "testProject-2"
+	const clusterName = "testCluster-2"
+	const targetNamespace = "test-namespace-2"
+
+	ctl := gomock.NewController(t)
+	clusterStore := mocks.NewMockOperatorClusterStore(ctl)
+	dictionary := resources.AtlasNameToKubernetesName()
+
+	featureValidator := mocks.NewMockFeatureValidator(ctl)
+
+	t.Run("Can import Serverless deployment", func(t *testing.T) {
+		speID := "TestPEId"
+		speCloudProviderEndpointID := "TestCloudProviderID"
+		speComment := "TestPEName"
+		spePrivateEndpointIPAddress := ""
+
+		spe := []atlasClustersPinned.ServerlessTenantEndpoint{
+			{
+				Id:                       &speID,
+				CloudProviderEndpointId:  &speCloudProviderEndpointID,
+				Comment:                  &speComment,
+				PrivateEndpointIpAddress: &spePrivateEndpointIPAddress,
+				ProviderName:             pointer.Get("AZURE"),
+			},
+		}
+
+		cluster := &atlasClustersPinned.ServerlessInstanceDescription{
+			Id:             pointer.Get("TestClusterID"),
+			GroupId:        pointer.Get("TestGroupID"),
+			MongoDBVersion: pointer.Get("5.0"),
+			Name:           pointer.Get(clusterName),
+			CreateDate:     pointer.Get(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)),
+			ProviderSettings: atlasClustersPinned.ServerlessProviderSettings{
+				BackingProviderName: "GCP",
+				ProviderName:        pointer.Get("GCP"),
+				RegionName:          "US_EAST_1",
+			},
+			StateName:               pointer.Get(""),
+			ServerlessBackupOptions: nil,
+			ConnectionStrings:       nil,
+			Links:                   nil,
+		}
+
+		clusterStore.EXPECT().GetServerlessInstance(projectName, clusterName).Return(cluster, nil)
+		clusterStore.EXPECT().ServerlessPrivateEndpoints(projectName, clusterName).Return(spe, nil).Times(0)
+
+		expected := &akov2.AtlasDeployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AtlasDeployment",
+				APIVersion: "atlas.mongodb.com/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      strings.ToLower(fmt.Sprintf("%s-%s", projectName, clusterName)),
+				Namespace: targetNamespace,
+				Labels: map[string]string{
+					features.ResourceVersion: resourceVersion,
+				},
+			},
+			Spec: akov2.AtlasDeploymentSpec{
+				Project: akov2common.ResourceRefNamespaced{
+					Name:      strings.ToLower(projectName),
+					Namespace: targetNamespace,
+				},
+				BackupScheduleRef: akov2common.ResourceRefNamespaced{},
+				ServerlessSpec: &akov2.ServerlessSpec{
+					Name: cluster.GetName(),
+					ProviderSettings: &akov2.ServerlessProviderSettingsSpec{
+						BackingProviderName: cluster.ProviderSettings.BackingProviderName,
+						ProviderName:        akov2provider.ProviderName(cluster.ProviderSettings.GetProviderName()),
+						RegionName:          cluster.ProviderSettings.RegionName,
+					},
+				},
+				ProcessArgs: nil,
+			},
+			Status: akov2status.AtlasDeploymentStatus{
+				Common: akoapi.Common{
+					Conditions: []akoapi.Condition{},
+				},
+			},
+		}
+
+		featureValidator.EXPECT().FeatureExist(features.ResourceAtlasDeployment, featureServerlessPrivateEndpoints).Return(true)
+
+		got, err := BuildServerlessDeployments(clusterStore, featureValidator, projectName, projectName, clusterName, targetNamespace, dictionary, resourceVersion)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		if !reflect.DeepEqual(expected, got) {
+			je, _ := json.MarshalIndent(expected, "", " ")
+			fmt.Println("Expected", string(je))
+			jg, _ := json.MarshalIndent(expected, "", " ")
+			fmt.Println("Got", string(jg))
+			t.Fatalf("Serverless deployment mismatch.\r\nexp: %v\r\ngot: %v\r\n", expected, got)
 		}
 	})
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Fixed the error when exporting a serverless instance on GCP, because of unsupported PE for GCP.

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-278461](https://jira.mongodb.org/browse/CLOUDP-278461)

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
