### PR TITLE
Flyby: Remove duplicate logging when refresh token expired

### DIFF
--- a/internal/cli/root/builder.go
+++ b/internal/cli/root/builder.go
@@ -159,7 +159,6 @@ Use the --help flag with any command for more info on that command.`,
 				func() error {
 					err := opts.RefreshAccessToken(cmd.Context())
 					if err != nil && authReq == RequiredAuth {
-						_, _ = log.Warningf("Could not refresh access token: %s\n", err.Error())
 						return err
 					}
 					return nil


### PR DESCRIPTION
## Proposed changes
When refreshing our refresh token we print:
```go
_, _ = log.Warningf("Could not refresh access token: %s\n", err.Error())
```

This is unnecessary since we also return the error to the caller function, which also logs the error.



Before:
```
mongodb-atlas-cli-master on  fix-double-auth-error [$] via 🐹 v1.23.3
❯ ./bin/atlas cluster watch Cluster03739
Could not refresh access token: session expired

Please note that your session expires periodically.
If you use Atlas CLI for automation, see https://www.mongodb.com/docs/atlas/cli/stable/atlas-cli-automate/ for best practices.
To login, run: atlas auth login
Error: session expired

Please note that your session expires periodically.
If you use Atlas CLI for automation, see https://www.mongodb.com/docs/atlas/cli/stable/atlas-cli-automate/ for best practices.
To login, run: atlas auth login
```

After
```
mongodb-atlas-cli-master on  fix-double-auth-error [$] via 🐹 v1.23.3
❯ ./bin/atlas cluster watch Cluster03739
Error: session expired

Please note that your session expires periodically.
If you use Atlas CLI for automation, see https://www.mongodb.com/docs/atlas/cli/stable/atlas-cli-automate/ for best practices.
To login, run: atlas auth login
```