### PR TITLE
[task] update golangci-lint to 1.64.6

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -25,7 +25,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837
         with:
-          version: v1.61.0
+          version: v1.64.6
   unit-tests:
     env:
       COVERAGE: coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,7 +119,6 @@ linters:
     - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
     - staticcheck # (megacheck) It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint. [fast: false, auto-fix: false]
     - stylecheck # Stylecheck is a replacement for golint [fast: false, auto-fix: false]
-    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17 [fast: false, auto-fix: false]
     - testableexamples # linter checks if examples are testable (have an expected output)
     - testifylint # Checks usage of github.com/stretchr/testify. [fast: false, auto-fix: false]
     - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers [fast: false, auto-fix: false]
@@ -128,6 +127,7 @@ linters:
     - unparam # Reports unused function parameters [fast: false, auto-fix: false]
     - unused # (megacheck) Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
     - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
+    - usetesting # A linter that detect the possibility to use variables/constants from the Go standard library. [fast, auto-fix]
     - wastedassign # wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
     - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,7 +127,7 @@ linters:
     - unparam # Reports unused function parameters [fast: false, auto-fix: false]
     - unused # (megacheck) Checks Go code for unused constants, variables, functions and types [fast: false, auto-fix: false]
     - usestdlibvars # A linter that detect the possibility to use variables/constants from the Go standard library. [fast: true, auto-fix: false]
-    - usetesting # A linter that detect the possibility to use variables/constants from the Go standard library. [fast, auto-fix]
+    - usetesting # Reports uses of functions with replacement inside the testing package. [auto-fix]
     - wastedassign # wastedassign finds wasted assignment statements. [fast: false, auto-fix: false]
     - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
-GOLANGCI_VERSION=v1.61.0
+GOLANGCI_VERSION=v1.64.6
 COVERAGE?=coverage.out
 export GOCOVERDIR?=$(abspath cov)
 

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/yuin/goldmark v1.7.8
 	go.mongodb.org/atlas v0.37.0
 	go.mongodb.org/atlas-sdk/v20240530005 v20240530005.0.0
+	go.mongodb.org/atlas-sdk/v20250219001 v20250219001.1.0
 	go.mongodb.org/mongo-driver v1.17.2
 	go.opentelemetry.io/otel v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0
@@ -60,8 +61,6 @@ require (
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-require go.mongodb.org/atlas-sdk/v20250219001 v20250219001.1.0
 
 require (
 	cloud.google.com/go v0.118.2 // indirect

--- a/internal/cli/datafederation/logs_test.go
+++ b/internal/cli/datafederation/logs_test.go
@@ -36,7 +36,7 @@ func TestLogOpts_Run(t *testing.T) {
 
 	const contents = "expected"
 
-	file, err := os.CreateTemp("", "")
+	file, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		require.NoError(t, err)
 	}

--- a/internal/telemetry/tracker_test.go
+++ b/internal/telemetry/tracker_test.go
@@ -63,9 +63,7 @@ func TestTrackCommandWithError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockEventsSender(ctrl)
 
-	cacheDir, err := os.MkdirTemp(os.TempDir(), config.AtlasCLI+"*")
-	require.NoError(t, err)
-
+	cacheDir := t.TempDir()
 	cmd := &cobra.Command{
 		Use: "test-command",
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -90,18 +88,14 @@ func TestTrackCommandWithError(t *testing.T) {
 		Return(nil).
 		Times(1)
 
-	err = tr.trackCommand(TrackOptions{
+	require.NoError(t, tr.trackCommand(TrackOptions{
 		Err: errCmd,
-	})
-	require.NoError(t, err)
+	}))
 }
 
 func TestTrackCommandWithSendError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockStore := mocks.NewMockEventsSender(ctrl)
-
-	cacheDir, err := os.MkdirTemp(os.TempDir(), config.AtlasCLI+"*")
-	require.NoError(t, err)
 
 	cmd := &cobra.Command{
 		Use: "test-command",
@@ -109,8 +103,9 @@ func TestTrackCommandWithSendError(t *testing.T) {
 		},
 	}
 	errCmd := cmd.ExecuteContext(NewContext())
-
 	require.NoError(t, errCmd)
+
+	cacheDir := t.TempDir()
 
 	tr := &tracker{
 		fs:               afero.NewMemMapFs(),
@@ -127,10 +122,9 @@ func TestTrackCommandWithSendError(t *testing.T) {
 		Return(errors.New("test send error")).
 		Times(1)
 
-	err = tr.trackCommand(TrackOptions{
+	require.NoError(t, tr.trackCommand(TrackOptions{
 		Err: errCmd,
-	})
-	require.NoError(t, err)
+	}))
 
 	// Verify that the file exists
 	filename := filepath.Join(cacheDir, cacheFilename)
@@ -144,9 +138,7 @@ func TestTrackCommandWithSendError(t *testing.T) {
 }
 
 func TestSave(t *testing.T) {
-	cacheDir, err := os.MkdirTemp(os.TempDir(), config.AtlasCLI+"*")
-	require.NoError(t, err)
-
+	cacheDir := os.TempDir()
 	tr := &tracker{
 		fs:               afero.NewMemMapFs(),
 		maxCacheFileSize: defaultMaxCacheFileSize,
@@ -175,9 +167,7 @@ func TestSave(t *testing.T) {
 }
 
 func TestSaveOverMaxCacheFileSize(t *testing.T) {
-	cacheDir, err := os.MkdirTemp(os.TempDir(), config.AtlasCLI+"*")
-	require.NoError(t, err)
-
+	cacheDir := os.TempDir()
 	tr := &tracker{
 		fs:               afero.NewMemMapFs(),
 		maxCacheFileSize: 10, // 10 bytes
@@ -200,16 +190,14 @@ func TestSaveOverMaxCacheFileSize(t *testing.T) {
 }
 
 func TestOpenCacheFile(t *testing.T) {
-	cacheDir, err := os.MkdirTemp(os.TempDir(), config.AtlasCLI+"*")
-	require.NoError(t, err)
-
+	cacheDir := t.TempDir()
 	tr := &tracker{
 		fs:               afero.NewMemMapFs(),
 		maxCacheFileSize: 10, // 10 bytes
 		cacheDir:         cacheDir,
 	}
 
-	_, err = tr.openCacheFile()
+	_, err := tr.openCacheFile()
 	require.NoError(t, err)
 	// Verify that the file exists
 	filename := path.Join(cacheDir, cacheFilename)
@@ -224,9 +212,7 @@ func TestOpenCacheFile(t *testing.T) {
 }
 
 func TestTrackSurvey(t *testing.T) {
-	cacheDir, err := os.MkdirTemp(os.TempDir(), config.AtlasCLI+"*")
-	require.NoError(t, err)
-
+	cacheDir := t.TempDir()
 	cmd := &cobra.Command{
 		Use: "test-command",
 		Run: func(_ *cobra.Command, _ []string) {
@@ -243,7 +229,7 @@ func TestTrackSurvey(t *testing.T) {
 	}
 
 	response := true
-	err = tr.trackSurvey(
+	err := tr.trackSurvey(
 		&survey.Confirm{Message: "test"},
 		&response,
 		nil,

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -311,7 +311,7 @@ func TestOptionalURL(t *testing.T) {
 }
 
 func TestPath(t *testing.T) {
-	f, err := os.CreateTemp("", "TestPath")
+	f, err := os.CreateTemp(t.TempDir(), "TestPath")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, f.Close())
@@ -354,7 +354,7 @@ func TestPath(t *testing.T) {
 }
 
 func TestOptionalPath(t *testing.T) {
-	f, err := os.CreateTemp("", "TestOptionalPath")
+	f, err := os.CreateTemp(t.TempDir(), "TestOptionalPath")
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, f.Close())

--- a/test/e2e/config/config_test.go
+++ b/test/e2e/config/config_test.go
@@ -39,11 +39,7 @@ func TestConfig(t *testing.T) {
 	cliPath, err := e2e.AtlasCLIBin()
 	require.NoError(t, err)
 	t.Run("config", func(t *testing.T) {
-		key := os.Getenv("MCLI_PRIVATE_API_KEY")
-		_ = os.Unsetenv("MCLI_PRIVATE_API_KEY")
-		t.Cleanup(func() {
-			_ = os.Setenv("MCLI_PRIVATE_API_KEY", key)
-		})
+		t.Setenv("MCLI_PRIVATE_API_KEY", "")
 		pty, tty, err := pseudotty.Open()
 		if err != nil {
 			t.Fatalf("failed to open pseudotty: %v", err)


### PR DESCRIPTION
Was having some issues with the old linter locally, tried to update to fix them and it works so let's keep it on latest