### PR TITLE
CLOUDP-289992: [AtlasCLI] add --description in the "atlas dbusers create" command

### DIFF
--- a/docs/command/atlas-dbusers-create.txt
+++ b/docs/command/atlas-dbusers-create.txt
@@ -65,6 +65,10 @@ Options
      - string
      - false
      - Timestamp in ISO 8601 in UTC after which Atlas deletes the user.
+   * - --desc
+     - string
+     - false
+     - Description of this database user.
    * - -h, --help
      - 
      - false

--- a/docs/command/atlas-dbusers-update.txt
+++ b/docs/command/atlas-dbusers-update.txt
@@ -57,6 +57,10 @@ Options
      - string
      - false
      - Authentication database name. If the user authenticates with AWS IAM, x.509, or LDAP, this value should be $external. If the user authenticates with SCRAM-SHA, this value should be admin.
+   * - --desc
+     - string
+     - false
+     - Description of this database user.
    * - -h, --help
      - 
      - false

--- a/internal/cli/dbusers/create.go
+++ b/internal/cli/dbusers/create.go
@@ -43,6 +43,7 @@ type CreateOpts struct {
 	ldapType    string
 	oidcType    string
 	deleteAfter string
+	description string
 	roles       []string
 	scopes      []string
 	store       store.DatabaseUserCreator
@@ -138,6 +139,10 @@ func (opts *CreateOpts) newDatabaseUser() *atlasv2.CloudDatabaseUser {
 
 	if opts.oidcType != "" {
 		u.OidcAuthType = &opts.oidcType
+	}
+
+	if opts.description != "" {
+		u.Description = &opts.description
 	}
 
 	return u
@@ -239,6 +244,7 @@ func CreateBuilder() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.username, flag.Username, flag.UsernameShort, "", usage.DBUsername)
 	cmd.Flags().StringVarP(&opts.password, flag.Password, flag.PasswordShort, "", usage.DBUserPassword)
 	cmd.Flags().StringVar(&opts.deleteAfter, flag.DeleteAfter, "", usage.BDUsersDeleteAfter)
+	cmd.Flags().StringVar(&opts.description, flag.Description, "", usage.DBUserDescription)
 	cmd.Flags().StringSliceVar(&opts.roles, flag.Role, []string{}, usage.RolesExtended)
 	cmd.Flags().StringSliceVar(&opts.scopes, flag.Scope, []string{}, usage.Scopes)
 	cmd.Flags().StringVar(&opts.x509Type, flag.X509Type, none, usage.X509Type)

--- a/internal/cli/dbusers/create_test.go
+++ b/internal/cli/dbusers/create_test.go
@@ -49,12 +49,13 @@ func TestDBUserCreateOpts_Run(t *testing.T) {
 
 func TestCreateOpts_validate(t *testing.T) {
 	type fields struct {
-		x509Type   string
-		awsIamType string
-		oidcType   string
-		ldapType   string
-		password   string
-		roles      []string
+		x509Type    string
+		awsIamType  string
+		oidcType    string
+		ldapType    string
+		password    string
+		description string
+		roles       []string
 	}
 	tests := []struct {
 		name    string
@@ -113,23 +114,25 @@ func TestCreateOpts_validate(t *testing.T) {
 		{
 			name: "awsIamType and password",
 			fields: fields{
-				roles:      []string{"test"},
-				awsIamType: user,
-				ldapType:   none,
-				oidcType:   none,
-				x509Type:   none,
-				password:   "password",
+				roles:       []string{"test"},
+				awsIamType:  user,
+				ldapType:    none,
+				oidcType:    none,
+				x509Type:    none,
+				description: "test",
+				password:    "password",
 			},
 			wantErr: true,
 		},
 		{
 			name: "no external auth",
 			fields: fields{
-				roles:      []string{"test"},
-				awsIamType: none,
-				ldapType:   none,
-				x509Type:   none,
-				oidcType:   none,
+				roles:       []string{"test"},
+				awsIamType:  none,
+				ldapType:    none,
+				x509Type:    none,
+				description: "test",
+				oidcType:    none,
 			},
 			wantErr: false,
 		},
@@ -163,12 +166,13 @@ func TestCreateOpts_validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			opts := &CreateOpts{
-				x509Type:   fields.x509Type,
-				awsIamType: fields.awsIamType,
-				ldapType:   fields.ldapType,
-				oidcType:   fields.oidcType,
-				roles:      fields.roles,
-				password:   fields.password,
+				x509Type:    fields.x509Type,
+				awsIamType:  fields.awsIamType,
+				ldapType:    fields.ldapType,
+				oidcType:    fields.oidcType,
+				roles:       fields.roles,
+				password:    fields.password,
+				description: fields.description,
 			}
 			if err := opts.validate(); (err != nil) != wantErr {
 				t.Errorf("validate() error = %v, wantErr %v", err, wantErr)

--- a/internal/cli/dbusers/update.go
+++ b/internal/cli/dbusers/update.go
@@ -39,9 +39,10 @@ type UpdateOpts struct {
 	currentUsername string
 	password        string
 	authDB          string
+	x509Type        string
+	description     string
 	roles           []string
 	scopes          []string
-	x509Type        string
 	store           store.DatabaseUserUpdater
 }
 
@@ -80,6 +81,10 @@ func (opts *UpdateOpts) update(out *admin.CloudDatabaseUser) {
 	}
 	if opts.password != "" {
 		out.Password = &opts.password
+	}
+
+	if opts.description != "" {
+		out.Description = &opts.description
 	}
 
 	roles := convert.BuildAtlasRoles(opts.roles)
@@ -136,6 +141,7 @@ func UpdateBuilder() *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.username, flag.Username, flag.UsernameShort, "", usage.DBUsername)
 	cmd.Flags().StringVarP(&opts.password, flag.Password, flag.PasswordShort, "", usage.DBUserPassword)
+	cmd.Flags().StringVar(&opts.description, flag.Description, "", usage.DBUserDescription)
 	cmd.Flags().StringVar(&opts.authDB, flag.AuthDB, "", usage.AtlasAuthDB)
 	cmd.Flags().StringSliceVar(&opts.roles, flag.Role, []string{}, usage.Roles+usage.UpdateWarning)
 	cmd.Flags().StringSliceVar(&opts.scopes, flag.Scope, []string{}, usage.Scopes+usage.UpdateWarning)

--- a/internal/cli/dbusers/update_test.go
+++ b/internal/cli/dbusers/update_test.go
@@ -35,6 +35,7 @@ func TestDBUserUpdate_Run(t *testing.T) {
 		currentUsername: "test4",
 		password:        "US",
 		roles:           []string{"admin@admin"},
+		description:     "test",
 		store:           mockStore,
 	}
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -51,6 +51,7 @@ const (
 	Username                                 = "Name that identifies the user. You must specify a valid email address."
 	TeamUsername                             = "Comma-separated list that contains the valid usernames of the MongoDB users to add to the new team. A team must have at least one user. New users must accept the invitation to join an organization before you can add them to a team."
 	DBUsername                               = "Username for authenticating to MongoDB."
+	DBUserDescription                        = "Description of this database user."
 	TeamName                                 = "Label that identifies the team."
 	UserID                                   = "Unique 24-digit identifier of the user."
 	LDAPHostname                             = "Hostname or IP address of the LDAP server."


### PR DESCRIPTION
_Jira ticket:_ CLOUDP-289992


### Create command
```json
./bin/atlas dbusers create atlasAdmin --username myAdmin --desc "test" -o json                                                         
? Password: ****
{
  "awsIAMType": "NONE",
  "databaseName": "admin",
  "description": "test",
  "groupId": "64e35909e8391140696332c0",
  "labels": [],
  "ldapAuthType": "NONE",
  "links": [
    {
      "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/64e35909e8391140696332c0/databaseUsers/admin/myAdmin",
      "rel": "self"
    }
  ],
  "oidcAuthType": "NONE",
  "roles": [
    {
      "databaseName": "admin",
      "roleName": "atlasAdmin"
    }
  ],
  "scopes": [],
  "username": "myAdmin",
  "x509Type": "NONE"
}
```
### Update Command

```json
./bin/atlas dbuser update myAdmin --desc "test Update" -o json                                                      
{
  "awsIAMType": "NONE",
  "databaseName": "admin",
  "description": "test Update",
  "groupId": "64e35909e8391140696332c0",
  "labels": [],
  "ldapAuthType": "NONE",
  "links": [
    {
      "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/64e35909e8391140696332c0/databaseUsers/admin/myAdmin",
      "rel": "self"
    }
  ],
  "oidcAuthType": "NONE",
  "roles": [],
  "scopes": [],
  "username": "myAdmin",
  "x509Type": "NONE"
}
```