### PR TITLE
CLOUDP-302438: [AtlasCLI] Print warning when user provides unsupported fields in JSON/YAML files

### DIFF
--- a/test/e2e/atlas/clusters_file_test.go
+++ b/test/e2e/atlas/clusters_file_test.go
@@ -129,6 +129,8 @@ func TestClustersFile(t *testing.T) {
 	})
 
 	t.Run("Create index with unknown fields", func(t *testing.T) {
+		var stdErr bytes.Buffer
+
 		cmd := exec.Command(cliPath,
 			clustersEntity,
 			indexEntity,
@@ -139,8 +141,9 @@ func TestClustersFile(t *testing.T) {
 		)
 
 		cmd.Env = os.Environ()
-		resp, _ := cmd.CombinedOutput()
-		assert.Contains(t, string(resp), `json: unknown field "unique"`)
+		cmd.Stderr = &stdErr
+		_ = cmd.Run()
+		assert.Contains(t, stdErr.String(), `json: unknown field "unique"`)
 	})
 
 	t.Run("Update via file", func(t *testing.T) {

--- a/test/e2e/atlas/clusters_file_test.go
+++ b/test/e2e/atlas/clusters_file_test.go
@@ -128,6 +128,21 @@ func TestClustersFile(t *testing.T) {
 		require.NoError(t, err, string(resp))
 	})
 
+	t.Run("Create index with unknown fields", func(t *testing.T) {
+		cmd := exec.Command(cliPath,
+			clustersEntity,
+			indexEntity,
+			"create",
+			"--clusterName", clusterFileName,
+			"--file=data/create_index_test-unknown-fields.json",
+			"--projectId", g.projectID,
+		)
+
+		cmd.Env = os.Environ()
+		resp, _ := cmd.CombinedOutput()
+		assert.Contains(t, string(resp), `json: unknown field "unique"`)
+	})
+
 	t.Run("Update via file", func(t *testing.T) {
 		cmd := exec.Command(cliPath,
 			clustersEntity,

--- a/test/e2e/atlas/data/create_index_test-unknown-fields.json
+++ b/test/e2e/atlas/data/create_index_test-unknown-fields.json
@@ -1,0 +1,14 @@
+
+{
+    "db": "sample_airbnb",
+    "collection": "accounts",
+    "keys": [
+        {
+            "property_type": "1",
+            "test_field": "1"
+        }
+    ],
+    "options": {
+        "unique": true
+    }
+}


### PR DESCRIPTION
## Proposed changes
- Print warning when JSON/Yaml contains unknown fields
- Added unit tests
- Added e2e tests

_Jira ticket:_ CLOUDP-302438
