### PR TITLE
Revert "fix: periodic builds not running"

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -2079,13 +2079,13 @@ buildvariants:
       - name: ".snyk"
 patch_aliases:
   - alias: "localdev"
-    variant_tags: [".localdev .cron"]
+    variant_tags: ["localdev cron"]
     task: ".*"
   - alias: "packer"
-    variant_tags: [".packer .cron"]
+    variant_tags: ["packer cron"]
     task: ".*"
   - alias: "cleanup"
-    variant_tags: [".cleanup .cron"]
+    variant_tags: ["cleanup cron"]
     task: ".*"
   - alias: "snyk"
     variant_tags: ["snyk cron"]


### PR DESCRIPTION
Reverts mongodb/mongodb-atlas-cli#3433

This PR is stopping the periodic builds from running, not fixing the original issue.

I noticed because I copied the "fix" as an example and my periodic build never worked.
After removing the dots in the tags, periodic builds work again.

PR: https://github.com/mongodb/mongodb-atlas-cli/pull/3512
Working periodic build run: https://spruce.mongodb.com/version/67769f6c31e0eb000723a0b7/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC