### PR TITLE
CLOUDP-285948: add support for flex clusters to 'atlas backup snaphots get'

### DIFF
--- a/internal/cli/backup/snapshots/describe.go
+++ b/internal/cli/backup/snapshots/describe.go
@@ -54,19 +54,18 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 
 func (opts *DescribeOpts) Run() error {
 	r, err := opts.store.FlexClusterSnapshot(opts.ConfigProjectID(), opts.clusterName, opts.snapshot)
-	apiError, ok := atlasv2.AsError(err)
-	if !ok {
+	if err == nil {
 		opts.Template = describeTemplateFlex
 		return opts.Print(r)
+	}
+
+	apiError, ok := atlasv2.AsError(err)
+	if !ok {
+		return err
 	}
 
 	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode {
 		return err
-	}
-
-	if err == nil {
-		opts.Template = describeTemplateFlex
-		return opts.Print(r)
 	}
 
 	snapshots, err := opts.store.Snapshot(opts.ConfigProjectID(), opts.clusterName, opts.snapshot)

--- a/internal/cli/backup/snapshots/describe_test.go
+++ b/internal/cli/backup/snapshots/describe_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20241113002/admin"
 )
 
@@ -35,14 +36,40 @@ func TestDescribe_Run(t *testing.T) {
 		store: mockStore,
 	}
 
+	expectedError := &atlasv2.GenericOpenAPIError{}
+	expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
+
+	mockStore.
+		EXPECT().
+		FlexClusterSnapshot(describeOpts.ProjectID, describeOpts.clusterName, describeOpts.snapshot).
+		Return(nil, expectedError).
+		Times(1)
+
 	mockStore.
 		EXPECT().
 		Snapshot(describeOpts.ProjectID, describeOpts.clusterName, describeOpts.snapshot).
 		Return(&expected, nil).
 		Times(1)
 
-	if err := describeOpts.Run(); err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
-	}
+	require.NoError(t, describeOpts.Run())
 	test.VerifyOutputTemplate(t, describeTemplate, expected)
+}
+
+func TestDescribe_Run_FlexCluster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockSnapshotsDescriber(ctrl)
+	expected := &atlasv2.FlexBackupSnapshot20241113{}
+
+	describeOpts := &DescribeOpts{
+		store: mockStore,
+	}
+
+	mockStore.
+		EXPECT().
+		FlexClusterSnapshot(describeOpts.ProjectID, describeOpts.clusterName, describeOpts.snapshot).
+		Return(expected, nil).
+		Times(1)
+
+	require.NoError(t, describeOpts.Run())
+	test.VerifyOutputTemplate(t, describeTemplateFlex, expected)
 }

--- a/internal/cli/backup/snapshots/snapshots.go
+++ b/internal/cli/backup/snapshots/snapshots.go
@@ -19,6 +19,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	cannotUseNotFlexWithFlexApisErrorCode = "CANNOT_USE_NON_FLEX_CLUSTER_IN_FLEX_API"
+)
+
 func Builder() *cobra.Command {
 	const use = "snapshots"
 	cmd := &cobra.Command{


### PR DESCRIPTION
Ticket: CLOUDP-285948
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
This PR adds support for Flex Cluster to `atlas backup snaphots get`


## Flex Cluster

```json
 ./bin/atlas backup snapshots get 6760158f52708c22437edb7a --clusterName ClusterFlex -P prod -o json                               
 {
  "expiration": "2024-12-24T11:56:22Z",
  "finishTime": "2024-12-16T11:58:50Z",
  "id": "6760158f52708c22437edb7a",
  "mongoDBVersion": "8.0.3",
  "scheduledTime": "2024-12-16T11:56:22Z",
  "startTime": "2024-12-16T11:57:09Z",
  "status": "COMPLETED"
}
```
```bash

 ./bin/atlas backup snapshots get 6760158f52708c22437edb7a --clusterName ClusterFlex -P prod                                          
ID                         STATUS      MONGODB VERSION   START TIME                      FINISH TIME                     EXPIRATION
6760158f52708c22437edb7a   COMPLETED   8.0.3             2024-12-16 11:57:09 +0000 UTC   2024-12-16 11:58:50 +0000 UTC   2024-12-24 11:56:22 +0000 UTC
```


## Dedicated Cluster
```bash
./bin/atlas backup snapshots get 676145dc6af0b746ef72aaec --clusterName ClusterDedicated -P prod                                           
ID                         SNAPSHOT TYPE   TYPE         DESCRIPTION   EXPIRES AT
676145dc6af0b746ef72aaec   onDemand        replicaSet   t1            2024-12-20 09:39:07 +0000 UTC
```