### PR TITLE
CLOUDP-295778: [AtlasCLI] Fix prompt when deleting search node

### DIFF
--- a/internal/cli/delete_opts.go
+++ b/internal/cli/delete_opts.go
@@ -23,24 +23,34 @@ import (
 )
 
 const (
-	fallbackSuccessMessage = "'%s' deleted\n"
-	fallbackFailMessage    = "Entry not deleted"
+	fallbackSuccessMessage    = "'%s' deleted\n"
+	fallbackFailMessage       = "Entry not deleted"
+	defaultConfirmationPrompt = "Are you sure you want to delete: %s"
 )
 
 // DeleteOpts options required when deleting a resource.
 // A command can compose this struct and then safely rely on the methods Prompt, or Delete
 // to manage the interactions with the user.
 type DeleteOpts struct {
-	Entry      string
-	Confirm    bool
-	successMsg string
-	failMsg    string
+	Entry              string
+	Confirm            bool
+	confirmationPrompt string
+	successMsg         string
+	failMsg            string
 }
 
 func NewDeleteOpts(successMsg, failMsg string) *DeleteOpts {
 	return &DeleteOpts{
 		successMsg: successMsg,
 		failMsg:    failMsg,
+	}
+}
+
+func NewDeleteOptsWithPrompt(successMsg, failMsg, confirmationPrompt string) *DeleteOpts {
+	return &DeleteOpts{
+		successMsg:         successMsg,
+		failMsg:            failMsg,
+		confirmationPrompt: confirmationPrompt,
 	}
 }
 
@@ -86,7 +96,13 @@ func (opts *DeleteOpts) Prompt() error {
 		return nil
 	}
 
-	p := prompt.NewDeleteConfirm(opts.Entry)
+	var template = opts.confirmationPrompt
+	if template == "" {
+		template = defaultConfirmationPrompt
+	}
+
+	message := fmt.Sprintf(template, opts.Entry)
+	p := prompt.NewConfirm(message)
 	return telemetry.TrackAskOne(p, &opts.Confirm)
 }
 

--- a/internal/cli/maintenance/clear.go
+++ b/internal/cli/maintenance/clear.go
@@ -64,7 +64,7 @@ func (opts *ClearOpts) Prompt() error {
 		return nil
 	}
 
-	p := prompt.NewDeleteConfirm("maintenance window")
+	p := prompt.NewConfirm("Are you sure you want to delete: maintenance window")
 	return telemetry.TrackAskOne(p, &opts.Confirm)
 }
 

--- a/internal/cli/search/nodes/delete.go
+++ b/internal/cli/search/nodes/delete.go
@@ -85,7 +85,7 @@ func (opts *DeleteOpts) watcher() (any, bool, error) {
 // atlas clusters search nodes delete [--clusterName clusterName].
 func DeleteBuilder() *cobra.Command {
 	opts := &DeleteOpts{
-		DeleteOpts: cli.NewDeleteOpts(deleteTemplate, "Search node not deleted."),
+		DeleteOpts: cli.NewDeleteOptsWithPrompt(deleteTemplate, "Search node not deleted.", "Are you sure you want to delete search nodes for cluster: %s"),
 	}
 
 	cmd := &cobra.Command{

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -18,14 +18,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 )
 
-// NewDeleteConfirm creates a prompt to confirm if the entry should be deleted.
-func NewDeleteConfirm(entry string) survey.Prompt {
-	prompt := &survey.Confirm{
-		Message: "Are you sure you want to delete: " + entry,
-	}
-	return prompt
-}
-
 // NewConfirm creates a prompt to confirm if the entry should be deleted.
 func NewConfirm(message string) survey.Prompt {
 	prompt := &survey.Confirm{


### PR DESCRIPTION
## Proposed changes
- Improved search node delete prompt
- added functionality to delete opts to provide a template
- fixed broken command caused by deleting `NewDeleteConfirm`

_Jira ticket:_ CLOUDP-295778