### PR TITLE
CLOUDP-292067: fix bug on cluster commands when getting the projectId

### DIFF
--- a/internal/cli/clusters/create.go
+++ b/internal/cli/clusters/create.go
@@ -174,7 +174,7 @@ func (opts *CreateOpts) PostRunFlexCluster() error {
 		*watchers.ClusterCreated,
 		watchers.NewAtlasFlexClusterStateDescriber(
 			opts.store.(store.ClusterDescriber),
-			opts.ProjectID,
+			opts.ConfigProjectID(),
 			opts.name,
 		),
 		opts.GetDefaultWait(),
@@ -199,7 +199,7 @@ func (opts *CreateOpts) PostRunDedicatedCluster() error {
 		*watchers.ClusterCreated,
 		watchers.NewAtlasClusterStateDescriber(
 			opts.store.(store.ClusterDescriber),
-			opts.ProjectID,
+			opts.ConfigProjectID(),
 			opts.name,
 		),
 		opts.GetDefaultWait(),

--- a/internal/cli/clusters/delete.go
+++ b/internal/cli/clusters/delete.go
@@ -82,7 +82,7 @@ func (opts *DeleteOpts) PostRun() error {
 		*watchers.ClusterDeleted,
 		watchers.NewAtlasClusterStateDescriber(
 			opts.store.(store.ClusterDescriber),
-			opts.ProjectID,
+			opts.ConfigProjectID(),
 			opts.Entry,
 		),
 	)
@@ -100,7 +100,7 @@ func (opts *DeleteOpts) PostRunFlexCluster() error {
 		*watchers.ClusterDeleted,
 		watchers.NewAtlasFlexClusterStateDescriber(
 			opts.store.(store.ClusterDescriber),
-			opts.ProjectID,
+			opts.ConfigProjectID(),
 			opts.Entry,
 		),
 		opts.GetDefaultWait(),

--- a/internal/cli/clusters/update.go
+++ b/internal/cli/clusters/update.go
@@ -179,7 +179,7 @@ func (opts *UpdateOpts) cluster() (*atlasClustersPinned.AdvancedClusterDescripti
 
 		return cluster, nil
 	}
-	return opts.store.AtlasCluster(opts.ProjectID, opts.name)
+	return opts.store.AtlasCluster(opts.ConfigProjectID(), opts.name)
 }
 
 func (opts *UpdateOpts) patchOpts(out *atlasClustersPinned.AdvancedClusterDescription) {

--- a/internal/cli/clusters/upgrade.go
+++ b/internal/cli/clusters/upgrade.go
@@ -220,7 +220,7 @@ func (opts *UpgradeOpts) cluster() (*atlas.Cluster, error) {
 		return cluster, nil
 	}
 
-	return opts.store.AtlasSharedCluster(opts.ProjectID, opts.name)
+	return opts.store.AtlasSharedCluster(opts.ConfigProjectID(), opts.name)
 }
 
 func (opts *UpgradeOpts) patchOpts(out *atlas.Cluster) {


### PR DESCRIPTION
_Jira ticket:_ CLOUDP-292067

# Description:
While testing locally I noticed that some cluster commands retrieve the projectID directly from the opts instead of using `ConfigProjectID`. We must use `ConfigProjectID` so that we retrieve the projectID from the config file when its value is not provided via flag.