### PR TITLE
CLOUDP-310542: Add message to remove vscode connections from `atlas deployment delete` help text

### DIFF
--- a/docs/command/atlas-deployments-delete.txt
+++ b/docs/command/atlas-deployments-delete.txt
@@ -18,6 +18,7 @@ The command prompts you to confirm the operation when you run the command withou
 		
 Deleting an Atlas deployment also deletes any backup snapshots for that cluster.
 Deleting a Local deployment also deletes any local data volumes.
+Deleting a deployment will not remove saved connections from MongoDB for VsCode. This must be done manually, see https://www.mongodb.com/docs/mongodb-vscode/connect/#remove-a-connection
 
 To use this command, you must authenticate with a user account or an API key with the Project Owner role.
 

--- a/docs/command/atlas-deployments-delete.txt
+++ b/docs/command/atlas-deployments-delete.txt
@@ -18,7 +18,7 @@ The command prompts you to confirm the operation when you run the command withou
 		
 Deleting an Atlas deployment also deletes any backup snapshots for that cluster.
 Deleting a Local deployment also deletes any local data volumes.
-Deleting a deployment will not remove saved connections from MongoDB for VsCode. This must be done manually, see https://www.mongodb.com/docs/mongodb-vscode/connect/#remove-a-connection
+Deleting a deployment will not remove saved connections from MongoDB for VS Code. This must be done manually. To learn more, see https://www.mongodb.com/docs/mongodb-vscode/connect/#remove-a-connection.
 
 To use this command, you must authenticate with a user account or an API key with the Project Owner role.
 

--- a/internal/cli/deployments/delete.go
+++ b/internal/cli/deployments/delete.go
@@ -125,7 +125,7 @@ func DeleteBuilder() *cobra.Command {
 		
 Deleting an Atlas deployment also deletes any backup snapshots for that cluster.
 Deleting a Local deployment also deletes any local data volumes.
-Deleting a deployment will not remove saved connections from MongoDB for VsCode. This must be done manually, see https://www.mongodb.com/docs/mongodb-vscode/connect/#remove-a-connection
+Deleting a deployment will not remove saved connections from MongoDB for VS Code. This must be done manually. To learn more, see https://www.mongodb.com/docs/mongodb-vscode/connect/#remove-a-connection.
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: `  # Remove an Atlas deployment named myDeployment after prompting for a confirmation:

--- a/internal/cli/deployments/delete.go
+++ b/internal/cli/deployments/delete.go
@@ -125,6 +125,7 @@ func DeleteBuilder() *cobra.Command {
 		
 Deleting an Atlas deployment also deletes any backup snapshots for that cluster.
 Deleting a Local deployment also deletes any local data volumes.
+Deleting a deployment will not remove saved connections from MongoDB for VsCode. This must be done manually, see https://www.mongodb.com/docs/mongodb-vscode/connect/#remove-a-connection
 
 ` + fmt.Sprintf(usage.RequiredRole, "Project Owner"),
 		Example: `  # Remove an Atlas deployment named myDeployment after prompting for a confirmation:


### PR DESCRIPTION
## Proposed changes

`atlas deployment delete` will not include logic to remove VsCode connections when deleting a deployment as a part of this epic.

This work adds a message informing users of this behaviour and that these connections must be removed manually, pointing to MongoDB for VsCode documentation.

_Jira ticket:_ [CLOUDP-310542](https://jira.mongodb.org/browse/CLOUDP-310542)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
