### PR TITLE
CLOUDP-303934: Drop mdb5.0 from atlascli

### DIFF
--- a/tools/genevergreen/generate/generate.go
+++ b/tools/genevergreen/generate/generate.go
@@ -28,7 +28,6 @@ const (
 
 var (
 	serverVersions = []string{
-		"5.0",
 		"6.0",
 		"7.0",
 		"8.0",
@@ -38,7 +37,6 @@ var (
 		"8.0": {"debian11"},
 		"7.0": {"ubuntu2404"},
 		"6.0": {"ubuntu2404"},
-		"5.0": {"ubuntu2404"},
 	}
 
 	oses = []string{
@@ -99,13 +97,11 @@ func RepoTasks(c *shrub.Configuration) {
 				if repo == "org" {
 					mongoRepo = "https://repo.mongodb.org"
 				}
-
-				t := &shrub.Task{
-					Name: fmt.Sprintf("test_repo_atlascli_%v_%v_%v", os, repo, serverVersion),
-				}
-
 				if slices.Contains(unsupportedNewOsByVersion[serverVersion], newOs[os]) {
 					continue
+				}
+				t := &shrub.Task{
+					Name: fmt.Sprintf("test_repo_atlascli_%s_%s_%s", os, repo, serverVersion),
 				}
 
 				t = t.Stepback(false).
@@ -117,7 +113,7 @@ func RepoTasks(c *shrub.Configuration) {
 						"package":        pkg,
 						"entrypoint":     entrypoint,
 						"image":          os,
-						"mongo_package":  fmt.Sprintf("mongodb-%v", repo),
+						"mongo_package":  "mongodb-" + repo,
 						"mongo_repo":     mongoRepo,
 					})
 				c.Tasks = append(c.Tasks, t)
@@ -138,7 +134,7 @@ func PostPkgTasks(c *shrub.Configuration) {
 
 	for _, os := range oses {
 		t := &shrub.Task{
-			Name: fmt.Sprintf("pkg_test_atlascli_docker_%v", os),
+			Name: fmt.Sprintf("pkg_test_atlascli_docker_%s", os),
 		}
 		t = t.Dependency(shrub.TaskDependency{
 			Name:    "package_goreleaser",

--- a/tools/genevergreen/generate/generate.go
+++ b/tools/genevergreen/generate/generate.go
@@ -134,7 +134,7 @@ func PostPkgTasks(c *shrub.Configuration) {
 
 	for _, os := range oses {
 		t := &shrub.Task{
-			Name: fmt.Sprintf("pkg_test_atlascli_docker_%s", os),
+			Name: "pkg_test_atlascli_docker_" + os,
 		}
 		t = t.Dependency(shrub.TaskDependency{
 			Name:    "package_goreleaser",

--- a/tools/genevergreen/generate/generate_test.go
+++ b/tools/genevergreen/generate/generate_test.go
@@ -70,8 +70,8 @@ func TestPublishStableTasks(t *testing.T) {
 	}
 
 	assert.True(t, commandFound, "expected to find a push command")
-	assert.Len(t, c.Variants, 4)
-	assert.Len(t, c.Tasks, 120)
+	assert.Len(t, c.Variants, 3)
+	assert.Len(t, c.Tasks, 90)
 }
 
 func TestPostPkgMetaTasks(t *testing.T) {
@@ -94,7 +94,7 @@ func TestPostPkgMetaTasks(t *testing.T) {
 		}
 	}
 	assert.Len(t, c.Variants, 1)
-	assert.Len(t, c.Tasks, 28)
+	assert.Len(t, c.Tasks, 21)
 }
 
 func TestRepoTasks(t *testing.T) {
@@ -114,6 +114,6 @@ func TestRepoTasks(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, c.Variants, 4)
-	assert.Len(t, c.Tasks, 56)
+	assert.Len(t, c.Variants, 3)
+	assert.Len(t, c.Tasks, 42)
 }


### PR DESCRIPTION
## Proposed changes

CLOUDP-303934

MDB5.0 has been EOL since last year, let's stop publishing to the repo and drop support for it 