### PR TITLE
CLOUDP-296375: Adds k8s command to gen docs command tree

### DIFF
--- a/docs/command/atlas.txt
+++ b/docs/command/atlas.txt
@@ -68,6 +68,7 @@ Related Commands
 * :ref:`atlas-events` - Manage events for your organization or project.
 * :ref:`atlas-federatedAuthentication` - Manage Atlas Federated Authentication.
 * :ref:`atlas-integrations` - Configure third-party integrations for your Atlas project.
+* :ref:`atlas-kubernetes` - Manage Kubernetes resources.
 * :ref:`atlas-liveMigrations` - Manage a Live Migration to Atlas for your organization.
 * :ref:`atlas-logs` - Download host logs for your project.
 * :ref:`atlas-maintenanceWindows` - Manage Atlas maintenance windows.
@@ -107,6 +108,7 @@ Related Commands
    events </command/atlas-events>
    federatedAuthentication </command/atlas-federatedAuthentication>
    integrations </command/atlas-integrations>
+   kubernetes </command/atlas-kubernetes>
    liveMigrations </command/atlas-liveMigrations>
    logs </command/atlas-logs>
    maintenanceWindows </command/atlas-maintenanceWindows>

--- a/internal/cli/plugin/first_class.go
+++ b/internal/cli/plugin/first_class.go
@@ -1,4 +1,4 @@
-// Copyright 2024 MongoDB Inc
+// Copyright 2025 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ const (
 )
 
 // uncomment example plugin to test first class plugin feature.
-var firstClassPlugins = []*FirstClassPlugin{
+var FirstClassPlugins = []*FirstClassPlugin{
 	// {
 	// 	Name: "atlas-cli-first-class-plugin-example",
 	// 	Github: &Github{
@@ -51,7 +51,7 @@ var firstClassPlugins = []*FirstClassPlugin{
 		Commands: []*Command{
 			{
 				Name:        "kubernetes",
-				Description: "Root command of the Atlas CLI Kuberenetes plugin",
+				Description: "Manage Kubernetes resources.",
 			},
 		},
 	},
@@ -143,7 +143,7 @@ func (fcp *FirstClassPlugin) getCommands() []*cobra.Command {
 func getFirstClassPluginCommands(plugins []*plugin.Plugin) []*cobra.Command {
 	var commands []*cobra.Command
 	// create cobra commands to install first class plugins when their commands are run
-	for _, firstClassPlugin := range firstClassPlugins {
+	for _, firstClassPlugin := range FirstClassPlugins {
 		if firstClassPlugin.isAlreadyInstalled(plugins) {
 			continue
 		}

--- a/tools/docs/main.go
+++ b/tools/docs/main.go
@@ -58,11 +58,11 @@ func main() {
 		log.Fatal(err)
 	}
 
-	firstClassPath := []string{
+	firstClassPaths := []string{
 		"./docs/command/atlas-kubernetes.txt",
 	}
 
-	for _, filePath := range firstClassPath {
+	for _, filePath := range firstClassPaths {
 		err := os.Remove(filePath)
 		if err != nil {
 			log.Fatal(err)

--- a/tools/docs/main.go
+++ b/tools/docs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 MongoDB Inc
+// Copyright 2025 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ func main() {
 	atlasBuilder := root.Builder()
 
 	for _, cmd := range atlasBuilder.Commands() {
-		if plugin.IsPluginCmd(cmd) || pluginCmd.IsFirstClassPluginCmd(cmd) {
+		if plugin.IsPluginCmd(cmd) && !isFCP(cmd) {
 			atlasBuilder.RemoveCommand(cmd)
 		}
 	}
@@ -57,4 +57,27 @@ func main() {
 	if err := cobra2snooty.GenTreeDocs(atlasBuilder, "./docs/command"); err != nil {
 		log.Fatal(err)
 	}
+
+	firstClassPath := []string{
+		"./docs/command/atlas-kubernetes.txt",
+	}
+
+	for _, filePath := range firstClassPath {
+		err := os.Remove(filePath)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func isFCP(command *cobra.Command) bool {
+	for _, fcp := range pluginCmd.FirstClassPlugins {
+		cmd := fcp.Commands
+		for _, c := range cmd {
+			if command.Name() == c.Name {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/tools/docs/main.go
+++ b/tools/docs/main.go
@@ -45,7 +45,7 @@ func main() {
 	atlasBuilder := root.Builder()
 
 	for _, cmd := range atlasBuilder.Commands() {
-		if plugin.IsPluginCmd(cmd) && !isFCP(cmd) {
+		if plugin.IsPluginCmd(cmd) && !isFirstClassPlugin(cmd) {
 			atlasBuilder.RemoveCommand(cmd)
 		}
 	}
@@ -58,8 +58,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	firstClassPaths := []string{
-		"./docs/command/atlas-kubernetes.txt",
+	firstClassPaths := make([]string, 0, len(pluginCmd.FirstClassPlugins))
+	for _, fcp := range pluginCmd.FirstClassPlugins {
+		cmd := fcp.Commands
+		for _, c := range cmd {
+			filePath := "./docs/command/atlas-" + c.Name + ".txt"
+			firstClassPaths = append(firstClassPaths, filePath)
+		}
 	}
 
 	for _, filePath := range firstClassPaths {
@@ -70,7 +75,7 @@ func main() {
 	}
 }
 
-func isFCP(command *cobra.Command) bool {
+func isFirstClassPlugin(command *cobra.Command) bool {
 	for _, fcp := range pluginCmd.FirstClassPlugins {
 		cmd := fcp.Commands
 		for _, c := range cmd {


### PR DESCRIPTION
## Proposed changes

The current logic in the doc generator tool removes all plugins for being included in the docs generation. This has resulted in a change in `atlas.txt` where ```* :ref:`atlas-kubernetes` - Manage Kubernetes resources.```  is removed from the document.

This ticket modifies logic in the docs generator tool to include first class plugin commands. 

_Jira ticket:_ CLOUDP-296375

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments