### PR TITLE
CLOUDP-283522: Investigate better pattern for composite commands

### DIFF
--- a/internal/cli/composite_opts.go
+++ b/internal/cli/composite_opts.go
@@ -1,0 +1,76 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/log"
+	"github.com/spf13/cobra"
+)
+
+type CompositeOpts struct {
+	stdOut  *bytes.Buffer
+	stdErr  *bytes.Buffer
+	stdIn   io.Reader
+	rootCmd *cobra.Command
+}
+
+func (opts *CompositeOpts) InitComposite(cmd *cobra.Command) {
+	opts.rootCmd = cmd
+	if opts.rootCmd == nil {
+		return
+	}
+	for opts.rootCmd.Parent() != nil {
+		opts.rootCmd = opts.rootCmd.Parent()
+	}
+}
+
+func (opts *CompositeOpts) StdOut() io.Reader {
+	return opts.stdOut
+}
+
+func (opts *CompositeOpts) StdErr() io.Reader {
+	return opts.stdErr
+}
+
+func (opts *CompositeOpts) SetStdIn(in io.Reader) {
+	opts.stdIn = in
+}
+
+func (opts *CompositeOpts) RunCommand(ctx context.Context, args ...string) error {
+	opts.stdOut = &bytes.Buffer{}
+	opts.stdErr = &bytes.Buffer{}
+	opts.rootCmd.SetOut(opts.stdOut)
+	opts.rootCmd.SetErr(opts.stdErr)
+	if opts.stdIn != nil {
+		opts.rootCmd.SetIn(opts.stdIn)
+	}
+
+	log.Debugf("running command '%s'", "atlas "+strings.Join(args, " "))
+
+	currentArgs := args
+
+	if !strings.EqualFold(config.Default().Name(), "default") {
+		currentArgs = append(currentArgs, "--profile", config.Default().Name())
+	}
+
+	opts.rootCmd.SetArgs(currentArgs)
+	return opts.rootCmd.ExecuteContext(ctx)
+}

--- a/internal/cli/setup/dbuser_setup.go
+++ b/internal/cli/setup/dbuser_setup.go
@@ -15,24 +15,20 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/convert"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/randgen"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/telemetry"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 )
 
-func (opts *Opts) createDatabaseUser() error {
-	if _, err := opts.store.CreateDatabaseUser(opts.newDatabaseUser()); err != nil {
-		return err
-	}
-
-	return nil
+func (opts *Opts) createDatabaseUser(ctx context.Context) error {
+	return opts.RunCommand(ctx, "dbuser", "create", "--role", atlasAdmin, "--username", opts.DBUsername, "--password", opts.DBUserPassword, "--projectId", opts.ConfigProjectID())
 }
 
 func (opts *Opts) askDBUserOptions() error {
@@ -89,20 +85,6 @@ func (opts *Opts) validateUniqueUsername(val any) error {
 		return err
 	}
 	return fmt.Errorf("a user with this username %s already exists", username)
-}
-
-func (opts *Opts) newDatabaseUser() *atlasv2.CloudDatabaseUser {
-	var none = "NONE"
-	return &atlasv2.CloudDatabaseUser{
-		Roles:        pointer.Get(convert.BuildAtlasRoles([]string{atlasAdmin})),
-		GroupId:      opts.ConfigProjectID(),
-		Password:     &opts.DBUserPassword,
-		X509Type:     &none,
-		AwsIAMType:   &none,
-		LdapAuthType: &none,
-		DatabaseName: convert.AdminDB,
-		Username:     opts.DBUsername,
-	}
 }
 
 func generatePassword() (string, error) {


### PR DESCRIPTION
# pattern for composite commands

historically most commands in CLI has been one API call to our [admin APIs](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/)

When we've done `atlas quickstart` and `atlas setup` we unfortunately took the path of reusing code without formalizing a proper pattern to follow, making our code base a bit difficult to navigate.

This *incomplete* PR shows how a pattern of reusing cobra and using its internal `SetArgs` paired with `ExecuteContext` could give us the advantage of running multiple commands together.