### PR TITLE
CLOUDP-295015: [Local Atlas Experience] Add support for private Docker registries

### DIFF
--- a/internal/cli/deployments/options/deployment_opts.go
+++ b/internal/cli/deployments/options/deployment_opts.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -130,8 +131,23 @@ func (opts *DeploymentOpts) LocalMongodHostname() string {
 
 var LocalDevImage = "docker.io/mongodb/mongodb-atlas-local"
 
+func getLocalDevImage() string {
+	// First check environment variable
+	if envImage := os.Getenv("ATLAS_LOCAL_DEPLOYMENT_IMAGE"); envImage != "" {
+		return envImage
+	}
+
+	// Then check profile settings
+	if profileImage := config.Default().GetLocalDeploymentImage(); profileImage != "" {
+		return profileImage
+	}
+
+	// Fall back to default image
+	return LocalDevImage
+}
+
 func (opts *DeploymentOpts) MongodDockerImageName() string {
-	return LocalDevImage + ":" + opts.MdbVersion
+	return getLocalDevImage() + ":" + opts.MdbVersion
 }
 
 func (opts *DeploymentOpts) Spin(funcs ...func() error) error {

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -72,6 +72,7 @@ const (
 	DockerContainerHostName  = "container"
 	GitHubActionsHostName    = "all_github_actions"
 	AtlasActionHostName      = "atlascli_github_action"
+	LocalDeploymentImage     = "local_deployment_image" // LocalDeploymentImage is the config key for the MongoDB Local Dev Docker image
 )
 
 var (
@@ -121,6 +122,7 @@ func Properties() []string {
 		TelemetryEnabledProperty,
 		AccessTokenField,
 		RefreshTokenField,
+		LocalDeploymentImage,
 	}
 }
 
@@ -742,4 +744,16 @@ func Path(f string) (string, error) {
 	p.WriteString(h)
 	p.WriteString(f)
 	return p.String(), nil
+}
+
+// GetLocalDeploymentImage returns the configured MongoDB Docker image URL.
+func GetLocalDeploymentImage() string { return Default().GetLocalDeploymentImage() }
+func (p *Profile) GetLocalDeploymentImage() string {
+	return p.GetString(LocalDeploymentImage)
+}
+
+// SetLocalDeploymentImage sets the MongoDB Docker image URL.
+func SetLocalDeploymentImage(v string) { Default().SetLocalDeploymentImage(v) }
+func (p *Profile) SetLocalDeploymentImage(v string) {
+	p.Set(LocalDeploymentImage, v)
 }

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -122,7 +122,6 @@ func Properties() []string {
 		TelemetryEnabledProperty,
 		AccessTokenField,
 		RefreshTokenField,
-		LocalDeploymentImage,
 	}
 }
 
@@ -138,6 +137,7 @@ func GlobalProperties() []string {
 		skipUpdateCheck,
 		TelemetryEnabledProperty,
 		mongoShellPath,
+		LocalDeploymentImage,
 	}
 }
 
@@ -754,6 +754,6 @@ func (p *Profile) GetLocalDeploymentImage() string {
 
 // SetLocalDeploymentImage sets the MongoDB Docker image URL.
 func SetLocalDeploymentImage(v string) { Default().SetLocalDeploymentImage(v) }
-func (p *Profile) SetLocalDeploymentImage(v string) {
-	p.Set(LocalDeploymentImage, v)
+func (*Profile) SetLocalDeploymentImage(v string) {
+	SetGlobal(LocalDeploymentImage, v)
 }


### PR DESCRIPTION
## Proposed changes
Look for a custom "Atlas local development" image in the following places and order:
1. `ATLAS_LOCAL_DEPLOYMENT_IMAGE` environment variable
2. `local_deployment_image` profile setting
3. Fallback to hardcoded `docker.io/mongodb/mongodb-atlas-local` (can still be overridden by build)

_Jira ticket:_ CLOUDP-295015