### PR TITLE
CLOUDP-308812: Adds vscode connection option to deployment connect

### DIFF
--- a/docs/command/atlas-deployments-connect.txt
+++ b/docs/command/atlas-deployments-connect.txt
@@ -54,7 +54,7 @@ Options
    * - --connectWith
      - string
      - false
-     - Method for connecting to the deployment. Valid values are compass, connectionString and mongosh.
+     - Method for connecting to the deployment. Valid values are compass, connectionString, mongosh, and vscode.
    * - --connectionStringType
      - string
      - false

--- a/internal/cli/deployments/connect.go
+++ b/internal/cli/deployments/connect.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/vscode"
 	"github.com/spf13/cobra"
 )
 
@@ -184,6 +185,14 @@ func (opts *ConnectOpts) connectToDeployment(connectionString string) error {
 			return mongosh.ErrMongoshNotInstalled
 		}
 		return mongosh.Run(opts.DBUsername, opts.DBUserPassword, connectionString)
+	case options.VsCodeConnect:
+		if !vscode.Detect() {
+			return vscode.ErrVsCodeCliNotInstalled
+		}
+		if _, err := log.Warningln("Launching VsCode..."); err != nil {
+			return err
+		}
+		return vscode.SaveConnection(connectionString, opts.DeploymentName, opts.DeploymentType)
 	}
 
 	return nil

--- a/internal/cli/deployments/options/deployment_opts_connect_with.go
+++ b/internal/cli/deployments/options/deployment_opts_connect_with.go
@@ -27,15 +27,17 @@ const (
 	ConnectWithConnectionString = "connectionString"
 	ConnectWithMongosh          = "mongosh"
 	ConnectWithCompass          = "compass"
+	ConnectWithVsCode           = "vscode"
 )
 
 var (
 	ErrInvalidConnectWith  = errors.New("invalid --connectWith option")
-	ConnectWithOptions     = []string{ConnectWithMongosh, ConnectWithCompass, ConnectWithConnectionString}
+	ConnectWithOptions     = []string{ConnectWithMongosh, ConnectWithCompass, ConnectWithVsCode, ConnectWithConnectionString}
 	connectWithDescription = map[string]string{
 		ConnectWithConnectionString: "Connection String",
 		ConnectWithMongosh:          "MongoDB Shell",
 		ConnectWithCompass:          "MongoDB Compass",
+		ConnectWithVsCode:           "MongoDB for VsCode",
 	}
 )
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -371,7 +371,7 @@ dbName and collection are required only for built-in roles.`
 	MongodPort                                    = "Port that the MongoDB server listens to for client connections."
 	ConnectWithAtlasSetup                         = "Method for connecting to the cluster. Valid values are compass, mongosh, vscode and skip."
 	ConnectWithSetup                              = "Method for connecting to the deployment. Valid values are compass, mongosh, vscode, and skip."
-	ConnectWithConnect                            = "Method for connecting to the deployment. Valid values are compass, connectionString and mongosh."
+	ConnectWithConnect                            = "Method for connecting to the deployment. Valid values are compass, connectionString, mongosh, and vscode."
 	AlertConfigFilename                           = "Path to the JSON configuration file that defines alert configuration settings. Note: Unsupported fields in the JSON file are ignored. To learn more about alert configuration files for the Atlas CLI, see https://dochub.mongodb.org/core/alert-config-atlas-cli."
 	DeploymentName                                = "Name of the deployment."
 	LogName                                       = "Name of the log file (e.g. mongodb.gz|mongos.gz|mongosqld.gz|mongodb-audit-log.gz|mongos-audit-log.gz)."

--- a/internal/vscode/vscode_test.go
+++ b/internal/vscode/vscode_test.go
@@ -39,11 +39,19 @@ func TestVscode_BuildDeeplink(t *testing.T) {
 		},
 		{
 			name:           "local deployment with telemetry disabled",
-			uri:            "mongodb://user:123@localhost:11111/?directConnection=true",
+			uri:            "mongodb://localhost:11111/?directConnection=true",
 			deploymentName: "testDeployment",
 			deploymentType: "local",
 			telemetry:      false,
-			expected:       "vscode://mongodb.mongodb-vscode/connectWithURI?connectionString=mongodb%253A%252F%252Fuser%253A123%2540localhost%253A11111%252F%253FdirectConnection%253Dtrue&name=testDeployment+%2528Local%2529&reuseExisting=true",
+			expected:       "vscode://mongodb.mongodb-vscode/connectWithURI?connectionString=mongodb%253A%252F%252Flocalhost%253A11111%252F%253FdirectConnection%253Dtrue&name=testDeployment+%2528Local%2529&reuseExisting=true",
+		},
+		{
+			name:           "special characters present in password",
+			uri:            "mongodb://user:123%%%@localhost:11111/?directConnection=true",
+			deploymentName: "testDeployment",
+			deploymentType: "local",
+			telemetry:      false,
+			expected:       "vscode://mongodb.mongodb-vscode/connectWithURI?connectionString=mongodb%253A%252F%252Fuser%253A123%2525%2525%2525%2540localhost%253A11111%252F%253FdirectConnection%253Dtrue&name=testDeployment+%2528Local%2529&reuseExisting=true",
 		},
 	}
 	for _, testCase := range testCases {

--- a/internal/vscode/vscode_test.go
+++ b/internal/vscode/vscode_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vscode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVscode_BuildDeeplink(t *testing.T) {
+	testCases := []struct {
+		name           string
+		uri            string
+		deploymentName string
+		deploymentType string
+		telemetry      bool
+		expected       string
+	}{
+		{
+			name:           "atlas deployment with telemetry enabled",
+			uri:            "mongodb+srv://testDeployment.abcdef.mongodb-qa.net",
+			deploymentName: "testDeployment",
+			deploymentType: "atlas",
+			telemetry:      true,
+			expected:       "vscode://mongodb.mongodb-vscode/connectWithURI?connectionString=mongodb%252Bsrv%253A%252F%252FtestDeployment.abcdef.mongodb-qa.net&name=testDeployment+%2528Atlas%2529&reuseExisting=true&utm_source=AtlasCLI",
+		},
+		{
+			name:           "local deployment with telemetry disabled",
+			uri:            "mongodb://user:123@localhost:11111/?directConnection=true",
+			deploymentName: "testDeployment",
+			deploymentType: "local",
+			telemetry:      false,
+			expected:       "vscode://mongodb.mongodb-vscode/connectWithURI?connectionString=mongodb%253A%252F%252Fuser%253A123%2540localhost%253A11111%252F%253FdirectConnection%253Dtrue&name=testDeployment+%2528Local%2529&reuseExisting=true",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			output := buildDeeplink(testCase.uri, testCase.deploymentName, testCase.deploymentType, testCase.telemetry)
+			assert.Equal(t, testCase.expected, output)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

Adds new connection option VsCode (MongoDB for VSCode) for `atlas deployment connect` command.
Restructures `vscode.go` and adds unit testing.

Logic is same as described in #3798, on selecting `vscode` as connection option:
1. the connection string is obtained
2. the vscode extension deeplink is built and called
3. vscode will open with the connection saved under name `<deployment-name> (<deployment-type>)`



Notes:
* For local deployments with username and password set, the user must provide these details for a connection string with correct authorisation to be generated. Similar to the other connection options (mongosh, compass), no warning is provided if these details are not provided; the user will be connected to the deployment but unable to access any contents of the deployment.

_Jira ticket:_ [CLOUDP-308812](https://jira.mongodb.org/browse/CLOUDP-308812)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
