### PR TITLE
CLOUDP-275876: UX: atlas deployment logs

### DIFF
--- a/internal/cli/deployments/logs_test.go
+++ b/internal/cli/deployments/logs_test.go
@@ -92,8 +92,8 @@ func TestLogs_RunAtlas(t *testing.T) {
 		},
 		DeploymentOpts: *deploymentTest.Opts,
 		downloadStore:  mockStore,
-		host:           "test",
-		name:           "mongodb.gz",
+		Host:           "test",
+		Name:           "mongodb.gz",
 	}
 
 	downloadOpts.Fs = afero.NewMemMapFs()


### PR DESCRIPTION
## Proposed changes
After selecting an atlas deployment, prompt `--host` and `--name` when they're not provided, instead of failing the command.

_Jira ticket:_ CLOUDP-275876