### PR TITLE
Added write permissions to code-health workflow

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   pull_request:
+permissions:
+  pull-requests: write  # For PR-specific operations
+  issues: write        # For commenting functionality
 jobs:
   golangci:
     name: lint


### PR DESCRIPTION
Coverage doesn't seem to have sufficient permissions to comment: https://github.com/mongodb/mongodb-atlas-cli/actions/runs/12117387295/job/33784007552