### PR TITLE
[tests] remove references to MCLI

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -116,17 +116,16 @@ functions:
         include_expansions_in_env:
           - go_base_path
           - workdir
-          - MCLI_ORG_ID
-          - MCLI_PROJECT_ID
-          - MCLI_PRIVATE_API_KEY
-          - MCLI_PUBLIC_API_KEY
-          - MCLI_SERVICE
+          - MONGODB_ATLAS_ORG_ID
+          - MONGODB_ATLAS_PROJECT_ID
+          - MONGODB_ATLAS_PUBLIC_API_KEY
+          - MONGODB_ATLAS_PRIVATE_API_KEY
+          - MONGODB_ATLAS_SERVICE
           - TEST_CMD
           - E2E_TAGS
           - E2E_TEST_BUCKET
           - E2E_CLOUD_ROLE_ID
-          - MCLI_OPS_MANAGER_URL
-          - OM_VERSION
+          - MONGODB_ATLAS_OPS_MANAGER_URL
           - LOCAL_KEY
           - KMIP_CA
           - KMIP_CERT
@@ -145,7 +144,7 @@ functions:
           - revision
         env:
           <<: *go_env
-          MCLI_SKIP_UPDATE_CHECK: "yes"
+          MONGODB_ATLAS_SKIP_UPDATE_CHECK: "yes"
           DO_NOT_TRACK: "1"
           TEST_CMD: gotestsum --junitfile e2e-tests.xml --format standard-verbose --
         command: make e2e-test
@@ -550,12 +549,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,generic
           IDENTITY_PROVIDER_ID: ${identity_provider_id}
   - name: atlas_gov_generic_e2e
@@ -569,12 +568,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,generic
           IDENTITY_PROVIDER_ID: ${identity_provider_id}
   # This is all about cluster which tends to be slow to get a healthy one
@@ -589,12 +588,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,clusters,flags
   - name: atlas_autogeneration_commands_e2e
     tags: ["e2e","autogeneration","atlas"]
@@ -607,12 +606,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,autogeneration
   - name: atlas_clusters_file_e2e
     tags: ["e2e","clusters","atlas"]
@@ -625,12 +624,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,clusters,file
   - name: atlas_clusters_sharded_e2e
     tags: ["e2e","clusters","atlas"]
@@ -643,12 +642,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,clusters,sharded
   - name: atlas_clusters_flex_e2e
     tags: ["e2e","clusters","atlas"]
@@ -661,12 +660,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,clusters,flex
   - name: atlas_plugin_install
     tags: ["e2e","atlas","plugin","install"]
@@ -675,12 +674,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,plugin,install
   - name: atlas_plugin_run
     tags: ["e2e","atlas","plugin"]
@@ -689,12 +688,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,plugin,run
   - name: atlas_plugin_uninstall
     tags: ["e2e","atlas","plugin"]
@@ -703,12 +702,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,plugin,uninstall
   - name: atlas_plugin_update
     tags: ["e2e","atlas","plugin"]
@@ -717,12 +716,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,plugin,update
   - name: atlas_clusters_m0_e2e
     tags: ["e2e","clusters","atlas"]
@@ -735,12 +734,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,clusters,m0
   - name: atlas_kubernetes_plugin
     tags: ["e2e","atlas","plugin","kubernetes"]
@@ -749,12 +748,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,plugin,kubenetes
   - name: atlas_clusters_upgrade_e2e
     tags: ["e2e","clusters","atlas"]
@@ -767,12 +766,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,clusters,upgrade
   - name: atlas_interactive_e2e
     tags: ["e2e","atlas", "interactive"]
@@ -785,12 +784,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,interactive
   - name: atlas_serverless_e2e
     tags: ["e2e","clusters","atlas"]
@@ -803,12 +802,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,serverless,instance
   - name: atlas_gov_clusters_flags_e2e
     tags: ["e2e","clusters","atlasgov"]
@@ -821,12 +820,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,clusters,flags
   - name: atlas_gov_clusters_file_e2e
     tags: ["e2e","clusters","atlasgov"]
@@ -839,12 +838,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,clusters,file
   - name: atlas_gov_clusters_sharded_e2e
     tags: ["e2e","clusters","atlasgov"]
@@ -857,12 +856,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,clusters,sharded
   # LDAP Configuration depends on a cluster running
   - name: atlas_ldap_e2e
@@ -876,12 +875,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,ldap
   # Logs depend on a cluster running to get logs from
   - name: atlas_logs_e2e
@@ -895,12 +894,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,logs
   - name: atlas_gov_logs_e2e
     tags: ["e2e","clusters","atlasgov"]
@@ -913,12 +912,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,logs
   # Metrics depend on a cluster running to get metrics from
   - name: atlas_metrics_e2e
@@ -932,12 +931,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,metrics
   - name: atlas_gov_metrics_e2e
     tags: ["e2e","clusters","atlasgov"]
@@ -950,12 +949,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,metrics
   # Processes depend on a cluster running
   - name: atlas_processes_e2e
@@ -969,12 +968,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,processes
   - name: atlas_gov_processes_e2e
     tags: ["e2e","clusters","atlasgov"]
@@ -987,12 +986,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,processes
   # Online archives depend on a cluster to create the archive against
   - name: atlas_online_archive_e2e
@@ -1006,12 +1005,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,onlinearchive
   # Performance Advisor depend on a cluster
   - name: atlas_performance_advisor_e2e
@@ -1025,12 +1024,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,performanceAdvisor
   - name: atlas_gov_performance_advisor_e2e
     tags: ["e2e","clusters","atlasgov"]
@@ -1043,12 +1042,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,performanceAdvisor
   # Search depend on a cluster to create the indexes against
   - name: atlas_search_e2e
@@ -1063,12 +1062,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,search
           E2E_TIMEOUT: 3h
   - name: atlas_gov_search_e2e
@@ -1082,12 +1081,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,search
   - name: atlas_search_nodes_e2e
     tags: ["e2e","clusters","atlas"]
@@ -1100,12 +1099,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,search_nodes
   # Private endpoints can be flaky when multiple tests run concurrently so keeping this out of the PR suite
   - name: atlas_private_endpoint_e2e
@@ -1119,12 +1118,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,networking
   # datafederation requires cloud provider role authentication and an s3 bucket created
   - name: atlas_datafederation_db_e2e
@@ -1138,12 +1137,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,datafederation,db
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
@@ -1159,12 +1158,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,datafederation,privatenetwork
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
@@ -1180,12 +1179,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,datafederation,querylimits
           E2E_TEST_BUCKET: ${e2e_test_bucket}
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
@@ -1201,12 +1200,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: iam,atlas
   - name: atlas_gov_iam_e2e
     tags: ["e2e","generic","atlas"]
@@ -1219,12 +1218,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: iam
     # Live migration endpoints can be flaky when multiple tests run concurrently so keeping this out of the PR suite
   - name: atlas_live_migrations_link_token_e2e
@@ -1238,12 +1237,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,livemigrations
   # Streams commands tests
   - name: atlas_streams
@@ -1257,12 +1256,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,streams
   - name: atlas_streams_with_cluster
     tags: [ "e2e","streams","atlas","assigned_to_jira_team_cloudp_atlas_streams"]
@@ -1275,12 +1274,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,streams_with_cluster
   - name: atlas_decrypt_e2e
     tags: [ "e2e","decrypt" ]
@@ -1294,12 +1293,12 @@ tasks:
       - func: "build"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           GCP_CREDENTIALS: ${logs_decrypt_gcp_credentials}
           AWS_ACCESS_KEY: ${logs_decrypt_aws_access_key}
           AWS_SECRET_ACCESS_KEY: ${logs_decrypt_aws_secret_access_key}
@@ -1318,12 +1317,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,backup,snapshot
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
@@ -1338,12 +1337,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,backup,schedule
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
@@ -1358,12 +1357,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,backup,exports,buckets
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
@@ -1378,12 +1377,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,backup,exports,jobs
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
@@ -1398,12 +1397,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,backup,flex
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
@@ -1421,12 +1420,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,backup,restores
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
@@ -1444,12 +1443,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,backup,compliancepolicy
           E2E_CLOUD_ROLE_ID: ${e2e_cloud_role_id}
           E2E_TEST_BUCKET: ${e2e_test_bucket}
@@ -1468,12 +1467,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,cleanup
           E2E_PARALLEL: 16
           E2E_TIMEOUT: 3h
@@ -1491,12 +1490,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_gov_org_id}
-          MCLI_PROJECT_ID: ${atlas_gov_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
-          MCLI_SERVICE: cloudgov
+          MONGODB_ATLAS_ORG_ID: ${atlas_gov_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_gov_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_gov_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_gov_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_cloud_gov_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloudgov
           E2E_TAGS: atlas,cleanup
           E2E_TIMEOUT: 3h
           E2E_PARALLEL: 16
@@ -1513,12 +1512,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,deployments,atlasclusters
           E2E_TIMEOUT: 3h
   - name: atlas_deployments_local_noauth_e2e
@@ -1532,12 +1531,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,deployments,local,noauth
           E2E_TIMEOUT: 3h
           LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
@@ -1552,12 +1551,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,deployments,local,nocli
           E2E_TIMEOUT: 3h
           LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
@@ -1572,12 +1571,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,deployments,local,auth,new
           E2E_TIMEOUT: 3h
           LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
@@ -1592,12 +1591,12 @@ tasks:
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
-          MCLI_ORG_ID: ${atlas_org_id}
-          MCLI_PROJECT_ID: ${atlas_project_id}
-          MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
-          MCLI_PUBLIC_API_KEY: ${atlas_public_api_key}
-          MCLI_OPS_MANAGER_URL: ${mcli_ops_manager_url}
-          MCLI_SERVICE: cloud
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
           E2E_TAGS: atlas,deployments,local,auth,deprecated
           E2E_TIMEOUT: 3h
           LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local

--- a/test/e2e/atlas/backup_flex_test.go
+++ b/test/e2e/atlas/backup_flex_test.go
@@ -36,7 +36,7 @@ func TestFlexBackup(t *testing.T) {
 	require.NoError(t, err)
 
 	g := newAtlasE2ETestGenerator(t)
-	g.projectID = os.Getenv("MCLI_PROJECT_ID")
+	g.projectID = os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	g.generateFlexCluster()
 
 	clusterName := os.Getenv("E2E_FLEX_INSTANCE_NAME")

--- a/test/e2e/atlas/cleanup_test.go
+++ b/test/e2e/atlas/cleanup_test.go
@@ -52,7 +52,7 @@ func TestCleanup(t *testing.T) {
 		"--limit=500",
 		"-o=json",
 	}
-	if orgID, set := os.LookupEnv("MCLI_ORG_ID"); set {
+	if orgID, set := os.LookupEnv("MONGODB_ATLAS_ORG_ID"); set {
 		args = append(args, "--orgId", orgID)
 	}
 	cmd := exec.Command(cliPath, args...)
@@ -64,8 +64,8 @@ func TestCleanup(t *testing.T) {
 	t.Logf("projects:\n%s\n", resp)
 	for _, project := range projects.GetResults() {
 		projectID := project.GetId()
-		if projectID == os.Getenv("MCLI_PROJECT_ID") {
-			// we have to cleanup data federations from default project
+		if projectID == os.Getenv("MONGODB_ATLAS_PROJECT_ID") {
+			// we have to clean up data federations from default project
 			// as this is the only project configured for data federation
 			// (has a configured awsRoleId)
 			t.Run("delete data federations", func(t *testing.T) {

--- a/test/e2e/atlas/clusters_file_test.go
+++ b/test/e2e/atlas/clusters_file_test.go
@@ -205,7 +205,7 @@ func generateClusterFile(mdbVersion string) (string, error) {
 	}
 
 	templateFile := "data/create_cluster_test.json"
-	if service := os.Getenv("MCLI_SERVICE"); service == config.CloudGovService {
+	if service := os.Getenv("MONGODB_ATLAS_SERVICE"); service == config.CloudGovService {
 		templateFile = "data/create_cluster_gov_test.json"
 	}
 

--- a/test/e2e/atlas/clusters_file_test.go
+++ b/test/e2e/atlas/clusters_file_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -205,7 +204,8 @@ func generateClusterFile(mdbVersion string) (string, error) {
 	}
 
 	templateFile := "data/create_cluster_test.json"
-	if service := os.Getenv("MONGODB_ATLAS_SERVICE"); service == config.CloudGovService {
+
+	if IsGov() {
 		templateFile = "data/create_cluster_gov_test.json"
 	}
 

--- a/test/e2e/atlas/helper_test.go
+++ b/test/e2e/atlas/helper_test.go
@@ -547,7 +547,7 @@ func RandEntityWithRevision(entity string) (string, error) {
 
 func MongoDBMajorVersion() (string, error) {
 	atlasClient := mongodbatlas.NewClient(nil)
-	atlasURL := os.Getenv("MCLI_OPS_MANAGER_URL")
+	atlasURL := os.Getenv("MONGODB_ATLAS_OPS_MANAGER_URL")
 	baseURL, err := url.Parse(atlasURL)
 	if err != nil {
 		return "", err
@@ -577,7 +577,7 @@ func getIntegrationType(val atlasv2.ThirdPartyIntegration) string {
 }
 
 func IsGov() bool {
-	return os.Getenv("MCLI_SERVICE") == "cloudgov"
+	return os.Getenv("MONGODB_ATLAS_SERVICE") == "cloudgov"
 }
 
 func createProject(projectName string) (string, error) {
@@ -1017,7 +1017,7 @@ func getFedSettingsID(t *testing.T, cliPath string) string {
 		"describe",
 		"-o=json",
 	}
-	if orgID, set := os.LookupEnv("MCLI_ORG_ID"); set {
+	if orgID, set := os.LookupEnv("MONGODB_ATLAS_ORG_ID"); set {
 		args = append(args, "--orgId", orgID)
 	}
 	cmd := exec.Command(cliPath, args...)

--- a/test/e2e/atlas/setup_failure_test.go
+++ b/test/e2e/atlas/setup_failure_test.go
@@ -34,7 +34,7 @@ func TestSetupFailureFlow(t *testing.T) {
 	req.NoError(err)
 
 	t.Run("Invalid Public Key", func(t *testing.T) {
-		t.Setenv("MCLI_PUBLIC_API_KEY", "invalid_public_key")
+		t.Setenv("MONGODB_ATLAS_PUBLIC_API_KEY", "invalid_public_key")
 		cmd := exec.Command(cliPath,
 			setupEntity,
 			"--skipMongosh",
@@ -47,7 +47,7 @@ func TestSetupFailureFlow(t *testing.T) {
 	})
 
 	t.Run("Invalid Private Key", func(t *testing.T) {
-		t.Setenv("MCLI_PRIVATE_API_KEY", "invalid_private_key")
+		t.Setenv("MONGODB_ATLAS_PRIVATE_API_KEY", "invalid_private_key")
 		cmd := exec.Command(cliPath,
 			setupEntity,
 			"--skipMongosh",

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -39,7 +39,7 @@ func TestConfig(t *testing.T) {
 	cliPath, err := e2e.AtlasCLIBin()
 	require.NoError(t, err)
 	t.Run("config", func(t *testing.T) {
-		t.Setenv("MCLI_PRIVATE_API_KEY", "")
+		t.Setenv("MONGODB_ATLAS_PRIVATE_API_KEY", "")
 		pty, tty, err := pseudotty.Open()
 		if err != nil {
 			t.Fatalf("failed to open pseudotty: %v", err)

--- a/test/e2e/iam/atlas_orgs_test.go
+++ b/test/e2e/iam/atlas_orgs_test.go
@@ -116,11 +116,11 @@ func TestAtlasOrgs(t *testing.T) {
 
 	t.Run("Delete", func(t *testing.T) {
 		t.Skip("Skipping delete org e2e test, exceeded max number of linked orgs. Will re-enable post cleanup")
-		if os.Getenv("MCLI_SERVICE") == "cloudgov" {
+		if os.Getenv("MONGODB_ATLAS_SERVICE") == "cloudgov" {
 			t.Skip("not available for gov")
 		}
-		t.Setenv("MCLI_PUBLIC_API_KEY", publicAPIKey)
-		t.Setenv("MCLI_PRIVATE_API_KEY", privateAPIKey)
+		t.Setenv("MONGODB_ATLAS_PUBLIC_API_KEY", publicAPIKey)
+		t.Setenv("MONGODB_ATLAS_PRIVATE_API_KEY", privateAPIKey)
 		cmd := exec.Command(cliPath,
 			orgEntity,
 			"delete",


### PR DESCRIPTION
Remove references to MCLI which was the legacy namespace from the monoglci days, and update to the Atlas documented one `MONGODB_ATLAS`