### PR TITLE
(DOCSP-45722) Removes mention of a users list command since there is none available

### DIFF
--- a/docs/command/atlas-users.txt
+++ b/docs/command/atlas-users.txt
@@ -14,7 +14,7 @@ atlas users
 
 Manage your Atlas users.
 
-Create, list and manage your Atlas users.
+Create and manage your Atlas users.
 
 Options
 -------

--- a/internal/cli/users/users.go
+++ b/internal/cli/users/users.go
@@ -20,7 +20,7 @@ import (
 )
 
 func Builder() *cobra.Command {
-	description := "Create, list and manage your Atlas users."
+	description := "Create and manage your Atlas users."
 
 	const use = "users"
 	cmd := &cobra.Command{


### PR DESCRIPTION
## Proposed changes

A user filed docs feedback that pointed out that no "atlas users list" command is available. This PR removes mention of it from the top-level docs page and --help.

_Jira ticket:_ https://jira.mongodb.org/browse/DOCSP-45722

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
