### PR TITLE
CLOUDP-297379: Improve plugin install/update error message

### DIFF
--- a/internal/cli/plugin/plugin_github_asset.go
+++ b/internal/cli/plugin/plugin_github_asset.go
@@ -87,7 +87,7 @@ func (g *GithubAsset) getReleaseAssets() ([]*github.ReleaseAsset, error) {
 		})
 
 		if err != nil {
-			return nil, fmt.Errorf("could not fetch releases for %s, access to GitHub is required, see <placeholder> %w", g.repository(), err)
+			return nil, fmt.Errorf("could not fetch releases for %s, access to GitHub is required, %w", g.repository(), err)
 		}
 
 		// get the latest release that doesn't have prerelease info or metadata in the version tag

--- a/internal/cli/plugin/plugin_github_asset.go
+++ b/internal/cli/plugin/plugin_github_asset.go
@@ -87,7 +87,7 @@ func (g *GithubAsset) getReleaseAssets() ([]*github.ReleaseAsset, error) {
 		})
 
 		if err != nil {
-			return nil, fmt.Errorf("could not fetch releases for %s %w", g.repository(), err)
+			return nil, fmt.Errorf("could not fetch releases for %s, access to GitHub is required, see <placeholder> %w", g.repository(), err)
 		}
 
 		// get the latest release that doesn't have prerelease info or metadata in the version tag


### PR DESCRIPTION
## Proposed changes

Improves error message for failure on retrieving github assets by explicitly noting Github access is required. 

_Future works:_ When [DOCSP-46527](https://jira.mongodb.org/browse/DOCSP-46527) is completed, a link to the troubleshooting docs outlining this will be included.

_Jira ticket:_ [CLOUDP-297379](https://jira.mongodb.org/browse/CLOUDP-297379)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments
