### PR TITLE
CLOUDP-297411: Implement --watch support

### DIFF
--- a/internal/api/executor.go
+++ b/internal/api/executor.go
@@ -115,6 +115,7 @@ func (e *Executor) ExecuteCommand(ctx context.Context, commandRequest CommandReq
 
 	//nolint: mnd // httpResponse.StatusCode >= StatusOK && httpResponse.StatusCode < StatusMultipleChoices makes this code harder to read
 	isSuccess := httpResponse.StatusCode >= 200 && httpResponse.StatusCode < 300
+	httpCode := httpResponse.StatusCode
 	output := httpResponse.Body
 
 	if isSuccess {
@@ -128,6 +129,7 @@ func (e *Executor) ExecuteCommand(ctx context.Context, commandRequest CommandReq
 
 	response := CommandResponse{
 		IsSuccess: isSuccess,
+		HTTPCode:  httpCode,
 		Output:    output,
 	}
 

--- a/internal/api/executor.go
+++ b/internal/api/executor.go
@@ -60,7 +60,7 @@ func NewExecutor(commandConverter CommandConverter, httpClient *http.Client, for
 }
 
 // Executor wired up to use the default profile and static functions on config.
-func NewDefaultExecutor() (*Executor, error) {
+func NewDefaultExecutor(formatter ResponseFormatter) (*Executor, error) {
 	profile := config.Default()
 
 	client := &http.Client{
@@ -72,8 +72,6 @@ func NewDefaultExecutor() (*Executor, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	formatter := NewFormatter()
 
 	return NewExecutor(
 		commandConverter,
@@ -117,15 +115,6 @@ func (e *Executor) ExecuteCommand(ctx context.Context, commandRequest CommandReq
 	isSuccess := httpResponse.StatusCode >= 200 && httpResponse.StatusCode < 300
 	httpCode := httpResponse.StatusCode
 	output := httpResponse.Body
-
-	if isSuccess {
-		formattedOutput, err := e.formatter.Format(commandRequest.Format, output)
-		if err != nil {
-			return nil, err
-		}
-
-		output = formattedOutput
-	}
 
 	response := CommandResponse{
 		IsSuccess: isSuccess,

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -47,6 +47,7 @@ type CommandRequest struct {
 
 type CommandResponse struct {
 	IsSuccess bool
+	HTTPCode  int
 	Output    io.ReadCloser
 }
 

--- a/internal/api/watcher.go
+++ b/internal/api/watcher.go
@@ -2,15 +2,23 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"reflect"
+	"slices"
 	"time"
+
+	"github.com/PaesslerAG/jsonpath"
 )
 
 var (
-	ErrWatcherFailedToBuildRequest        = errors.New("failed to build watcher request")
-	ErrWatcherFailedToWatch               = errors.New("failed to watch")
-	ErrWatcherFailedToExecuteWatchRequest = errors.New("failed to execute watch request")
+	ErrWatcherFailedToBuildRequest                   = errors.New("failed to build watcher request")
+	ErrWatcherFailedToWatch                          = errors.New("failed to watch")
+	ErrWatcherFailedToExecuteWatchRequest            = errors.New("failed to execute watch request")
+	ErrWatcherGetCommandNotFound                     = errors.New("watcher get command not found")
+	ErrWatcherFailedToApplyJSONPathToWatcherResponse = errors.New("failed to apply json path to watcher response")
 )
 
 const (
@@ -22,10 +30,10 @@ type Watcher struct {
 }
 
 func (w *Watcher) Watch(ctx context.Context, props WatcherProperties) error {
-	// TODO: add timeout support
-	//ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	//defer cancel()
-	request, err := buildRequest(props)
+	// TODO: add timeout support, separate ticket (also add flag)
+	// ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// defer cancel()
+	request, err := buildRequest(Commands, props)
 	if err != nil || request == nil {
 		return errors.Join(ErrWatcherFailedToBuildRequest, err)
 	}
@@ -35,8 +43,13 @@ func (w *Watcher) Watch(ctx context.Context, props WatcherProperties) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			if err := watchInner(ctx, w.executor, *request); err != nil {
+			done, err := watchInner(ctx, w.executor, props.Expect, *request)
+			if err != nil {
 				return errors.Join(ErrWatcherFailedToWatch, err)
+			}
+
+			if done {
+				return nil
 			}
 
 			time.Sleep(WatcherWatchInterval)
@@ -44,16 +57,94 @@ func (w *Watcher) Watch(ctx context.Context, props WatcherProperties) error {
 	}
 }
 
-func buildRequest(props WatcherProperties) (*CommandRequest, error) {
-	panic(fmt.Sprintf("TODO. UNUSED:%v", props))
-}
-
-// Actual watcher logic without handling
-func watchInner(ctx context.Context, executor CommandExecutor, commandRequest CommandRequest) error {
-	response, err := executor.ExecuteCommand(ctx, commandRequest)
-	if err != nil {
-		return errors.Join(ErrWatcherFailedToExecuteWatchRequest, err)
+func buildRequest(allCommands GroupedAndSortedCommands, props WatcherProperties) (*CommandRequest, error) {
+	var command *Command
+	for _, commandGroup := range allCommands {
+		for _, loopCommand := range commandGroup.Commands {
+			if loopCommand.OperationID == props.Get.OperationID {
+				command = &loopCommand
+			}
+		}
 	}
 
-	panic(fmt.Sprintf("TODO. UNUSED:%v", response))
+	if command == nil {
+		return nil, fmt.Errorf("%w (OperationID=%s)", ErrWatcherGetCommandNotFound, props.Get.OperationID)
+	}
+
+	requestParams := make(map[string][]string, len(props.Get.Params))
+	for key, value := range props.Get.Params {
+		requestParams[key] = []string{value}
+	}
+
+	return &CommandRequest{
+		Command:    *command,
+		Format:     "json",
+		Parameters: requestParams,
+		Version:    props.Get.Version,
+	}, nil
+}
+
+// Actual watcher logic without handling.
+func watchInner(ctx context.Context, executor CommandExecutor, expect *WatcherExpectProperties, commandRequest CommandRequest) (bool, error) {
+	// execute the command using the executor
+	response, err := executor.ExecuteCommand(ctx, commandRequest)
+	if err != nil {
+		return false, errors.Join(ErrWatcherFailedToExecuteWatchRequest, err)
+	}
+
+	// verify the HTTPCode, 200 is the default when nothing is provided
+	expectedHTTPCode := 200
+	if expect != nil && expect.HTTPCode != 0 {
+		expectedHTTPCode = expect.HTTPCode
+	}
+
+	if expectedHTTPCode != response.HTTPCode {
+		return false, nil
+	}
+
+	// check if we need to match the contents or not
+	if expect != nil && expect.Match != nil && expect.Match.Values != nil {
+		// get the value from the response.output
+		value, err := applyJSONPath(response.Output, expect.Match.Path)
+		if err != nil {
+			return false, errors.Join(ErrWatcherFailedToApplyJSONPathToWatcherResponse, err)
+		}
+
+		// check if the value is one of the expected values
+		return slices.Contains(expect.Match.Values, value), nil
+	}
+
+	// if we get here, everything is ok!
+	return true, nil
+}
+
+func applyJSONPath(readerCloser io.ReadCloser, jsonPath string) (string, error) {
+	var data any
+	if err := json.NewDecoder(readerCloser).Decode(&data); err != nil {
+		return "", err
+	}
+
+	output, err := jsonpath.Get(jsonPath, data)
+	if err != nil {
+		return "", err
+	}
+
+	return anyToString(output), nil
+}
+
+func anyToString(v any) string {
+	if v == nil {
+		return ""
+	}
+
+	// Handle slice types
+	if reflect.TypeOf(v).Kind() == reflect.Slice {
+		slice := reflect.ValueOf(v)
+		if slice.Len() > 0 {
+			return fmt.Sprint(slice.Index(0).Interface())
+		}
+		return ""
+	}
+
+	return fmt.Sprint(v)
 }

--- a/internal/api/watcher.go
+++ b/internal/api/watcher.go
@@ -1,3 +1,17 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (
@@ -8,56 +22,66 @@ import (
 	"io"
 	"reflect"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
 )
 
 var (
-	ErrWatcherFailedToBuildRequest                   = errors.New("failed to build watcher request")
-	ErrWatcherFailedToWatch                          = errors.New("failed to watch")
-	ErrWatcherFailedToExecuteWatchRequest            = errors.New("failed to execute watch request")
-	ErrWatcherGetCommandNotFound                     = errors.New("watcher get command not found")
-	ErrWatcherFailedToApplyJSONPathToWatcherResponse = errors.New("failed to apply json path to watcher response")
+	ErrWatcherFailedToBuildRequest                           = errors.New("failed to build watcher request")
+	ErrWatcherFailedToBuildRequestParameters                 = errors.New("failed to build watcher request parameters")
+	ErrWatcherFailedToBuildRequestParametersInvalidParameter = errors.New("invalid parameter")
+	ErrWatcherFailedToBuildRequestFailedToApplyJSONPath      = errors.New("request parameter failed to apply jsonpath")
+	ErrWatcherFailedToBuildRequestInputParameterNotFound     = errors.New("input parameter not found")
+	ErrWatcherFailedToBuildRequestInvalidParameterOperation  = errors.New("parameter operation not found")
+	ErrWatcherFailedToExecuteWatchRequest                    = errors.New("failed to execute watch request")
+	ErrWatcherGetCommandNotFound                             = errors.New("watcher get command not found")
+	ErrWatcherFailedToApplyJSONPathToWatcherResponse         = errors.New("failed to apply json path to watcher response")
 )
 
 const (
 	WatcherWatchInterval = 1 * time.Second
 )
 
+// Watcher provides the functionality to watch a certain operation
+//
+// The main goal of the watcher is to execute one operation over and verify that the output matches `expect`
+// This is the API layer watcher, so this watcher struct is only responsible for execting the operation and verifying operation output.
 type Watcher struct {
 	executor CommandExecutor
+	request  *CommandRequest
+	expect   *WatcherExpectProperties
 }
 
-func (w *Watcher) Watch(ctx context.Context, props WatcherProperties) error {
-	// TODO: add timeout support, separate ticket (also add flag)
-	// ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	// defer cancel()
-	request, err := buildRequest(Commands, props)
+// Create a new watcher
+//
+//   - executor: executor used to make the API calls
+//   - requestParams: parameters used for the preceding call
+//     for example we're watching until a cluster is deleted then requestParams would contain the parameters which
+//     were used to execute the deleteCluster operation.
+//   - responseBody: the body from the preceding call
+//   - props: the watcher configuration, this is generated using the api-generator tool
+func NewWatcher(executor CommandExecutor, requestParams map[string][]string, responseBody []byte, props WatcherProperties) (*Watcher, error) {
+	// We're making the same request over and over again, so we only have to build it once
+	request, err := buildRequest(Commands, requestParams, responseBody, props)
 	if err != nil || request == nil {
-		return errors.Join(ErrWatcherFailedToBuildRequest, err)
+		return nil, errors.Join(ErrWatcherFailedToBuildRequest, err)
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			done, err := watchInner(ctx, w.executor, props.Expect, *request)
-			if err != nil {
-				return errors.Join(ErrWatcherFailedToWatch, err)
-			}
-
-			if done {
-				return nil
-			}
-
-			time.Sleep(WatcherWatchInterval)
-		}
-	}
+	return &Watcher{
+		executor: executor,
+		request:  request,
+		expect:   props.Expect,
+	}, nil
 }
 
-func buildRequest(allCommands GroupedAndSortedCommands, props WatcherProperties) (*CommandRequest, error) {
+// Builds the request we're going to send over and over again until it returns what we expect
+//
+// - `allCommands`, array with all command definitions, realisticly this will always be the static `Commands` variable, but this allows easier unit testing
+// See `NewWatcher` for other parameter descriptions.
+func buildRequest(allCommands GroupedAndSortedCommands, requestParams map[string][]string, responseBody []byte, props WatcherProperties) (*CommandRequest, error) {
+	// Search for the command definition that we're expected to execute
 	var command *Command
 	for _, commandGroup := range allCommands {
 		for _, loopCommand := range commandGroup.Commands {
@@ -71,17 +95,72 @@ func buildRequest(allCommands GroupedAndSortedCommands, props WatcherProperties)
 		return nil, fmt.Errorf("%w (OperationID=%s)", ErrWatcherGetCommandNotFound, props.Get.OperationID)
 	}
 
-	requestParams := make(map[string][]string, len(props.Get.Params))
-	for key, value := range props.Get.Params {
-		requestParams[key] = []string{value}
+	// Transform the previous request context into parameters for our watch request
+	watcherRequestParams, err := buildRequestParameters(requestParams, responseBody, props.Get.Params)
+	if err != nil {
+		return nil, errors.Join(ErrWatcherFailedToBuildRequestParameters, err)
 	}
 
 	return &CommandRequest{
 		Command:    *command,
 		Format:     "json",
-		Parameters: requestParams,
+		Parameters: watcherRequestParams,
 		Version:    props.Get.Version,
 	}, nil
+}
+
+// This function takes the preceding commands context (requestParams, responseBody) and turns it into parameters for the watcher request
+//
+// Right now watchers support 3 types of functions/transformations:
+// - `input:[variable_name]`: copy the parameter from requestParams
+// - `body:[json_path]`: execute a jsonpath query on `responseBody` and use that value
+// - `const:[value]`: use a const value.
+func buildRequestParameters(requestParams map[string][]string, responseBody []byte, watcherParams map[string]string) (map[string][]string, error) {
+	watcherRequestParams := make(map[string][]string, len(watcherParams))
+
+	// we don't care if the serialization fails or not
+	// the response doesn't have to be json if the watcherParameters don't use the "body:" function
+	// if the watcherParameters do use the "body:" function then we'll return an error in that place
+	var response any
+	_ = json.Unmarshal(responseBody, &response)
+
+	// Loop through all the watch parameters we need to create
+	for watcherParameterKey, watcherParameterValue := range watcherParams {
+		// Split the parameter value so we can use it as follows: `[function]:[args]`
+		parameterFunction, parameterArgs, found := strings.Cut(watcherParameterValue, ":")
+		if !found {
+			return nil, fmt.Errorf("%w: %s", ErrWatcherFailedToBuildRequestParametersInvalidParameter, watcherParameterValue)
+		}
+
+		// Apply the function
+		switch parameterFunction {
+		case "body":
+			value, err := applyJSONPathToObject(response, parameterArgs)
+			if err != nil {
+				return nil, errors.Join(ErrWatcherFailedToBuildRequestFailedToApplyJSONPath, err)
+			}
+			watcherRequestParams[watcherParameterKey] = []string{value}
+		case "input":
+			values, ok := requestParams[parameterArgs]
+			if !ok {
+				return nil, fmt.Errorf("%w: %s", ErrWatcherFailedToBuildRequestInputParameterNotFound, watcherParameterKey)
+			}
+			watcherRequestParams[watcherParameterKey] = values
+		case "const":
+			watcherRequestParams[watcherParameterKey] = []string{parameterArgs}
+		default:
+			return nil, fmt.Errorf("%w: '%s'", ErrWatcherFailedToBuildRequestInvalidParameterOperation, parameterFunction)
+		}
+	}
+
+	return watcherRequestParams, nil
+}
+
+// This function will make the API request once and return true if the expected output was returned.
+// - This function does not sleep
+// - This function only fails when the HTTP call fails, not when the endpoint returns a non-OK response.
+func (w *Watcher) WatchOne(ctx context.Context) (bool, error) {
+	return watchInner(ctx, w.executor, w.expect, *w.request)
 }
 
 // Actual watcher logic without handling.
@@ -118,13 +197,18 @@ func watchInner(ctx context.Context, executor CommandExecutor, expect *WatcherEx
 	return true, nil
 }
 
+// Apply a JSON path to a reader which contains a JSON stream.
 func applyJSONPath(readerCloser io.ReadCloser, jsonPath string) (string, error) {
 	var data any
 	if err := json.NewDecoder(readerCloser).Decode(&data); err != nil {
 		return "", err
 	}
 
-	output, err := jsonpath.Get(jsonPath, data)
+	return applyJSONPathToObject(data, jsonPath)
+}
+
+func applyJSONPathToObject(object any, jsonPath string) (string, error) {
+	output, err := jsonpath.Get(jsonPath, object)
 	if err != nil {
 		return "", err
 	}
@@ -132,6 +216,7 @@ func applyJSONPath(readerCloser io.ReadCloser, jsonPath string) (string, error) 
 	return anyToString(output), nil
 }
 
+// Convert any type to string, for slices we take the first value.
 func anyToString(v any) string {
 	if v == nil {
 		return ""

--- a/internal/api/watcher.go
+++ b/internal/api/watcher.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+var (
+	ErrWatcherFailedToBuildRequest        = errors.New("failed to build watcher request")
+	ErrWatcherFailedToWatch               = errors.New("failed to watch")
+	ErrWatcherFailedToExecuteWatchRequest = errors.New("failed to execute watch request")
+)
+
+const (
+	WatcherWatchInterval = 1 * time.Second
+)
+
+type Watcher struct {
+	executor CommandExecutor
+}
+
+func (w *Watcher) Watch(ctx context.Context, props WatcherProperties) error {
+	// TODO: add timeout support
+	//ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	//defer cancel()
+	request, err := buildRequest(props)
+	if err != nil || request == nil {
+		return errors.Join(ErrWatcherFailedToBuildRequest, err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if err := watchInner(ctx, w.executor, *request); err != nil {
+				return errors.Join(ErrWatcherFailedToWatch, err)
+			}
+
+			time.Sleep(WatcherWatchInterval)
+		}
+	}
+}
+
+func buildRequest(props WatcherProperties) (*CommandRequest, error) {
+	panic(fmt.Sprintf("TODO. UNUSED:%v", props))
+}
+
+// Actual watcher logic without handling
+func watchInner(ctx context.Context, executor CommandExecutor, commandRequest CommandRequest) error {
+	response, err := executor.ExecuteCommand(ctx, commandRequest)
+	if err != nil {
+		return errors.Join(ErrWatcherFailedToExecuteWatchRequest, err)
+	}
+
+	panic(fmt.Sprintf("TODO. UNUSED:%v", response))
+}

--- a/internal/api/watcher.go
+++ b/internal/api/watcher.go
@@ -78,7 +78,7 @@ func NewWatcher(executor CommandExecutor, requestParams map[string][]string, res
 
 // Builds the request we're going to send over and over again until it returns what we expect
 //
-// - `allCommands`, array with all command definitions, realisticly this will always be the static `Commands` variable, but this allows easier unit testing
+// - `allCommands`, array with all command definitions, realistically this will always be the static `Commands` variable, but this allows easier unit testing
 // See `NewWatcher` for other parameter descriptions.
 func buildRequest(allCommands GroupedAndSortedCommands, requestParams map[string][]string, responseBody []byte, props WatcherProperties) (*CommandRequest, error) {
 	// Search for the command definition that we're expected to execute

--- a/internal/api/watcher_test.go
+++ b/internal/api/watcher_test.go
@@ -1,0 +1,466 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestAnyToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		// Test nil
+		{
+			name:     "nil value",
+			input:    nil,
+			expected: "",
+		},
+
+		// Test basic types
+		{
+			name:     "string value",
+			input:    "hello",
+			expected: "hello",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "integer value",
+			input:    42,
+			expected: "42",
+		},
+		{
+			name:     "negative integer",
+			input:    -123,
+			expected: "-123",
+		},
+		{
+			name:     "float value",
+			input:    3.14,
+			expected: "3.14",
+		},
+		{
+			name:     "negative float",
+			input:    -0.5,
+			expected: "-0.5",
+		},
+		{
+			name:     "boolean true",
+			input:    true,
+			expected: "true",
+		},
+		{
+			name:     "boolean false",
+			input:    false,
+			expected: "false",
+		},
+
+		// Test slices
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: "",
+		},
+		{
+			name:     "string slice with one element",
+			input:    []string{"first"},
+			expected: "first",
+		},
+		{
+			name:     "string slice with multiple elements",
+			input:    []string{"first", "second", "third"},
+			expected: "first",
+		},
+		{
+			name:     "integer slice",
+			input:    []int{1, 2, 3},
+			expected: "1",
+		},
+		{
+			name:     "float slice",
+			input:    []float64{1.1, 2.2, 3.3},
+			expected: "1.1",
+		},
+		{
+			name:     "boolean slice",
+			input:    []bool{true, false},
+			expected: "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := anyToString(tt.input)
+			if result != tt.expected {
+				t.Errorf("anyToString(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyJsonPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		json        string
+		jsonPath    string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "basic object with string",
+			json:        `{"name": "Cluster0", "status": "IDLE"}`,
+			jsonPath:    "$.name",
+			expected:    "Cluster0",
+			expectError: false,
+		},
+		{
+			name:        "basic object with different field",
+			json:        `{"name": "Cluster0", "status": "IDLE"}`,
+			jsonPath:    "$.status",
+			expected:    "IDLE",
+			expectError: false,
+		},
+		{
+			name:        "object with integer",
+			json:        `{"id": 123, "name": "Test"}`,
+			jsonPath:    "$.id",
+			expected:    "123",
+			expectError: false,
+		},
+		{
+			name:        "object with boolean",
+			json:        `{"active": true, "name": "Test"}`,
+			jsonPath:    "$.active",
+			expected:    "true",
+			expectError: false,
+		},
+		{
+			name:        "array first element",
+			json:        `{"tags": ["dev", "prod", "staging"]}`,
+			jsonPath:    "$.tags[0]",
+			expected:    "dev",
+			expectError: false,
+		},
+		{
+			name:        "nested object",
+			json:        `{"cluster": {"name": "Cluster0", "status": "IDLE"}}`,
+			jsonPath:    "$.cluster.name",
+			expected:    "Cluster0",
+			expectError: false,
+		},
+		{
+			name:        "invalid JSON",
+			json:        `{"name": "Cluster0", "status": "IDLE"`, // Missing closing brace
+			jsonPath:    "$.name",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "invalid JSONPath",
+			json:        `{"name": "Cluster0", "status": "IDLE"}`,
+			jsonPath:    "$.[invalid",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "non-existent path",
+			json:        `{"name": "Cluster0", "status": "IDLE"}`,
+			jsonPath:    "$.nonexistent",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "empty JSON object",
+			json:        `{}`,
+			jsonPath:    "$.name",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "array of objects first element",
+			json:        `{"clusters": [{"name": "Cluster0"}, {"name": "Cluster1"}]}`,
+			jsonPath:    "$.clusters[0].name",
+			expected:    "Cluster0",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a ReadCloser from the JSON string
+			reader := io.NopCloser(strings.NewReader(tt.json))
+
+			result, err := applyJSONPath(reader, tt.jsonPath)
+
+			// Check error expectations
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got none")
+				return
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// If we're not expecting an error, check the result
+			if !tt.expectError {
+				if result != tt.expected {
+					t.Errorf("got %v, want %v", result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyJsonPathReaderError tests the case where the reader fails.
+func TestApplyJsonPathReaderError(t *testing.T) {
+	// Create a mock reader that always fails
+	failingReader := &mockFailingReader{
+		err: io.ErrClosedPipe,
+	}
+
+	_, err := applyJSONPath(failingReader, "$.name")
+	if err == nil {
+		t.Error("expected error from failing reader, got nil")
+	}
+}
+
+// mockFailingReader implements io.ReadCloser and always returns an error.
+type mockFailingReader struct {
+	err error
+}
+
+func (m *mockFailingReader) Read(_ []byte) (n int, err error) {
+	return 0, m.err
+}
+
+func (*mockFailingReader) Close() error {
+	return nil
+}
+
+// MockCommandExecutor implements CommandExecutor interface for testing.
+type MockCommandExecutor struct {
+	response *CommandResponse
+	err      error
+}
+
+func (m *MockCommandExecutor) ExecuteCommand(_ context.Context, _ CommandRequest) (*CommandResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.response, nil
+}
+
+func TestWatchInner(t *testing.T) {
+	tests := []struct {
+		name              string
+		executor          *MockCommandExecutor
+		expect            *WatcherExpectProperties
+		commandRequest    CommandRequest
+		expectedCompleted bool
+		expectedErr       error
+	}{
+		{
+			name: "Delete cluster - waiting for 404",
+			executor: &MockCommandExecutor{
+				response: &CommandResponse{
+					IsSuccess: false,
+					HTTPCode:  404,
+				},
+			},
+			expect: &WatcherExpectProperties{
+				HTTPCode: 404,
+			},
+			commandRequest: CommandRequest{
+				Command: Command{
+					OperationID: "GetCluster",
+				},
+			},
+			expectedCompleted: true,
+			expectedErr:       nil,
+		},
+		{
+			name: "Create cluster - wait for IDLE status",
+			executor: &MockCommandExecutor{
+				response: &CommandResponse{
+					IsSuccess: true,
+					HTTPCode:  200,
+					Output:    io.NopCloser(strings.NewReader(`{"status": "IDLE"}`)),
+				},
+			},
+			expect: &WatcherExpectProperties{
+				HTTPCode: 200,
+				Match: &WatcherMatchProperties{
+					Path:   "$.status",
+					Values: []string{"IDLE"},
+				},
+			},
+			commandRequest: CommandRequest{
+				Command: Command{
+					OperationID: "GetCluster",
+				},
+			},
+			expectedCompleted: true,
+			expectedErr:       nil,
+		},
+		{
+			name: "Create cluster - wait for IDLE or DONE status",
+			executor: &MockCommandExecutor{
+				response: &CommandResponse{
+					IsSuccess: true,
+					HTTPCode:  200,
+					Output:    io.NopCloser(strings.NewReader(`{"status": "DONE"}`)),
+				},
+			},
+			expect: &WatcherExpectProperties{
+				HTTPCode: 200,
+				Match: &WatcherMatchProperties{
+					Path:   "$.status",
+					Values: []string{"IDLE", "DONE"},
+				},
+			},
+			commandRequest: CommandRequest{
+				Command: Command{
+					OperationID: "GetCluster",
+				},
+			},
+			expectedCompleted: true,
+			expectedErr:       nil,
+		},
+		{
+			name: "Executor returns error",
+			executor: &MockCommandExecutor{
+				err: errors.New("execution failed"),
+			},
+			expect: &WatcherExpectProperties{
+				HTTPCode: 200,
+			},
+			commandRequest: CommandRequest{
+				Command: Command{
+					OperationID: "GetCluster",
+				},
+			},
+			expectedCompleted: false,
+			expectedErr:       ErrWatcherFailedToExecuteWatchRequest,
+		},
+		{
+			name: "HTTP code mismatch",
+			executor: &MockCommandExecutor{
+				response: &CommandResponse{
+					IsSuccess: false,
+					HTTPCode:  400,
+					Output:    io.NopCloser(strings.NewReader(`{}`)),
+				},
+			},
+			expect: &WatcherExpectProperties{
+				HTTPCode: 200,
+			},
+			commandRequest: CommandRequest{
+				Command: Command{
+					OperationID: "GetCluster",
+				},
+			},
+			expectedCompleted: false,
+			expectedErr:       nil,
+		},
+		{
+			name: "Default HTTP code (200)",
+			executor: &MockCommandExecutor{
+				response: &CommandResponse{
+					IsSuccess: true,
+					HTTPCode:  200,
+					Output:    io.NopCloser(strings.NewReader(`{}`)),
+				},
+			},
+			expect: nil,
+			commandRequest: CommandRequest{
+				Command: Command{
+					OperationID: "GetCluster",
+				},
+			},
+			expectedCompleted: true,
+			expectedErr:       nil,
+		},
+		{
+			name: "Invalid JSON in response",
+			executor: &MockCommandExecutor{
+				response: &CommandResponse{
+					IsSuccess: true,
+					HTTPCode:  200,
+					Output:    io.NopCloser(strings.NewReader(`invalid json`)),
+				},
+			},
+			expect: &WatcherExpectProperties{
+				HTTPCode: 200,
+				Match: &WatcherMatchProperties{
+					Path:   "$.status",
+					Values: []string{"IDLE"},
+				},
+			},
+			commandRequest: CommandRequest{
+				Command: Command{
+					OperationID: "GetCluster",
+				},
+			},
+			expectedCompleted: false,
+			expectedErr:       ErrWatcherFailedToApplyJSONPathToWatcherResponse,
+		},
+		{
+			name: "Status not in expected values",
+			executor: &MockCommandExecutor{
+				response: &CommandResponse{
+					IsSuccess: true,
+					HTTPCode:  200,
+					Output:    io.NopCloser(strings.NewReader(`{"status": "CREATING"}`)),
+				},
+			},
+			expect: &WatcherExpectProperties{
+				HTTPCode: 200,
+				Match: &WatcherMatchProperties{
+					Path:   "$.status",
+					Values: []string{"IDLE", "DONE"},
+				},
+			},
+			commandRequest: CommandRequest{
+				Command: Command{
+					OperationID: "GetCluster",
+				},
+			},
+			expectedCompleted: false,
+			expectedErr:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			result, err := watchInner(ctx, tt.executor, tt.expect, tt.commandRequest)
+
+			// Check error
+			if tt.expectedErr != nil {
+				if err == nil {
+					t.Errorf("expected error containing %v, got nil", tt.expectedErr)
+					return
+				}
+				if !errors.Is(err, tt.expectedErr) {
+					t.Errorf("expected error containing %v, got %v", tt.expectedErr, err)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Check result
+			if result != tt.expectedCompleted {
+				t.Errorf("got result %v, want %v", result, tt.expectedCompleted)
+			}
+		})
+	}
+}

--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/log"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -95,6 +96,7 @@ func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 	format := ""
 	outputFile := ""
 	version, err := defaultAPIVersion(command)
+	watch := false
 	if err != nil {
 		return nil, err
 	}
@@ -198,6 +200,7 @@ func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 	}
 
 	// Common flags
+	addWatchFlagIfNeeded(cmd, command, &watch)
 	addVersionFlag(cmd, command, &version)
 
 	if needsFileFlag(command) {
@@ -373,6 +376,14 @@ func needsFileFlag(apiCommand api.Command) bool {
 	}
 
 	return false
+}
+
+func addWatchFlagIfNeeded(cmd *cobra.Command, apiCommand api.Command, watch *bool) {
+	if apiCommand.Watcher == nil || apiCommand.Watcher.Get.OperationID == "" {
+		return
+	}
+
+	cmd.Flags().BoolVarP(watch, flag.EnableWatch, flag.EnableWatchShort, false, usage.EnableWatchDefault)
 }
 
 func addVersionFlag(cmd *cobra.Command, apiCommand api.Command, version *string) {

--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -187,8 +187,6 @@ func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 
 			// If the response was successful, handle --format
 			if result.IsSuccess {
-				// output := result.Output
-
 				// If we're watching, we need to cache the original output before formatting so we don't read twice from the same reader
 				// In case we're not watching the http output will be piped straight into the formatter, which should be a little more memory efficient
 				if watch {

--- a/internal/cli/api/watcher.go
+++ b/internal/cli/api/watcher.go
@@ -1,0 +1,103 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/api"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/terminal"
+)
+
+const (
+	spinnerSpeed  = 100 * time.Millisecond
+	watchInterval = time.Second
+)
+
+// Watcher provides the functionality to wait until a certain operation is in the expected state
+//
+// The main goal of this watcher is to:
+// - Call the API layer watcher
+// - Handle sleeps and cancellations
+// - Handle an optional spinner to Stdout if the terminal is not piped.
+type Watcher struct {
+	apiWatcher api.Watcher
+	spinner    *spinner.Spinner
+}
+
+// Construct a new CLI layer watcher
+//
+// See api.NewWatcher for docs on arguments.
+func NewWatcher(executor api.CommandExecutor, requestParams map[string][]string, responseBody []byte, props api.WatcherProperties) (*Watcher, error) {
+	apiWatcher, err := api.NewWatcher(executor, requestParams, responseBody, props)
+	if err != nil {
+		return nil, err
+	}
+
+	// We only want to spin when Stderr is not piped
+	// We're showing the spinner on Stderr because then the output of Stdout is still usable in scripts
+	var s *spinner.Spinner
+	if terminal.IsTerminal(os.Stderr) {
+		s = spinner.New(spinner.CharSets[9], spinnerSpeed, spinner.WithWriter(os.Stderr))
+	}
+
+	return &Watcher{
+		apiWatcher: *apiWatcher,
+		spinner:    s,
+	}, nil
+}
+
+func (w *Watcher) Wait(ctx context.Context) error {
+	// Take care of the spinner if we're in terminal mode
+	w.startSpinner()
+	defer w.stopSpinner()
+
+	// Keep calling WatchOne until one of the following events happens
+	// - watcher completes successfully
+	// - watcher returns an error
+	// - the context is cancelled (example user presses crtl+c)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			done, err := w.apiWatcher.WatchOne(ctx)
+			if err != nil {
+				return err
+			}
+
+			if done {
+				return nil
+			}
+
+			time.Sleep(watchInterval)
+		}
+	}
+}
+
+func (w *Watcher) startSpinner() {
+	if w.spinner != nil {
+		w.spinner.Start()
+	}
+}
+
+func (w *Watcher) stopSpinner() {
+	if w.spinner != nil {
+		w.spinner.Stop()
+	}
+}


### PR DESCRIPTION
## Proposed changes
Added `--watch` support for autogenerated commands.

Introduced two watcher structs:
- `api.Watcher`: Takes care of executing the API call and verifying the output
- `cli.Watcher`: Takes care of calling `api.Watcher` in a loop, cancellation, showing spinner

Changes to Executor:
- I had to move formatting out of the executor because we need to feed the original request's unformatted response to the watcher.
- I only save the response to memory when a watcher is enabled; if not, I pass the HTTP reader to the formatted without storing the response in memory.
- Executing a command now also exposes the HTTPCode so that we can watch the HTTP code

Testing:
- I added new unit tests for most functions, which should cover most cases
- I tested manually by adding the watcher configuration for `DeleteCluster` and running the CLI manually (reverted before committing)

_Jira ticket:_ CLOUDP-297411