### PR TITLE
CLOUDP-285956 Update AtlasCLI commands with the --tier flag to print a warning message to stderr whenever M2 or M5 tier values are specified, indicating that these values are deprecated and will be removed in a future release.

### DIFF
--- a/docs/command/atlas-clusters-create.txt
+++ b/docs/command/atlas-clusters-create.txt
@@ -135,7 +135,7 @@ Options
      - false
      - Tier for each data-bearing server in the cluster. To learn more about cluster tiers, see https://dochub.mongodb.org/core/cluster-tier-atlas.
 
-       Mutually exclusive with --file. This value defaults to "M2".
+       Mutually exclusive with --file. This value defaults to "FLEX".
    * - --type
      - string
      - false

--- a/internal/cli/clusters/availableregions/list.go
+++ b/internal/cli/clusters/availableregions/list.go
@@ -40,7 +40,7 @@ type ListOpts struct {
 const (
 	atlasM2                    = "M2"
 	atlasM5                    = "M5"
-	deprecateMessageSharedTier = "The '%s' tier is deprecated. Please use 'atlas cluster create <ClusterName> --tier FLEX' instead. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.\n"
+	deprecateMessageSharedTier = "The '%s' tier is deprecated. Please use '--tier FLEX' instead. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.\n"
 )
 
 func (opts *ListOpts) initStore(ctx context.Context) func() error {

--- a/internal/cli/clusters/availableregions/list.go
+++ b/internal/cli/clusters/availableregions/list.go
@@ -17,6 +17,8 @@ package availableregions
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/require"
@@ -34,6 +36,12 @@ type ListOpts struct {
 	provider string
 	tier     string
 }
+
+const (
+	atlasM2                    = "M2"
+	atlasM5                    = "M5"
+	deprecateMessageSharedTier = "The '%s' tier is deprecated. Please use 'atlas cluster create <ClusterName> --tier FLEX' instead. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.\n"
+)
 
 func (opts *ListOpts) initStore(ctx context.Context) func() error {
 	return func() error {
@@ -62,6 +70,14 @@ func (opts *ListOpts) Run() error {
 	return opts.Print(r)
 }
 
+func (opts *ListOpts) validateTier() error {
+	opts.tier = strings.ToUpper(opts.tier)
+	if opts.tier == atlasM2 || opts.tier == atlasM5 {
+		_, _ = fmt.Fprintf(os.Stderr, deprecateMessageSharedTier, opts.tier)
+	}
+	return nil
+}
+
 // ListBuilder atlas cluster(s) availableRegions list --provider provider --tier tier --projectId projectId.
 func ListBuilder() *cobra.Command {
 	opts := &ListOpts{}
@@ -81,6 +97,7 @@ func ListBuilder() *cobra.Command {
 			}
 
 			return opts.PreRunE(
+				opts.validateTier,
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), listTemplate),

--- a/internal/cli/clusters/clusters.go
+++ b/internal/cli/clusters/clusters.go
@@ -35,6 +35,7 @@ var errFailedToLoadClusterFileMessage = errors.New("failed to parse JSON file")
 
 const (
 	cannotUseFlexWithClusterApisErrorCode = "CANNOT_USE_FLEX_CLUSTER_IN_CLUSTER_API"
+	deprecateMessageSharedTier            = "The '%s' tier is deprecated. Please use 'atlas cluster create <ClusterName> --tier FLEX' instead. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.\n"
 )
 
 func Builder() *cobra.Command {

--- a/internal/cli/clusters/clusters.go
+++ b/internal/cli/clusters/clusters.go
@@ -35,7 +35,7 @@ var errFailedToLoadClusterFileMessage = errors.New("failed to parse JSON file")
 
 const (
 	cannotUseFlexWithClusterApisErrorCode = "CANNOT_USE_FLEX_CLUSTER_IN_CLUSTER_API"
-	deprecateMessageSharedTier            = "The '%s' tier is deprecated. Please use 'atlas cluster create <ClusterName> --tier FLEX' instead. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.\n"
+	deprecateMessageSharedTier            = "The '%s' tier is deprecated. Please use '--tier FLEX' instead. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.\n"
 )
 
 func Builder() *cobra.Command {

--- a/internal/cli/clusters/create.go
+++ b/internal/cli/clusters/create.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -336,6 +337,14 @@ func (opts *CreateOpts) newIsFlexCluster() error {
 	return nil
 }
 
+func (opts *CreateOpts) validateTier() error {
+	opts.tier = strings.ToUpper(opts.tier)
+	if opts.tier == atlasM2 || opts.tier == atlasM5 {
+		_, _ = fmt.Fprintf(os.Stderr, deprecateMessageSharedTier, opts.tier)
+	}
+	return nil
+}
+
 // CreateBuilder builds a cobra.Command that can run as:
 // create <name> --projectId projectId --provider AWS|GCP|AZURE --region regionName [--members N] [--tier M#] [--diskSizeGB N] [--backup] [--mdbVersion] [--tag key=value].
 func CreateBuilder() *cobra.Command {
@@ -383,6 +392,7 @@ For full control of your deployment, or to create multi-cloud clusters, provide 
 			opts.tier = strings.ToUpper(opts.tier)
 			opts.region = strings.ToUpper(opts.region)
 			return opts.PreRunE(
+				opts.validateTier,
 				opts.newIsFlexCluster,
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
@@ -411,7 +421,7 @@ For full control of your deployment, or to create multi-cloud clusters, provide 
 	cmd.Flags().StringVar(&opts.provider, flag.Provider, "", usage.CreateProvider)
 	cmd.Flags().StringVarP(&opts.region, flag.Region, flag.RegionShort, "", usage.CreateRegion)
 	cmd.Flags().IntVarP(&opts.members, flag.Members, flag.MembersShort, defaultMembersSize, usage.Members)
-	cmd.Flags().StringVar(&opts.tier, flag.Tier, atlasM2, usage.Tier)
+	cmd.Flags().StringVar(&opts.tier, flag.Tier, atlasFlex, usage.Tier)
 	cmd.Flags().Float64Var(&opts.diskSizeGB, flag.DiskSizeGB, defaultDiskSize, usage.DiskSizeGB)
 	cmd.Flags().StringVar(&opts.mdbVersion, flag.MDBVersion, currentMDBVersion, usage.MDBVersion)
 	cmd.Flags().BoolVar(&opts.backup, flag.Backup, false, usage.Backup)

--- a/internal/cli/clusters/update.go
+++ b/internal/cli/clusters/update.go
@@ -17,6 +17,7 @@ package clusters
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
@@ -238,6 +239,14 @@ func (opts *UpdateOpts) newIsFlexCluster() error {
 	return nil
 }
 
+func (opts *UpdateOpts) validateTier() error {
+	opts.tier = strings.ToUpper(opts.tier)
+	if opts.tier == atlasM2 || opts.tier == atlasM5 {
+		_, _ = fmt.Fprintf(os.Stderr, deprecateMessageSharedTier, opts.tier)
+	}
+	return nil
+}
+
 // UpdateBuilder builds a cobra.Command that can run as:
 // atlas cluster(s) update [clusterName] --projectId projectId [--tier M#] [--diskSizeGB N] [--mdbVersion] [--tag key=value].
 func UpdateBuilder() *cobra.Command {
@@ -277,6 +286,7 @@ You can only update a replica set to a single-shard cluster; you cannot update a
 				opts.name = args[0]
 			}
 			return opts.PreRunE(
+				opts.validateTier,
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), updateTmpl),

--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -50,16 +50,19 @@ import (
 )
 
 const (
-	internalMongodPort = 27017
-	mdb7               = "7.0"
-	mdb8               = "8.0"
-	defaultSettings    = "default"
-	customSettings     = "custom"
-	cancelSettings     = "cancel"
-	skipConnect        = "skip"
-	autoassignPort     = "autoassign"
-	spinnerSpeed       = 100 * time.Millisecond
-	steps              = 3
+	internalMongodPort         = 27017
+	mdb7                       = "7.0"
+	mdb8                       = "8.0"
+	defaultSettings            = "default"
+	customSettings             = "custom"
+	cancelSettings             = "cancel"
+	skipConnect                = "skip"
+	autoassignPort             = "autoassign"
+	spinnerSpeed               = 100 * time.Millisecond
+	steps                      = 3
+	atlasM2                    = "M2"
+	atlasM5                    = "M5"
+	deprecateMessageSharedTier = "The '%s' tier is deprecated. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.\n"
 )
 
 var (
@@ -676,6 +679,15 @@ func (opts *SetupOpts) PostRun() {
 	opts.DeploymentTelemetry.AppendDeploymentType()
 }
 
+func (opts *SetupOpts) validateTier() error {
+	opts.atlasSetup.Tier = strings.ToUpper(opts.atlasSetup.Tier)
+	if opts.atlasSetup.Tier == atlasM2 || opts.atlasSetup.Tier == atlasM5 {
+		_, _ = fmt.Fprintf(os.Stderr, deprecateMessageSharedTier, opts.atlasSetup.Tier)
+	}
+	return nil
+}
+
+// SetupBuilder builds a cobra.Command that can run as:
 // atlas deployments setup.
 func SetupBuilder() *cobra.Command {
 	opts := &SetupOpts{
@@ -701,6 +713,7 @@ func SetupBuilder() *cobra.Command {
 			opts.DBUserPassword = opts.atlasSetup.DBUserPassword
 
 			return opts.PreRunE(
+				opts.validateTier,
 				opts.InitOutput(cmd.OutOrStdout(), ""),
 				opts.InitInput(cmd.InOrStdin()),
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),

--- a/internal/cli/setup/setup_cmd.go
+++ b/internal/cli/setup/setup_cmd.go
@@ -46,21 +46,22 @@ import (
 )
 
 const (
-	DefaultAtlasTier    = "M0"
-	defaultAtlasGovTier = "M30"
-	atlasAdmin          = "atlasAdmin"
-	replicaSet          = "REPLICASET"
-	defaultProvider     = "AWS"
-	defaultRegion       = "US_EAST_1"
-	defaultRegionGCP    = "US_EAST_4"
-	defaultRegionAzure  = "US_EAST_2"
-	defaultRegionGov    = "US_GOV_EAST_1"
-	defaultSettings     = "default"
-	customSettings      = "custom"
-	cancelSettings      = "cancel"
-	skipConnect         = "skip"
-	compassConnect      = "compass"
-	mongoshConnect      = "mongosh"
+	DefaultAtlasTier           = "M0"
+	defaultAtlasGovTier        = "M30"
+	atlasAdmin                 = "atlasAdmin"
+	replicaSet                 = "REPLICASET"
+	defaultProvider            = "AWS"
+	defaultRegion              = "US_EAST_1"
+	defaultRegionGCP           = "US_EAST_4"
+	defaultRegionAzure         = "US_EAST_2"
+	defaultRegionGov           = "US_GOV_EAST_1"
+	defaultSettings            = "default"
+	customSettings             = "custom"
+	cancelSettings             = "cancel"
+	skipConnect                = "skip"
+	compassConnect             = "compass"
+	mongoshConnect             = "mongosh"
+	deprecateMessageSharedTier = "The '%s' tier is deprecated. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.\n"
 )
 
 var (
@@ -618,6 +619,14 @@ func (opts *Opts) SetupFlowFlags(cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive(flag.SkipMongosh, flag.ConnectWith)
 }
 
+func (opts *Opts) validateTier() error {
+	opts.Tier = strings.ToUpper(opts.Tier)
+	if opts.Tier == atlasM2 || opts.Tier == atlasM5 {
+		_, _ = fmt.Fprintf(os.Stderr, deprecateMessageSharedTier, opts.Tier)
+	}
+	return nil
+}
+
 // Builder
 // atlas setup
 //
@@ -667,6 +676,7 @@ func Builder() *cobra.Command {
 			if !opts.skipLogin && opts.skipRegister {
 				preRun = append(preRun, opts.register.LoginPreRun(cmd.Context()))
 			}
+			preRun = append(preRun, opts.validateTier)
 
 			return opts.PreRunE(preRun...)
 		},


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-285956

This PR updates the following commands to print a wanting message in the `stderror` that M2 and M5 are deprecated.

- atlas cluster create
- atlas cluster update
- atlas deployment setup
- atlas setup
- atlas cluster availableRegions list



```bash
./bin/atlas cluster create testClusterM2 --tier M2 --provider AWS --region US_EAST_1 -P prod                                     
The 'M2' tier is deprecated. Please use '--tier FLEX' instead. For the migration guide and timeline, visit: https://dochub.mongodb.org/core/flex-migration.

Cluster 'testClusterM2' is being created.
```


### Evergreen Patch

https://spruce.mongodb.com/version/67644bdc79983200077dafbd/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC