### PR TITLE
CLOUDP-284609 Failed Task: mongodb-atlas-cli-master-atlas_deployments_local_auth_e2e/e2e_local_deployments_ubuntu22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 GOLANGCI_VERSION=v1.61.0
 COVERAGE=coverage.out
 
-MCLI_GIT_SHA?=$(shell git rev-parse HEAD)
+GIT_SHA?=$(shell git rev-parse HEAD)
 
 ATLAS_SOURCE_FILES?=./cmd/atlas
 ifeq ($(OS),Windows_NT)
@@ -16,8 +16,8 @@ endif
 ATLAS_DESTINATION=./bin/$(ATLAS_BINARY_NAME)
 ATLAS_INSTALL_PATH="${GOPATH}/bin/$(ATLAS_BINARY_NAME)"
 
-LINKER_FLAGS=-s -w -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version.GitCommit=${MCLI_GIT_SHA}
-ATLAS_LINKER_FLAGS=${LINKER_FLAGS} -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version.Version=${ATLAS_VERSION}
+LOCALDEV_IMAGE?=docker.io/mongodb/mongodb-atlas-local
+LINKER_FLAGS=-s -w -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version.GitCommit=${GIT_SHA} -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version.Version=${ATLAS_VERSION} -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/options.LocalDevImage=${LOCALDEV_IMAGE}
 ATLAS_E2E_BINARY?=../../../bin/${ATLAS_BINARY_NAME}
 
 DEBUG_FLAGS=all=-N -l
@@ -118,17 +118,17 @@ gen-mocks: ## Generate mocks
 .PHONY: gen-docs
 gen-docs: ## Generate docs for atlascli commands
 	@echo "==> Generating docs"
-	go run -ldflags "$(ATLAS_LINKER_FLAGS)" ./tools/docs/main.go
+	go run -ldflags "$(LINKER_FLAGS)" ./tools/docs/main.go
 
 .PHONY: build
 build: ## Generate an atlas binary in ./bin
 	@echo "==> Building $(ATLAS_BINARY_NAME) binary"
-	go build -ldflags "$(ATLAS_LINKER_FLAGS)" $(BUILD_FLAGS) -o $(ATLAS_DESTINATION) $(ATLAS_SOURCE_FILES)
+	go build -ldflags "$(LINKER_FLAGS)" $(BUILD_FLAGS) -o $(ATLAS_DESTINATION) $(ATLAS_SOURCE_FILES)
 
 .PHONY: build-debug
 build-debug: ## Generate a binary in ./bin for debugging atlascli
 	@echo "==> Building $(ATLAS_BINARY_NAME) binary for debugging"
-	go build -gcflags="$(DEBUG_FLAGS)" -ldflags "$(ATLAS_LINKER_FLAGS)" $(BUILD_FLAGS) -o $(ATLAS_DESTINATION) $(ATLAS_SOURCE_FILES)
+	go build -gcflags="$(DEBUG_FLAGS)" -ldflags "$(LINKER_FLAGS)" $(BUILD_FLAGS) -o $(ATLAS_DESTINATION) $(ATLAS_SOURCE_FILES)
 
 .PHONY: e2e-test
 e2e-test: build ## Run E2E tests
@@ -149,7 +149,7 @@ unit-test: ## Run unit-tests
 .PHONY: install
 install: ## Install a binary in $GOPATH/bin
 	@echo "==> Installing $(ATLAS_BINARY_NAME) to $(ATLAS_INSTALL_PATH)"
-	go install -ldflags "$(ATLAS_LINKER_FLAGS)" $(ATLAS_SOURCE_FILES)
+	go install -ldflags "$(LINKER_FLAGS)" $(ATLAS_SOURCE_FILES)
 	@echo "==> Done..."
 
 .PHONY: list

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -140,6 +140,7 @@ functions:
           - E2E_SERVERLESS_INSTANCE_NAME
           - E2E_PARALLEL
           - IDENTITY_PROVIDER_ID
+          - LOCALDEV_IMAGE
           - revision
         env:
           <<: *go_env
@@ -425,12 +426,6 @@ functions:
         args:
           - -f
           - expansions.yaml
-  "docker_login":
-    - command: shell.exec
-      params:
-        shell: bash
-        script: |
-          echo "${dockerhub_password}" | docker login -u ${dockerhub_username} --password-stdin
 tasks:
   - name: compile
     tags: ["code_health"]
@@ -1454,7 +1449,6 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
-      - func: "docker_login"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
@@ -1466,6 +1460,7 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,deployments,local,noauth
           E2E_TIMEOUT: 3h
+          LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
   - name: atlas_deployments_local_nocli_e2e
     tags: ["e2e","deployments","local","nocli"]
     must_have_test_results: true
@@ -1474,7 +1469,6 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
-      - func: "docker_login"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
@@ -1486,6 +1480,7 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,deployments,local,nocli
           E2E_TIMEOUT: 3h
+          LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
   - name: atlas_deployments_local_auth_e2e
     tags: ["e2e","deployments","local","auth","new"]
     must_have_test_results: true
@@ -1494,7 +1489,6 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
-      - func: "docker_login"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
@@ -1506,6 +1500,7 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,deployments,local,auth,new
           E2E_TIMEOUT: 3h
+          LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
   - name: atlas_deployments_local_auth_deprecated_e2e
     tags: ["e2e","deployments","local","auth","deprecated"]
     must_have_test_results: true
@@ -1514,7 +1509,6 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
-      - func: "docker_login"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
@@ -1526,6 +1520,7 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,deployments,local,auth,deprecated
           E2E_TIMEOUT: 3h
+          LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
   - name: build_win11_image
     tags: ["packer", "windows", "win11"]
     commands:

--- a/internal/cli/deployments/options/deployment_opts.go
+++ b/internal/cli/deployments/options/deployment_opts.go
@@ -130,8 +130,10 @@ func (opts *DeploymentOpts) LocalMongodHostname() string {
 	return opts.DeploymentName
 }
 
+var LocalDevImage = "docker.io/mongodb/mongodb-atlas-local"
+
 func (opts *DeploymentOpts) MongodDockerImageName() string {
-	return "docker.io/mongodb/mongodb-atlas-local:" + opts.MdbVersion
+	return LocalDevImage + ":" + opts.MdbVersion
 }
 
 func (opts *DeploymentOpts) Spin(funcs ...func() error) error {

--- a/internal/decryption/log_record.go
+++ b/internal/decryption/log_record.go
@@ -106,7 +106,7 @@ func (logLine *AuditLogLine) logAdditionalAuthData() []byte {
 	const AADByteSize = 8
 
 	additionalAuthData := make([]byte, AADByteSize)
-	//nolint:gosec
+
 	binary.LittleEndian.PutUint64(additionalAuthData, uint64(logLine.TS.UnixMilli()))
 	return additionalAuthData
 }

--- a/internal/decryption/log_record.go
+++ b/internal/decryption/log_record.go
@@ -106,7 +106,7 @@ func (logLine *AuditLogLine) logAdditionalAuthData() []byte {
 	const AADByteSize = 8
 
 	additionalAuthData := make([]byte, AADByteSize)
-
+	
 	binary.LittleEndian.PutUint64(additionalAuthData, uint64(logLine.TS.UnixMilli()))
 	return additionalAuthData
 }

--- a/internal/decryption/log_record.go
+++ b/internal/decryption/log_record.go
@@ -106,7 +106,7 @@ func (logLine *AuditLogLine) logAdditionalAuthData() []byte {
 	const AADByteSize = 8
 
 	additionalAuthData := make([]byte, AADByteSize)
-	
+	//nolint:gosec
 	binary.LittleEndian.PutUint64(additionalAuthData, uint64(logLine.TS.UnixMilli()))
 	return additionalAuthData
 }

--- a/test/e2e/atlas/deployments_local_nocli_test.go
+++ b/test/e2e/atlas/deployments_local_nocli_test.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"testing"
 
+	opt "github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/options" //nolint:importas //unique of this test
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,10 +57,15 @@ func TestDeploymentsLocalWithNoCLI(t *testing.T) {
 		bin = "podman"
 	}
 
+	image := os.Getenv("LOCALDEV_IMAGE")
+	if image == "" {
+		image = opt.LocalDevImage
+	}
+
 	t.Run("Pull", func(t *testing.T) {
 		cmd := exec.Command(bin,
 			"pull",
-			"docker.io/mongodb/mongodb-atlas-local",
+			image,
 		)
 		r, setupErr := e2e.RunAndGetStdOut(cmd)
 		require.NoError(t, setupErr, string(r))
@@ -73,7 +79,7 @@ func TestDeploymentsLocalWithNoCLI(t *testing.T) {
 			"-P",
 			"-e", "MONGODB_INITDB_ROOT_USERNAME="+dbUsername,
 			"-e", "MONGODB_INITDB_ROOT_PASSWORD="+dbUserPassword,
-			"docker.io/mongodb/mongodb-atlas-local",
+			image,
 		)
 
 		cmd.Env = os.Environ()


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Failed Task: mongodb-atlas-cli-master-atlas_deployments_local_auth_e2e/e2e_local_deployments_ubuntu22
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-284609

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
This change pulls localdev image from artifactory instead of docker, this is effectively caching the image in our infra the only drawback is we might run slightly outdated images which for CLI tests should not be a big deal, more updated tests should live in the image repo anyways
