### PR TITLE
CLOUDP-285949: add support for flex clusters to `atlas backup snaphots list`

### DIFF
--- a/internal/cli/backup/snapshots/list.go
+++ b/internal/cli/backup/snapshots/list.go
@@ -46,10 +46,14 @@ func (opts *ListOpts) initStore(ctx context.Context) func() error {
 var listTemplate = `ID	TYPE	STATUS	CREATED AT	EXPIRES AT{{range valueOrEmptySlice .Results}}
 {{.Id}}	{{.SnapshotType}}	{{.Status}}	{{.CreatedAt}}	{{.ExpiresAt}}{{end}}
 `
+var listTemplateFlex = `ID	STATUS	MONGODB VERSION	START TIME	FINISH TIME	EXPIRATION{{range valueOrEmptySlice .Results}}
+{{.Id}}	{{.Status}}	{{.MongoDBVersion}}	{{.StartTime}}	{{.FinishTime}}	{{.Expiration}}{{end}}
+`
 
 func (opts *ListOpts) Run() error {
 	r, err := opts.store.FlexClusterSnapshots(opts.newListFlexBackupsAPIParams())
 	if err == nil {
+		opts.Template = listTemplateFlex
 		return opts.Print(r)
 	}
 

--- a/internal/cli/backup/snapshots/list_test.go
+++ b/internal/cli/backup/snapshots/list_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20241113002/admin"
 )
 
@@ -52,14 +53,45 @@ func TestList_Run(t *testing.T) {
 		},
 	}
 
+	expectedError := &atlasv2.GenericOpenAPIError{}
+	expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
+
+	mockStore.
+		EXPECT().
+		FlexClusterSnapshots(listOpts.newListFlexBackupsAPIParams()).
+		Return(nil, expectedError).
+		Times(1)
+
 	mockStore.
 		EXPECT().
 		Snapshots(listOpts.ProjectID, "Cluster0", listOpts.NewListOptions()).
 		Return(expected, nil).
 		Times(1)
 
-	if err := listOpts.Run(); err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
+	require.NoError(t, listOpts.Run())
+	test.VerifyOutputTemplate(t, listTemplate, expected)
+}
+
+func TestList_Run_FlexCluster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockSnapshotsLister(ctrl)
+	expected := &atlasv2.PaginatedApiAtlasFlexBackupSnapshot20241113{}
+	buf := new(bytes.Buffer)
+	listOpts := &ListOpts{
+		store:       mockStore,
+		clusterName: "Cluster0",
+		OutputOpts: cli.OutputOpts{
+			Template:  listTemplate,
+			OutWriter: buf,
+		},
 	}
+
+	mockStore.
+		EXPECT().
+		FlexClusterSnapshots(listOpts.newListFlexBackupsAPIParams()).
+		Return(expected, nil).
+		Times(1)
+
+	require.NoError(t, listOpts.Run())
 	test.VerifyOutputTemplate(t, listTemplate, expected)
 }


### PR DESCRIPTION
Ticket: CLOUDP-285949

This PR adds support for Flex Cluster to `atlas backup snapshot ls`


<details>
  <summary>Flex Cluster </summary>

```
./bin/atlas backup snapshots list ClusterFlex -P prod

ID                         STATUS      MONGODB VERSION   START TIME                      FINISH TIME                     EXPIRATION
675acf673a6b85483b198fd9   COMPLETED   8.0.3             2024-12-12 11:56:29 +0000 UTC   2024-12-12 11:58:09 +0000 UTC   2024-12-20 11:56:22 +0000 UTC
675c210196f62d6daa176b5c   COMPLETED   8.0.3             2024-12-13 11:56:55 +0000 UTC   2024-12-13 11:58:34 +0000 UTC   2024-12-21 11:56:22 +0000 UTC
675d728f52708c2243e0b536   COMPLETED   8.0.3             2024-12-14 11:57:09 +0000 UTC   2024-12-14 11:58:50 +0000 UTC   2024-12-22 11:56:22 +0000 UTC
675ec41052708c22432f5ad6   COMPLETED   8.0.3             2024-12-15 11:57:10 +0000 UTC   2024-12-15 11:58:50 +0000 UTC   2024-12-23 11:56:22 +0000 UTC
6760158f52708c22437edb7a   COMPLETED   8.0.3             2024-12-16 11:57:09 +0000 UTC   2024-12-16 11:58:50 +0000 UTC   2024-12-24 11:56:22 +0000 UTC
6761671152708c2243d5258c   COMPLETED   8.0.3             2024-12-17 11:57:10 +0000 UTC   2024-12-17 11:58:44 +0000 UTC   2024-12-25 11:56:22 +0000 UTC
```
```json
./bin/atlas backup snapshots list ClusterFlex -P prod -o json                                                                     
{
  "links": [
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/flexClusters/ClusterFlex/backup/snapshots?includeCount=true\u0026pageNum=1\u0026itemsPerPage=100",
      "rel": "self"
    }
  ],
  "results": [
    {
      "expiration": "2024-12-20T11:56:22Z",
      "finishTime": "2024-12-12T11:58:09Z",
      "id": "675acf673a6b85483b198fd9",
      "mongoDBVersion": "8.0.3",
      "scheduledTime": "2024-12-12T11:56:22Z",
      "startTime": "2024-12-12T11:56:29Z",
      "status": "COMPLETED"
    },
    {
      "expiration": "2024-12-21T11:56:22Z",
      "finishTime": "2024-12-13T11:58:34Z",
      "id": "675c210196f62d6daa176b5c",
      "mongoDBVersion": "8.0.3",
      "scheduledTime": "2024-12-13T11:56:22Z",
      "startTime": "2024-12-13T11:56:55Z",
      "status": "COMPLETED"
    },
    {
      "expiration": "2024-12-22T11:56:22Z",
      "finishTime": "2024-12-14T11:58:50Z",
      "id": "675d728f52708c2243e0b536",
      "mongoDBVersion": "8.0.3",
      "scheduledTime": "2024-12-14T11:56:22Z",
      "startTime": "2024-12-14T11:57:09Z",
      "status": "COMPLETED"
    },
    {
      "expiration": "2024-12-23T11:56:22Z",
      "finishTime": "2024-12-15T11:58:50Z",
      "id": "675ec41052708c22432f5ad6",
      "mongoDBVersion": "8.0.3",
      "scheduledTime": "2024-12-15T11:56:22Z",
      "startTime": "2024-12-15T11:57:10Z",
      "status": "COMPLETED"
    },
    {
      "expiration": "2024-12-24T11:56:22Z",
      "finishTime": "2024-12-16T11:58:50Z",
      "id": "6760158f52708c22437edb7a",
      "mongoDBVersion": "8.0.3",
      "scheduledTime": "2024-12-16T11:56:22Z",
      "startTime": "2024-12-16T11:57:09Z",
      "status": "COMPLETED"
    },
    {
      "expiration": "2024-12-25T11:56:22Z",
      "finishTime": "2024-12-17T11:58:44Z",
      "id": "6761671152708c2243d5258c",
      "mongoDBVersion": "8.0.3",
      "scheduledTime": "2024-12-17T11:56:22Z",
      "startTime": "2024-12-17T11:57:10Z",
      "status": "COMPLETED"
    }
  ],
  "totalCount": 6
}
```

</details>

<details>
  <summary>Dedicated Cluster </summary>

```
./bin/atlas backup snapshots list ClusterDedicated -P prod                                                                               
ID                         TYPE       STATUS      CREATED AT                      EXPIRES AT
676145dc6af0b746ef72aaec   onDemand   completed   2024-12-17 09:37:50 +0000 UTC   2024-12-20 09:39:07 +0000 UTC
```

</details>
