### PR TITLE
CLOUDP-305822: `atlas dbusers update [USER] --password [PASS]`is resetting the roles to an empty array

### DIFF
--- a/internal/cli/dbusers/update.go
+++ b/internal/cli/dbusers/update.go
@@ -87,8 +87,11 @@ func (opts *UpdateOpts) update(out *admin.CloudDatabaseUser) {
 		out.Description = &opts.description
 	}
 
-	roles := convert.BuildAtlasRoles(opts.roles)
-	out.Roles = &roles
+	if len(opts.roles) > 0 {
+		roles := convert.BuildAtlasRoles(opts.roles)
+		out.Roles = &roles
+	}
+
 	scopes := convert.BuildAtlasScopes(opts.scopes)
 	out.Scopes = &scopes
 	out.DatabaseName = opts.authDB

--- a/internal/cli/dbusers/update.go
+++ b/internal/cli/dbusers/update.go
@@ -92,8 +92,11 @@ func (opts *UpdateOpts) update(out *admin.CloudDatabaseUser) {
 		out.Roles = &roles
 	}
 
-	scopes := convert.BuildAtlasScopes(opts.scopes)
-	out.Scopes = &scopes
+	if len(opts.scopes) > 0 {
+		scopes := convert.BuildAtlasScopes(opts.scopes)
+		out.Scopes = &scopes
+	}
+
 	out.DatabaseName = opts.authDB
 	if opts.authDB == "" {
 		out.DatabaseName = convert.GetAuthDB(out)

--- a/test/e2e/atlas/dbusers_test.go
+++ b/test/e2e/atlas/dbusers_test.go
@@ -122,6 +122,20 @@ func TestDBUserWithFlags(t *testing.T) {
 		testUpdateUserCmd(t, cmd, username)
 	})
 
+	t.Run("Update only password", func(t *testing.T) {
+		pwd, err := generateRandomBase64String()
+		require.NoError(t, err)
+		cmd := exec.Command(cliPath,
+			dbusersEntity,
+			"update",
+			username,
+			"--password",
+			pwd,
+			"-o=json")
+
+		testUpdateUserCmd(t, cmd, username)
+	})
+
 	t.Run("Delete", func(t *testing.T) {
 		testDeleteUser(t, cliPath, dbusersEntity, username)
 	})


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-305822

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->
# Bug 
The `atlas dbusers update [USER] --password [PASS]` sets the roles and scope array to empty.


# Fix
Set the roles and scope in the request body only when the user provides their flags.

# Testing

### Before
```json
atlas dbusers get Quickstart-1635259359 -P dev -o dev
{
  "awsIAMType": "NONE",
  "databaseName": "admin",
  "groupId": "5e4e593f70dfbf1010295836",
  "labels": [],
  "ldapAuthType": "NONE",
  "links": [
    {
      "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/5e4e593f70dfbf1010295836/databaseUsers/admin/Quickstart-1635259359",
      "rel": "self"
    }
  ],
  "oidcAuthType": "NONE",
  "roles": [
    {
      "databaseName": "admin",
      "roleName": "atlasAdmin"
    }
  ],
  "scopes": [],
  "username": "Quickstart-1635259359",
  "x509Type": "NONE"
}
```

```json
atlas dbusers update Quickstart-1635259359  --password 'test' -P dev -o json                                                                              
{
  "awsIAMType": "NONE",
  "databaseName": "admin",
  "groupId": "5e4e593f70dfbf1010295836",
  "labels": [],
  "ldapAuthType": "NONE",
  "links": [
    {
      "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/5e4e593f70dfbf1010295836/databaseUsers/admin/Quickstart-1635259359",
      "rel": "self"
    }
  ],
  "oidcAuthType": "NONE",
  "roles": [],
  "scopes": [],
  "username": "Quickstart-1635259359",
  "x509Type": "NONE"
}
```

### After the fix

```json
./bin/atlas dbusers update thirdUser --password 'test' -P dev -o json                                                                                    
{
  "awsIAMType": "NONE",
  "databaseName": "admin",
  "groupId": "5e4e593f70dfbf1010295836",
  "labels": [],
  "ldapAuthType": "NONE",
  "links": [
    {
      "href": "https://cloud-dev.mongodb.com/api/atlas/v2/groups/5e4e593f70dfbf1010295836/databaseUsers/admin/thirdUser",
      "rel": "self"
    }
  ],
  "oidcAuthType": "NONE",
  "roles": [
    {
      "databaseName": "admin",
      "roleName": "readWriteAnyDatabase"
    },
    {
      "databaseName": "admin",
      "roleName": "clusterMonitor"
    }
  ],
  "scopes": [],
  "username": "thirdUser",
  "x509Type": "NONE"
}
```