### PR TITLE
CLOUDP-283513: IP Access List new resource

### DIFF
--- a/internal/kubernetes/operator/config_exporter.go
+++ b/internal/kubernetes/operator/config_exporter.go
@@ -276,6 +276,28 @@ func (e *ConfigExporter) exportProject() ([]runtime.Object, string, error) {
 		}
 	}
 
+	if e.featureValidator.IsResourceSupported(features.ResourceAtlasIPAccessList) {
+		ipAccessList, isEmpty, err := project.BuildIPAccessList(
+			e.dataProvider,
+			project.IPAccessListRequest{
+				ProjectName:         projectData.Project.Name,
+				ProjectID:           e.projectID,
+				TargetNamespace:     e.targetNamespace,
+				Version:             e.operatorVersion,
+				Credentials:         credentialsName,
+				IndependentResource: e.independentResources,
+				Dictionary:          e.dictionaryForAtlasNames,
+			},
+		)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if !isEmpty {
+			r = append(r, ipAccessList)
+		}
+	}
+
 	// DB users
 	usersData, relatedSecrets, err := dbusers.BuildDBUsers(
 		e.dataProvider,

--- a/internal/kubernetes/operator/project/customroles_test.go
+++ b/internal/kubernetes/operator/project/customroles_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 //nolint:all
 package project
 

--- a/internal/kubernetes/operator/project/ipaccesslist.go
+++ b/internal/kubernetes/operator/project/ipaccesslist.go
@@ -1,0 +1,118 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/kubernetes/operator/features"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/kubernetes/operator/resources"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
+	akoapi "github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+	akov2common "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
+	akov2status "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
+	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type IPAccessListRequest struct {
+	ProjectName         string
+	ProjectID           string
+	TargetNamespace     string
+	Version             string
+	Credentials         string
+	IndependentResource bool
+	Dictionary          map[string]string
+}
+
+func BuildIPAccessList(
+	provider store.ProjectIPAccessListLister,
+	request IPAccessListRequest,
+) (*akov2.AtlasIPAccessList, bool, error) {
+	ipAccessLists, err := provider.ProjectIPAccessLists(request.ProjectID, &store.ListOptions{ItemsPerPage: MaxItems})
+	if err != nil {
+		return nil, false, err
+	}
+
+	if len(ipAccessLists.GetResults()) == 0 {
+		return nil, true, nil
+	}
+
+	entries := make([]akov2.IPAccessEntry, 0, len(ipAccessLists.GetResults()))
+	for _, ipAccessList := range ipAccessLists.GetResults() {
+		entries = append(entries, fromAtlas(ipAccessList))
+	}
+
+	resource := akov2.AtlasIPAccessList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AtlasIPAccessList",
+			APIVersion: "atlas.mongodb.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.NormalizeAtlasName(request.ProjectName+"-ip-access-list", request.Dictionary),
+			Namespace: request.TargetNamespace,
+			Labels: map[string]string{
+				features.ResourceVersion: request.Version,
+			},
+		},
+		Spec: akov2.AtlasIPAccessListSpec{
+			Entries: entries,
+		},
+		Status: akov2status.AtlasIPAccessListStatus{
+			Common: akoapi.Common{
+				Conditions: []akoapi.Condition{},
+			},
+		},
+	}
+
+	if request.IndependentResource {
+		resource.Spec.ProjectDualReference = akov2.ProjectDualReference{
+			ExternalProjectRef: &akov2.ExternalProjectReference{
+				ID: request.ProjectID,
+			},
+			ConnectionSecret: &akoapi.LocalObjectReference{
+				Name: resources.NormalizeAtlasName(request.Credentials, request.Dictionary),
+			},
+		}
+	} else {
+		resource.Spec.ProjectDualReference = akov2.ProjectDualReference{
+			ProjectRef: &akov2common.ResourceRefNamespaced{
+				Name:      request.ProjectName,
+				Namespace: request.TargetNamespace,
+			},
+		}
+	}
+
+	return &resource, false, nil
+}
+
+func fromAtlas(entry admin.NetworkPermissionEntry) akov2.IPAccessEntry {
+	result := akov2.IPAccessEntry{
+		AwsSecurityGroup: entry.GetAwsSecurityGroup(),
+		Comment:          entry.GetComment(),
+	}
+
+	if _, ok := entry.GetDeleteAfterDateOk(); ok {
+		deleteAfter := metav1.NewTime(entry.GetDeleteAfterDate())
+		result.DeleteAfterDate = &deleteAfter
+	}
+
+	if _, ok := entry.GetIpAddressOk(); ok {
+		result.IPAddress = entry.GetIpAddress()
+	} else if _, ok := entry.GetCidrBlockOk(); ok {
+		result.CIDRBlock = entry.GetCidrBlock()
+	}
+
+	return result
+}

--- a/internal/kubernetes/operator/project/ipaccesslist_test.go
+++ b/internal/kubernetes/operator/project/ipaccesslist_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unit
+
+package project
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/kubernetes/operator/features"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/kubernetes/operator/resources"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mocks"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
+	akoapi "github.com/mongodb/mongodb-atlas-kubernetes/v2/api"
+	akov2 "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1"
+	akov2common "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
+	akov2status "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/status"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/atlas-sdk/v20241113004/admin"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildIPAccessList(t *testing.T) {
+	projectID := "project-ial-id"
+	projectName := "projectName-ial"
+	targetNamespace := "ialNamespace"
+	credentialName := "ial-creds"
+	deleteAfter := metav1.NewTime(time.Now().Add(time.Hour))
+
+	tests := map[string]struct {
+		ipAccessList        []admin.NetworkPermissionEntry
+		independentResource bool
+		expectedEmpty       bool
+		expectedResource    *akov2.AtlasIPAccessList
+	}{
+		"ip access list is empty": {
+			ipAccessList:  []admin.NetworkPermissionEntry{},
+			expectedEmpty: true,
+		},
+		"generate ip access list with kubernetes project reference": {
+			ipAccessList: []admin.NetworkPermissionEntry{
+				{
+					IpAddress: pointer.Get("192.168.100.233"),
+					Comment:   pointer.Get("My private access"),
+				},
+				{
+					CidrBlock: pointer.Get("10.1.1.0/24"),
+					Comment:   pointer.Get("Company network"),
+				},
+				{
+					AwsSecurityGroup: pointer.Get("sg-123456"),
+					Comment:          pointer.Get("Cloud network"),
+				},
+				{
+					IpAddress:       pointer.Get("172.16.100.10"),
+					DeleteAfterDate: pointer.Get(deleteAfter.Time),
+					Comment:         pointer.Get("Third party temporary access"),
+				},
+			},
+			expectedResource: &akov2.AtlasIPAccessList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AtlasIPAccessList",
+					APIVersion: "atlas.mongodb.com/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "projectname-ial-ip-access-list",
+					Namespace: targetNamespace,
+					Labels: map[string]string{
+						features.ResourceVersion: "2.7.0",
+					},
+				},
+				Spec: akov2.AtlasIPAccessListSpec{
+					ProjectDualReference: akov2.ProjectDualReference{
+						ProjectRef: &akov2common.ResourceRefNamespaced{
+							Name:      projectName,
+							Namespace: targetNamespace,
+						},
+					},
+					Entries: []akov2.IPAccessEntry{
+						{
+							IPAddress: "192.168.100.233",
+							Comment:   "My private access",
+						},
+						{
+							CIDRBlock: "10.1.1.0/24",
+							Comment:   "Company network",
+						},
+						{
+							AwsSecurityGroup: "sg-123456",
+							Comment:          "Cloud network",
+						},
+						{
+							IPAddress:       "172.16.100.10",
+							DeleteAfterDate: pointer.Get(deleteAfter),
+							Comment:         "Third party temporary access",
+						},
+					},
+				},
+				Status: akov2status.AtlasIPAccessListStatus{
+					Common: akoapi.Common{
+						Conditions: []akoapi.Condition{},
+					},
+				},
+			},
+		},
+		"generate ip access list with external project reference": {
+			ipAccessList: []admin.NetworkPermissionEntry{
+				{
+					IpAddress: pointer.Get("192.168.100.233"),
+					Comment:   pointer.Get("My private access"),
+				},
+				{
+					CidrBlock: pointer.Get("10.1.1.0/24"),
+					Comment:   pointer.Get("Company network"),
+				},
+			},
+			independentResource: true,
+			expectedResource: &akov2.AtlasIPAccessList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AtlasIPAccessList",
+					APIVersion: "atlas.mongodb.com/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "projectname-ial-ip-access-list",
+					Namespace: targetNamespace,
+					Labels: map[string]string{
+						features.ResourceVersion: "2.7.0",
+					},
+				},
+				Spec: akov2.AtlasIPAccessListSpec{
+					ProjectDualReference: akov2.ProjectDualReference{
+						ExternalProjectRef: &akov2.ExternalProjectReference{
+							ID: projectID,
+						},
+						ConnectionSecret: &akoapi.LocalObjectReference{
+							Name: credentialName,
+						},
+					},
+					Entries: []akov2.IPAccessEntry{
+						{
+							IPAddress: "192.168.100.233",
+							Comment:   "My private access",
+						},
+						{
+							CIDRBlock: "10.1.1.0/24",
+							Comment:   "Company network",
+						},
+					},
+				},
+				Status: akov2status.AtlasIPAccessListStatus{
+					Common: akoapi.Common{
+						Conditions: []akoapi.Condition{},
+					},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctl := gomock.NewController(t)
+			ialStore := mocks.NewMockProjectIPAccessListLister(ctl)
+			dictionary := resources.AtlasNameToKubernetesName()
+
+			ialStore.EXPECT().ProjectIPAccessLists(projectID, &store.ListOptions{ItemsPerPage: MaxItems}).
+				Return(&admin.PaginatedNetworkAccess{Results: &tt.ipAccessList}, nil)
+
+			atlasIPAccessList, isEmpty, err := BuildIPAccessList(
+				ialStore,
+				IPAccessListRequest{
+					ProjectName:         projectName,
+					ProjectID:           projectID,
+					TargetNamespace:     targetNamespace,
+					Version:             "2.7.0",
+					Credentials:         credentialName,
+					IndependentResource: tt.independentResource,
+					Dictionary:          dictionary,
+				},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedEmpty, isEmpty)
+			assert.Equal(t, tt.expectedResource, atlasIPAccessList)
+		})
+	}
+}

--- a/internal/kubernetes/operator/project/privateendpoints_test.go
+++ b/internal/kubernetes/operator/project/privateendpoints_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package project
 
 import (

--- a/internal/kubernetes/operator/project/project.go
+++ b/internal/kubernetes/operator/project/project.go
@@ -94,7 +94,7 @@ func BuildAtlasProject(br *AtlasProjectBuildRequest) (*AtlasProjectResult, error
 		Teams:   nil,
 	}
 
-	if br.Validator.FeatureExist(features.ResourceAtlasProject, featureAccessLists) {
+	if br.Validator.FeatureExist(features.ResourceAtlasProject, featureAccessLists) && !br.Validator.IsResourceSupported(features.ResourceAtlasIPAccessList) {
 		ipAccessList, ferr := buildAccessLists(br.ProjectStore, br.ProjectID)
 		if ferr != nil {
 			return nil, ferr

--- a/internal/kubernetes/operator/project/project_test.go
+++ b/internal/kubernetes/operator/project/project_test.go
@@ -597,15 +597,6 @@ func TestBuildAtlasProject(t *testing.T) {
 					ConnectionSecret: &akov2common.ResourceRefNamespaced{
 						Name: resources.NormalizeAtlasName(fmt.Sprintf(credSecretFormat, p.Name), dictionary),
 					},
-					ProjectIPAccessList: []akov2project.IPAccessList{
-						{
-							AwsSecurityGroup: ipAccessLists.GetResults()[0].GetAwsSecurityGroup(),
-							CIDRBlock:        ipAccessLists.GetResults()[0].GetCidrBlock(),
-							Comment:          ipAccessLists.GetResults()[0].GetComment(),
-							DeleteAfterDate:  ipAccessLists.GetResults()[0].GetDeleteAfterDate().String(),
-							IPAddress:        ipAccessLists.GetResults()[0].GetIpAddress(),
-						},
-					},
 					MaintenanceWindow: akov2project.MaintenanceWindow{
 						DayOfWeek: mw.DayOfWeek,
 						HourOfDay: mw.GetHourOfDay(),
@@ -711,7 +702,6 @@ func TestBuildAtlasProject(t *testing.T) {
 		projectStore := mocks.NewMockOperatorProjectStore(ctl)
 		featureValidator := mocks.NewMockFeatureValidator(ctl)
 		t.Run(name, func(t *testing.T) {
-			projectStore.EXPECT().ProjectIPAccessLists(projectID, listOption).Return(ipAccessLists, nil)
 			projectStore.EXPECT().MaintenanceWindow(projectID).Return(mw, nil)
 			projectStore.EXPECT().Integrations(projectID).Return(thirdPartyIntegrations, nil)
 			projectStore.EXPECT().PeeringConnections(projectID, containerListOptionAWS).Return(peeringConnections, nil)
@@ -728,6 +718,7 @@ func TestBuildAtlasProject(t *testing.T) {
 			projectStore.EXPECT().DescribeCompliancePolicy(projectID).Return(bcp, nil)
 			tt.privateEndpointMock(projectStore)
 			if !tt.independentResource {
+				projectStore.EXPECT().ProjectIPAccessLists(projectID, listOption).Return(ipAccessLists, nil)
 				projectStore.EXPECT().DatabaseRoles(projectID).Return(customRoles, nil)
 			}
 
@@ -746,6 +737,7 @@ func TestBuildAtlasProject(t *testing.T) {
 			featureValidator.EXPECT().FeatureExist(features.ResourceAtlasProject, featureBCP).Return(true)
 			featureValidator.EXPECT().IsResourceSupported(features.ResourceAtlasPrivateEndpoint).Return(tt.independentResource)
 			featureValidator.EXPECT().IsResourceSupported(features.ResourceAtlasCustomRole).Return(tt.independentResource)
+			featureValidator.EXPECT().IsResourceSupported(features.ResourceAtlasIPAccessList).Return(tt.independentResource)
 
 			projectResult, err := BuildAtlasProject(&AtlasProjectBuildRequest{
 				ProjectStore:    projectStore,


### PR DESCRIPTION
## Proposed changes

This PR add the support to export the new custom resource for IP Access List

_Jira ticket:_ CLOUDP-283513

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
