### PR TITLE
CLOUDP-297955: Pin third-party GitHub Actions to a specific SHA

### DIFF
--- a/.github/workflows/autoupdate-sdk.yaml
+++ b/.github/workflows/autoupdate-sdk.yaml
@@ -20,7 +20,7 @@ jobs:
         run:  echo "VERSION=$(curl -sSfL -X GET  https://api.github.com/repos/mongodb/atlas-sdk-go/releases/latest | jq -r '.tag_name')" >> "$GITHUB_OUTPUT"
       - run:  make update-atlas-sdk
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v20.0.1
+        uses: tj-actions/verify-changed-files@6b59fb7cbb8d9a6ecc10ee556496d0078a9ed957
         id: verify-changed-files
         with:
           files: |
@@ -30,7 +30,7 @@ jobs:
       - name: Find JIRA ticket
         id: find
         if: steps.verify-changed-files.outputs.files_changed == 'true'
-        uses: mongodb/apix-action/find-jira@v5
+        uses: mongodb/apix-action/find-jira@d74254f04d46b8e94ef22248607d47225c8a171a
         with:
           token: ${{ secrets.JIRA_API_TOKEN }}
           jql: project = CLOUDP and summary ~ "Bump Atlas GO SDK to '${{ steps.version.outputs.VERSION }}'"
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "JIRA_KEY=${{steps.find.outputs.issue-key}}" >> "$GITHUB_ENV"
       - name: Create JIRA ticket
-        uses: mongodb/apix-action/create-jira@v5
+        uses: mongodb/apix-action/create-jira@d74254f04d46b8e94ef22248607d47225c8a171a
         id: create
         if: (steps.verify-changed-files.outputs.files_changed == 'true') && (steps.find.outputs.found == 'false')
         with:
@@ -69,11 +69,11 @@ jobs:
       - name: set Apix Bot token
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         id: app-token
-        uses: mongodb/apix-action/token@v5
+        uses: mongodb/apix-action/token@d74254f04d46b8e94ef22248607d47225c8a171a
         with:
           app-id: ${{ secrets.APIXBOT_APP_ID }}
           private-key: ${{ secrets.APIXBOT_APP_PEM }}
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f
         id: pr
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         with:

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -23,7 +23,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.2.0
+        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae
         with:
           version: v1.61.0
   unit-tests:
@@ -54,7 +54,7 @@ jobs:
       - run: make unit-test
       - name: Test Summary
         id: test_summary
-        uses: test-summary/action@v2.4
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
         with:
           paths: unit-tests.xml
         if: always() && matrix.os == 'ubuntu-latest'
@@ -146,7 +146,7 @@ jobs:
           app-id: ${{ secrets.APIXBOT_APP_ID }}
           private-key: ${{ secrets.APIXBOT_APP_PEM }}
       - name: Comment PR
-        uses: marocchino/sticky-pull-request-comment@v2.9.1
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728
         with:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           recreate: true
@@ -271,7 +271,7 @@ jobs:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - uses: actions/checkout@v4
       - name: Run ShellCheck
-        uses: bewuethr/shellcheck-action@v2
+        uses: bewuethr/shellcheck-action@d01912909579c4b1a335828b8fca197fbb8e0aa4
   tidy:
     runs-on: ubuntu-latest
     steps:
@@ -338,11 +338,11 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
       - name: Linting
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
         with:
           dockerfile: Dockerfile
       - name: Enable containerd image store
-        uses: crazy-max/ghaction-setup-docker@v4.1.0
+        uses: docker/setup-docker-action@370a7dad4b8ce8dbf00f9363e1652e5074dd6abe
         with:
           version: v24.0.6
           daemon-config: |
@@ -352,9 +352,9 @@ jobs:
               }
             }
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.8.0
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
       - name: Build image to dockerhub staging registry
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -78,7 +78,7 @@
           echo "The following JIRA ticket has been created: ${JIRA_TICKET_ID}"
           echo "jira-ticket-id=${JIRA_TICKET_ID}" >> "${GITHUB_OUTPUT}"
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -144,7 +144,7 @@ jobs:
             --tag ${{ env.IMAGE_REPOSITORY }}:${{ env.LATEST_VERSION }}-${{ env.DATE }} \
             ${{ env.STAGING_IMAGE_REPOSITORY }}:latest
       - name: Login to Quay
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
           registry: "${{ env.QUAY }}"
           username: "${{ secrets.QUAY_USER }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
           E2E_TAGS: config
       - name: Test Summary
         id: test_summary
-        uses: test-summary/action@v2.4
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
         with:
           paths: e2e-tests.xml
   brew:
@@ -64,6 +64,6 @@ jobs:
           E2E_TAGS: brew
       - name: Test Summary
         id: test_summary
-        uses: test-summary/action@v2.4
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
         with:
           paths: e2e-tests.xml

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -61,7 +61,7 @@
           echo "The following JIRA ticket has been created: ${JIRA_TICKET_ID}"
           echo "jira-ticket-id=${JIRA_TICKET_ID}" >> "${GITHUB_OUTPUT}"
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Pin third-party GitHub Actions to a specific SHA
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-297955

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->
