### PR TITLE
test: Adds e2e test to verify k8s plugin installs

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -767,7 +767,7 @@ tasks:
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,clusters,m0
-  - name: atlas_kubernetes_generate_e2e
+  - name: atlas_kubernetes_plugin
     tags: ["e2e","atlas","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas"]
     must_have_test_results: true
     depends_on:
@@ -784,7 +784,7 @@ tasks:
           MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,cluster,kubernetes,generate
+          E2E_TAGS: atlas,plugin,kubenetes
   - name: atlas_kubernetes_apply_e2e
     tags: [ "e2e","atlas","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas" ]
     must_have_test_results: true

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -768,12 +768,8 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,clusters,m0
   - name: atlas_kubernetes_plugin
-    tags: ["e2e","atlas","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas"]
+    tags: ["e2e","atlas","plugin","kubernetes"]
     must_have_test_results: true
-    depends_on:
-      - name: atlas_clusters_flags_e2e
-        variant: "e2e_atlas_clusters"
-        patch_optional: true
     commands:
       - func: "install gotestsum"
       - func: "e2e test"
@@ -785,24 +781,6 @@ tasks:
           MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
           MCLI_SERVICE: cloud
           E2E_TAGS: atlas,plugin,kubenetes
-  - name: atlas_kubernetes_apply_e2e
-    tags: [ "e2e","atlas","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas" ]
-    must_have_test_results: true
-    depends_on:
-      - name: atlas_clusters_flags_e2e
-        variant: "e2e_atlas_clusters"
-        patch_optional: true
-    commands:
-      - func: "install gotestsum"
-      - func: "e2e test"
-        vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
-          E2E_TAGS: atlas,cluster,kubernetes,apply
   - name: atlas_clusters_upgrade_e2e
     tags: ["e2e","clusters","atlas"]
     must_have_test_results: true
@@ -1835,14 +1813,14 @@ buildvariants:
       <<: *go_linux_version
     tasks:
       - name: ".e2e .clusters .atlas"
-  - name: e2e_atlas_kubernetes
-    display_name: "E2E Atlas Kubernetes Tests"
+  - name: e2e_atlas_kubernetes_plugin
+    display_name: "E2E Atlas Kubernetes Plugin Tests"
     run_on:
       - ubuntu2204-small
     expansions:
       <<: *go_linux_version
     tasks:
-      - name: ".e2e .atlas .kubernetes"
+      - name: ".e2e .atlas .plugin .kubernetes"
   - name: e2e_decryption
     display_name: "E2E Decryption Tests"
     run_on:

--- a/test/e2e/atlas/plugin_first_class_test.go
+++ b/test/e2e/atlas/plugin_first_class_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e || kubernetes || (atlas && plugin)
+
+package atlas_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/test/e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginKubernetes(t *testing.T) {
+	t.Helper()
+	cliPath, err := e2e.AtlasCLIBin()
+	require.NoError(t, err)
+
+	t.Run("should install K8s plugin", func(t *testing.T) {
+		removeFirstClassPlugin(t, "atlas-cli-plugin-kubernetes", cliPath)
+
+		cmd := exec.Command(cliPath,
+			"kubernetes")
+		cmd.Env = os.Environ()
+		resp, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(resp))
+		assert.Contains(t, string(resp), "Plugin mongodb/atlas-cli-plugin-kubernetes successfully installed\n")
+	})
+}
+
+func removeFirstClassPlugin(t *testing.T, name, cliPath string) {
+	t.Helper()
+	cmd := exec.Command(cliPath,
+		"plugin",
+		"uninstall",
+		name)
+	resp, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(resp))
+}

--- a/test/e2e/atlas/plugin_first_class_test.go
+++ b/test/e2e/atlas/plugin_first_class_test.go
@@ -50,5 +50,8 @@ func removeFirstClassPlugin(t *testing.T, name, cliPath string) {
 		"uninstall",
 		name)
 	resp, err := cmd.CombinedOutput()
-	require.NoError(t, err, string(resp))
+	if err != nil {
+		require.Contains(t, string(resp), "Error: could not find plugin with name atlas-cli-plugin-kubernetes")
+		return
+	}
 }


### PR DESCRIPTION
## Proposed changes

Adds an e2e test as a part of the Evergreen workflow to verify that the K8s plugin is successfully installed.

_Jira ticket:_ [CLOUDP-293169](https://jira.mongodb.org/browse/CLOUDP-293169)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments
