### PR TITLE
CLOUDP-304933 Add operationId to API commands and restructure docs generation tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ gen-mocks: ## Generate mocks
 .PHONY: gen-docs
 gen-docs: ## Generate docs for atlascli commands
 	@echo "==> Generating docs"
-	go run -ldflags "$(LINKER_FLAGS)" ./tools/docs/main.go
+	go run -ldflags "$(LINKER_FLAGS)" ./tools/docs
 
 .PHONY: build
 build: ## Generate an atlas binary in ./bin

--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -111,6 +111,9 @@ func convertAPIToCobraCommand(command api.Command) (*cobra.Command, error) {
 		Aliases: command.Aliases,
 		Short:   shortDescription,
 		Long:    longDescription,
+		Annotations: map[string]string{
+			"operationId": command.OperationID,
+		},
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			// Go through all commands that have not been touched/modified by the user and try to populate them from the users profile
 			// Common usecases:

--- a/tools/docs/main.go
+++ b/tools/docs/main.go
@@ -17,79 +17,11 @@ package main
 import (
 	"log"
 	"os"
-	"strings"
 
 	"github.com/mongodb-labs/cobra2snooty"
 	pluginCmd "github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/plugin"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/root"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/plugin"
-	"github.com/spf13/cobra"
 )
-
-const apiCommandName = "api"
-
-func setDisableAutoGenTag(cmd *cobra.Command) {
-	cmd.DisableAutoGenTag = true
-	for _, cmd := range cmd.Commands() {
-		setDisableAutoGenTag(cmd)
-	}
-}
-
-func addExperimenalToAPICommands(cmd *cobra.Command) {
-	var apiCommand *cobra.Command
-	for _, subCommand := range cmd.Commands() {
-		if subCommand.Use == apiCommandName {
-			apiCommand = subCommand
-		}
-	}
-
-	if apiCommand == nil {
-		panic("api command not found!")
-	}
-
-	markExperimentalRecursively(apiCommand)
-}
-
-func markExperimentalRecursively(cmd *cobra.Command) {
-	cmd.Short = "`experimental <https://www.mongodb.com/docs/atlas/cli/current/command/atlas-api/>`_: " + cmd.Short
-
-	for _, subCommand := range cmd.Commands() {
-		markExperimentalRecursively(subCommand)
-	}
-}
-
-func updateAPICommandDescription(cmd *cobra.Command) {
-	var apiCommand *cobra.Command
-	for _, subCommand := range cmd.Commands() {
-		if subCommand.Use == apiCommandName {
-			apiCommand = subCommand
-		}
-	}
-
-	if apiCommand == nil {
-		panic("api command not found!")
-	}
-
-	updateLeafDescriptions(apiCommand)
-}
-
-func updateLeafDescriptions(cmd *cobra.Command) {
-	if len(cmd.Commands()) == 0 {
-		lines := strings.Split(cmd.Long, "\n")
-		// Replace last line if it contains the extected text: "For more information and examples, see: <AtlasCLI docs url>"
-		if strings.HasPrefix(lines[len(lines)-1], "For more information and examples, see: https://www.mongodb.com/docs/atlas/cli/current/command/") {
-			lines = lines[:len(lines)-1]
-			newLine := "For more information and examples, see the referenced API documentation linked above."
-			lines = append(lines, newLine)
-		}
-
-		cmd.Long = strings.Join(lines, "\n")
-	}
-
-	for _, subCommand := range cmd.Commands() {
-		updateLeafDescriptions(subCommand)
-	}
-}
 
 func main() {
 	if err := os.RemoveAll("./docs/command"); err != nil {
@@ -103,22 +35,20 @@ func main() {
 
 	atlasBuilder := root.Builder()
 
-	for _, cmd := range atlasBuilder.Commands() {
-		if plugin.IsPluginCmd(cmd) && !isFirstClassPlugin(cmd) {
-			atlasBuilder.RemoveCommand(cmd)
-		}
-	}
-
 	atlasBuilder.InitDefaultCompletionCmd()
 
-	setDisableAutoGenTag(atlasBuilder)
-	addExperimenalToAPICommands(atlasBuilder)
-	updateAPICommandDescription(atlasBuilder)
+	applyTransformations(atlasBuilder)
 
 	if err := cobra2snooty.GenTreeDocs(atlasBuilder, "./docs/command"); err != nil {
 		log.Fatal(err)
 	}
 
+	if err := removeFirstClassPluginCommandDocs(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func removeFirstClassPluginCommandDocs() error {
 	firstClassPaths := make([]string, 0, len(pluginCmd.FirstClassPlugins))
 	for _, fcp := range pluginCmd.FirstClassPlugins {
 		cmd := fcp.Commands
@@ -129,21 +59,9 @@ func main() {
 	}
 
 	for _, filePath := range firstClassPaths {
-		err := os.Remove(filePath)
-		if err != nil {
-			log.Fatal(err)
+		if err := os.Remove(filePath); err != nil {
+			return err
 		}
 	}
-}
-
-func isFirstClassPlugin(command *cobra.Command) bool {
-	for _, fcp := range pluginCmd.FirstClassPlugins {
-		cmd := fcp.Commands
-		for _, c := range cmd {
-			if command.Name() == c.Name {
-				return true
-			}
-		}
-	}
-	return false
+	return nil
 }

--- a/tools/docs/transformations.go
+++ b/tools/docs/transformations.go
@@ -1,0 +1,63 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func isAPICommand(cmd *cobra.Command) bool {
+	return regexp.MustCompile("^atlas api( |$)").MatchString(cmd.CommandPath())
+}
+
+func setDisableAutoGenTag(cmd *cobra.Command) {
+	cmd.DisableAutoGenTag = true
+}
+
+func markExperimenalToAPICommands(cmd *cobra.Command) {
+	cmd.Short = "`experimental <https://www.mongodb.com/docs/atlas/cli/current/command/atlas-api/>`_: " + cmd.Short
+}
+
+func updateAPICommandDescription(cmd *cobra.Command) {
+	if len(cmd.Commands()) > 0 {
+		return
+	}
+
+	lines := strings.Split(cmd.Long, "\n")
+	// Replace last line if it contains the extected text: "For more information and examples, see: <AtlasCLI docs url>"
+	if strings.HasPrefix(lines[len(lines)-1], "For more information and examples, see: https://www.mongodb.com/docs/atlas/cli/current/command/") {
+		lines = lines[:len(lines)-1]
+		newLine := "For more information and examples, see the referenced API documentation linked above."
+		lines = append(lines, newLine)
+	}
+
+	cmd.Long = strings.Join(lines, "\n")
+}
+
+func applyTransformations(cmd *cobra.Command) {
+	setDisableAutoGenTag(cmd)
+
+	if isAPICommand(cmd) {
+		markExperimenalToAPICommands(cmd)
+		updateAPICommandDescription(cmd)
+	}
+
+	for _, subCmd := range cmd.Commands() {
+		applyTransformations(subCmd)
+	}
+}

--- a/tools/docs/transformations.go
+++ b/tools/docs/transformations.go
@@ -18,6 +18,8 @@ import (
 	"regexp"
 	"strings"
 
+	pluginCmd "github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/plugin"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/plugin"
 	"github.com/spf13/cobra"
 )
 
@@ -49,8 +51,27 @@ func updateAPICommandDescription(cmd *cobra.Command) {
 	cmd.Long = strings.Join(lines, "\n")
 }
 
+func isFirstClassPlugin(command *cobra.Command) bool {
+	for _, fcp := range pluginCmd.FirstClassPlugins {
+		cmd := fcp.Commands
+		for _, c := range cmd {
+			if command.Name() == c.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func removePluginCommands(cmd *cobra.Command) {
+	if plugin.IsPluginCmd(cmd) && !isFirstClassPlugin(cmd) {
+		cmd.Parent().RemoveCommand(cmd)
+	}
+}
+
 func applyTransformations(cmd *cobra.Command) {
 	setDisableAutoGenTag(cmd)
+	removePluginCommands(cmd)
 
 	if isAPICommand(cmd) {
 		markExperimenalToAPICommands(cmd)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
Add operationId to API commands and restructure docs generation tool
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-304933

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
