### PR TITLE
CLOUDP-291947: fix template error with `backup restore get`

### DIFF
--- a/internal/cli/backup/restores/describe.go
+++ b/internal/cli/backup/restores/describe.go
@@ -49,7 +49,7 @@ var restoreDescribeTemplate = `ID	SNAPSHOT	CLUSTER	TYPE	EXPIRES AT	URLs
 `
 
 var restoreDescribeFlexClusterTemplate = `ID	SNAPSHOT	CLUSTER	TYPE	EXPIRES AT	URLs
-{{.Id}}	{{.SnapshotId}}	{{.TargetDeploymentItemName}}	{{.DeliveryType}}	{{.ExpirationDate}}	{{range $index, $element := valueOrEmptySlice .SnapshotUrl}}{{if $index}}; {{end}}{{$element}}{{end}}
+{{.Id}}	{{.SnapshotId}}	{{.TargetDeploymentItemName}}	{{.DeliveryType}}	{{.ExpirationDate}}	{{.SnapshotUrl}}
 `
 
 func (opts *DescribeOpts) Run() error {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-291947

The `backup restore get` does not print the download URL for flex cluster because the current template uses an array instead of a string. This PR updates the template to use the correct type
