### PR TITLE
CLOUDP-299544: `atlas backup restore start download` requires targetProjectId for dedicated cluster

### DIFF
--- a/internal/cli/backup/restores/start.go
+++ b/internal/cli/backup/restores/start.go
@@ -166,7 +166,7 @@ func (opts *StartOpts) newIsFlexCluster() error {
 		return nil
 	}
 
-	if atlasClustersPinned.IsErrorCode(err, cannotUseFlexWithClusterApisErrorCode) {
+	if !atlasClustersPinned.IsErrorCode(err, cannotUseFlexWithClusterApisErrorCode) {
 		return err
 	}
 

--- a/internal/cli/backup/restores/start.go
+++ b/internal/cli/backup/restores/start.go
@@ -166,12 +166,7 @@ func (opts *StartOpts) newIsFlexCluster() error {
 		return nil
 	}
 
-	apiError, ok := atlasClustersPinned.AsError(err)
-	if !ok {
-		return err
-	}
-
-	if *apiError.ErrorCode != cannotUseFlexWithClusterApisErrorCode {
+	if atlasClustersPinned.IsErrorCode(err, cannotUseFlexWithClusterApisErrorCode) {
 		return err
 	}
 

--- a/internal/cli/backup/restores/start.go
+++ b/internal/cli/backup/restores/start.go
@@ -26,13 +26,15 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
 	"github.com/spf13/cobra"
+	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 )
 
 const (
-	automatedRestore   = "automated"
-	downloadRestore    = "download"
-	pointInTimeRestore = "pointInTime"
+	automatedRestore                      = "automated"
+	downloadRestore                       = "download"
+	pointInTimeRestore                    = "pointInTime"
+	cannotUseFlexWithClusterApisErrorCode = "CANNOT_USE_FLEX_CLUSTER_IN_CLUSTER_API"
 )
 
 type StartOpts struct {
@@ -42,10 +44,11 @@ type StartOpts struct {
 	clusterName           string
 	targetProjectID       string
 	targetClusterName     string
+	snapshotID            string
 	oplogTS               int
 	oplogInc              int
-	snapshotID            string
 	pointInTimeUTCSeconds int
+	isFlexCluster         bool
 	store                 store.RestoreJobsCreator
 }
 
@@ -60,23 +63,16 @@ func (opts *StartOpts) initStore(ctx context.Context) func() error {
 var startTemplate = "Restore job '{{.Id}}' successfully started\n"
 
 func (opts *StartOpts) Run() error {
-	r, err := opts.store.CreateRestoreFlexClusterJobs(opts.ConfigProjectID(), opts.clusterName, opts.newFlexBackupRestoreJobCreate())
-	if err == nil {
+	if opts.isFlexCluster {
+		r, err := opts.store.CreateRestoreFlexClusterJobs(opts.ConfigProjectID(), opts.clusterName, opts.newFlexBackupRestoreJobCreate())
+		if err != nil {
+			return commonerrors.Check(err)
+		}
 		return opts.Print(r)
-	}
-
-	apiError, ok := admin.AsError(err)
-	if !ok {
-		return commonerrors.Check(err)
-	}
-
-	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != featureUnsupported {
-		return commonerrors.Check(err)
 	}
 
 	request := opts.newCloudProviderSnapshotRestoreJob()
 	restoreJob, err := opts.store.CreateRestoreJobs(opts.ConfigProjectID(), opts.clusterName, request)
-
 	if err != nil {
 		return commonerrors.Check(err)
 	}
@@ -162,6 +158,27 @@ func markRequiredPointInTimeRestoreFlags(cmd *cobra.Command) error {
 	return cmd.MarkFlagRequired(flag.TargetClusterName)
 }
 
+// newIsFlexCluster sets the opts.isFlexCluster that indicates if the cluster is a FlexCluster.
+func (opts *StartOpts) newIsFlexCluster() error {
+	_, err := opts.store.AtlasCluster(opts.ConfigProjectID(), opts.clusterName)
+	if err == nil {
+		opts.isFlexCluster = false
+		return nil
+	}
+
+	apiError, ok := atlasClustersPinned.AsError(err)
+	if !ok {
+		return err
+	}
+
+	if *apiError.ErrorCode != cannotUseFlexWithClusterApisErrorCode {
+		return err
+	}
+
+	opts.isFlexCluster = true
+	return nil
+}
+
 // StartBuilder builds a cobra.Command that can run as:
 // atlas backup(s) restore(s) job(s) start <automated|download|pointInTime>.
 func StartBuilder() *cobra.Command {
@@ -228,6 +245,7 @@ func StartBuilder() *cobra.Command {
 			return opts.PreRunE(
 				opts.ValidateProjectID,
 				opts.initStore(cmd.Context()),
+				opts.newIsFlexCluster,
 				opts.InitOutput(cmd.OutOrStdout(), startTemplate),
 			)
 		},

--- a/internal/cli/backup/restores/start_test.go
+++ b/internal/cli/backup/restores/start_test.go
@@ -28,7 +28,6 @@ import (
 func TestStart_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockRestoreJobsCreator(ctrl)
-
 	expected := &atlasv2.DiskBackupSnapshotRestoreJob{}
 
 	t.Run(automatedRestore, func(t *testing.T) {
@@ -38,20 +37,12 @@ func TestStart_Run(t *testing.T) {
 			clusterName:       "Cluster0",
 			targetClusterName: "Cluster1",
 			targetProjectID:   "1",
+			isFlexCluster:     false,
 		}
 
-		expectedError := &atlasv2.GenericOpenAPIError{}
-		expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
-
 		mockStore.
 			EXPECT().
-			CreateRestoreFlexClusterJobs(listOpts.ProjectID, "Cluster0", listOpts.newFlexBackupRestoreJobCreate()).
-			Return(nil, expectedError).
-			Times(1)
-
-		mockStore.
-			EXPECT().
-			CreateRestoreJobs(listOpts.ProjectID, "Cluster0", listOpts.newCloudProviderSnapshotRestoreJob()).
+			CreateRestoreJobs(listOpts.ProjectID, listOpts.clusterName, listOpts.newCloudProviderSnapshotRestoreJob()).
 			Return(expected, nil).
 			Times(1)
 
@@ -65,12 +56,10 @@ func TestStart_Run(t *testing.T) {
 			clusterName:       "Cluster0",
 			targetClusterName: "Cluster1",
 			targetProjectID:   "1",
+			isFlexCluster:     true,
 		}
 
 		expectedFlex := &atlasv2.FlexBackupRestoreJob20241113{}
-		expectedError := &atlasv2.GenericOpenAPIError{}
-		expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
-
 		mockStore.
 			EXPECT().
 			CreateRestoreFlexClusterJobs(listOpts.ProjectID, "Cluster0", listOpts.newFlexBackupRestoreJobCreate()).
@@ -87,16 +76,8 @@ func TestStart_Run(t *testing.T) {
 			clusterName:       "Cluster0",
 			targetClusterName: "Cluster1",
 			targetProjectID:   "1",
+			isFlexCluster:     false,
 		}
-
-		expectedError := &atlasv2.GenericOpenAPIError{}
-		expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
-
-		mockStore.
-			EXPECT().
-			CreateRestoreFlexClusterJobs(listOpts.ProjectID, "Cluster0", listOpts.newFlexBackupRestoreJobCreate()).
-			Return(nil, expectedError).
-			Times(1)
 
 		mockStore.
 			EXPECT().
@@ -109,19 +90,11 @@ func TestStart_Run(t *testing.T) {
 
 	t.Run(downloadRestore, func(t *testing.T) {
 		listOpts := &StartOpts{
-			store:       mockStore,
-			method:      downloadRestore,
-			clusterName: "Cluster0",
+			store:         mockStore,
+			method:        downloadRestore,
+			clusterName:   "Cluster0",
+			isFlexCluster: false,
 		}
-
-		expectedError := &atlasv2.GenericOpenAPIError{}
-		expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
-
-		mockStore.
-			EXPECT().
-			CreateRestoreFlexClusterJobs(listOpts.ProjectID, "Cluster0", listOpts.newFlexBackupRestoreJobCreate()).
-			Return(nil, expectedError).
-			Times(1)
 
 		mockStore.
 			EXPECT().

--- a/internal/mocks/mock_cloud_provider_backup.go
+++ b/internal/mocks/mock_cloud_provider_backup.go
@@ -142,6 +142,21 @@ func (m *MockRestoreJobsCreator) EXPECT() *MockRestoreJobsCreatorMockRecorder {
 	return m.recorder
 }
 
+// AtlasCluster mocks base method.
+func (m *MockRestoreJobsCreator) AtlasCluster(arg0, arg1 string) (*admin.AdvancedClusterDescription, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtlasCluster", arg0, arg1)
+	ret0, _ := ret[0].(*admin.AdvancedClusterDescription)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AtlasCluster indicates an expected call of AtlasCluster.
+func (mr *MockRestoreJobsCreatorMockRecorder) AtlasCluster(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtlasCluster", reflect.TypeOf((*MockRestoreJobsCreator)(nil).AtlasCluster), arg0, arg1)
+}
+
 // CreateRestoreFlexClusterJobs mocks base method.
 func (m *MockRestoreJobsCreator) CreateRestoreFlexClusterJobs(arg0, arg1 string, arg2 *admin0.FlexBackupRestoreJobCreate20241113) (*admin0.FlexBackupRestoreJob20241113, error) {
 	m.ctrl.T.Helper()

--- a/internal/store/cloud_provider_backup.go
+++ b/internal/store/cloud_provider_backup.go
@@ -38,6 +38,7 @@ type RestoreJobsDescriber interface {
 type RestoreJobsCreator interface {
 	CreateRestoreJobs(string, string, *atlasv2.DiskBackupSnapshotRestoreJob) (*atlasv2.DiskBackupSnapshotRestoreJob, error)
 	CreateRestoreFlexClusterJobs(string, string, *atlasv2.FlexBackupRestoreJobCreate20241113) (*atlasv2.FlexBackupRestoreJob20241113, error)
+	AtlasCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)
 }
 
 type SnapshotsLister interface {

--- a/test/e2e/atlas/backup_flex_test.go
+++ b/test/e2e/atlas/backup_flex_test.go
@@ -118,7 +118,9 @@ func TestFlexBackup(t *testing.T) {
 		var result atlasv2.FlexBackupRestoreJob20241113
 		require.NoError(t, json.Unmarshal(resp, &result), string(resp))
 		restoreJobID = result.GetId()
-		t.Log("snapshotID", restoreJobID)
+		t.Log("restoreJobId", restoreJobID)
+		t.Log("Response:", string(resp))
+
 		require.NotEmpty(t, restoreJobID)
 	})
 

--- a/test/e2e/atlas/backup_flex_test.go
+++ b/test/e2e/atlas/backup_flex_test.go
@@ -96,7 +96,7 @@ func TestFlexBackup(t *testing.T) {
 
 	var restoreJobID string
 
-	t.Run("Restores Create", func(t *testing.T) {
+	t.Run("Restores Create - Automated", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			backupsEntity,
 			restoresEntity,
@@ -168,6 +168,47 @@ func TestFlexBackup(t *testing.T) {
 		var result atlasv2.FlexBackupRestoreJob20241113
 		require.NoError(t, json.Unmarshal(resp, &result))
 		assert.NotEmpty(t, result)
+	})
+
+	t.Run("Restores Create - Download", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			restoresEntity,
+			"start",
+			"download",
+			"--clusterName",
+			clusterName,
+			"--snapshotId",
+			snapshotID,
+			"--targetClusterName",
+			g.clusterName,
+			"--targetProjectId",
+			g.projectID,
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := e2e.RunAndGetStdOut(cmd)
+
+		require.NoError(t, err, string(resp))
+		var result atlasv2.FlexBackupRestoreJob20241113
+		require.NoError(t, json.Unmarshal(resp, &result), string(resp))
+		restoreJobID = result.GetId()
+		t.Log("snapshotID", restoreJobID)
+		require.NotEmpty(t, restoreJobID)
+	})
+
+	t.Run("Restores Watch - Download", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			restoresEntity,
+			"watch",
+			restoreJobID,
+			"--clusterName",
+			clusterName,
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := e2e.RunAndGetStdOut(cmd)
+
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Delete flex cluster", func(t *testing.T) {

--- a/test/e2e/atlas/backup_flex_test.go
+++ b/test/e2e/atlas/backup_flex_test.go
@@ -119,7 +119,6 @@ func TestFlexBackup(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp, &result), string(resp))
 		restoreJobID = result.GetId()
 		t.Log("restoreJobId", restoreJobID)
-		t.Log("Response:", string(resp))
 
 		require.NotEmpty(t, restoreJobID)
 	})

--- a/test/e2e/atlas/backup_restores_test.go
+++ b/test/e2e/atlas/backup_restores_test.go
@@ -79,7 +79,7 @@ func TestRestores(t *testing.T) {
 		t.Log(string(resp))
 	})
 
-	t.Run("Restores Create", func(t *testing.T) {
+	t.Run("Restores Create - Automated", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			backupsEntity,
 			restoresEntity,
@@ -159,6 +159,45 @@ func TestRestores(t *testing.T) {
 		var result atlasv2.DiskBackupSnapshotRestoreJob
 		require.NoError(t, json.Unmarshal(resp, &result), string(resp))
 		assert.NotEmpty(t, result)
+	})
+
+	t.Run("Restores Create - Download", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			restoresEntity,
+			"start",
+			"download",
+			"--clusterName",
+			g.clusterName,
+			"--snapshotId",
+			snapshotID,
+			"--projectId",
+			g.projectID,
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := e2e.RunAndGetStdOut(cmd)
+
+		require.NoError(t, err, string(resp))
+		var result atlasv2.DiskBackupSnapshotRestoreJob
+		require.NoError(t, json.Unmarshal(resp, &result))
+		restoreJobID = result.GetId()
+	})
+
+	t.Run("Restores Watch - Download", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			backupsEntity,
+			restoresEntity,
+			"watch",
+			restoreJobID,
+			"--clusterName",
+			g.clusterName,
+			"--projectId",
+			g.projectID,
+			"-o=json")
+		cmd.Env = os.Environ()
+		resp, err := e2e.RunAndGetStdOut(cmd)
+
+		require.NoError(t, err, string(resp))
 	})
 
 	t.Run("Delete snapshot", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-299544

Bug:
The `atlas backup restore start download` returns `MISSING_ATTRIBUTE` error when trying a restore download with a Dedicated Cluster. The reason is that we are wrongly calling the Flex API.

This PR updates the command logic to get the cluster first to see if is flex or not, and then call the right API.

```bash
atlas backup restore start download --clusterName Cluster0 --snapshotId 67a645ae781f9601bf0925bb -P prod
Error: https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/flexClusters/Cluster0/backup/restoreJobs POST: HTTP 400 Bad Request (Error code: "MISSING_ATTRIBUTE") Detail: The required attribute targetProjectId was not specified. Reason: Bad Request. Params: [targetProjectId], BadRequestDetail:
```

Fix:
```bash
./bin/atlas backup restore start download --clusterName Cluster0 --snapshotId 67a645ae781f9601bf0925bb -P prod
Restore job '67a64a93781f9601bf0da6c2' successfully started
```

For Flex cluster we still see the error:
```bash 
./bin/atlas backup restore start download --clusterName FlexCluster --snapshotId 67a645ae781f9601bf0925bb -P prod
Error: https://cloud.mongodb.com/api/atlas/v2/groups/663268874ddd3b236fd2f107/flexClusters/FlexCluster/backup/restoreJobs POST: HTTP 400 Bad Request (Error code: "MISSING_ATTRIBUTE") Detail: The required attribute targetProjectId was not specified. Reason: Bad Request. Params: [targetProjectId], BadRequestDetail:
```

```
/bin/atlas backup restore start download --clusterName FlexCluster --snapshotId 67a76aae20363e4226209201 --targetProjectId 663268874ddd3b236fd2f107 -P prod --targetClusterName FlexCluster

Restore job '67aa2b8870e79e22dfac338a' successfully started
```
