### PR TITLE
CLOUDP-293859: test/e2e/atlas/kube: fix tests

### DIFF
--- a/internal/kubernetes/operator/install.go
+++ b/internal/kubernetes/operator/install.go
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"k8s.io/client-go/util/retry"
-
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/kubernetes"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/kubernetes/operator/features"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/kubernetes/operator/resources"
@@ -30,6 +28,7 @@ import (
 	akov2common "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -292,10 +291,7 @@ func (i *Install) ensureCredentialsAssignment(ctx context.Context) error {
 
 			project.Spec.ConnectionSecret = connectionSecret
 
-			if err := i.kubectl.Update(ctx, &project); err != nil {
-				return err
-			}
-			return nil
+			return i.kubectl.Update(ctx, &project)
 		})
 		if err != nil {
 			return fmt.Errorf("failed to update atlas project %s: %w", i.projectName, err)

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -53,9 +53,9 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"install",
 			"--operatorVersion", "1.1.0")
 		cmd.Env = os.Environ()
-		resp, inErr := e2e.RunAndGetStdOut(cmd)
-		require.Error(t, inErr, string(resp))
-		assert.Equal(t, "Error: version 1.1.0 is not supported\n", string(resp))
+		_, inErr := e2e.RunAndGetStdOutAndErr(cmd)
+		require.Error(t, inErr, inErr)
+		assert.Equal(t, "Error: version 1.1.0 is not supported\n (exit status 1)", inErr.Error())
 	})
 
 	t.Run("should failed to install a non-existing version of the operator", func(t *testing.T) {
@@ -65,9 +65,9 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"install",
 			"--operatorVersion", "100.0.0")
 		cmd.Env = os.Environ()
-		resp, inErr := e2e.RunAndGetStdOut(cmd)
-		require.Error(t, inErr, string(resp))
-		assert.Equal(t, "Error: version 100.0.0 is not supported\n", string(resp))
+		_, inErr := e2e.RunAndGetStdOutAndErr(cmd)
+		require.Error(t, inErr, inErr)
+		assert.Equal(t, "Error: version 100.0.0 is not supported\n (exit status 1)", inErr.Error())
 	})
 
 	t.Run("should failed when unable to setup connection to the cluster", func(t *testing.T) {
@@ -77,9 +77,9 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"install",
 			"--kubeconfig", "/path/to/non/existing/config")
 		cmd.Env = os.Environ()
-		resp, inErr := e2e.RunAndGetStdOut(cmd)
-		require.Error(t, inErr, string(resp))
-		assert.Equal(t, "Error: unable to prepare client configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable\n", string(resp))
+		_, inErr := e2e.RunAndGetStdOutAndErr(cmd)
+		require.Error(t, inErr, inErr)
+		assert.Equal(t, "Error: unable to prepare client configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable\n (exit status 1)", inErr.Error())
 	})
 
 	t.Run("should install operator with default options", func(t *testing.T) {
@@ -179,8 +179,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--import",
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
-		resp, inErr := e2e.RunAndGetStdOut(cmd)
-		require.NoError(t, inErr, string(resp))
+		resp, inErr := e2e.RunAndGetStdOutAndErr(cmd)
+		require.NoError(t, inErr, inErr)
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
 		checkDeployment(t, operator, operatorNamespace)
@@ -296,8 +296,8 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			deployment,
 			false,
 		))
-		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--resourceDeletionProtection=false")
-		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--subresourceDeletionProtection=false")
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--object-deletion-protection=false")
+		assert.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--subobject-deletion-protection=false")
 
 		cleanUpKeys(t, operator, operatorNamespace, cliPath)
 	})

--- a/test/e2e/atlas/kubernetes_operator_install_test.go
+++ b/test/e2e/atlas/kubernetes_operator_install_test.go
@@ -54,7 +54,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--operatorVersion", "1.1.0")
 		cmd.Env = os.Environ()
 		_, inErr := e2e.RunAndGetStdOutAndErr(cmd)
-		require.Error(t, inErr, inErr)
+		require.Error(t, inErr)
 		assert.Equal(t, "Error: version 1.1.0 is not supported\n (exit status 1)", inErr.Error())
 	})
 
@@ -66,7 +66,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--operatorVersion", "100.0.0")
 		cmd.Env = os.Environ()
 		_, inErr := e2e.RunAndGetStdOutAndErr(cmd)
-		require.Error(t, inErr, inErr)
+		require.Error(t, inErr)
 		assert.Equal(t, "Error: version 100.0.0 is not supported\n (exit status 1)", inErr.Error())
 	})
 
@@ -78,7 +78,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--kubeconfig", "/path/to/non/existing/config")
 		cmd.Env = os.Environ()
 		_, inErr := e2e.RunAndGetStdOutAndErr(cmd)
-		require.Error(t, inErr, inErr)
+		require.Error(t, inErr)
 		assert.Equal(t, "Error: unable to prepare client configuration: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable\n (exit status 1)", inErr.Error())
 	})
 
@@ -180,7 +180,7 @@ func TestKubernetesOperatorInstall(t *testing.T) {
 			"--kubeContext", context)
 		cmd.Env = os.Environ()
 		resp, inErr := e2e.RunAndGetStdOutAndErr(cmd)
-		require.NoError(t, inErr, inErr)
+		require.NoError(t, inErr)
 		assert.Equal(t, "Atlas Kubernetes Operator installed successfully\n", string(resp))
 
 		checkDeployment(t, operator, operatorNamespace)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-293859

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

This fixes the re-enabled tests that have been turned on as part of https://github.com/mongodb/mongodb-atlas-cli/pull/3530.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
