### PR TITLE
CLOUDP-285945: Add support for Flex Clusters to `atlas cluster remove`

### DIFF
--- a/internal/cli/clusters/delete.go
+++ b/internal/cli/clusters/delete.go
@@ -46,8 +46,7 @@ func (opts *DeleteOpts) initStore(ctx context.Context) func() error {
 }
 
 func (opts *DeleteOpts) Run() error {
-	err := opts.Delete(opts.store.DeleteCluster, opts.ConfigProjectID())
-	if err != nil {
+	if err := opts.Delete(opts.store.DeleteCluster, opts.ConfigProjectID()); err != nil {
 		return opts.RunFlexCluster(err)
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-285945


This PR updates `atlas cluster delete` to support Flex Clusters.


```
./bin/atlas cluster delete ClusterFlex -P prod                                                                                           
? This operation will delete the cluster and all of its data. Confirm your backup settings before terminating your cluster. This action cannot be undone.
Are you sure you want to terminate ClusterFlex? Yes
Deleting cluster 'ClusterFlex'
```

```
./bin/atlas cluster delete ClusterM10 -P prod --force                                                                                      
Deleting cluster 'ClusterM10'
```