### PR TITLE
task: update documentation for golang

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ To make the contribution process as seamless as possible, we ask for the followi
 #### Prerequisite Tools
 
 - [Git](https://git-scm.com/)
-- [Go (at least Go 1.22)](https://golang.org/dl/)
+- [Go (at least Go 1.23.1)](https://golang.org/dl/)
 
 #### Environment
 


### PR DESCRIPTION
## Description

Updating documentation to cover golang version requirement

## Reason
```
 Building atlas binary
go build -ldflags "-s -w -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version.GitCommit=436cdc259407d225f622e5a407a43e43f4070d99 -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version.Version=1.19.0-374-g436cdc259"  -o ./bin/atlas ./cmd/atlas
go: go.mod requires go >= 1.23.1 (running go 1.21.3; GOTOOLCHAIN=local)
make: *** [build] Error 1
```
## Separate concern

Go.mod file does not use toolchain directive which can automatically request proper golang version to be used. 
Since I moved from Atlas CLI I noticed we no longer use adsf tools definitions.

  