### PR TITLE
CLOUDP-297944: [AtlasCLI] Improve config properties handling

### DIFF
--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -90,7 +90,7 @@ func SetBuilder() *cobra.Command {
 			"propertyNameDesc": "Property to set in the profile. Valid values for Atlas CLI are project_id, org_id, service, public_api_key, private_api_key, output, mongosh_path, skip_update_check, telemetry_enabled, access_token, and refresh_token.",
 			"valueDesc":        "Value for the property to set in the profile.",
 		},
-		ValidArgs: config.Properties(),
+		ValidArgs: config.AllProperties(),
 		RunE: func(_ *cobra.Command, args []string) error {
 			opts := &SetOpts{
 				store: config.Default(),

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -108,23 +108,8 @@ type Profile struct {
 	err       error
 }
 
-func Properties() []string {
-	return []string{
-		projectID,
-		orgID,
-		service,
-		publicAPIKey,
-		privateAPIKey,
-		output,
-		OpsManagerURLField,
-		baseURL,
-		mongoShellPath,
-		skipUpdateCheck,
-		TelemetryEnabledProperty,
-		AccessTokenField,
-		RefreshTokenField,
-		apiVersion,
-	}
+func AllProperties() []string {
+	return append(ProfileProperties(), GlobalProperties()...)
 }
 
 func BooleanProperties() []string {
@@ -134,12 +119,28 @@ func BooleanProperties() []string {
 	}
 }
 
+func ProfileProperties() []string {
+	return []string{
+		AccessTokenField,
+		apiVersion,
+		baseURL,
+		OpsManagerURLField,
+		orgID,
+		output,
+		privateAPIKey,
+		projectID,
+		publicAPIKey,
+		RefreshTokenField,
+		service,
+	}
+}
+
 func GlobalProperties() []string {
 	return []string{
+		LocalDeploymentImage,
+		mongoShellPath,
 		skipUpdateCheck,
 		TelemetryEnabledProperty,
-		mongoShellPath,
-		LocalDeploymentImage,
 	}
 }
 
@@ -162,7 +163,7 @@ func List() []string {
 
 	keys := make([]string, 0, len(m))
 	for k := range m {
-		if !slices.Contains(Properties(), k) {
+		if !slices.Contains(AllProperties(), k) {
 			keys = append(keys, k)
 		}
 	}


### PR DESCRIPTION
## Proposed changes

Improved property handling in `profile.go`

Originally, we had: `GlobalProperties` and `Properties`.
- `GlobalProperties` contains only global properties
- `Properties` on the other hand should contain `GlobalProperties` + the properties in the profile, which is not clear

Changes:
- Renamed `Properties` -> `AllProperties`
- Introduced `ProfileProperties`
-  `AllProperties` now returns a combination of `GlobalProperties` + `ProfileProperties`

This should avoid bugs in the future.

_Jira ticket:_ CLOUDP-297944
