### PR TITLE
CLOUDP-285952: add support for flex clusters to `atlas backup restores list`

### DIFF
--- a/internal/cli/backup/restores/list.go
+++ b/internal/cli/backup/restores/list.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
 	"github.com/spf13/cobra"
+	atlasv2 "go.mongodb.org/atlas-sdk/v20241113002/admin"
 )
 
 type ListOpts struct {
@@ -45,17 +46,47 @@ func (opts *ListOpts) initStore(ctx context.Context) func() error {
 var restoreListTemplate = `ID	SNAPSHOT	CLUSTER	TYPE	EXPIRES AT{{range valueOrEmptySlice .Results}}
 {{.Id}}	{{.SnapshotId}}	{{.TargetClusterName}}	{{.DeliveryType}}	{{.ExpiresAt}}{{end}}
 `
+var restoreListFlexClusterTemplate = `ID	SNAPSHOT	CLUSTER	TYPE	EXPIRES AT{{range valueOrEmptySlice .Results}}
+{{.Id}}	{{.SnapshotId}}	{{.TargetDeploymentItemName}}	{{.DeliveryType}}	{{.ExpirationDate}}{{end}}
+`
 
 func (opts *ListOpts) Run() error {
+	r, err := opts.store.RestoreFlexClusterJobs(opts.newListFlexBackupRestoreJobsAPIParams())
+	if err == nil {
+		opts.Template = restoreListFlexClusterTemplate
+		return opts.Print(r)
+	}
+
+	apiError, ok := atlasv2.AsError(err)
+	if !ok {
+		return err
+	}
+
+	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode {
+		return err
+	}
+
 	listOpts := opts.NewListOptions()
-	r, err := opts.store.RestoreJobs(opts.ConfigProjectID(), opts.clusterName, listOpts)
+	restoreJobs, err := opts.store.RestoreJobs(opts.ConfigProjectID(), opts.clusterName, listOpts)
 	if err != nil {
 		return err
 	}
 
-	return opts.Print(r)
+	return opts.Print(restoreJobs)
 }
 
+func (opts *ListOpts) newListFlexBackupRestoreJobsAPIParams() *atlasv2.ListFlexBackupRestoreJobsApiParams {
+	includeCount := !opts.OmitCount
+	return &atlasv2.ListFlexBackupRestoreJobsApiParams{
+		GroupId:      opts.ConfigProjectID(),
+		Name:         opts.clusterName,
+		IncludeCount: &includeCount,
+		ItemsPerPage: &opts.ItemsPerPage,
+		PageNum:      &opts.PageNum,
+	}
+}
+
+// ListBuilder builds a cobra.Command that can run as:
 // atlas backup(s) restore(s) job(s) list <clusterName> [--page N] [--limit N].
 func ListBuilder() *cobra.Command {
 	opts := new(ListOpts)

--- a/internal/cli/backup/restores/list_test.go
+++ b/internal/cli/backup/restores/list_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/test"
+	"github.com/stretchr/testify/require"
 	atlasv2 "go.mongodb.org/atlas-sdk/v20241113002/admin"
 )
 
@@ -36,15 +37,42 @@ func TestListOpts_Run(t *testing.T) {
 		clusterName: "Cluster0",
 	}
 
+	expectedError := &atlasv2.GenericOpenAPIError{}
+	expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
+
+	mockStore.
+		EXPECT().
+		RestoreFlexClusterJobs(listOpts.newListFlexBackupRestoreJobsAPIParams()).
+		Return(nil, expectedError).
+		Times(1)
+
 	mockStore.
 		EXPECT().
 		RestoreJobs(listOpts.ProjectID, "Cluster0", listOpts.NewListOptions()).
 		Return(expected, nil).
 		Times(1)
 
-	if err := listOpts.Run(); err != nil {
-		t.Fatalf("Run() unexpected error: %v", err)
+	require.NoError(t, listOpts.Run())
+	test.VerifyOutputTemplate(t, restoreListTemplate, expected)
+}
+
+func TestListOpts_Run_FlexCluster(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := mocks.NewMockRestoreJobsLister(ctrl)
+
+	expected := &atlasv2.PaginatedApiAtlasFlexBackupRestoreJob20241113{}
+
+	listOpts := &ListOpts{
+		store:       mockStore,
+		clusterName: "Cluster0",
 	}
 
-	test.VerifyOutputTemplate(t, restoreListTemplate, expected)
+	mockStore.
+		EXPECT().
+		RestoreFlexClusterJobs(listOpts.newListFlexBackupRestoreJobsAPIParams()).
+		Return(nil, nil).
+		Times(1)
+
+	require.NoError(t, listOpts.Run())
+	test.VerifyOutputTemplate(t, restoreListFlexClusterTemplate, expected)
 }

--- a/internal/cli/backup/restores/restores.go
+++ b/internal/cli/backup/restores/restores.go
@@ -19,6 +19,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	cannotUseNotFlexWithFlexApisErrorCode = "CANNOT_USE_NON_FLEX_CLUSTER_IN_FLEX_API"
+)
+
 func Builder() *cobra.Command {
 	const use = "restores"
 	cmd := &cobra.Command{


### PR DESCRIPTION

<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-285952


<details>
<summary> Flex Cluster </summary>

```bash
./bin/atlas backup restore list ClusterFlex -P prod                                                                                       
ID                         SNAPSHOT                   CLUSTER       TYPE      EXPIRES AT
676199f379377141139ad79c   6760158f52708c22437edb7a   ClusterFlex   RESTORE   2024-12-17 21:34:11 +0000 UTC
```

```json
./bin/atlas backup restore list ClusterFlex -P prod -o json                                                                               
{
  "links": [
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/flexClusters/ClusterFlex/backup/restoreJobs?includeCount=true\u0026pageNum=1\u0026itemsPerPage=100",
      "rel": "self"
    }
  ],
  "results": [
    {
      "deliveryType": "RESTORE",
      "expirationDate": "2024-12-17T21:34:11Z",
      "id": "676199f379377141139ad79c",
      "instanceName": "ClusterFlex",
      "projectId": "663268874ddd3b236fd2f107",
      "restoreFinishedDate": "2024-12-17T15:35:01Z",
      "restoreScheduledDate": "2024-12-17T15:34:11Z",
      "snapshotFinishedDate": "2024-12-16T11:58:50Z",
      "snapshotId": "6760158f52708c22437edb7a",
      "status": "COMPLETED",
      "targetDeploymentItemName": "ClusterFlex",
      "targetProjectId": "663268874ddd3b236fd2f107"
    }
  ],
  "totalCount": 1
}
```


</details>


<details>

<summary> Dedidcated Clusters </summary>

```bash
./bin/atlas backup restore list ClusterFlex1 -P prod                                                                                    
ID                         SNAPSHOT                   CLUSTER        TYPE          EXPIRES AT
6762b574ac7a500609061084   676145dc6af0b746ef72aaec   ClusterDedicated   pointInTime   <nil>
```

```json
./bin/atlas backup restore list ClusterFlex1 -P prod -o json                                                                          
{
  "links": [
    {
      "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/ClusterFlex1/backup/restoreJobs?includeCount=true\u0026pageNum=1\u0026itemsPerPage=100",
      "rel": "self"
    }
  ],
  "results": [
    {
      "cancelled": false,
      "deliveryType": "pointInTime",
      "deliveryUrl": [],
      "desiredTimestamp": {
        "date": "2024-12-17T12:00:00Z",
        "increment": 0
      },
      "expired": false,
      "failed": false,
      "finishedAt": "2024-12-18T11:57:40Z",
      "id": "6762b574ac7a500609061084",
      "links": [
        {
          "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/ClusterFlex1/backup/restoreJobs/6762b574ac7a500609061084",
          "rel": "self"
        },
        {
          "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/ClusterFlex1/backup/snapshots/676145dc6af0b746ef72aaec",
          "rel": "https://cloud.mongodb.com/snapshot"
        },
        {
          "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/clusters/ClusterFlex1",
          "rel": "https://cloud.mongodb.com/cluster"
        },
        {
          "href": "https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107",
          "rel": "https://cloud.mongodb.com/group"
        }
      ],
      "snapshotId": "676145dc6af0b746ef72aaec",
      "targetClusterName": "ClusterDedicated",
      "targetGroupId": "663268874ddd3b236fd2f107",
      "timestamp": "2024-12-17T09:37:50Z"
    }
  ],
  "totalCount": 1
}
```