### PR TITLE
CLOUDP-280747: Build a layer to handle --format

### DIFF
--- a/docs/command/atlas-clusters-create.txt
+++ b/docs/command/atlas-clusters-create.txt
@@ -91,7 +91,7 @@ Options
      - false
      - Major MongoDB version of the cluster.
 
-       Mutually exclusive with --file. This value defaults to "7.0".
+       Mutually exclusive with --file. This value defaults to "8.0".
    * - -m, --members
      - int
      - false

--- a/internal/api/formatter.go
+++ b/internal/api/formatter.go
@@ -1,0 +1,89 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"text/template"
+)
+
+var (
+	ErrFormatterFailedToParseFormatString = errors.New("failed to parse format string")
+)
+
+type Formatter struct {
+}
+
+func NewFormatter() *Formatter {
+	return &Formatter{}
+}
+
+func (f *Formatter) Format(format string, in io.ReadCloser) (io.ReadCloser, error) {
+	if isGoTemplate(format) {
+		return f.formatJSON(format, in)
+	}
+
+	return in, nil
+}
+
+func (*Formatter) formatJSON(format string, readerCloser io.ReadCloser) (io.ReadCloser, error) {
+	// Make sure the readerCloser reader gets closed
+	defer readerCloser.Close()
+
+	// Attempt to parse the format string
+	tmpl, err := template.New("formatter-template").Parse(format)
+	if err != nil {
+		return nil, errors.Join(ErrFormatterFailedToParseFormatString, err)
+	}
+
+	// Decode the Reader as a json
+	var data any
+	if err := json.NewDecoder(readerCloser).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	// buffer contains the result of the execute template
+	var buffer bytes.Buffer
+	if err := tmpl.Execute(&buffer, data); err != nil {
+		return nil, err
+	}
+
+	// Transform the buffer into a io.ReadCloser
+	reader := bytes.NewReader(buffer.Bytes())
+	readCloser := io.NopCloser(reader)
+
+	return readCloser, nil
+}
+
+func (*Formatter) ContentType(format string) (string, error) {
+	if isGoTemplate(format) {
+		return "json", nil
+	}
+
+	return format, nil
+}
+
+// checks if the format string is a go template or not
+// this is a basic check checking if the format string has an opening {{ and closing template }} tag.
+func isGoTemplate(format string) bool {
+	openTagIdx := strings.Index(format, "{{")
+	closeTagIdx := strings.Index(format, "}}")
+
+	return openTagIdx != -1 && closeTagIdx != -1 && openTagIdx < closeTagIdx
+}

--- a/internal/api/formatter_test.go
+++ b/internal/api/formatter_test.go
@@ -1,0 +1,153 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsGoTemplate(t *testing.T) {
+	tests := []struct {
+		format       string
+		isGoTemplate bool
+	}{
+		{
+			format:       "json",
+			isGoTemplate: false,
+		},
+		{
+			format:       "csv",
+			isGoTemplate: false,
+		},
+		{
+			format:       "gzip",
+			isGoTemplate: false,
+		},
+		{
+			format:       "{foo}",
+			isGoTemplate: false,
+		},
+		{
+			format:       "{{bar}",
+			isGoTemplate: false,
+		},
+		{
+			format:       "{baz}}",
+			isGoTemplate: false,
+		},
+		{
+			format:       "{qux}}",
+			isGoTemplate: false,
+		},
+		{
+			format:       "}}quux{{",
+			isGoTemplate: false,
+		},
+		{
+			format:       "{{quuux}}",
+			isGoTemplate: true,
+		},
+		{
+			format:       "with prefix {{quuuux}}",
+			isGoTemplate: true,
+		},
+		{
+			format:       "with prefix {{quuuuux}} and suffix",
+			isGoTemplate: true,
+		},
+		{
+			format:       "{{quuuuuux}} with suffix",
+			isGoTemplate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			isGoTemplate := isGoTemplate(tt.format)
+			require.Equal(t, tt.isGoTemplate, isGoTemplate)
+		})
+	}
+}
+
+func TestFormatJSON(t *testing.T) {
+	const listClustersForAllProjectsJSON = `{"links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/clusters?envelope=false&includeCount=false&pretty=false&pageNum=1&itemsPerPage=1","rel":"self"},{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/clusters?envelope=false&includeCount=false&pretty=false&itemsPerPage=1&pageNum=2","rel":"next"}],"results":[{"clusters":[{"alertCount":0,"atlasClusterType":"SERVERLESS","authEnabled":true,"availability":"available","backupEnabled":true,"clusterId":"6421b576bfa6c84992728bf7","dataSizeBytes":374626829,"isServerlessInstanceAboveFlexOpsThreshold":false,"isServerlessInstanceGrandfatheredToFlex":false,"name":"apix-atlascli-do-not-delete-e2e","nodeCount":-1,"serverlessPrivateEndpointId":null,"sslEnabled":true,"type":"sharded cluster","versions":["8.0.3"]}],"groupId":"5efda6aea3f2ed2e7dd6ce05","groupName":"Atlas CLI E2E","orgId":"5efda682a3f2ed2e7dd6cde4","orgName":"Atlas CLI E2E","planType":"Atlas","tags":[]}],"totalCount":2}`
+
+	tests := []struct {
+		name       string
+		json       string
+		template   string
+		output     string
+		shouldFail bool
+	}{
+		{
+			name:       "listClustersForAllProjectsJson, valid 1",
+			json:       listClustersForAllProjectsJSON,
+			template:   "{{ (index (index .results 0).clusters 0).clusterId }}",
+			output:     "6421b576bfa6c84992728bf7",
+			shouldFail: false,
+		},
+		{
+			name:       "listClustersForAllProjectsJson, valid 2",
+			json:       listClustersForAllProjectsJSON,
+			template:   "groupId: {{ index (index .results 0).groupId }}",
+			output:     "groupId: 5efda6aea3f2ed2e7dd6ce05",
+			shouldFail: false,
+		},
+		{
+			name:       "invalid json",
+			json:       "{notJson",
+			template:   "groupId: {{ index (index .results 0).groupId }}",
+			shouldFail: true,
+		},
+		{
+			name:       "invalid template",
+			json:       listClustersForAllProjectsJSON,
+			template:   "groupId: {{ ** }}",
+			shouldFail: true,
+		},
+		{
+			name:       "incompatible response",
+			json:       listClustersForAllProjectsJSON,
+			template:   "foo: {{ .foo }}",
+			output:     "foo: <no value>",
+			shouldFail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		formatter := NewFormatter()
+
+		t.Run(tt.name, func(t *testing.T) {
+			jsonReader := io.NopCloser(strings.NewReader(tt.json))
+			output, err := formatter.formatJSON(tt.template, jsonReader)
+
+			if tt.shouldFail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				outputBytes, err := io.ReadAll(output)
+				require.NoError(t, err)
+				outputStr := string(outputBytes)
+
+				require.Equal(t, tt.output, outputStr)
+			}
+		})
+	}
+}

--- a/internal/api/httprequest.go
+++ b/internal/api/httprequest.go
@@ -79,7 +79,7 @@ func ConvertToHTTPRequest(baseURL string, request CommandRequest) (*http.Request
 	}
 
 	// Set accept header
-	accept, err := acceptHeader(version, request.Format)
+	accept, err := acceptHeader(version, request.ContentType)
 	if err != nil {
 		return nil, errors.Join(ErrUnsupportedContentType, err)
 	}
@@ -163,7 +163,7 @@ func acceptHeader(version *Version, requestedContentType string) (string, error)
 	}
 
 	if contentType == "" {
-		return "", fmt.Errorf("expected one of the following values: [%s]", strings.Join(supportedTypes, ","))
+		return "", fmt.Errorf("expected one of the following values: [%s], but got '%s' instead", strings.Join(supportedTypes, ","), requestedContentType)
 	}
 
 	return fmt.Sprintf("application/vnd.atlas.%s+%s", version.Version, contentType), nil

--- a/internal/api/httprequest_test.go
+++ b/internal/api/httprequest_test.go
@@ -183,9 +183,9 @@ func TestConvertToHttpRequest(t *testing.T) {
 			name:    "valid get request (getCollStatsLatencyNamespaceClusterMeasurementsCommand)",
 			baseURL: "https://base_url",
 			request: CommandRequest{
-				Command: getCollStatsLatencyNamespaceClusterMeasurementsCommand,
-				Content: strings.NewReader(""),
-				Format:  "json",
+				Command:     getCollStatsLatencyNamespaceClusterMeasurementsCommand,
+				Content:     strings.NewReader(""),
+				ContentType: "json",
 				Parameters: map[string][]string{
 					"groupId":        {"abcdef1234"},
 					"clusterName":    {"cluster-01"},
@@ -208,9 +208,9 @@ func TestConvertToHttpRequest(t *testing.T) {
 			name:    "valid post request (createClusterCommand)",
 			baseURL: "http://another_base",
 			request: CommandRequest{
-				Command: createClusterCommand,
-				Content: strings.NewReader(`{"very_pretty_json":true}`),
-				Format:  "json",
+				Command:     createClusterCommand,
+				Content:     strings.NewReader(`{"very_pretty_json":true}`),
+				ContentType: "json",
 				Parameters: map[string][]string{
 					"groupId": {"0ff00ff00ff0"},
 					"pretty":  {"true"},
@@ -225,19 +225,19 @@ func TestConvertToHttpRequest(t *testing.T) {
 			expectedHTTPBody:              `{"very_pretty_json":true}`,
 		},
 		{
-			name:    "valid post request, custom format (createClusterCommand), should work after CLOUDP-280747 is implemented",
+			name:    "invalid post request",
 			baseURL: "http://another_base",
 			request: CommandRequest{
-				Command: createClusterCommand,
-				Content: strings.NewReader(`{"very_pretty_json":true}`),
-				Format:  `{{ .Id }}`,
+				Command:     createClusterCommand,
+				Content:     strings.NewReader(`{"very_pretty_json":true}`),
+				ContentType: `{{ .Id }}`,
 				Parameters: map[string][]string{
 					"groupId": {"0ff00ff00ff0"},
 					"pretty":  {"true"},
 				},
 				Version: "2024-08-05",
 			},
-			shouldFail:                    true, // TODO: should fail until CLOUDP-280747 is implemented
+			shouldFail:                    true,
 			expectedURL:                   "http://another_base/api/atlas/v2/groups/0ff00ff00ff0/clusters?pretty=true",
 			expectedHTTPVerb:              http.MethodPost,
 			expectedHTTPAcceptHeader:      "application/vnd.atlas.2024-08-05+json",
@@ -248,9 +248,9 @@ func TestConvertToHttpRequest(t *testing.T) {
 			name:    "invalid post request, missing groupId (createClusterCommand)",
 			baseURL: "http://another_base",
 			request: CommandRequest{
-				Command: createClusterCommand,
-				Content: strings.NewReader(`{"very_pretty_json":true}`),
-				Format:  "json",
+				Command:     createClusterCommand,
+				Content:     strings.NewReader(`{"very_pretty_json":true}`),
+				ContentType: "json",
 				Parameters: map[string][]string{
 					"pretty": {"true"},
 				},
@@ -262,9 +262,9 @@ func TestConvertToHttpRequest(t *testing.T) {
 			name:    "invalid post request, invalid version (createClusterCommand)",
 			baseURL: "http://another_base",
 			request: CommandRequest{
-				Command: createClusterCommand,
-				Content: strings.NewReader(`{"very_pretty_json":true}`),
-				Format:  "json",
+				Command:     createClusterCommand,
+				Content:     strings.NewReader(`{"very_pretty_json":true}`),
+				ContentType: "json",
 				Parameters: map[string][]string{
 					"groupId": {"0ff00ff00ff0"},
 					"pretty":  {"true"},

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -37,14 +37,20 @@ type CommandConverter interface {
 }
 
 type CommandRequest struct {
-	Command    Command
-	Content    io.Reader
-	Format     string
-	Parameters map[string][]string
-	Version    string
+	Command     Command
+	Content     io.Reader
+	ContentType string
+	Format      string
+	Parameters  map[string][]string
+	Version     string
 }
 
 type CommandResponse struct {
 	IsSuccess bool
 	Output    io.ReadCloser
+}
+
+type ResponseFormatter interface {
+	ContentType(format string) (string, error)
+	Format(format string, readerCloser io.ReadCloser) (io.ReadCloser, error)
 }

--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -78,7 +78,7 @@ func createAPICommandGroupToCobraCommand(group api.Group) *cobra.Command {
 	}
 }
 
-//nolint: gocyclo
+//nolint:gocyclo
 func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 	// command properties
 	commandName := strcase.ToLowerCamel(command.OperationID)

--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
+	"strings"
 
 	"github.com/iancoleman/strcase"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/api"
@@ -31,6 +33,7 @@ var (
 	ErrFailedToSetUntouchedFlags         = errors.New("failed to set untouched flags")
 	ErrServerReturnedAnErrorResponseCode = errors.New("server returned an error response code")
 	ErrAPICommandsHasNoVersions          = errors.New("api command has no versions")
+	BinaryOutputTypes                    = []string{"gzip"}
 )
 
 func Builder() *cobra.Command {
@@ -75,6 +78,7 @@ func createAPICommandGroupToCobraCommand(group api.Group) *cobra.Command {
 	}
 }
 
+//nolint: gocyclo
 func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 	// command properties
 	commandName := strcase.ToLowerCamel(command.OperationID)
@@ -82,6 +86,8 @@ func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 
 	// flag values
 	file := ""
+	format := ""
+	outputFile := ""
 	version, err := defaultAPIVersion(command)
 	if err != nil {
 		return nil, err
@@ -92,14 +98,33 @@ func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 		Short: shortDescription,
 		Long:  longDescription,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Go through all commands that have not been touched/modified by the user and try to populate them from the users profile
+			// Common usecases:
+			// - set orgId
+			// - set projectId
 			if err := setUnTouchedFlags(NewProfileFlagValueProviderForDefaultProfile(), cmd); err != nil {
 				return errors.Join(ErrFailedToSetUntouchedFlags, err)
+			}
+
+			// Detect if stdout is being piped (atlas api myTag myOperationId > output.json)
+			isPiped, err := IsStdOutPiped()
+			if err != nil {
+				return err
+			}
+
+			// If the selected output format is binary and stdout is not being piped, mark output as required
+			// This ensures that the console isn't flooded with binary contents (for example gzip contents)
+			if slices.Contains(BinaryOutputTypes, format) && !isPiped {
+				if err := cmd.MarkFlagRequired("output"); err != nil {
+					return err
+				}
 			}
 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Get the request input if needed
+			// This is needed for most PATCH/POST/PUT requests
 			var content io.ReadCloser
 			if needsFileFlag(command) {
 				content, err = handleInput(cmd)
@@ -110,30 +135,45 @@ func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 			}
 
 			// Create a new executor
+			// This is the piece of code which knows how to execute api.Commands
 			executor, err := api.NewDefaultExecutor()
 			if err != nil {
 				return err
 			}
 
 			// Convert the api command + cobra command into a api command request
-			commandRequest, err := NewCommandRequestFromCobraCommand(cmd, command, content, version)
+			commandRequest, err := NewCommandRequestFromCobraCommand(cmd, command, content, format, version)
 			if err != nil {
 				return err
 			}
 
 			// Execute the api command request
+			// This function will return an error if the http request failed
+			// When the http request returns a non-success code error will still be nil
 			result, err := executor.ExecuteCommand(cmd.Context(), *commandRequest)
 			if err != nil {
 				return err
 			}
 
-			// TODO: handle output + custom output format, separate ticket: CLOUDP-280747
+			// Properly free up result output
 			defer result.Output.Close()
-			_, err = io.Copy(os.Stdout, result.Output)
+
+			// Determine where to write the
+			output, err := getOutputWriteCloser(outputFile)
+			if err != nil {
+				return err
+			}
+			// Properly free up output
+			defer output.Close()
+
+			// Write the output
+			_, err = io.Copy(output, result.Output)
 			if err != nil {
 				return err
 			}
 
+			// In case the http status code was non-success
+			// Return an error, this causes the CLI to exit with a non-zero exit code while still running all telemetry code
 			if !result.IsSuccess {
 				return ErrServerReturnedAnErrorResponseCode
 			}
@@ -142,13 +182,21 @@ func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 		},
 	}
 
-	// common flags
+	// Common flags
 	// TODO: proper flag description and constants, CLOUDP-280742
 	cmd.Flags().StringVar(&version, "version", version, "api version")
 	if needsFileFlag(command) {
 		cmd.Flags().StringVar(&file, "file", "", "api request file content")
 	}
 
+	// Add format flags:
+	// - `--format`: desired output format, translates to ContentType. Can also be a go template
+	// - `--output`: file where we want to write the output to
+	if err := addFormatFlags(cmd, command, &format, &outputFile); err != nil {
+		return nil, err
+	}
+
+	//
 	if err := addParameters(cmd, command.RequestParameters.URLParameters); err != nil {
 		return nil, err
 	}
@@ -213,18 +261,14 @@ func setUnTouchedFlags(flagValueProvider FlagValueProvider, cmd *cobra.Command) 
 }
 
 func handleInput(cmd *cobra.Command) (io.ReadCloser, error) {
-	// Check if data is being piped to stdin
-	info, err := os.Stdin.Stat()
+	isPiped, err := IsStdInPiped()
 	if err != nil {
-		return nil, fmt.Errorf("error checking stdin: %w", err)
+		return nil, err
 	}
-
-	// Check if there's data in stdin (piped input)
-	isPiped := (info.Mode() & os.ModeCharDevice) == 0
 
 	if isPiped {
 		// Use stdin as the input
-		return os.Stdin, nil
+		return nil, nil
 	}
 
 	// If not piped, get the file flag
@@ -247,6 +291,27 @@ func handleInput(cmd *cobra.Command) (io.ReadCloser, error) {
 	return file, nil
 }
 
+func IsStdInPiped() (bool, error) {
+	return isPiped(os.Stdin)
+}
+
+func IsStdOutPiped() (bool, error) {
+	return isPiped(os.Stdout)
+}
+
+func isPiped(file *os.File) (bool, error) {
+	// Check if data is being piped to stdin
+	info, err := file.Stat()
+	if err != nil {
+		return false, fmt.Errorf("isPiped, error checking: %w", err)
+	}
+
+	// Check if there's data in stdin (piped input)
+	isPiped := (info.Mode() & os.ModeCharDevice) == 0
+
+	return isPiped, nil
+}
+
 func defaultAPIVersion(command api.Command) (string, error) {
 	// Command versions are sorted by the generation tool
 	nVersions := len(command.Versions)
@@ -266,4 +331,74 @@ func needsFileFlag(apiCommand api.Command) bool {
 	}
 
 	return false
+}
+
+func addFormatFlags(cmd *cobra.Command, apiCommand api.Command, format *string, outputFile *string) error {
+	// Get the list of supported content types for the apiCommand
+	supportedContentTypesList := getContentTypes(&apiCommand)
+
+	// If there's only one content type, set the format to that
+	numSupportedContentTypes := len(supportedContentTypesList)
+	if numSupportedContentTypes == 1 {
+		*format = supportedContentTypesList[0]
+	}
+
+	// If the content type has json, also add {{go template}} as an option to the --format help
+	if slices.Contains(supportedContentTypesList, "json") {
+		supportedContentTypesList = append(supportedContentTypesList, "{{go template}}")
+	}
+
+	// Generate a list of supported content types and add it to --help for --format
+	// Example [csv, json, {{go template}}]
+	supportedContentTypesString := strings.Join(supportedContentTypesList, ", ")
+
+	// Set the flags
+	cmd.Flags().StringVar(format, "format", *format, fmt.Sprintf("preferred api format, can be [%s]", supportedContentTypesString))
+	cmd.Flags().StringVar(outputFile, "output", "", "file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip).")
+
+	// If there's multiple content types, mark --format as required
+	if numSupportedContentTypes > 1 {
+		if err := cmd.MarkFlagRequired("format"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getContentTypes(apiCommand *api.Command) []string {
+	// Create a unique list of all supported content types
+	// First create a map to convert 2 nested lists into a map
+	supportedContentTypes := make(map[string]struct{}, 0)
+	for _, version := range apiCommand.Versions {
+		for _, contentType := range version.ResponseContentTypes {
+			supportedContentTypes[contentType] = struct{}{}
+		}
+	}
+
+	// Convert the keys of the map into a list
+	supportedContentTypesList := make([]string, 0, len(supportedContentTypes))
+	for contentType := range supportedContentTypes {
+		supportedContentTypesList = append(supportedContentTypesList, contentType)
+	}
+
+	// Sort the list
+	slices.Sort(supportedContentTypesList)
+
+	return supportedContentTypesList
+}
+
+func getOutputWriteCloser(outputFile string) (io.WriteCloser, error) {
+	// If an output file is specified, create/open the file and return the writer
+	if outputFile != "" {
+		//nolint: mnd
+		file, err := os.OpenFile(outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return nil, err
+		}
+		return file, nil
+	}
+
+	// Return stdout by default
+	return os.Stdout, nil
 }

--- a/internal/cli/api/command_request.go
+++ b/internal/cli/api/command_request.go
@@ -22,11 +22,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func NewCommandRequestFromCobraCommand(cobraCommand *cobra.Command, apiCommand api.Command, content io.Reader, version string) (*api.CommandRequest, error) {
+func NewCommandRequestFromCobraCommand(cobraCommand *cobra.Command, apiCommand api.Command, content io.Reader, format string, version string) (*api.CommandRequest, error) {
 	return &api.CommandRequest{
 		Command:    apiCommand,
-		Content:    content, // content has to be set by caller
-		Format:     "json",  // part of CLOUDP-280747
+		Content:    content,
+		Format:     format,
 		Parameters: cobraFlagsToRequestParameters(cobraCommand),
 		Version:    version,
 	}, nil
@@ -41,6 +41,12 @@ func cobraFlagsToRequestParameters(cobraCommand *cobra.Command) map[string][]str
 
 	cobraCommand.LocalFlags().VisitAll(func(flag *pflag.Flag) {
 		if _, ignoreFlag := flagsToIgnore[flag.Name]; ignoreFlag {
+			return
+		}
+
+		// If the flag has not been set, don't set the value
+		// Doing this would cause the request to contain all default values and might set not required values to not desired values
+		if !flag.Changed {
 			return
 		}
 

--- a/internal/cli/api/command_request_test.go
+++ b/internal/cli/api/command_request_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCobraFlagsToRequestParameters(t *testing.T) {
+	cmd := func(args string) *cobra.Command {
+		t.Helper()
+
+		cmd := new(cobra.Command)
+		cmd.Flags().String("foo", "foo-default-value", "foo-usage")
+		cmd.Flags().Int("bar", 42, "bar-usage")
+		cmd.Flags().Bool("baz", true, "baz-usage")
+		cmd.Flags().StringSlice("qux", []string{"qux", "quz"}, "qux-usage")
+		require.NoError(t, cmd.ParseFlags(strings.Split(args, " ")))
+		return cmd
+	}
+
+	tests := []struct {
+		name               string
+		command            *cobra.Command
+		expectedParameters map[string][]string
+	}{
+		{
+			name:               "empty string",
+			command:            cmd(""),
+			expectedParameters: map[string][]string{},
+		},
+		{
+			name:    "--foo fooo",
+			command: cmd("--foo fooo"),
+			expectedParameters: map[string][]string{
+				"foo": {"fooo"},
+			},
+		},
+		{
+			name:    "basic type",
+			command: cmd("--foo fooo --bar 2 --baz=false"),
+			expectedParameters: map[string][]string{
+				"foo": {"fooo"},
+				"bar": {"2"},
+				"baz": {"false"},
+			},
+		},
+		{
+			name:    "slice 1",
+			command: cmd("--qux foo,bar"),
+			expectedParameters: map[string][]string{
+				"qux": {"foo", "bar"},
+			},
+		},
+		{
+			name:    "slice 2",
+			command: cmd("--qux foo --qux bar"),
+			expectedParameters: map[string][]string{
+				"qux": {"foo", "bar"},
+			},
+		},
+		{
+			name:    "all",
+			command: cmd("--foo f --qux foo --bar 99 --baz --qux bar"),
+			expectedParameters: map[string][]string{
+				"qux": {"foo", "bar"},
+				"foo": {"f"},
+				"bar": {"99"},
+				"baz": {"true"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parameters := cobraFlagsToRequestParameters(tt.command)
+			require.Equal(t, tt.expectedParameters, parameters)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes
- support for `--format`
    - support content type
    - support go templates
- support for `--output`
    - `--output` is required when not piping `stdout` and content type is binary
- fixed bug where all flags were set even though the user did not set them + added more tests

_Jira ticket:_ CLOUDP-280747
