### PR TITLE
CLOUDP-298177: Improve apiKey creation examples

### DIFF
--- a/docs/command/atlas-projects-apiKeys-create.txt
+++ b/docs/command/atlas-projects-apiKeys-create.txt
@@ -15,9 +15,9 @@ atlas projects apiKeys create
 Create an organization API key and assign it to your project.
 
 MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
-By default, the specified project's parent organization will be assigned as organization member. You must authenicate with a user account or API key with the Organization User Admin role to set organization roles.
+If you don't provide an organization level role, the API Key defaults to organization member of the project parent organization.
 
-To use this command, you must authenticate with a user account or an API key with the Project User Admin role.
+To use this command, you must authenticate with a user account or an API key with any of the following roles: Project User Admin or Organization User Admin to manage organization level roles.
 
 Syntax
 ------

--- a/docs/command/atlas-projects-apiKeys-create.txt
+++ b/docs/command/atlas-projects-apiKeys-create.txt
@@ -15,7 +15,7 @@ atlas projects apiKeys create
 Create an organization API key and assign it to your project.
 
 MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
-		By default, the specified project's parent organization will be assigned as organization member.
+By default, the specified project's parent organization will be assigned as organization member. You must authenicate with a user account or API key with the Organization User Admin role to set organization roles.
 
 To use this command, you must authenticate with a user account or an API key with the Project User Admin role.
 
@@ -102,5 +102,5 @@ Examples
 .. code-block::
    :copyable: false
 
-   # Create an organization API key with the ORG_OWNER and GROUP_SEARCH_INDEX_EDITOR roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
-   atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role ORG_OWNER,GROUP_SEARCH_INDEX_EDITOR --output json
+   # Create an organization API key with the GROUP_SEARCH_INDEX_EDITOR and GROUP_DATABASE_ACCESS_ADMIN roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_SEARCH_INDEX_EDITOR,GROUP_DATABASE_ACCESS_ADMIN --output json

--- a/docs/command/atlas-projects-apiKeys-create.txt
+++ b/docs/command/atlas-projects-apiKeys-create.txt
@@ -15,6 +15,7 @@ atlas projects apiKeys create
 Create an organization API key and assign it to your project.
 
 MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
+		By default, the specified project's parent organization will be assigned as organization member.
 
 To use this command, you must authenticate with a user account or an API key with the Project User Admin role.
 
@@ -101,5 +102,5 @@ Examples
 .. code-block::
    :copyable: false
 
-   # Create an organization API key with the GROUP_SEARCH_INDEX_EDITOR and GROUP_DATABASE_ACCESS_ADMIN roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
-   atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_SEARCH_INDEX_EDITOR,GROUP_DATABASE_ACCESS_ADMIN --output json
+   # Create an organization API key with the ORG_OWNER and GROUP_SEARCH_INDEX_EDITOR roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role ORG_OWNER,GROUP_SEARCH_INDEX_EDITOR --output json

--- a/docs/command/atlas-projects-apiKeys-create.txt
+++ b/docs/command/atlas-projects-apiKeys-create.txt
@@ -96,3 +96,10 @@ Examples
 
    # Create an organization API key with the GROUP_OWNER role and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
    atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_OWNER --output json
+   
+   
+.. code-block::
+   :copyable: false
+
+   # Create an organization API key with the GROUP_SEARCH_INDEX_EDITOR and GROUP_DATABASE_ACCESS_ADMIN roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
+   atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_SEARCH_INDEX_EDITOR,GROUP_DATABASE_ACCESS_ADMIN --output json

--- a/internal/cli/projects/apikeys/create.go
+++ b/internal/cli/projects/apikeys/create.go
@@ -77,7 +77,10 @@ func CreateBuilder() *cobra.Command {
 		},
 		Args: require.NoArgs,
 		Example: `  # Create an organization API key with the GROUP_OWNER role and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
-  atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_OWNER --output json`,
+  atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_OWNER --output json
+  
+  # Create an organization API key with the GROUP_SEARCH_INDEX_EDITOR and GROUP_DATABASE_ACCESS_ADMIN roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
+  atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_SEARCH_INDEX_EDITOR,GROUP_DATABASE_ACCESS_ADMIN --output json`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/projects/apikeys/create.go
+++ b/internal/cli/projects/apikeys/create.go
@@ -70,7 +70,7 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create",
 		Short: "Create an organization API key and assign it to your project.",
 		Long: `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
-		By default, the specified project's parent organization will be assigned as organization member.
+By default, the specified project's parent organization will be assigned as organization member. You must authenicate with a user account or API key with the Organization User Admin role to set organization roles.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Annotations: map[string]string{
@@ -80,8 +80,8 @@ func CreateBuilder() *cobra.Command {
 		Example: `  # Create an organization API key with the GROUP_OWNER role and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
   atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_OWNER --output json
   
-  # Create an organization API key with the ORG_OWNER and GROUP_SEARCH_INDEX_EDITOR roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
-  atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role ORG_OWNER,GROUP_SEARCH_INDEX_EDITOR --output json`,
+  # Create an organization API key with the GROUP_SEARCH_INDEX_EDITOR and GROUP_DATABASE_ACCESS_ADMIN roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
+  atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_SEARCH_INDEX_EDITOR,GROUP_DATABASE_ACCESS_ADMIN --output json`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,

--- a/internal/cli/projects/apikeys/create.go
+++ b/internal/cli/projects/apikeys/create.go
@@ -70,9 +70,9 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create",
 		Short: "Create an organization API key and assign it to your project.",
 		Long: `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
-By default, the specified project's parent organization will be assigned as organization member. You must authenicate with a user account or API key with the Organization User Admin role to set organization roles.
+If you don't provide an organization level role, the API Key defaults to organization member of the project parent organization.
 
-` + fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
+` + fmt.Sprintf(usage.RequiredOneOfRoles, "Project User Admin or Organization User Admin to manage organization level roles"),
 		Annotations: map[string]string{
 			"output": createTemplate,
 		},

--- a/internal/cli/projects/apikeys/create.go
+++ b/internal/cli/projects/apikeys/create.go
@@ -70,6 +70,7 @@ func CreateBuilder() *cobra.Command {
 		Use:   "create",
 		Short: "Create an organization API key and assign it to your project.",
 		Long: `MongoDB returns the private API key only once. After you run this command, immediately copy, save, and secure both the public and private API keys.
+		By default, the specified project's parent organization will be assigned as organization member.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project User Admin"),
 		Annotations: map[string]string{
@@ -79,8 +80,8 @@ func CreateBuilder() *cobra.Command {
 		Example: `  # Create an organization API key with the GROUP_OWNER role and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
   atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_OWNER --output json
   
-  # Create an organization API key with the GROUP_SEARCH_INDEX_EDITOR and GROUP_DATABASE_ACCESS_ADMIN roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
-  atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role GROUP_SEARCH_INDEX_EDITOR,GROUP_DATABASE_ACCESS_ADMIN --output json`,
+  # Create an organization API key with the ORG_OWNER and GROUP_SEARCH_INDEX_EDITOR roles and assign it to the project with ID 5e2211c17a3e5a48f5497de3:
+  atlas projects apiKeys create --desc "My API key" --projectId 5e1234c17a3e5a48f5497de3 --role ORG_OWNER,GROUP_SEARCH_INDEX_EDITOR --output json`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return opts.PreRunE(
 				opts.ValidateProjectID,


### PR DESCRIPTION
## Proposed changes

Adds example to `atlas projects apiKeys create` outlining how to use the command with multiple lesser privilege roles. 

Allowing for UI role names has not been implemented now that [linked documentation](https://www.mongodb.com/docs/atlas/reference/user-roles/) explicits the mapping of role names across UI and CLI/API/etc.

_Jira ticket:_ [CLOUDP-298177](https://jira.mongodb.org/browse/CLOUDP-298177)


## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
