### PR TITLE
CLOUDP-285953: add support for flex clusters to `atlas backup restores get`

### DIFF
--- a/internal/cli/backup/restores/describe.go
+++ b/internal/cli/backup/restores/describe.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
 	"github.com/spf13/cobra"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20241113002/admin"
 )
 
 type DescribeOpts struct {
@@ -47,23 +48,44 @@ var restoreDescribeTemplate = `ID	SNAPSHOT	CLUSTER	TYPE	EXPIRES AT	URLs
 {{.Id}}	{{.SnapshotId}}	{{.TargetClusterName}}	{{.DeliveryType}}	{{.ExpiresAt}}	{{range $index, $element := valueOrEmptySlice .DeliveryUrl}}{{if $index}}; {{end}}{{$element}}{{end}}
 `
 
+var restoreDescribeFlexClusterTemplate = `ID	SNAPSHOT	CLUSTER	TYPE	EXPIRES AT	URLs
+{{.Id}}	{{.SnapshotId}}	{{.TargetDeploymentItemName}}	{{.DeliveryType}}	{{.ExpirationDate}}	{{range $index, $element := valueOrEmptySlice .SnapshotUrl}}{{if $index}}; {{end}}{{$element}}{{end}}
+`
+
 func (opts *DescribeOpts) Run() error {
-	r, err := opts.store.RestoreJob(opts.ConfigProjectID(), opts.clusterName, opts.id)
+	r, err := opts.store.RestoreFlexClusterJob(opts.ConfigProjectID(), opts.clusterName, opts.id)
+	if err == nil {
+		opts.Template = restoreDescribeFlexClusterTemplate
+		return opts.Print(r)
+	}
+
+	apiError, ok := atlasv2.AsError(err)
+	if !ok {
+		return err
+	}
+
+	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode {
+		return err
+	}
+
+	restoreJob, err := opts.store.RestoreJob(opts.ConfigProjectID(), opts.clusterName, opts.id)
 	if err != nil {
 		return err
 	}
 
-	return opts.Print(r)
+	return opts.Print(restoreJob)
 }
 
+// DescribeBuilder builds a cobra.Command that can run as:
 // atlas backup(s) restore(s) job(s) describe <ID>.
 func DescribeBuilder() *cobra.Command {
 	opts := new(DescribeOpts)
 	cmd := &cobra.Command{
-		Use:   "describe <restoreJobId>",
-		Short: "Describe a cloud backup restore job.",
-		Long:  fmt.Sprintf(usage.RequiredRole, "Project Owner"),
-		Args:  require.ExactArgs(1),
+		Use:     "describe <restoreJobId>",
+		Aliases: []string{"get"},
+		Short:   "Describe a cloud backup restore job.",
+		Long:    fmt.Sprintf(usage.RequiredRole, "Project Owner"),
+		Args:    require.ExactArgs(1),
 		Annotations: map[string]string{
 			"restoreJobIdDesc": "ID of the restore job.",
 		},

--- a/internal/cli/backup/restores/restores.go
+++ b/internal/cli/backup/restores/restores.go
@@ -19,6 +19,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	cannotUseNotFlexWithFlexApisErrorCode = "CANNOT_USE_NON_FLEX_CLUSTER_IN_FLEX_API"
+)
+
 func Builder() *cobra.Command {
 	const use = "restores"
 	cmd := &cobra.Command{


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-285953

This PR updates `atlas backup restores get` to support flex clusters.
<details>
<summary> Flex Cluster </summary>

```json
./bin/atlas backup restore get 676199f379377141139ad79c --clusterName ClusterFlex -P prod -o json                                   
{
  "deliveryType": "RESTORE",
  "expirationDate": "2024-12-17T21:34:11Z",
  "id": "676199f379377141139ad79c",
  "instanceName": "ClusterFlex",
  "projectId": "663268874ddd3b236fd2f107",
  "restoreFinishedDate": "2024-12-17T15:35:01Z",
  "restoreScheduledDate": "2024-12-17T15:34:11Z",
  "snapshotFinishedDate": "2024-12-16T11:58:50Z",
  "snapshotId": "6760158f52708c22437edb7a",
  "status": "COMPLETED",
  "targetDeploymentItemName": "ClusterFlex",
  "targetProjectId": "663268874ddd3b236fd2f107"
}
```

```bash
 ./bin/atlas backup restore get 676199f379377141139ad79c --clusterName ClusterFlex -P prod                                            
 ID                         SNAPSHOT                   CLUSTER       TYPE      EXPIRES AT                      URLs
676199f379377141139ad79c   6760158f52708c22437edb7a   ClusterFlex   RESTORE   2024-12-17 21:34:11 +0000 UTC

```

</details>

<details>
<summary>Dedicated Cluster </summary>

```json
./bin/atlas backup restore get 6762b574ac7a500609061084 --clusterName ClusterDedicated -P prod -o json                                  
{
  "cancelled": false,
  "deliveryType": "pointInTime",
  "deliveryUrl": [],
  "desiredTimestamp": {
    "date": "2024-12-17T12:00:00Z",
    "increment": 0
  },
  "expired": false,
  "failed": false,
  "id": "6762b574ac7a500609061084",
  "links": [
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/ClusterFlex1/backup/restoreJobs/6762b574ac7a500609061084",
      "rel": "self"
    },
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/ClusterFlex1/backup/snapshots/676145dc6af0b746ef72aaec",
      "rel": "https://cloud.mongodb.com/snapshot"
    },
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/ClusterFlex1",
      "rel": "https://cloud.mongodb.com/cluster"
    },
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107",
      "rel": "https://cloud.mongodb.com/group"
    }
  ],
  "snapshotId": "676145dc6af0b746ef72aaec",
  "targetClusterName": "ClusterDedicated",
  "targetGroupId": "663268874ddd3b236fd2f107",
  "timestamp": "2024-12-17T09:37:50Z"
}
```

```bash
./bin/atlas backup restore get 6762b574ac7a500609061084 --clusterName ClusterDedicated -P prod                                        
ID                         SNAPSHOT                   CLUSTER        TYPE          EXPIRES AT   URLs
6762b574ac7a500609061084   676145dc6af0b746ef72aaec   ClusterDedicated   pointInTime   <nil>
```