### PR TITLE
CLOUDP-287243: e2e cleanup key deletion failure

### DIFF
--- a/test/e2e/atlas/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas/atlas_e2e_test_generator_test.go
@@ -299,7 +299,7 @@ func deleteKeys(t *testing.T, cliPath string, toDelete map[string]struct{}) {
 			keyID,
 			"--force")
 		cmd.Env = os.Environ()
-		_, err = e2e.RunAndGetStdOut(cmd)
+		_, err = e2e.RunAndGetStdOutAndErr(cmd)
 		if err != nil && !strings.Contains(err.Error(), "API_KEY_NOT_FOUND") {
 			errors = append(errors, err)
 		}

--- a/test/e2e/helper.go
+++ b/test/e2e/helper.go
@@ -102,3 +102,13 @@ func RunAndGetStdOut(cmd *exec.Cmd) ([]byte, error) {
 
 	return resp, nil
 }
+
+func RunAndGetStdOutAndErr(cmd *exec.Cmd) ([]byte, error) {
+	resp, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return nil, fmt.Errorf("%s (%w)", string(resp), err)
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
## Proposed changes

Could not find API_KEY_NOT_FOUND because only stdout was checked

_Jira ticket:_ CLOUDP-287243