### PR TITLE
CLOUDP-306589: Extend `--debug` to include Docker logs on `atlas deployments setup --type local`

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1540,6 +1540,26 @@ tasks:
           E2E_TAGS: atlas,deployments,local,noauth
           E2E_TIMEOUT: 3h
           LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
+  - name: atlas_deployments_local_seed
+    tags: ["e2e","deployments","local","seed"]
+    must_have_test_results: true
+    exec_timeout_secs: 11400 # 3 hours 10 minutes
+    commands:
+      - func: "install gotestsum"
+      - func: "install mongodb database tools"
+      - func: "increase inotify limits"
+      - func: "e2e test"
+        timeout_secs: 11400 # 3 hours 10 minutes
+        vars:
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
+          E2E_TAGS: atlas,deployments,local,seed
+          E2E_TIMEOUT: 3h
+          LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
   - name: atlas_deployments_local_nocli_e2e
     tags: ["e2e","deployments","local","nocli"]
     must_have_test_results: true

--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -201,8 +201,11 @@ func (opts *SetupOpts) createLocalDeployment(ctx context.Context) error {
 
 func (opts *SetupOpts) configureContainer(ctx context.Context) error {
 	envVars := map[string]string{
-		"TOOL":            "ATLASCLI",
-		"RUNNER_LOG_FILE": "/dev/stdout",
+		"TOOL": "ATLASCLI",
+	}
+
+	if log.IsDebugLevel() {
+		envVars["RUNNER_LOG_FILE"] = "/dev/stdout"
 	}
 
 	if !config.TelemetryEnabled() {
@@ -258,7 +261,7 @@ func (opts *SetupOpts) configureContainer(ctx context.Context) error {
 	const healthyDeploymentTimeout = 10 * time.Minute
 
 	err = opts.WaitForHealthyDeployment(ctx, healthyDeploymentTimeout)
-	if err != nil {
+	if err != nil && log.IsDebugLevel() {
 		logs, err := opts.ContainerEngine.ContainerLogs(ctx, opts.LocalMongodHostname())
 		if err != nil {
 			_, _ = log.Debugf("Container unhealthy (hostname=%s), failed to get container logs : %s\n", opts.LocalMongodHostname(), err)

--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -201,7 +201,8 @@ func (opts *SetupOpts) createLocalDeployment(ctx context.Context) error {
 
 func (opts *SetupOpts) configureContainer(ctx context.Context) error {
 	envVars := map[string]string{
-		"TOOL": "ATLASCLI",
+		"TOOL":            "ATLASCLI",
+		"RUNNER_LOG_FILE": "/dev/stdout",
 	}
 
 	if !config.TelemetryEnabled() {
@@ -254,9 +255,22 @@ func (opts *SetupOpts) configureContainer(ctx context.Context) error {
 	}
 
 	// This can be a high number because the container will become unhealthy before the 10 minutes is reached
-	const healthyDeploymentTimeout = 3 * time.Minute
+	const healthyDeploymentTimeout = 10 * time.Minute
 
-	return opts.WaitForHealthyDeployment(ctx, healthyDeploymentTimeout)
+	err = opts.WaitForHealthyDeployment(ctx, healthyDeploymentTimeout)
+	if err != nil {
+		logs, err := opts.ContainerEngine.ContainerLogs(ctx, opts.LocalMongodHostname())
+		if err != nil {
+			_, _ = log.Debugf("Container unhealthy (hostname=%s), failed to get container logs : %s\n", opts.LocalMongodHostname(), err)
+		} else {
+			_, _ = log.Debugf("Container unhealthy (hostname=%s), container logs:\n", opts.LocalMongodHostname())
+			for _, logLine := range logs {
+				_, _ = log.Debugln(logLine)
+			}
+		}
+	}
+
+	return err
 }
 
 func (opts *SetupOpts) WaitForHealthyDeployment(ctx context.Context, duration time.Duration) error {

--- a/internal/cli/deployments/setup_test.go
+++ b/internal/cli/deployments/setup_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/test/fixture"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/container"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/log"
 )
 
 func TestSetupOpts_PostRun(t *testing.T) {
@@ -266,6 +267,7 @@ func TestSetupOpts_LocalDev_RemoveUnhealthyDeployment(t *testing.T) {
 	ctx := context.Background()
 	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
 	buf := new(bytes.Buffer)
+	log.SetLevel(log.DebugLevel)
 
 	opts := &SetupOpts{
 		DeploymentOpts: *deploymentTest.Opts,

--- a/internal/cli/deployments/setup_test.go
+++ b/internal/cli/deployments/setup_test.go
@@ -300,6 +300,9 @@ func TestSetupOpts_LocalDev_RemoveUnhealthyDeployment(t *testing.T) {
 	// Container is unhealthy
 	deploymentTest.MockContainerEngine.EXPECT().ContainerHealthStatus(ctx, deploymentName).Return(container.DockerHealthcheckStatusUnhealthy, nil).Times(1)
 
+	// Docker logs
+	deploymentTest.MockContainerEngine.EXPECT().ContainerLogs(ctx, deploymentName).Return([]string{"something", "went", "wrong"}, nil).Times(1)
+
 	// Container is removed
 	deploymentTest.MockContainerEngine.EXPECT().ContainerRm(ctx, deploymentName).Return(nil).Times(1)
 

--- a/test/e2e/data/db_seed_fail/fail.sh
+++ b/test/e2e/data/db_seed_fail/fail.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2025 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # Sleep for 10 seconds
 sleep 10

--- a/test/e2e/data/db_seed_fail/fail.sh
+++ b/test/e2e/data/db_seed_fail/fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Sleep for 10 seconds
+sleep 10
+
+# Echo some tokens we can find in the e2e test
+echo "CATASTROPHIC_SEED_FAILURE_PANIC_DONT_PANIC"
+
+# Exit with code 1
+exit 1

--- a/test/e2e/deployments_local_seed_fail_test.go
+++ b/test/e2e/deployments_local_seed_fail_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build e2e || (atlas && deployments && local && seed)
+
+package e2e_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeploymentsLocalSeedFail(t *testing.T) {
+	const (
+		deploymentName = "test-seed-fail"
+		dbUsername     = "admin"
+		dbUserPassword = "testpwd"
+	)
+
+	cliPath, err := AtlasCLIBin()
+	req := require.New(t)
+	req.NoError(err)
+
+	t.Run("Test failed seed setup", func(t *testing.T) {
+		t.Cleanup(func() {
+			// This shouldn't be required, since setup should fail
+			// but in case there's a bug we might create a deployment, so try to delete it just in case
+			cmd := exec.Command(cliPath,
+				deploymentEntity,
+				"delete",
+				deploymentName,
+				"--type",
+				"local",
+				"--force",
+			)
+
+			cmd.Env = os.Environ()
+
+			_, _ = RunAndGetStdOutAndErr(cmd)
+		})
+
+		cmd := exec.Command(cliPath,
+			deploymentEntity,
+			"setup",
+			deploymentName,
+			"--type", "local",
+			"--username", dbUsername,
+			"--password", dbUserPassword,
+			"--initdb", "./data/db_seed_fail",
+			"--bindIpAll",
+			"--force",
+			"--debug",
+		)
+
+		cmd.Env = os.Environ()
+
+		_, setupErr := RunAndGetStdOutAndErr(cmd)
+		require.Error(t, setupErr, "expected seeding to fail")
+		require.Contains(t, setupErr.Error(), "CATASTROPHIC_SEED_FAILURE_PANIC_DONT_PANIC")
+	})
+}


### PR DESCRIPTION
## Proposed changes

`--debug` now includes docker logs when `atlas deployment setup` fails

_Jira ticket:_ CLOUDP-306589