### PR TITLE
DOCSP-41212: Add dochub links to cluster configuration file page

### DIFF
--- a/docs/command/mongocli-cloud-manager-clusters-create.txt
+++ b/docs/command/mongocli-cloud-manager-clusters-create.txt
@@ -38,7 +38,7 @@ Options
    * - -f, --file
      - string
      - true
-     - Filename to use to create the cluster
+     - Filename to use to create the cluster. To learn more about configuration files, see https://dochub.mongodb.org/core/mongocli-cluster-config-file.
    * - -h, --help
      - 
      - false

--- a/docs/command/mongocli-cloud-manager-clusters-update.txt
+++ b/docs/command/mongocli-cloud-manager-clusters-update.txt
@@ -38,7 +38,7 @@ Options
    * - -f, --file
      - string
      - true
-     - Filename to use to update the cluster
+     - Filename to use to update the cluster. To learn more about configuration files, see https://dochub.mongodb.org/core/mongocli-cluster-config-file.
    * - -h, --help
      - 
      - false

--- a/docs/command/mongocli-ops-manager-clusters-create.txt
+++ b/docs/command/mongocli-ops-manager-clusters-create.txt
@@ -38,7 +38,7 @@ Options
    * - -f, --file
      - string
      - true
-     - Filename to use to create the cluster
+     - Filename to use to create the cluster. To learn more about configuration files, see https://dochub.mongodb.org/core/mongocli-cluster-config-file.
    * - -h, --help
      - 
      - false

--- a/docs/command/mongocli-ops-manager-clusters-update.txt
+++ b/docs/command/mongocli-ops-manager-clusters-update.txt
@@ -38,7 +38,7 @@ Options
    * - -f, --file
      - string
      - true
-     - Filename to use to update the cluster
+     - Filename to use to update the cluster. To learn more about configuration files, see https://dochub.mongodb.org/core/mongocli-cluster-config-file.
    * - -h, --help
      - 
      - false

--- a/internal/cli/opsmanager/clusters/create.go
+++ b/internal/cli/opsmanager/clusters/create.go
@@ -90,7 +90,7 @@ func CreateBuilder() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.filename, flag.File, flag.FileShort, "", "Filename to use to create the cluster")
+	cmd.Flags().StringVarP(&opts.filename, flag.File, flag.FileShort, "", "Filename to use to create the cluster. To learn more about configuration files, see https://dochub.mongodb.org/core/mongocli-cluster-config-file.")
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 

--- a/internal/cli/opsmanager/clusters/update.go
+++ b/internal/cli/opsmanager/clusters/update.go
@@ -90,7 +90,7 @@ func UpdateBuilder() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.filename, flag.File, flag.FileShort, "", "Filename to use to update the cluster")
+	cmd.Flags().StringVarP(&opts.filename, flag.File, flag.FileShort, "", "Filename to use to update the cluster. To learn more about configuration files, see https://dochub.mongodb.org/core/mongocli-cluster-config-file.")
 
 	cmd.Flags().StringVar(&opts.ProjectID, flag.ProjectID, "", usage.ProjectID)
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Adds dochub links to cluster config file docs
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Note: To my knowledge there is no way to hyperlink in the .go file parameters

_Jira ticket:_ DOCSP-41212

