### PR TITLE
fix: goreleaser evergreent task

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-atlas-cli/atlascli
 
-go 1.23.7
+go 1.23.6
 
 require (
 	cloud.google.com/go/kms v1.21.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodb-atlas-cli/atlascli
 
-go 1.24.1
+go 1.23.7
 
 require (
 	cloud.google.com/go/kms v1.21.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/mongodb/mongodb-atlas-cli/atlascli
 
-go 1.23.6
-
-toolchain go1.24.1
+go 1.24.1
 
 require (
 	cloud.google.com/go/kms v1.21.1


### PR DESCRIPTION
[packate_goreleaser](https://evergreen.mongodb.com/task/mongodb_atlas_cli_master_goreleaser_atlascli_snapshot_package_goreleaser_08e275995977046fc45f4a0453014eff01a4e828_25_04_01_09_02_28) is failing on waterfall. The reason is that go 1.24.1 is not yet supported in evergreen.