### PR TITLE
CLOUDP-309119: laky Test: `atlas_gov_performance_advisor_e2e`

### DIFF
--- a/test/e2e/helper_test.go
+++ b/test/e2e/helper_test.go
@@ -550,10 +550,21 @@ func RandClusterNameWithPrefix(prefix string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	clusterName := fmt.Sprintf("%s-%d", prefix, n)
 	if revision, ok := os.LookupEnv("revision"); ok {
-		return fmt.Sprintf("%s-%v-%s", prefix, n, revision), nil
+		clusterName = fmt.Sprintf("%s-%v-%s", prefix, n, revision)
 	}
-	return fmt.Sprintf("%s-%v", prefix, n), nil
+
+	if len(clusterName) > 23 {
+		clusterName = clusterName[:23]
+	}
+
+	if clusterName[len(clusterName)-1] == '-' {
+		clusterName = clusterName[:len(clusterName)-1]
+	}
+
+	return clusterName, nil
 }
 
 func RandIdentityProviderName() (string, error) {
@@ -583,10 +594,21 @@ func RandProjectName() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	projectName := fmt.Sprintf("e2e-%v", n)
 	if revision, ok := os.LookupEnv("revision"); ok {
-		return fmt.Sprintf("%v-%s", n, revision), nil
+		projectName = fmt.Sprintf("%v-%s", n, revision)
 	}
-	return fmt.Sprintf("e2e-%v", n), nil
+
+	if len(projectName) > 23 {
+		projectName = projectName[:23]
+	}
+
+	if projectName[len(projectName)-1] == '-' {
+		projectName = projectName[:len(projectName)-1]
+	}
+
+	return projectName, nil
 }
 
 func RandUsername() (string, error) {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
[atlas_gov_performance_advisor_e2e](https://evergreen.mongodb.com/task/mongodb_atlas_cli_master_e2e_atlas_gov_clusters_atlas_gov_performance_advisor_e2e_5619801f7de4d40cc20a5668fac229f4e100f760_25_03_26_17_17_46) is flaky on evergreen. The latest build failed with this [error](https://evergreen.mongodb.com/test_log/mongodb_atlas_cli_master_e2e_atlas_gov_clusters_atlas_gov_performance_advisor_e2e_5619801f7de4d40cc20a5668fac229f4e100f760_25_03_26_17_17_46/2?test_name=f74df5f3ca2a0136a6ef7c5c99be743a#L4) related to the cluster name generated by the e2e logic:

```
 POST: HTTP 400 Bad Request (Error code: "CLUSTER_NAME_PREFIX_INVALID") Detail: Cluster name "performanceAdvisor-538-5619801f7de4d40cc20a5668fac229f4e100f760" is invalid. Atlas truncates cluster names to 23 characters which results in an invalid hostname due to a trailing "-" in the generated cluster name prefix "performanceAdvisor-538-". Reason: Bad Request. Params: [performanceAdvisor-538-5619801f7de4d40cc20a5668fac229f4e100f760 23 performanceAdvisor-538-]
```

This PR updates the clusterName logic to ensure the string is maximum 23 chars and the last element is not `-`