### PR TITLE
CLOUDP-293170: Update copybara to exclude k8s docs

### DIFF
--- a/build/ci/copy.bara.sky.template
+++ b/build/ci/copy.bara.sky.template
@@ -23,7 +23,7 @@ core.workflow(
         integrates = [],
     ),
     origin_files = glob(["docs/command/**"], exclude = ["docs/command/atlas-completion**"]),
-    destination_files = glob(["source/includes/command/**"]),
+    destination_files = glob(["source/includes/command/**"], exclude=["source/includes/command/atlas-kubernetes**"]),
     authoring = authoring.pass_thru(author),
     transformations = [
         core.move("docs/command", "source/includes/command"),
@@ -46,7 +46,7 @@ core.workflow(
         integrates = [],
     ),
     origin_files = glob(["docs/command/**"]),
-    destination_files = glob(["source/command/**"]),
+    destination_files = glob(["source/command/**"], exclude=["source/includes/command/atlas-kubernetes**"]),
     authoring = authoring.pass_thru(author),
     transformations = [
         core.move("docs/command", "source/command"),


### PR DESCRIPTION
## Proposed changes

Updates Copybara actions such that kubernetes docs are not removed from the docs repos.

This method was tested in a PoC [here](https://github.com/mongodb/atlas-cli-plugin-example/commit/c36cd6bd6c2102b0c3d1510a92021b01945ba41c) using github actions instead of Evergreen. The resulting PR in a fork of Docs Atlas CLI was [this](https://github.com/cveticm/docs-atlas-cli-fork/pull/17), where no K8s docs are modified despite not being present in the test plugin repo, as expected.

_Jira ticket:_ [CLOUDP-293170](https://jira.mongodb.org/browse/CLOUDP-293170)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments