### PR TITLE
CLOUDP-303343: Create example for auto-generated projectIPAcessList CRUD operations

### DIFF
--- a/internal/api/httprequest.go
+++ b/internal/api/httprequest.go
@@ -105,6 +105,11 @@ func buildPath(path string, commandURLParameters []Parameter, parameterValues ma
 			return "", fmt.Errorf("url parameter '%s' is not set", commandURLParameter.Name)
 		}
 
+		// Path encode all values
+		for i := range values {
+			values[i] = url.PathEscape(values[i])
+		}
+
 		value := strings.Join(values, ",")
 		path = strings.ReplaceAll(path, "{"+commandURLParameter.Name+"}", value)
 	}

--- a/internal/api/httprequest_test.go
+++ b/internal/api/httprequest_test.go
@@ -151,6 +151,20 @@ func TestBuildPath(t *testing.T) {
 			shouldFail:    true,
 			expectedValue: "",
 		},
+		{
+			name:         "escape path values",
+			pathTemplate: "/api/atlas/v2/groups/{groupId}/accessList/{entryValue}",
+			commandURLParameters: []Parameter{
+				{Name: "groupId", Required: true, Type: ParameterType{IsArray: false, Type: TypeString}},
+				{Name: "entryValue", Required: true, Type: ParameterType{IsArray: false, Type: TypeString}},
+			},
+			parameterValues: map[string][]string{
+				"groupId":    {"groupId-01"},
+				"entryValue": {"192.168.1.0/24"},
+			},
+			shouldFail:    false,
+			expectedValue: "/api/atlas/v2/groups/groupId-01/accessList/192.168.1.0%2F24",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tools/cmd/api-generator/convert_metadata.go
+++ b/tools/cmd/api-generator/convert_metadata.go
@@ -104,9 +104,9 @@ func extractRequestBodyExamples(requestBody *openapi3.RequestBodyRef) (map[strin
 				exampleName = exampleRef.Value.Summary
 			}
 
-			var value map[string]any
+			var value any
 			if exampleRef.Value != nil && exampleRef.Value.Value != nil {
-				value = exampleRef.Value.Value.(map[string]any)
+				value = exampleRef.Value.Value
 			}
 
 			result := metadatatypes.RequestBodyExample{
@@ -130,8 +130,8 @@ func extractRequestBodyExamples(requestBody *openapi3.RequestBodyRef) (map[strin
 	return results, nil
 }
 
-func toJSONString(data map[string]any) string {
-	if len(data) == 0 {
+func toJSONString(data any) string {
+	if data == nil {
 		return ""
 	}
 

--- a/tools/cmd/api-generator/overlays/examples_project_ip_access_list.yaml
+++ b/tools/cmd/api-generator/overlays/examples_project_ip_access_list.yaml
@@ -1,0 +1,56 @@
+overlay: 1.0.0
+info:
+  title: Configure groupId flag
+  version: 1.0.0
+actions:
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/accessList'].get
+    update:
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            examples:
+              project_ip_access_list_list:
+                summary: Return project IP access list
+                value:
+                description: Returns all access list entries from the specified project's IP access list.
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/accessList'].post.requestBody.content['application/vnd.atlas.2023-01-01+json']
+    update:
+      examples:
+        project_ip_access_list_add:
+          summary: Add Entries to Project IP Access List
+          value:
+            - cidrBlock: "192.168.1.0/24"
+              comment: "Internal network range"
+            - cidrBlock: "10.0.0.0/16"
+              comment: "VPC network range"
+          description: Adds multiple access list entries to the specified project
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/accessList/{entryValue}'].get
+    update:
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            examples:
+              project_ip_access_list_get:
+                summary: Return One Project IP Access List Entry
+                value:
+                description: "Returns one access list entry from the specified project's IP access list: 10.0.0.0/16"
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/accessList/{entryValue}/status'].get
+    update:
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            examples:
+              project_ip_access_list_get_status:
+                summary: Return Status of One Project IP Access List Entry
+                value:
+                description: "Returns the status of 10.0.0.0/16"
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/accessList/{entryValue}'].delete
+    update:
+      requestBody:
+        content:
+          application/vnd.atlas.2023-01-01+json:
+            examples:
+              project_ip_access_list_delete:
+                summary: Remove One Entry from One Project IP Access List
+                value:
+                description: Removes one access list entry from the specified project's IP access list

--- a/tools/cmd/docs/metadata.go
+++ b/tools/cmd/docs/metadata.go
@@ -475,6 +475,29 @@ var EndpointExamples = map[string]metadatatypes.Metadata{
 			},
 		},
 	},
+	`createProjectIpAccessList`: {
+		ParameterExample: map[string]string{
+			`groupId`: `32b6e34b3d91647abb20e7b8`,
+		},
+		RequestBodyExamples: map[string][]metadatatypes.RequestBodyExample{
+			`2023-01-01`: {
+				{
+					Name:        `Add Entries to Project IP Access List`,
+					Description: `Adds multiple access list entries to the specified project`,
+					Value: `[
+  {
+    "cidrBlock": "192.168.1.0/24",
+    "comment": "Internal network range"
+  },
+  {
+    "cidrBlock": "10.0.0.0/16",
+    "comment": "VPC network range"
+  }
+]`,
+				},
+			},
+		},
+	},
 	`createRollingIndex`: {
 		ParameterExample: map[string]string{
 			`groupId`: `32b6e34b3d91647abb20e7b8`,
@@ -589,6 +612,20 @@ var EndpointExamples = map[string]metadatatypes.Metadata{
 			},
 		},
 	},
+	`deleteProjectIpAccessList`: {
+		ParameterExample: map[string]string{
+			`entryValue`: `IPv4: 192.0.2.0%2F24 or IPv6: 2001:db8:85a3:8d3:1319:8a2e:370:7348 or IPv4 CIDR: 198.51.100.0%2f24 or IPv6 CIDR: 2001:db8::%2f58 or AWS SG: sg-903004f8`,
+			`groupId`:    `32b6e34b3d91647abb20e7b8`,
+		},
+		RequestBodyExamples: map[string][]metadatatypes.RequestBodyExample{
+			`2023-01-01`: {
+				{
+					Name:        `Remove One Entry from One Project IP Access List`,
+					Description: `Removes one access list entry from the specified project's IP access list`,
+				},
+			},
+		},
+	},
 	`getProject`: {
 		ParameterExample: map[string]string{
 			`groupId`: `32b6e34b3d91647abb20e7b8`,
@@ -598,6 +635,47 @@ var EndpointExamples = map[string]metadatatypes.Metadata{
 				{
 					Name:        `Get a project`,
 					Description: `Get a project using a project id`,
+				},
+			},
+		},
+	},
+	`getProjectIpAccessListStatus`: {
+		ParameterExample: map[string]string{
+			`entryValue`: `IPv4: 192.0.2.0%2F24 or IPv6: 2001:db8:85a3:8d3:1319:8a2e:370:7348 or IPv4 CIDR: 198.51.100.0%2f24 or IPv6 CIDR: 2001:db8::%2f58 or AWS SG: sg-903004f8`,
+			`groupId`:    `32b6e34b3d91647abb20e7b8`,
+		},
+		RequestBodyExamples: map[string][]metadatatypes.RequestBodyExample{
+			`2023-01-01`: {
+				{
+					Name:        `Return Status of One Project IP Access List Entry`,
+					Description: `Returns the status of 10.0.0.0/16`,
+				},
+			},
+		},
+	},
+	`getProjectIpList`: {
+		ParameterExample: map[string]string{
+			`entryValue`: `IPv4: 192.0.2.0%2F24 or IPv6: 2001:db8:85a3:8d3:1319:8a2e:370:7348 or IPv4 CIDR: 198.51.100.0%2f24 or IPv6 CIDR: 2001:db8::%2f58 or AWS SG: sg-903004f8`,
+			`groupId`:    `32b6e34b3d91647abb20e7b8`,
+		},
+		RequestBodyExamples: map[string][]metadatatypes.RequestBodyExample{
+			`2023-01-01`: {
+				{
+					Name:        `Return One Project IP Access List Entry`,
+					Description: `Returns one access list entry from the specified project's IP access list: 10.0.0.0/16`,
+				},
+			},
+		},
+	},
+	`listProjectIpAccessLists`: {
+		ParameterExample: map[string]string{
+			`groupId`: `32b6e34b3d91647abb20e7b8`,
+		},
+		RequestBodyExamples: map[string][]metadatatypes.RequestBodyExample{
+			`2023-01-01`: {
+				{
+					Name:        `Return project IP access list`,
+					Description: `Returns all access list entries from the specified project's IP access list.`,
 				},
 			},
 		},


### PR DESCRIPTION
## Proposed changes
Added examples for:
- `createProjectIpAccessList`
- `deleteProjectIpAccessList`
- `getProjectIpAccessListStatus`
- `getProjectIpList`
- `listProjectIpAccessLists`

_Jira ticket:_ CLOUDP-303343
