### PR TITLE
fix: add toolchain support for out of the box go version management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ else
 endif
 export TERM := linux-m
 export GO111MODULE := on
-export GOTOOLCHAIN := local
+export GOTOOLCHAIN := local+auto
 export ATLAS_E2E_BINARY
 
 .PHONY: pre-commit

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/mongodb/mongodb-atlas-cli/atlascli
 
 go 1.23.1
 
+toolchain go1.23.0
+
 require (
 	cloud.google.com/go/kms v1.20.0
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
 ## Proposed changes

Adding toolchain to the go.mod file with ability to automatically select remote toolchain for builds.
Creating PR to see if CI/CD will still use local toolchain. Not ready for review/will discuss it with project leads offline. 
