### PR TITLE
CLOUDP-305570: Add --watch to Outage simulation

### DIFF
--- a/docs/command/atlas-api-clusterOutageSimulation-endOutageSimulation.txt
+++ b/docs/command/atlas-api-clusterOutageSimulation-endOutageSimulation.txt
@@ -71,6 +71,14 @@ Options
      - string
      - false
      - api version to use when calling the api call [options: "2023-01-01"], defaults to the latest version or the profiles api_version config value if set This value defaults to "2023-01-01".
+   * - -w, --watch
+     - 
+     - false
+     - Flag that indicates whether to watch the command until it completes its execution or the watch times out.
+   * - --watchTimeout
+     - int
+     - false
+     - Time in seconds until a watch times out. After a watch times out, the CLI no longer watches the command.
 
 Inherited Options
 -----------------

--- a/docs/command/atlas-api-clusterOutageSimulation-startOutageSimulation.txt
+++ b/docs/command/atlas-api-clusterOutageSimulation-startOutageSimulation.txt
@@ -75,6 +75,14 @@ Options
      - string
      - false
      - api version to use when calling the api call [options: "2023-01-01"], defaults to the latest version or the profiles api_version config value if set This value defaults to "2023-01-01".
+   * - -w, --watch
+     - 
+     - false
+     - Flag that indicates whether to watch the command until it completes its execution or the watch times out.
+   * - --watchTimeout
+     - int
+     - false
+     - Time in seconds until a watch times out. After a watch times out, the CLI no longer watches the command.
 
 Inherited Options
 -----------------

--- a/internal/api/commands.go
+++ b/internal/api/commands.go
@@ -6417,6 +6417,20 @@ NOTE: Groups and projects are synonymous terms. Your group id is the same as you
 						},
 					},
 				},
+				Watcher: &WatcherProperties{
+					Get: WatcherGetProperties{
+						OperationID: `getOutageSimulation`,
+						Version:     `2023-01-01`,
+						Params: map[string]string{
+							`clusterName`: `input:clusterName`,
+							`groupId`:     `input:groupId`,
+						},
+					},
+					Expect: &WatcherExpectProperties{
+						HTTPCode: 404, //nolint
+						Match:    nil,
+					},
+				},
 			},
 			{
 				OperationID: `getOutageSimulation`,
@@ -6554,6 +6568,24 @@ NOTE: Groups and projects are synonymous terms. Your group id is the same as you
 						RequestContentType: `json`,
 						ResponseContentTypes: []string{
 							`json`,
+						},
+					},
+				},
+				Watcher: &WatcherProperties{
+					Get: WatcherGetProperties{
+						OperationID: `getOutageSimulation`,
+						Version:     `2023-01-01`,
+						Params: map[string]string{
+							`clusterName`: `input:clusterName`,
+							`groupId`:     `input:groupId`,
+						},
+					},
+					Expect: &WatcherExpectProperties{
+						Match: &WatcherMatchProperties{
+							Path: `$.state`,
+							Values: []string{
+								`SIMULATING`,
+							},
 						},
 					},
 				},

--- a/tools/api-generator/overlays/watchers.yaml
+++ b/tools/api-generator/overlays/watchers.yaml
@@ -441,3 +441,30 @@ actions:
               values:
                 - completed
                 - failed
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation'].post
+    update:
+      x-xgen-atlascli:
+        watcher:
+          get:
+            version: "2023-01-01"
+            operation-id: getOutageSimulation
+            params:
+              groupId: input:groupId
+              clusterName: input:clusterName
+          expect:
+            match:
+              path: $.state
+              values:
+                - SIMULATING
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation'].delete
+    update:
+      x-xgen-atlascli:
+        watcher:
+          get:
+            version: "2023-01-01"
+            operation-id: getOutageSimulation
+            params:
+              groupId: input:groupId
+              clusterName: input:clusterName
+          expect:
+            http-code: 404


### PR DESCRIPTION
## Proposed changes
- added `--watch` to cluster outage simulation commands start/end

_Jira ticket:_ CLOUDP-305570

## Testing
Ran these commands:

### Start outage simulation
`outage_simulation.json`
```
{
    "outageFilters": [
      {
        "cloudProvider": "AWS",
        "regionName": "EU_WEST_3",
        "type": "REGION"
      }
    ]
  }
```

```sh
atlas api clusterOutageSimulation startOutageSimulation --version 2023-01-01 --clusterName Cluster0 --file outage_simulation.json --watch
```

### Stop outage simulation
```sh
atlas api clusterOutageSimulation endOutageSimulation --version 2023-01-01 --clusterName Cluster0 --watch
```