### PR TITLE
CLOUDP-297205: Fix duplicated telemetry and early uuid collection

### DIFF
--- a/internal/cli/deployments/connect.go
+++ b/internal/cli/deployments/connect.go
@@ -50,6 +50,7 @@ func Run(ctx context.Context, opts *ConnectOpts) error {
 
 func PostRun(opts *ConnectOpts) {
 	opts.DeploymentTelemetry.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
 }
 
 // atlas deployments connect [clusterName].

--- a/internal/cli/deployments/connect_test.go
+++ b/internal/cli/deployments/connect_test.go
@@ -157,5 +157,11 @@ func TestPostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentsTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	PostRun(opts)
 }

--- a/internal/cli/deployments/delete.go
+++ b/internal/cli/deployments/delete.go
@@ -85,6 +85,14 @@ func (opts *DeleteOpts) runLocal(ctx context.Context) error {
 	})
 }
 
+func (opts *DeleteOpts) PreRun() func() error {
+	// Collect UUID before deletion
+	return func() error {
+		opts.DeploymentTelemetry.AppendDeploymentUUID()
+		return nil
+	}
+}
+
 func (opts *DeleteOpts) PostRun() error {
 	opts.UpdateDeploymentTelemetry()
 	if !opts.EnableWatch || !opts.IsAtlasDeploymentType() {
@@ -141,10 +149,12 @@ Deleting a Local deployment also deletes any local data volumes.
 			if len(args) == 1 {
 				opts.DeploymentName = args[0]
 			}
+
 			return opts.PreRunE(
 				opts.initAtlasStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), ""),
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
+				opts.PreRun(),
 			)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/deployments/delete.go
+++ b/internal/cli/deployments/delete.go
@@ -69,6 +69,7 @@ func (opts *DeleteOpts) Run(ctx context.Context) error {
 	if opts.IsAtlasDeploymentType() {
 		return opts.runAtlas()
 	}
+
 	return opts.runLocal(ctx)
 }
 
@@ -80,17 +81,10 @@ func (opts *DeleteOpts) runLocal(ctx context.Context) error {
 	return opts.Delete(func() error {
 		_, _ = log.Warningln("deleting deployment...")
 		opts.StartSpinner()
+
 		defer opts.StopSpinner()
 		return opts.DeploymentOpts.RemoveLocal(ctx)
 	})
-}
-
-func (opts *DeleteOpts) PreRun() func() error {
-	// Collect UUID before deletion
-	return func() error {
-		opts.DeploymentTelemetry.AppendDeploymentUUID()
-		return nil
-	}
 }
 
 func (opts *DeleteOpts) PostRun() error {
@@ -154,7 +148,6 @@ Deleting a Local deployment also deletes any local data volumes.
 				opts.initAtlasStore(cmd.Context()),
 				opts.InitOutput(cmd.OutOrStdout(), ""),
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
-				opts.PreRun(),
 			)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/cli/deployments/delete.go
+++ b/internal/cli/deployments/delete.go
@@ -78,6 +78,9 @@ func (opts *DeleteOpts) runAtlas() error {
 }
 
 func (opts *DeleteOpts) runLocal(ctx context.Context) error {
+	// Collect UUID before deletion
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
+
 	return opts.Delete(func() error {
 		_, _ = log.Warningln("deleting deployment...")
 		opts.StartSpinner()

--- a/internal/cli/deployments/delete_test.go
+++ b/internal/cli/deployments/delete_test.go
@@ -83,18 +83,17 @@ func TestDelete_Run_Local(t *testing.T) {
 	opts.Confirm = true
 
 	deploymentsTest.LocalMockFlow(ctx)
+	deploymentsTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
 
 	deploymentsTest.
 		MockContainerEngine.
 		EXPECT().
 		ContainerRm(ctx, opts.DeploymentName).
 		Return(nil).
-		Times(1)
-
-	deploymentsTest.
-		MockDeploymentTelemetry.
-		EXPECT().
-		AppendDeploymentUUID().
 		Times(1)
 
 	if err := opts.Run(ctx); err != nil {

--- a/internal/cli/deployments/delete_test.go
+++ b/internal/cli/deployments/delete_test.go
@@ -91,6 +91,12 @@ func TestDelete_Run_Local(t *testing.T) {
 		Return(nil).
 		Times(1)
 
+	deploymentsTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	if err := opts.Run(ctx); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}

--- a/internal/cli/deployments/logs.go
+++ b/internal/cli/deployments/logs.go
@@ -229,6 +229,7 @@ func (opts *DownloadOpts) validateAtlasFlags() error {
 
 func (opts *DownloadOpts) PostRun() {
 	opts.DeploymentTelemetry.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
 }
 
 // atlas deployments logs.

--- a/internal/cli/deployments/logs_test.go
+++ b/internal/cli/deployments/logs_test.go
@@ -115,5 +115,11 @@ func TestDownloadOpts_PostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	opts.PostRun()
 }

--- a/internal/cli/deployments/options/deployment_opts_remove.go
+++ b/internal/cli/deployments/options/deployment_opts_remove.go
@@ -16,5 +16,8 @@ package options
 import "context"
 
 func (opts *DeploymentOpts) RemoveLocal(ctx context.Context) error {
+	// Collect UUID before deletion
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
+
 	return opts.ContainerEngine.ContainerRm(ctx, opts.LocalMongodHostname())
 }

--- a/internal/cli/deployments/options/deployment_opts_remove.go
+++ b/internal/cli/deployments/options/deployment_opts_remove.go
@@ -16,8 +16,5 @@ package options
 import "context"
 
 func (opts *DeploymentOpts) RemoveLocal(ctx context.Context) error {
-	// Collect UUID before deletion
-	opts.DeploymentTelemetry.AppendDeploymentUUID()
-
 	return opts.ContainerEngine.ContainerRm(ctx, opts.LocalMongodHostname())
 }

--- a/internal/cli/deployments/options/deployment_opts_telemetry.go
+++ b/internal/cli/deployments/options/deployment_opts_telemetry.go
@@ -92,9 +92,6 @@ func (opts *DeploymentOpts) AppendDeploymentType() {
 	var deploymentType string
 	if opts.IsLocalDeploymentType() {
 		deploymentType = LocalCluster
-		if err := opts.collectUUID(context.TODO()); err != nil {
-			_, _ = log.Debugf("error collecting deployment uuid: %v", err)
-		}
 	} else if opts.IsAtlasDeploymentType() {
 		deploymentType = AtlasCluster
 	}
@@ -104,7 +101,11 @@ func (opts *DeploymentOpts) AppendDeploymentType() {
 }
 
 func (opts *DeploymentOpts) AppendDeploymentUUID() {
-	if opts.DeploymentUUID != "" {
-		telemetry.AppendOption(telemetry.WithDeploymentUUID(opts.DeploymentUUID))
+	if opts.IsAtlasDeploymentType() || opts.DeploymentType == "" || opts.DeploymentUUID != "" {
+		return
+	}
+
+	if err := opts.collectUUID(context.TODO()); err != nil {
+		_, _ = log.Debugf("error collecting deployment uuid: %v", err)
 	}
 }

--- a/internal/cli/deployments/options/deployment_opts_telemetry.go
+++ b/internal/cli/deployments/options/deployment_opts_telemetry.go
@@ -38,6 +38,7 @@ var (
 //go:generate mockgen -destination=../../../mocks/mock_deployment_opts_telemetry.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/options DeploymentTelemetry
 type DeploymentTelemetry interface {
 	AppendDeploymentType()
+	AppendDeploymentUUID()
 }
 
 func NewDeploymentTypeTelemetry(opts *DeploymentOpts) DeploymentTelemetry {
@@ -99,5 +100,11 @@ func (opts *DeploymentOpts) AppendDeploymentType() {
 	}
 	if deploymentType != "" {
 		telemetry.AppendOption(telemetry.WithDeploymentType(deploymentType))
+	}
+}
+
+func (opts *DeploymentOpts) AppendDeploymentUUID() {
+	if opts.DeploymentUUID != "" {
+		telemetry.AppendOption(telemetry.WithDeploymentUUID(opts.DeploymentUUID))
 	}
 }

--- a/internal/cli/deployments/pause.go
+++ b/internal/cli/deployments/pause.go
@@ -111,6 +111,14 @@ func (opts *PauseOpts) PostRun() error {
 	return opts.PostRunMessages()
 }
 
+func (opts *PauseOpts) PreRun() func() error {
+	// Collect UUID before pausing
+	return func() error {
+		opts.DeploymentTelemetry.AppendDeploymentUUID()
+		return nil
+	}
+}
+
 func PauseBuilder() *cobra.Command {
 	opts := &PauseOpts{}
 	cmd := &cobra.Command{
@@ -130,7 +138,8 @@ func PauseBuilder() *cobra.Command {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
-				opts.InitOutput(log.Writer(), pauseTemplate))
+				opts.InitOutput(log.Writer(), pauseTemplate),
+				opts.PreRun())
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {

--- a/internal/cli/deployments/pause.go
+++ b/internal/cli/deployments/pause.go
@@ -70,6 +70,9 @@ func (opts *PauseOpts) Run(ctx context.Context) error {
 }
 
 func (opts *PauseOpts) RunLocal(ctx context.Context, deployment options.Deployment) error {
+	// Collect UUID before pausing
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
+
 	if err := opts.stopContainer(ctx, deployment); err != nil {
 		return err
 	}
@@ -111,14 +114,6 @@ func (opts *PauseOpts) PostRun() error {
 	return opts.PostRunMessages()
 }
 
-func (opts *PauseOpts) PreRun() func() error {
-	// Collect UUID before pausing
-	return func() error {
-		opts.DeploymentTelemetry.AppendDeploymentUUID()
-		return nil
-	}
-}
-
 func PauseBuilder() *cobra.Command {
 	opts := &PauseOpts{}
 	cmd := &cobra.Command{
@@ -138,8 +133,7 @@ func PauseBuilder() *cobra.Command {
 			return opts.PreRunE(
 				opts.initStore(cmd.Context()),
 				opts.InitStore(cmd.Context(), cmd.OutOrStdout()),
-				opts.InitOutput(log.Writer(), pauseTemplate),
-				opts.PreRun())
+				opts.InitOutput(log.Writer(), pauseTemplate))
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {

--- a/internal/cli/deployments/pause_test.go
+++ b/internal/cli/deployments/pause_test.go
@@ -128,3 +128,27 @@ func TestPauseOpts_PostRun(t *testing.T) {
 		t.Fatalf("PostRun() unexpected error: %v", err)
 	}
 }
+
+func TestPauseOpts_PreRun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+	buf := new(bytes.Buffer)
+
+	opts := &PauseOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+		OutputOpts: cli.OutputOpts{
+			OutWriter: buf,
+		},
+	}
+
+	deploymentTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
+	preRun := opts.PreRun()
+	if err := preRun(); err != nil {
+		t.Fatalf("PreRun() unexpected error: %v", err)
+	}
+}

--- a/internal/cli/deployments/pause_test.go
+++ b/internal/cli/deployments/pause_test.go
@@ -58,6 +58,12 @@ func TestPause_RunLocal(t *testing.T) {
 		Return(nil).
 		Times(1)
 
+	deploymentTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	if err := pauseOpts.Run(ctx); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
@@ -126,29 +132,5 @@ func TestPauseOpts_PostRun(t *testing.T) {
 
 	if err := opts.PostRun(); err != nil {
 		t.Fatalf("PostRun() unexpected error: %v", err)
-	}
-}
-
-func TestPauseOpts_PreRun(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
-	buf := new(bytes.Buffer)
-
-	opts := &PauseOpts{
-		DeploymentOpts: *deploymentTest.Opts,
-		OutputOpts: cli.OutputOpts{
-			OutWriter: buf,
-		},
-	}
-
-	deploymentTest.
-		MockDeploymentTelemetry.
-		EXPECT().
-		AppendDeploymentUUID().
-		Times(1)
-
-	preRun := opts.PreRun()
-	if err := preRun(); err != nil {
-		t.Fatalf("PreRun() unexpected error: %v", err)
 	}
 }

--- a/internal/cli/deployments/search/indexes/create.go
+++ b/internal/cli/deployments/search/indexes/create.go
@@ -304,7 +304,9 @@ func (opts *CreateOpts) watchAtlas(_ context.Context) (any, bool, error) {
 }
 
 func (opts *CreateOpts) PostRun(ctx context.Context) error {
-	opts.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
+
 	if !opts.EnableWatch {
 		return opts.Print(opts.indexID.Index)
 	}

--- a/internal/cli/deployments/search/indexes/create_test.go
+++ b/internal/cli/deployments/search/indexes/create_test.go
@@ -143,6 +143,18 @@ func TestCreate_RunLocal(t *testing.T) {
 		}, nil).
 		Times(1)
 
+	testDeployments.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentType().
+		Times(1)
+
+	testDeployments.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	if err := opts.Run(ctx); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)
 	}
@@ -293,6 +305,18 @@ func TestCreate_RunAtlas(t *testing.T) {
 		CreateSearchIndexesDeprecated(opts.ProjectID, opts.DeploymentName, index).
 		Times(1).
 		Return(indexWithID, nil)
+
+	deploymentTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentType().
+		Times(1)
+
+	deploymentTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
 
 	if err := opts.Run(ctx); err != nil {
 		t.Fatalf("Run() unexpected error: %v", err)

--- a/internal/cli/deployments/search/indexes/delete.go
+++ b/internal/cli/deployments/search/indexes/delete.go
@@ -108,6 +108,8 @@ func (opts *DeleteOpts) initMongoDBClient() error {
 
 func (opts *DeleteOpts) PostRun() {
 	opts.DeploymentTelemetry.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
+
 }
 
 func DeleteBuilder() *cobra.Command {

--- a/internal/cli/deployments/search/indexes/delete.go
+++ b/internal/cli/deployments/search/indexes/delete.go
@@ -109,7 +109,6 @@ func (opts *DeleteOpts) initMongoDBClient() error {
 func (opts *DeleteOpts) PostRun() {
 	opts.DeploymentTelemetry.AppendDeploymentType()
 	opts.DeploymentTelemetry.AppendDeploymentUUID()
-
 }
 
 func DeleteBuilder() *cobra.Command {

--- a/internal/cli/deployments/search/indexes/delete_test.go
+++ b/internal/cli/deployments/search/indexes/delete_test.go
@@ -179,5 +179,11 @@ func TestDeleteOpts_PostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	opts.PostRun()
 }

--- a/internal/cli/deployments/search/indexes/describe.go
+++ b/internal/cli/deployments/search/indexes/describe.go
@@ -112,6 +112,7 @@ func (opts *DescribeOpts) initStore(ctx context.Context) func() error {
 
 func (opts *DescribeOpts) PostRun() {
 	opts.DeploymentTelemetry.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
 }
 
 func DescribeBuilder() *cobra.Command {

--- a/internal/cli/deployments/search/indexes/describe_test.go
+++ b/internal/cli/deployments/search/indexes/describe_test.go
@@ -194,5 +194,11 @@ func TestDescribeOpts_PostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	opts.PostRun()
 }

--- a/internal/cli/deployments/search/indexes/list.go
+++ b/internal/cli/deployments/search/indexes/list.go
@@ -116,6 +116,7 @@ func (opts *ListOpts) validateAndPrompt() error {
 
 func (opts *ListOpts) PostRun() {
 	opts.DeploymentTelemetry.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
 }
 
 func ListBuilder() *cobra.Command {

--- a/internal/cli/deployments/search/indexes/list_test.go
+++ b/internal/cli/deployments/search/indexes/list_test.go
@@ -227,5 +227,11 @@ func TestList_PostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	opts.PostRun()
 }

--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -676,6 +676,7 @@ func (opts *SetupOpts) Run(ctx context.Context) error {
 
 func (opts *SetupOpts) PostRun() {
 	opts.DeploymentTelemetry.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
 }
 
 func (opts *SetupOpts) validateTier() error {

--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -667,7 +667,6 @@ func (opts *SetupOpts) Run(ctx context.Context) error {
 		return err
 	}
 
-	opts.AppendDeploymentType()
 	if strings.EqualFold(options.LocalCluster, opts.DeploymentType) {
 		return opts.runLocal(ctx)
 	}

--- a/internal/cli/deployments/setup_test.go
+++ b/internal/cli/deployments/setup_test.go
@@ -44,6 +44,10 @@ func TestSetupOpts_PostRun(t *testing.T) {
 		EXPECT().
 		AppendDeploymentType().
 		Times(1)
+	deploymentTest.MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
 
 	opts.PostRun()
 }

--- a/internal/cli/deployments/start.go
+++ b/internal/cli/deployments/start.go
@@ -87,6 +87,7 @@ func (opts *StartOpts) RunAtlas() error {
 
 func (opts *StartOpts) PostRun() error {
 	opts.DeploymentTelemetry.AppendDeploymentType()
+	opts.DeploymentTelemetry.AppendDeploymentUUID()
 	return opts.PostRunMessages()
 }
 

--- a/internal/cli/deployments/start_test.go
+++ b/internal/cli/deployments/start_test.go
@@ -151,6 +151,12 @@ func TestStartOpts_PostRun(t *testing.T) {
 		AppendDeploymentType().
 		Times(1)
 
+	deploymentsTest.
+		MockDeploymentTelemetry.
+		EXPECT().
+		AppendDeploymentUUID().
+		Times(1)
+
 	deploymentsTest.MockContainerEngine.EXPECT().Ready().Return(nil).Times(1)
 
 	require.NoError(t, opts.PostRun())

--- a/internal/mocks/mock_deployment_opts_telemetry.go
+++ b/internal/mocks/mock_deployment_opts_telemetry.go
@@ -44,3 +44,15 @@ func (mr *MockDeploymentTelemetryMockRecorder) AppendDeploymentType() *gomock.Ca
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendDeploymentType", reflect.TypeOf((*MockDeploymentTelemetry)(nil).AppendDeploymentType))
 }
+
+// AppendDeploymentUUID mocks base method.
+func (m *MockDeploymentTelemetry) AppendDeploymentUUID() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AppendDeploymentUUID")
+}
+
+// AppendDeploymentUUID indicates an expected call of AppendDeploymentUUID.
+func (mr *MockDeploymentTelemetryMockRecorder) AppendDeploymentUUID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendDeploymentUUID", reflect.TypeOf((*MockDeploymentTelemetry)(nil).AppendDeploymentUUID))
+}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-297205

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

- Decouples UUID collection into it's own method
- For pause and delete, moves collection to happen before the core command is ran and after selection is done, so that we can collect the UUID for the right deployments
- For other commands that end up with a healthy deployment, we collect at `PostRun`
- Deployments list does not do any collection 
## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
