### PR TITLE
chore: set provider to tenant if M0,M2 or M5

### DIFF
--- a/internal/cli/setup/cluster_setup.go
+++ b/internal/cli/setup/cluster_setup.go
@@ -101,7 +101,7 @@ func (opts *Opts) askClusterMDBVersion() error {
 		return nil
 	}
 
-	versions, defaultVersion, err := opts.mdbVersions(opts.Tier, opts.Provider)
+	versions, defaultVersion, err := opts.mdbVersions(opts.Tier)
 	if err != nil {
 		return err
 	}
@@ -262,7 +262,7 @@ func (opts *Opts) defaultRegions() ([]string, error) {
 	return defaultRegions, nil
 }
 
-func (opts *Opts) mdbVersions(instanceSize string, cloudProvider string) ([]string, string, error) {
+func (opts *Opts) mdbVersions(instanceSize string) ([]string, string, error) {
 	const maxItems = 500
 	versions, err := opts.store.MDBVersions(
 		opts.ConfigProjectID(),
@@ -270,8 +270,7 @@ func (opts *Opts) mdbVersions(instanceSize string, cloudProvider string) ([]stri
 			ListOptions: store.ListOptions{
 				ItemsPerPage: maxItems,
 			},
-			CloudProvider: &cloudProvider,
-			InstanceSize:  &instanceSize,
+			InstanceSize: &instanceSize,
 		},
 	)
 

--- a/internal/cli/setup/setup_cmd.go
+++ b/internal/cli/setup/setup_cmd.go
@@ -210,7 +210,7 @@ func (opts *Opts) newDefaultValues() (*clusterSettings, error) {
 
 	values.MdbVersion = opts.MDBVersion
 	if opts.MDBVersion == "" {
-		_, defaultVersion, err := opts.mdbVersions(opts.Tier, opts.Provider)
+		_, defaultVersion, err := opts.mdbVersions(opts.Tier)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

- Followed up why the endpoint stopped working because apparently we expect TENANT for providing the versions, I'm actually removing the need to set cloud provider here

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
