### PR TITLE
CLOUDP-285943: update `atlas cluster get` to support Flex Clusters

### DIFF
--- a/internal/cli/clusters/create.go
+++ b/internal/cli/clusters/create.go
@@ -40,6 +40,7 @@ const (
 	tenant     = "TENANT"
 	atlasM0    = "M0"
 	atlasM2    = "M2"
+	atlasFlex  = "FLEX"
 	atlasM5    = "M5"
 	zoneName   = "Zone 1"
 )

--- a/internal/cli/clusters/describe.go
+++ b/internal/cli/clusters/describe.go
@@ -25,10 +25,13 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
 	"github.com/spf13/cobra"
-	atlasv2 "go.mongodb.org/atlas-sdk/v20241113001/admin"
+	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 )
 
-const NonFoundCode = 404
+const (
+	cannotUseFlexWithClusterApisHTTPCode  = 400
+	cannotUseFlexWithClusterApisErrorCode = "CANNOT_USE_FLEX_CLUSTER_IN_CLUSTER_API"
+)
 
 type DescribeOpts struct {
 	cli.GlobalOpts
@@ -59,12 +62,12 @@ func (opts *DescribeOpts) Run() error {
 }
 
 func (opts *DescribeOpts) RunFlexCluster(err error) error {
-	apiError, ok := atlasv2.AsError(err)
+	apiError, ok := atlasClustersPinned.AsError(err)
 	if !ok {
 		return err
 	}
 
-	if apiError.Error != NonFoundCode {
+	if *apiError.Error != cannotUseFlexWithClusterApisHTTPCode && *apiError.ErrorCode != cannotUseFlexWithClusterApisErrorCode {
 		return err
 	}
 

--- a/internal/cli/clusters/describe.go
+++ b/internal/cli/clusters/describe.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	cannotUseFlexWithClusterApisHTTPCode  = 400
 	cannotUseFlexWithClusterApisErrorCode = "CANNOT_USE_FLEX_CLUSTER_IN_CLUSTER_API"
 )
 
@@ -67,7 +66,7 @@ func (opts *DescribeOpts) RunFlexCluster(err error) error {
 		return err
 	}
 
-	if *apiError.Error != cannotUseFlexWithClusterApisHTTPCode && *apiError.ErrorCode != cannotUseFlexWithClusterApisErrorCode {
+	if *apiError.ErrorCode != cannotUseFlexWithClusterApisErrorCode {
 		return err
 	}
 

--- a/internal/cli/clusters/describe_test.go
+++ b/internal/cli/clusters/describe_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 )
 
 func TestDescribe_Run(t *testing.T) {
@@ -39,6 +40,37 @@ func TestDescribe_Run(t *testing.T) {
 	mockStore.
 		EXPECT().
 		AtlasCluster(describeOpts.ProjectID, describeOpts.name).
+		Return(expected, nil).
+		Times(1)
+
+	if err := describeOpts.Run(); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	test.VerifyOutputTemplate(t, describeTemplate, expected)
+}
+
+func TestDescribe_RunFlexCluster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockClusterDescriber(ctrl)
+
+	expected := &atlasv2.FlexClusterDescription20241113{}
+	expectedError := &atlasv2.GenericOpenAPIError{}
+	expectedError.SetModel(atlasv2.ApiError{Error: NonFoundCode})
+
+	describeOpts := &DescribeOpts{
+		name:  "test",
+		store: mockStore,
+	}
+
+	mockStore.
+		EXPECT().
+		AtlasCluster(describeOpts.ProjectID, describeOpts.name).
+		Return(nil, expectedError).
+		Times(1)
+
+	mockStore.
+		EXPECT().
+		FlexCluster(describeOpts.ProjectID, describeOpts.name).
 		Return(expected, nil).
 		Times(1)
 

--- a/internal/cli/clusters/describe_test.go
+++ b/internal/cli/clusters/describe_test.go
@@ -56,7 +56,7 @@ func TestDescribe_RunFlexCluster(t *testing.T) {
 
 	expected := &atlasv2.FlexClusterDescription20241113{}
 	expectedError := &atlasClustersPinned.GenericOpenAPIError{}
-	expectedError.SetModel(atlasClustersPinned.ApiError{Error: pointer.Get(cannotUseFlexWithClusterApisHTTPCode), ErrorCode: pointer.Get(cannotUseFlexWithClusterApisErrorCode)})
+	expectedError.SetModel(atlasClustersPinned.ApiError{ErrorCode: pointer.Get(cannotUseFlexWithClusterApisErrorCode)})
 
 	describeOpts := &DescribeOpts{
 		name:  "test",

--- a/internal/cli/clusters/describe_test.go
+++ b/internal/cli/clusters/describe_test.go
@@ -17,11 +17,14 @@
 package clusters
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
+	"github.com/stretchr/testify/require"
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20241113001/admin"
 )
@@ -43,9 +46,7 @@ func TestDescribe_Run(t *testing.T) {
 		Return(expected, nil).
 		Times(1)
 
-	if err := describeOpts.Run(); err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
-	}
+	require.NoError(t, describeOpts.Run())
 	test.VerifyOutputTemplate(t, describeTemplate, expected)
 }
 
@@ -54,8 +55,8 @@ func TestDescribe_RunFlexCluster(t *testing.T) {
 	mockStore := mocks.NewMockClusterDescriber(ctrl)
 
 	expected := &atlasv2.FlexClusterDescription20241113{}
-	expectedError := &atlasv2.GenericOpenAPIError{}
-	expectedError.SetModel(atlasv2.ApiError{Error: NonFoundCode})
+	expectedError := &atlasClustersPinned.GenericOpenAPIError{}
+	expectedError.SetModel(atlasClustersPinned.ApiError{Error: pointer.Get(cannotUseFlexWithClusterApisHTTPCode), ErrorCode: pointer.Get(cannotUseFlexWithClusterApisErrorCode)})
 
 	describeOpts := &DescribeOpts{
 		name:  "test",
@@ -74,8 +75,33 @@ func TestDescribe_RunFlexCluster(t *testing.T) {
 		Return(expected, nil).
 		Times(1)
 
-	if err := describeOpts.Run(); err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
-	}
+	require.NoError(t, describeOpts.Run())
 	test.VerifyOutputTemplate(t, describeTemplate, expected)
+}
+
+func TestDescribe_RunFlexCluster_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockClusterDescriber(ctrl)
+
+	expected := &atlasv2.FlexClusterDescription20241113{}
+	expectedError := errors.New("test")
+
+	describeOpts := &DescribeOpts{
+		name:  "test",
+		store: mockStore,
+	}
+
+	mockStore.
+		EXPECT().
+		AtlasCluster(describeOpts.ProjectID, describeOpts.name).
+		Return(nil, expectedError).
+		Times(1)
+
+	mockStore.
+		EXPECT().
+		FlexCluster(describeOpts.ProjectID, describeOpts.name).
+		Return(expected, nil).
+		Times(0)
+
+	require.Error(t, describeOpts.Run())
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
This PR updates the `atlas cluster get` command to support Flex Cluster. The command tries to call the cluster API first and, in the event of a 400 error, calls the flex cluster APIs 



Here is the error that you get when using Cluster API with flex clusters                                                                                 
`Error: https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/Cluster22 GET: HTTP 400 Bad Request (Error code: "CANNOT_USE_FLEX_CLUSTER_IN_CLUSTER_API") Detail: Flex cluster Cluster22 cannot be used in the Cluster API. Reason: Bad Request. Params: [Cluster22]`

## Tests

<details>
  <summary>Dedicated Cluster </summary>

```bash
./bin/atlas cluster get Cluster0 -P prod                                                                                              
ID                         NAME       MDB VER   STATE
66d1b902e509e119a21ca4c8   Cluster0   7.0.15    IDLE
```

```json
./bin/atlas cluster get Cluster0 -P prod -o json                                                                                          
{
  "backupEnabled": false,
  "biConnector": {
    "enabled": false,
    "readPreference": "secondary"
  },
  "clusterType": "REPLICASET",
  "connectionStrings": {
    "standard": "mongodb://cluster0-shard-00-00.pkura.mongodb.net:27017,cluster0-shard-00-01.pkura.mongodb.net:27017,cluster0-shard-00-02.pkura.mongodb.net:27017/?ssl=true\u0026authSource=admin\u0026replicaSet=atlas-109val-shard-0",
    "standardSrv": "mongodb+srv://cluster0.pkura.mongodb.net"
  },
  "createDate": "2024-08-30T12:20:18Z",
  "diskSizeGB": 40,
  "diskWarmingMode": "FULLY_WARMED",
  "encryptionAtRestProvider": "NONE",
  "globalClusterSelfManagedSharding": false,
  "groupId": "663268874ddd3b236fd2f107",
  "id": "66d1b902e509e119a21ca4c8",
  "labels": [],
  "links": [
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/Cluster0",
      "rel": "self"
    },
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/Cluster0/backup/restoreJobs",
      "rel": "https://cloud.mongodb.com/restoreJobs"
    },
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/Cluster0/backup/snapshots",
      "rel": "https://cloud.mongodb.com/snapshots"
    }
  ],
  "mongoDBMajorVersion": "7.0",
  "mongoDBVersion": "7.0.15",
  "name": "Cluster0",
  "paused": true,
  "pitEnabled": false,
  "replicationSpecs": [
    {
      "id": "66d1b8fb08e4843269f73f1a",
      "numShards": 1,
      "regionConfigs": [
        {
          "electableSpecs": {
            "diskIOPS": 3000,
            "ebsVolumeType": "STANDARD",
            "instanceSize": "M30",
            "nodeCount": 3
          },
          "priority": 7,
          "providerName": "AWS",
          "regionName": "US_EAST_1",
          "analyticsAutoScaling": {
            "compute": {
              "enabled": true,
              "maxInstanceSize": "M40",
              "minInstanceSize": "M30",
              "scaleDownEnabled": true
            },
            "diskGB": {
              "enabled": true
            }
          },
          "analyticsSpecs": {
            "nodeCount": 0,
            "diskIOPS": 3000,
            "ebsVolumeType": "STANDARD",
            "instanceSize": "M30"
          },
          "autoScaling": {
            "compute": {
              "enabled": true,
              "maxInstanceSize": "M40",
              "minInstanceSize": "M30",
              "scaleDownEnabled": true
            },
            "diskGB": {
              "enabled": true
            }
          },
          "readOnlySpecs": {
            "nodeCount": 0,
            "diskIOPS": 3000,
            "ebsVolumeType": "STANDARD",
            "instanceSize": "M30"
          }
        }
      ],
      "zoneName": "Zone 1"
    }
  ],
  "rootCertType": "ISRGROOTX1",
  "stateName": "IDLE",
  "tags": [],
  "terminationProtectionEnabled": false,
  "versionReleaseSystem": "LTS"
}
```
</details>


<details>
  <summary>Flex Cluster </summary>

```bash
./bin/atlas cluster get Cluster22 -P prod                                                                                            
ID                         NAME        MDB VER   STATE
67406c8b74c55f6cea97513a   Cluster22   8.0.3     IDLE
```

```json
./bin/atlas cluster get Cluster22 -P prod -o json       
                                                                                  
{
  "backupSettings": {
    "enabled": true
  },
  "clusterType": "REPLICASET",
  "connectionStrings": {
    "standard": "mongodb://ac-41wbyjg-shard-00-00.xbvlwej.mongodb.net:27017,ac-41wbyjg-shard-00-01.xbvlwej.mongodb.net:27017,ac-41wbyjg-shard-00-02.xbvlwej.mongodb.net:27017/?ssl=true\u0026authSource=admin\u0026replicaSet=atlas-srjr8m-shard-0",
    "standardSrv": "mongodb+srv://cluster22.xbvlwej.mongodb.net"
  },
  "createDate": "2024-11-22T11:35:39Z",
  "groupId": "663268874ddd3b236fd2f107",
  "id": "67406c8b74c55f6cea97513a",
  "mongoDBVersion": "8.0.3",
  "name": "Cluster22",
  "providerSettings": {
    "backingProviderName": "AWS",
    "diskSizeGB": 5,
    "providerName": "FLEX",
    "regionName": "EU_WEST_1"
  },
  "stateName": "IDLE",
  "tags": [],
  "terminationProtectionEnabled": false,
  "versionReleaseSystem": "LTS"

```