### PR TITLE
(DOCSP-46837) Adds an exclude to avoid overwriting handwritten atlas-api file

### DIFF
--- a/build/ci/copy.bara.sky.template
+++ b/build/ci/copy.bara.sky.template
@@ -46,7 +46,7 @@ core.workflow(
         integrates = [],
     ),
     origin_files = glob(["docs/command/**"]),
-    destination_files = glob(["source/command/**"]),
+    destination_files = glob(["source/command/**"], exclude = ["source/command/atlas-api"]),
     authoring = authoring.pass_thru(author),
     transformations = [
         core.move("docs/command", "source/command"),


### PR DESCRIPTION
## Proposed changes

This adds an exclude to the destination_files for copybara for the Atlas CLI docs repo so that the handwritten atlas-api file we are adding in the following PR is never overwritten by copybara: https://github.com/mongodb/docs-atlas-cli/pull/838

**Please note, I am having trouble running copybara locally at the moment so I am unable to test this, but this should prevent overwriting the file**

_Jira ticket:_ 

https://jira.mongodb.org/browse/DOCSP-46837

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
