### PR TITLE
CLOUDP-296190: [Flex Clusters] --targetProjectId is not handled properly

### DIFF
--- a/internal/cli/backup/restores/start.go
+++ b/internal/cli/backup/restores/start.go
@@ -85,12 +85,17 @@ func (opts *StartOpts) Run() error {
 }
 
 func (opts *StartOpts) newFlexBackupRestoreJobCreate() *admin.FlexBackupRestoreJobCreate20241113 {
-	return &admin.FlexBackupRestoreJobCreate20241113{
+	request := &admin.FlexBackupRestoreJobCreate20241113{
 		SnapshotId:               opts.snapshotID,
 		TargetDeploymentItemName: opts.targetClusterName,
-		TargetProjectId:          &opts.targetProjectID,
 		InstanceName:             &opts.clusterName,
 	}
+
+	if opts.targetProjectID != "" {
+		request.TargetProjectId = &opts.targetProjectID
+	}
+
+	return request
 }
 
 func (opts *StartOpts) newCloudProviderSnapshotRestoreJob() *admin.DiskBackupSnapshotRestoreJob {

--- a/internal/kubernetes/operator/project/project.go
+++ b/internal/kubernetes/operator/project/project.go
@@ -184,7 +184,7 @@ func BuildAtlasProject(br *AtlasProjectBuildRequest) (*AtlasProjectResult, error
 	}
 
 	if br.Validator.FeatureExist(features.ResourceAtlasProject, featureCustomRoles) && !br.Validator.IsResourceSupported(features.ResourceAtlasCustomRole) {
-		customRoles, ferr := buildCustomRoles(br.ProjectStore, br.ProjectID)
+		customRoles, ferr := projectBuildCustomRoles(br.ProjectStore, br.ProjectID)
 		if ferr != nil {
 			return nil, ferr
 		}
@@ -275,8 +275,7 @@ func BuildProjectNamedConnectionSecret(credsProvider store.CredentialsGetter, na
 	return secret
 }
 
-//nolint:revive
-func buildCustomRoles(crProvider store.DatabaseRoleLister, projectID string) ([]akov2.CustomRole, error) {
+func projectBuildCustomRoles(crProvider store.DatabaseRoleLister, projectID string) ([]akov2.CustomRole, error) {
 	dbRoles, err := crProvider.DatabaseRoles(projectID)
 	if err != nil {
 		return nil, err

--- a/internal/kubernetes/operator/project/project_test.go
+++ b/internal/kubernetes/operator/project/project_test.go
@@ -1510,7 +1510,7 @@ func Test_buildCustomRoles(t *testing.T) {
 			},
 		}
 
-		got, err := buildCustomRoles(rolesProvider, projectID)
+		got, err := projectBuildCustomRoles(rolesProvider, projectID)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}


### PR DESCRIPTION
## Proposed changes

Flex: Fix bug with restore jobs, TargetProjectID is optional

_Jira ticket:_ [CLOUDP-296190](https://jira.mongodb.org/browse/CLOUDP-296190)

