### PR TITLE
CLOUDP-310107: [CLI] flag inconsistency for auto generated commands

### DIFF
--- a/docs/command/atlas-api-accessTracking-listAccessLogsByClusterName.txt
+++ b/docs/command/atlas-api-accessTracking-listAccessLogsByClusterName.txt
@@ -75,11 +75,11 @@ Options
      - int
      - false
      - Maximum number of lines from the log to return.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-accessTracking-listAccessLogsByClusterName.txt
+++ b/docs/command/atlas-api-accessTracking-listAccessLogsByClusterName.txt
@@ -79,7 +79,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-accessTracking-listAccessLogsByHostname.txt
+++ b/docs/command/atlas-api-accessTracking-listAccessLogsByHostname.txt
@@ -75,11 +75,11 @@ Options
      - int
      - false
      - Maximum number of lines from the log to return.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-accessTracking-listAccessLogsByHostname.txt
+++ b/docs/command/atlas-api-accessTracking-listAccessLogsByHostname.txt
@@ -79,7 +79,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-createAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-createAlertConfiguration.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-createAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-createAlertConfiguration.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for createAlertConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-deleteAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-deleteAlertConfiguration.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-deleteAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-deleteAlertConfiguration.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for deleteAlertConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-getAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-getAlertConfiguration.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-getAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-getAlertConfiguration.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for getAlertConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-listAlertConfigurationMatchersFieldNames.txt
+++ b/docs/command/atlas-api-alertConfigurations-listAlertConfigurationMatchersFieldNames.txt
@@ -53,7 +53,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-listAlertConfigurationMatchersFieldNames.txt
+++ b/docs/command/atlas-api-alertConfigurations-listAlertConfigurationMatchersFieldNames.txt
@@ -49,11 +49,11 @@ Options
      - 
      - false
      - help for listAlertConfigurationMatchersFieldNames
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-listAlertConfigurations.txt
+++ b/docs/command/atlas-api-alertConfigurations-listAlertConfigurations.txt
@@ -66,11 +66,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-listAlertConfigurations.txt
+++ b/docs/command/atlas-api-alertConfigurations-listAlertConfigurations.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-listAlertConfigurationsByAlertId.txt
+++ b/docs/command/atlas-api-alertConfigurations-listAlertConfigurationsByAlertId.txt
@@ -74,7 +74,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-listAlertConfigurationsByAlertId.txt
+++ b/docs/command/atlas-api-alertConfigurations-listAlertConfigurationsByAlertId.txt
@@ -70,11 +70,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-toggleAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-toggleAlertConfiguration.txt
@@ -73,7 +73,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-toggleAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-toggleAlertConfiguration.txt
@@ -69,11 +69,11 @@ Options
      - 
      - false
      - help for toggleAlertConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-updateAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-updateAlertConfiguration.txt
@@ -69,11 +69,11 @@ Options
      - 
      - false
      - help for updateAlertConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alertConfigurations-updateAlertConfiguration.txt
+++ b/docs/command/atlas-api-alertConfigurations-updateAlertConfiguration.txt
@@ -73,7 +73,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alerts-acknowledgeAlert.txt
+++ b/docs/command/atlas-api-alerts-acknowledgeAlert.txt
@@ -66,11 +66,11 @@ Options
      - 
      - false
      - help for acknowledgeAlert
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alerts-acknowledgeAlert.txt
+++ b/docs/command/atlas-api-alerts-acknowledgeAlert.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alerts-getAlert.txt
+++ b/docs/command/atlas-api-alerts-getAlert.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alerts-getAlert.txt
+++ b/docs/command/atlas-api-alerts-getAlert.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for getAlert
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alerts-listAlerts.txt
+++ b/docs/command/atlas-api-alerts-listAlerts.txt
@@ -66,11 +66,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alerts-listAlerts.txt
+++ b/docs/command/atlas-api-alerts-listAlerts.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alerts-listAlertsByAlertConfigurationId.txt
+++ b/docs/command/atlas-api-alerts-listAlertsByAlertConfigurationId.txt
@@ -74,7 +74,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-alerts-listAlertsByAlertConfigurationId.txt
+++ b/docs/command/atlas-api-alerts-listAlertsByAlertConfigurationId.txt
@@ -70,11 +70,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-createAtlasSearchDeployment.txt
+++ b/docs/command/atlas-api-atlasSearch-createAtlasSearchDeployment.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-createAtlasSearchDeployment.txt
+++ b/docs/command/atlas-api-atlasSearch-createAtlasSearchDeployment.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for createAtlasSearchDeployment
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-createAtlasSearchIndex.txt
+++ b/docs/command/atlas-api-atlasSearch-createAtlasSearchIndex.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-createAtlasSearchIndex.txt
+++ b/docs/command/atlas-api-atlasSearch-createAtlasSearchIndex.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createAtlasSearchIndex
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-createAtlasSearchIndexDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-createAtlasSearchIndexDeprecated.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-createAtlasSearchIndexDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-createAtlasSearchIndexDeprecated.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createAtlasSearchIndexDeprecated
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-deleteAtlasSearchDeployment.txt
+++ b/docs/command/atlas-api-atlasSearch-deleteAtlasSearchDeployment.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-deleteAtlasSearchDeployment.txt
+++ b/docs/command/atlas-api-atlasSearch-deleteAtlasSearchDeployment.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for deleteAtlasSearchDeployment
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndex.txt
+++ b/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndex.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndex.txt
+++ b/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndex.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the Atlas Search index. Use the [Get All Atlas Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Atlas Search indexes.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndexByName.txt
+++ b/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndexByName.txt
@@ -71,11 +71,11 @@ Options
      - string
      - true
      - Name of the Atlas Search index to delete.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndexByName.txt
+++ b/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndexByName.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndexDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndexDeprecated.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndexDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-deleteAtlasSearchIndexDeprecated.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the Atlas Search index. Use the [Get All Atlas Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Atlas Search indexes.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-getAtlasSearchDeployment.txt
+++ b/docs/command/atlas-api-atlasSearch-getAtlasSearchDeployment.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-getAtlasSearchDeployment.txt
+++ b/docs/command/atlas-api-atlasSearch-getAtlasSearchDeployment.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for getAtlasSearchDeployment
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-getAtlasSearchIndex.txt
+++ b/docs/command/atlas-api-atlasSearch-getAtlasSearchIndex.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-getAtlasSearchIndex.txt
+++ b/docs/command/atlas-api-atlasSearch-getAtlasSearchIndex.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the Application Search [index](https://dochub.mongodb.org/core/index-definitions-fts). Use the [Get All Application Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Application Search indexes.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-getAtlasSearchIndexByName.txt
+++ b/docs/command/atlas-api-atlasSearch-getAtlasSearchIndexByName.txt
@@ -71,11 +71,11 @@ Options
      - string
      - true
      - Name of the Atlas Search index to return.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-getAtlasSearchIndexByName.txt
+++ b/docs/command/atlas-api-atlasSearch-getAtlasSearchIndexByName.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-getAtlasSearchIndexDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-getAtlasSearchIndexDeprecated.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-getAtlasSearchIndexDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-getAtlasSearchIndexDeprecated.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the Application Search [index](https://dochub.mongodb.org/core/index-definitions-fts). Use the [Get All Application Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Application Search indexes.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexes.txt
+++ b/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexes.txt
@@ -67,11 +67,11 @@ Options
      - 
      - false
      - help for listAtlasSearchIndexes
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexes.txt
+++ b/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexes.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexesCluster.txt
+++ b/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexesCluster.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for listAtlasSearchIndexesCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexesCluster.txt
+++ b/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexesCluster.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexesDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexesDeprecated.txt
@@ -67,11 +67,11 @@ Options
      - 
      - false
      - help for listAtlasSearchIndexesDeprecated
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexesDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-listAtlasSearchIndexesDeprecated.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-updateAtlasSearchDeployment.txt
+++ b/docs/command/atlas-api-atlasSearch-updateAtlasSearchDeployment.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-updateAtlasSearchDeployment.txt
+++ b/docs/command/atlas-api-atlasSearch-updateAtlasSearchDeployment.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for updateAtlasSearchDeployment
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndex.txt
+++ b/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndex.txt
@@ -67,11 +67,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the Atlas Search [index](https://dochub.mongodb.org/core/index-definitions-fts). Use the [Get All Atlas Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Atlas Search indexes.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndex.txt
+++ b/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndex.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndexByName.txt
+++ b/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndexByName.txt
@@ -79,7 +79,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndexByName.txt
+++ b/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndexByName.txt
@@ -75,11 +75,11 @@ Options
      - string
      - true
      - Name of the Atlas Search index to update.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndexDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndexDeprecated.txt
@@ -67,11 +67,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the Atlas Search [index](https://dochub.mongodb.org/core/index-definitions-fts). Use the [Get All Atlas Search Indexes for a Collection API](https://docs.atlas.mongodb.com/reference/api/fts-indexes-get-all/) endpoint to find the IDs of all Atlas Search indexes.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndexDeprecated.txt
+++ b/docs/command/atlas-api-atlasSearch-updateAtlasSearchIndexDeprecated.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-auditing-getAuditingConfiguration.txt
+++ b/docs/command/atlas-api-auditing-getAuditingConfiguration.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getAuditingConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-auditing-getAuditingConfiguration.txt
+++ b/docs/command/atlas-api-auditing-getAuditingConfiguration.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-auditing-updateAuditingConfiguration.txt
+++ b/docs/command/atlas-api-auditing-updateAuditingConfiguration.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateAuditingConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-auditing-updateAuditingConfiguration.txt
+++ b/docs/command/atlas-api-auditing-updateAuditingConfiguration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-awsClustersDns-getAwsCustomDns.txt
+++ b/docs/command/atlas-api-awsClustersDns-getAwsCustomDns.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-awsClustersDns-getAwsCustomDns.txt
+++ b/docs/command/atlas-api-awsClustersDns-getAwsCustomDns.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getAwsCustomDns
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-awsClustersDns-toggleAwsCustomDns.txt
+++ b/docs/command/atlas-api-awsClustersDns-toggleAwsCustomDns.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for toggleAwsCustomDns
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-awsClustersDns-toggleAwsCustomDns.txt
+++ b/docs/command/atlas-api-awsClustersDns-toggleAwsCustomDns.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-cancelBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-cancelBackupRestoreJob.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-cancelBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-cancelBackupRestoreJob.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for cancelBackupRestoreJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-createBackupExportJob.txt
+++ b/docs/command/atlas-api-cloudBackups-createBackupExportJob.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createBackupExportJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-createBackupExportJob.txt
+++ b/docs/command/atlas-api-cloudBackups-createBackupExportJob.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-createBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-createBackupRestoreJob.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-createBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-createBackupRestoreJob.txt
@@ -66,11 +66,11 @@ Options
      - 
      - false
      - help for createBackupRestoreJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-createExportBucket.txt
+++ b/docs/command/atlas-api-cloudBackups-createExportBucket.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createExportBucket
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-createExportBucket.txt
+++ b/docs/command/atlas-api-cloudBackups-createExportBucket.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-createServerlessBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-createServerlessBackupRestoreJob.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-createServerlessBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-createServerlessBackupRestoreJob.txt
@@ -66,11 +66,11 @@ Options
      - 
      - false
      - help for createServerlessBackupRestoreJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-deleteAllBackupSchedules.txt
+++ b/docs/command/atlas-api-cloudBackups-deleteAllBackupSchedules.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteAllBackupSchedules
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-deleteAllBackupSchedules.txt
+++ b/docs/command/atlas-api-cloudBackups-deleteAllBackupSchedules.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-deleteExportBucket.txt
+++ b/docs/command/atlas-api-cloudBackups-deleteExportBucket.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteExportBucket
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-deleteExportBucket.txt
+++ b/docs/command/atlas-api-cloudBackups-deleteExportBucket.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-deleteReplicaSetBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-deleteReplicaSetBackup.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteReplicaSetBackup
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-deleteReplicaSetBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-deleteReplicaSetBackup.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-deleteShardedClusterBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-deleteShardedClusterBackup.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteShardedClusterBackup
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-deleteShardedClusterBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-deleteShardedClusterBackup.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-disableDataProtectionSettings.txt
+++ b/docs/command/atlas-api-cloudBackups-disableDataProtectionSettings.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-disableDataProtectionSettings.txt
+++ b/docs/command/atlas-api-cloudBackups-disableDataProtectionSettings.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for disableDataProtectionSettings
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getBackupExportJob.txt
+++ b/docs/command/atlas-api-cloudBackups-getBackupExportJob.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getBackupExportJob.txt
+++ b/docs/command/atlas-api-cloudBackups-getBackupExportJob.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for getBackupExportJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-getBackupRestoreJob.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getBackupRestoreJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-getBackupRestoreJob.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getBackupSchedule.txt
+++ b/docs/command/atlas-api-cloudBackups-getBackupSchedule.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getBackupSchedule
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getBackupSchedule.txt
+++ b/docs/command/atlas-api-cloudBackups-getBackupSchedule.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getDataProtectionSettings.txt
+++ b/docs/command/atlas-api-cloudBackups-getDataProtectionSettings.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getDataProtectionSettings.txt
+++ b/docs/command/atlas-api-cloudBackups-getDataProtectionSettings.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getDataProtectionSettings
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getExportBucket.txt
+++ b/docs/command/atlas-api-cloudBackups-getExportBucket.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getExportBucket
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getExportBucket.txt
+++ b/docs/command/atlas-api-cloudBackups-getExportBucket.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getReplicaSetBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-getReplicaSetBackup.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getReplicaSetBackup
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getReplicaSetBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-getReplicaSetBackup.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getServerlessBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-getServerlessBackup.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getServerlessBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-getServerlessBackup.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for getServerlessBackup
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getServerlessBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-getServerlessBackupRestoreJob.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getServerlessBackupRestoreJob.txt
+++ b/docs/command/atlas-api-cloudBackups-getServerlessBackupRestoreJob.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for getServerlessBackupRestoreJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getShardedClusterBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-getShardedClusterBackup.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getShardedClusterBackup
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-getShardedClusterBackup.txt
+++ b/docs/command/atlas-api-cloudBackups-getShardedClusterBackup.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listBackupExportJobs.txt
+++ b/docs/command/atlas-api-cloudBackups-listBackupExportJobs.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listBackupExportJobs.txt
+++ b/docs/command/atlas-api-cloudBackups-listBackupExportJobs.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-cloudBackups-listBackupRestoreJobs.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-cloudBackups-listBackupRestoreJobs.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listExportBuckets.txt
+++ b/docs/command/atlas-api-cloudBackups-listExportBuckets.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listExportBuckets.txt
+++ b/docs/command/atlas-api-cloudBackups-listExportBuckets.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listReplicaSetBackups.txt
+++ b/docs/command/atlas-api-cloudBackups-listReplicaSetBackups.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listReplicaSetBackups.txt
+++ b/docs/command/atlas-api-cloudBackups-listReplicaSetBackups.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listServerlessBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-cloudBackups-listServerlessBackupRestoreJobs.txt
@@ -74,7 +74,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listServerlessBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-cloudBackups-listServerlessBackupRestoreJobs.txt
@@ -70,11 +70,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listServerlessBackups.txt
+++ b/docs/command/atlas-api-cloudBackups-listServerlessBackups.txt
@@ -74,7 +74,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listServerlessBackups.txt
+++ b/docs/command/atlas-api-cloudBackups-listServerlessBackups.txt
@@ -70,11 +70,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listShardedClusterBackups.txt
+++ b/docs/command/atlas-api-cloudBackups-listShardedClusterBackups.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-listShardedClusterBackups.txt
+++ b/docs/command/atlas-api-cloudBackups-listShardedClusterBackups.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for listShardedClusterBackups
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-takeSnapshot.txt
+++ b/docs/command/atlas-api-cloudBackups-takeSnapshot.txt
@@ -66,11 +66,11 @@ Options
      - 
      - false
      - help for takeSnapshot
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-takeSnapshot.txt
+++ b/docs/command/atlas-api-cloudBackups-takeSnapshot.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-updateBackupSchedule.txt
+++ b/docs/command/atlas-api-cloudBackups-updateBackupSchedule.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-updateBackupSchedule.txt
+++ b/docs/command/atlas-api-cloudBackups-updateBackupSchedule.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updateBackupSchedule
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-updateDataProtectionSettings.txt
+++ b/docs/command/atlas-api-cloudBackups-updateDataProtectionSettings.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateDataProtectionSettings
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-updateDataProtectionSettings.txt
+++ b/docs/command/atlas-api-cloudBackups-updateDataProtectionSettings.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-updateSnapshotRetention.txt
+++ b/docs/command/atlas-api-cloudBackups-updateSnapshotRetention.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudBackups-updateSnapshotRetention.txt
+++ b/docs/command/atlas-api-cloudBackups-updateSnapshotRetention.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updateSnapshotRetention
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-createLinkToken.txt
+++ b/docs/command/atlas-api-cloudMigrationService-createLinkToken.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-createLinkToken.txt
+++ b/docs/command/atlas-api-cloudMigrationService-createLinkToken.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-createPushMigration.txt
+++ b/docs/command/atlas-api-cloudMigrationService-createPushMigration.txt
@@ -69,7 +69,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-createPushMigration.txt
+++ b/docs/command/atlas-api-cloudMigrationService-createPushMigration.txt
@@ -65,11 +65,11 @@ Options
      - 
      - false
      - help for createPushMigration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-cutoverMigration.txt
+++ b/docs/command/atlas-api-cloudMigrationService-cutoverMigration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-cutoverMigration.txt
+++ b/docs/command/atlas-api-cloudMigrationService-cutoverMigration.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the migration.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-deleteLinkToken.txt
+++ b/docs/command/atlas-api-cloudMigrationService-deleteLinkToken.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-deleteLinkToken.txt
+++ b/docs/command/atlas-api-cloudMigrationService-deleteLinkToken.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-getPushMigration.txt
+++ b/docs/command/atlas-api-cloudMigrationService-getPushMigration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-getPushMigration.txt
+++ b/docs/command/atlas-api-cloudMigrationService-getPushMigration.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the migration.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-getValidationStatus.txt
+++ b/docs/command/atlas-api-cloudMigrationService-getValidationStatus.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-getValidationStatus.txt
+++ b/docs/command/atlas-api-cloudMigrationService-getValidationStatus.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getValidationStatus
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-listSourceProjects.txt
+++ b/docs/command/atlas-api-cloudMigrationService-listSourceProjects.txt
@@ -55,7 +55,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-listSourceProjects.txt
+++ b/docs/command/atlas-api-cloudMigrationService-listSourceProjects.txt
@@ -51,11 +51,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-validateMigration.txt
+++ b/docs/command/atlas-api-cloudMigrationService-validateMigration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudMigrationService-validateMigration.txt
+++ b/docs/command/atlas-api-cloudMigrationService-validateMigration.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for validateMigration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-authorizeCloudProviderAccessRole.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-authorizeCloudProviderAccessRole.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for authorizeCloudProviderAccessRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-authorizeCloudProviderAccessRole.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-authorizeCloudProviderAccessRole.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-createCloudProviderAccessRole.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-createCloudProviderAccessRole.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createCloudProviderAccessRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-createCloudProviderAccessRole.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-createCloudProviderAccessRole.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-deauthorizeCloudProviderAccessRole.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-deauthorizeCloudProviderAccessRole.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deauthorizeCloudProviderAccessRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-deauthorizeCloudProviderAccessRole.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-deauthorizeCloudProviderAccessRole.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-getCloudProviderAccessRole.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-getCloudProviderAccessRole.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-getCloudProviderAccessRole.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-getCloudProviderAccessRole.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getCloudProviderAccessRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-listCloudProviderAccessRoles.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-listCloudProviderAccessRoles.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-cloudProviderAccess-listCloudProviderAccessRoles.txt
+++ b/docs/command/atlas-api-cloudProviderAccess-listCloudProviderAccessRoles.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listCloudProviderAccessRoles
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusterOutageSimulation-endOutageSimulation.txt
+++ b/docs/command/atlas-api-clusterOutageSimulation-endOutageSimulation.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusterOutageSimulation-endOutageSimulation.txt
+++ b/docs/command/atlas-api-clusterOutageSimulation-endOutageSimulation.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for endOutageSimulation
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusterOutageSimulation-getOutageSimulation.txt
+++ b/docs/command/atlas-api-clusterOutageSimulation-getOutageSimulation.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusterOutageSimulation-getOutageSimulation.txt
+++ b/docs/command/atlas-api-clusterOutageSimulation-getOutageSimulation.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for getOutageSimulation
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusterOutageSimulation-startOutageSimulation.txt
+++ b/docs/command/atlas-api-clusterOutageSimulation-startOutageSimulation.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for startOutageSimulation
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusterOutageSimulation-startOutageSimulation.txt
+++ b/docs/command/atlas-api-clusterOutageSimulation-startOutageSimulation.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-autoScalingConfiguration.txt
+++ b/docs/command/atlas-api-clusters-autoScalingConfiguration.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for autoScalingConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-autoScalingConfiguration.txt
+++ b/docs/command/atlas-api-clusters-autoScalingConfiguration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-createCluster.txt
+++ b/docs/command/atlas-api-clusters-createCluster.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-createCluster.txt
+++ b/docs/command/atlas-api-clusters-createCluster.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for createCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-deleteCluster.txt
+++ b/docs/command/atlas-api-clusters-deleteCluster.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for deleteCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-deleteCluster.txt
+++ b/docs/command/atlas-api-clusters-deleteCluster.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-getCluster.txt
+++ b/docs/command/atlas-api-clusters-getCluster.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-getCluster.txt
+++ b/docs/command/atlas-api-clusters-getCluster.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for getCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-getClusterAdvancedConfiguration.txt
+++ b/docs/command/atlas-api-clusters-getClusterAdvancedConfiguration.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getClusterAdvancedConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-getClusterAdvancedConfiguration.txt
+++ b/docs/command/atlas-api-clusters-getClusterAdvancedConfiguration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-getClusterStatus.txt
+++ b/docs/command/atlas-api-clusters-getClusterStatus.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getClusterStatus
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-getClusterStatus.txt
+++ b/docs/command/atlas-api-clusters-getClusterStatus.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-getSampleDatasetLoadStatus.txt
+++ b/docs/command/atlas-api-clusters-getSampleDatasetLoadStatus.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-getSampleDatasetLoadStatus.txt
+++ b/docs/command/atlas-api-clusters-getSampleDatasetLoadStatus.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getSampleDatasetLoadStatus
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-grantMongoDbEmployeeAccess.txt
+++ b/docs/command/atlas-api-clusters-grantMongoDbEmployeeAccess.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for grantMongoDbEmployeeAccess
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-grantMongoDbEmployeeAccess.txt
+++ b/docs/command/atlas-api-clusters-grantMongoDbEmployeeAccess.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-listCloudProviderRegions.txt
+++ b/docs/command/atlas-api-clusters-listCloudProviderRegions.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-listCloudProviderRegions.txt
+++ b/docs/command/atlas-api-clusters-listCloudProviderRegions.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-listClusters.txt
+++ b/docs/command/atlas-api-clusters-listClusters.txt
@@ -74,7 +74,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-listClusters.txt
+++ b/docs/command/atlas-api-clusters-listClusters.txt
@@ -70,11 +70,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-listClustersForAllProjects.txt
+++ b/docs/command/atlas-api-clusters-listClustersForAllProjects.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-listClustersForAllProjects.txt
+++ b/docs/command/atlas-api-clusters-listClustersForAllProjects.txt
@@ -57,11 +57,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-loadSampleDataset.txt
+++ b/docs/command/atlas-api-clusters-loadSampleDataset.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-loadSampleDataset.txt
+++ b/docs/command/atlas-api-clusters-loadSampleDataset.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the cluster into which you load the sample dataset.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-pinFeatureCompatibilityVersion.txt
+++ b/docs/command/atlas-api-clusters-pinFeatureCompatibilityVersion.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-pinFeatureCompatibilityVersion.txt
+++ b/docs/command/atlas-api-clusters-pinFeatureCompatibilityVersion.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for pinFeatureCompatibilityVersion
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-revokeMongoDbEmployeeAccess.txt
+++ b/docs/command/atlas-api-clusters-revokeMongoDbEmployeeAccess.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-revokeMongoDbEmployeeAccess.txt
+++ b/docs/command/atlas-api-clusters-revokeMongoDbEmployeeAccess.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for revokeMongoDbEmployeeAccess
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-testFailover.txt
+++ b/docs/command/atlas-api-clusters-testFailover.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for testFailover
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-testFailover.txt
+++ b/docs/command/atlas-api-clusters-testFailover.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-unpinFeatureCompatibilityVersion.txt
+++ b/docs/command/atlas-api-clusters-unpinFeatureCompatibilityVersion.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for unpinFeatureCompatibilityVersion
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-unpinFeatureCompatibilityVersion.txt
+++ b/docs/command/atlas-api-clusters-unpinFeatureCompatibilityVersion.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-updateCluster.txt
+++ b/docs/command/atlas-api-clusters-updateCluster.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-updateCluster.txt
+++ b/docs/command/atlas-api-clusters-updateCluster.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updateCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-updateClusterAdvancedConfiguration.txt
+++ b/docs/command/atlas-api-clusters-updateClusterAdvancedConfiguration.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-updateClusterAdvancedConfiguration.txt
+++ b/docs/command/atlas-api-clusters-updateClusterAdvancedConfiguration.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updateClusterAdvancedConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-upgradeSharedCluster.txt
+++ b/docs/command/atlas-api-clusters-upgradeSharedCluster.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-clusters-upgradeSharedCluster.txt
+++ b/docs/command/atlas-api-clusters-upgradeSharedCluster.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for upgradeSharedCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceClusterMeasurements.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceClusterMeasurements.txt
@@ -81,7 +81,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceClusterMeasurements.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceClusterMeasurements.txt
@@ -77,11 +77,11 @@ Options
      - stringArray
      - false
      - List that contains the metrics that you want to retrieve for the associated data series. If you don't set this parameter, this resource returns data series for all Coll Stats Latency metrics.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceHostMeasurements.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceHostMeasurements.txt
@@ -73,7 +73,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceHostMeasurements.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceHostMeasurements.txt
@@ -69,11 +69,11 @@ Options
      - stringArray
      - false
      - List that contains the metrics that you want to retrieve for the associated data series. If you don't set this parameter, this resource returns data series for all Coll Stats Latency metrics.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceMetrics.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceMetrics.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceMetrics.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespaceMetrics.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for getCollStatsLatencyNamespaceMetrics
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespacesForCluster.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespacesForCluster.txt
@@ -69,7 +69,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespacesForCluster.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespacesForCluster.txt
@@ -65,11 +65,11 @@ Options
      - 
      - false
      - help for getCollStatsLatencyNamespacesForCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespacesForHost.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespacesForHost.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespacesForHost.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getCollStatsLatencyNamespacesForHost.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for getCollStatsLatencyNamespacesForHost
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getPinnedNamespaces.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getPinnedNamespaces.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-getPinnedNamespaces.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-getPinnedNamespaces.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for getPinnedNamespaces
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-pinNamespacesPatch.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-pinNamespacesPatch.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-pinNamespacesPatch.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-pinNamespacesPatch.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for pinNamespacesPatch
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-pinNamespacesPut.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-pinNamespacesPut.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-pinNamespacesPut.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-pinNamespacesPut.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for pinNamespacesPut
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-unpinNamespaces.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-unpinNamespaces.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for unpinNamespaces
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-collectionLevelMetrics-unpinNamespaces.txt
+++ b/docs/command/atlas-api-collectionLevelMetrics-unpinNamespaces.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-createCustomDatabaseRole.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-createCustomDatabaseRole.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createCustomDatabaseRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-createCustomDatabaseRole.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-createCustomDatabaseRole.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-deleteCustomDatabaseRole.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-deleteCustomDatabaseRole.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-deleteCustomDatabaseRole.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-deleteCustomDatabaseRole.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for deleteCustomDatabaseRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-getCustomDatabaseRole.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-getCustomDatabaseRole.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-getCustomDatabaseRole.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-getCustomDatabaseRole.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getCustomDatabaseRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-listCustomDatabaseRoles.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-listCustomDatabaseRoles.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-listCustomDatabaseRoles.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-listCustomDatabaseRoles.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listCustomDatabaseRoles
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-updateCustomDatabaseRole.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-updateCustomDatabaseRole.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-customDatabaseRoles-updateCustomDatabaseRole.txt
+++ b/docs/command/atlas-api-customDatabaseRoles-updateCustomDatabaseRole.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateCustomDatabaseRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-createDataFederationPrivateEndpoint.txt
+++ b/docs/command/atlas-api-dataFederation-createDataFederationPrivateEndpoint.txt
@@ -90,7 +90,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-createDataFederationPrivateEndpoint.txt
+++ b/docs/command/atlas-api-dataFederation-createDataFederationPrivateEndpoint.txt
@@ -86,11 +86,11 @@ Options
      - 
      - false
      - help for createDataFederationPrivateEndpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-createFederatedDatabase.txt
+++ b/docs/command/atlas-api-dataFederation-createFederatedDatabase.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createFederatedDatabase
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-createFederatedDatabase.txt
+++ b/docs/command/atlas-api-dataFederation-createFederatedDatabase.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-createOneDataFederationQueryLimit.txt
+++ b/docs/command/atlas-api-dataFederation-createOneDataFederationQueryLimit.txt
@@ -71,11 +71,11 @@ Options
        | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A |
        | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A |
        
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-createOneDataFederationQueryLimit.txt
+++ b/docs/command/atlas-api-dataFederation-createOneDataFederationQueryLimit.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-deleteDataFederationPrivateEndpoint.txt
+++ b/docs/command/atlas-api-dataFederation-deleteDataFederationPrivateEndpoint.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteDataFederationPrivateEndpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-deleteDataFederationPrivateEndpoint.txt
+++ b/docs/command/atlas-api-dataFederation-deleteDataFederationPrivateEndpoint.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-deleteFederatedDatabase.txt
+++ b/docs/command/atlas-api-dataFederation-deleteFederatedDatabase.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-deleteFederatedDatabase.txt
+++ b/docs/command/atlas-api-dataFederation-deleteFederatedDatabase.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for deleteFederatedDatabase
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-deleteOneDataFederationInstanceQueryLimit.txt
+++ b/docs/command/atlas-api-dataFederation-deleteOneDataFederationInstanceQueryLimit.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-deleteOneDataFederationInstanceQueryLimit.txt
+++ b/docs/command/atlas-api-dataFederation-deleteOneDataFederationInstanceQueryLimit.txt
@@ -67,11 +67,11 @@ Options
        | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A |
        | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A |
        
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-downloadFederatedDatabaseQueryLogs.txt
+++ b/docs/command/atlas-api-dataFederation-downloadFederatedDatabaseQueryLogs.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for downloadFederatedDatabaseQueryLogs
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["gzip"] This value defaults to "gzip".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-downloadFederatedDatabaseQueryLogs.txt
+++ b/docs/command/atlas-api-dataFederation-downloadFederatedDatabaseQueryLogs.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["gzip"] This value defaults to "gzip".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-getDataFederationPrivateEndpoint.txt
+++ b/docs/command/atlas-api-dataFederation-getDataFederationPrivateEndpoint.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getDataFederationPrivateEndpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-getDataFederationPrivateEndpoint.txt
+++ b/docs/command/atlas-api-dataFederation-getDataFederationPrivateEndpoint.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-getFederatedDatabase.txt
+++ b/docs/command/atlas-api-dataFederation-getFederatedDatabase.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-getFederatedDatabase.txt
+++ b/docs/command/atlas-api-dataFederation-getFederatedDatabase.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getFederatedDatabase
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-listDataFederationPrivateEndpoints.txt
+++ b/docs/command/atlas-api-dataFederation-listDataFederationPrivateEndpoints.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-listDataFederationPrivateEndpoints.txt
+++ b/docs/command/atlas-api-dataFederation-listDataFederationPrivateEndpoints.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-listFederatedDatabases.txt
+++ b/docs/command/atlas-api-dataFederation-listFederatedDatabases.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-listFederatedDatabases.txt
+++ b/docs/command/atlas-api-dataFederation-listFederatedDatabases.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listFederatedDatabases
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-returnFederatedDatabaseQueryLimit.txt
+++ b/docs/command/atlas-api-dataFederation-returnFederatedDatabaseQueryLimit.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-returnFederatedDatabaseQueryLimit.txt
+++ b/docs/command/atlas-api-dataFederation-returnFederatedDatabaseQueryLimit.txt
@@ -67,11 +67,11 @@ Options
        | bytesProcessed.weekly | Limit on the number of bytes processed for the data federation instance for the current week | N/A |
        | bytesProcessed.monthly | Limit on the number of bytes processed for the data federation instance for the current month | N/A |
        
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-returnFederatedDatabaseQueryLimits.txt
+++ b/docs/command/atlas-api-dataFederation-returnFederatedDatabaseQueryLimits.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-returnFederatedDatabaseQueryLimits.txt
+++ b/docs/command/atlas-api-dataFederation-returnFederatedDatabaseQueryLimits.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for returnFederatedDatabaseQueryLimits
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-updateFederatedDatabase.txt
+++ b/docs/command/atlas-api-dataFederation-updateFederatedDatabase.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataFederation-updateFederatedDatabase.txt
+++ b/docs/command/atlas-api-dataFederation-updateFederatedDatabase.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateFederatedDatabase
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-createPipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-createPipeline.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for createPipeline
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-createPipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-createPipeline.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-deletePipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-deletePipeline.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-deletePipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-deletePipeline.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for deletePipeline
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-deletePipelineRunDataset.txt
+++ b/docs/command/atlas-api-dataLakePipelines-deletePipelineRunDataset.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-deletePipelineRunDataset.txt
+++ b/docs/command/atlas-api-dataLakePipelines-deletePipelineRunDataset.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for deletePipelineRunDataset
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-getPipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-getPipeline.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getPipeline
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-getPipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-getPipeline.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-getPipelineRun.txt
+++ b/docs/command/atlas-api-dataLakePipelines-getPipelineRun.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-getPipelineRun.txt
+++ b/docs/command/atlas-api-dataLakePipelines-getPipelineRun.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getPipelineRun
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-listPipelineRuns.txt
+++ b/docs/command/atlas-api-dataLakePipelines-listPipelineRuns.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-listPipelineRuns.txt
+++ b/docs/command/atlas-api-dataLakePipelines-listPipelineRuns.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-listPipelineSchedules.txt
+++ b/docs/command/atlas-api-dataLakePipelines-listPipelineSchedules.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-listPipelineSchedules.txt
+++ b/docs/command/atlas-api-dataLakePipelines-listPipelineSchedules.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listPipelineSchedules
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-listPipelineSnapshots.txt
+++ b/docs/command/atlas-api-dataLakePipelines-listPipelineSnapshots.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-listPipelineSnapshots.txt
+++ b/docs/command/atlas-api-dataLakePipelines-listPipelineSnapshots.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-listPipelines.txt
+++ b/docs/command/atlas-api-dataLakePipelines-listPipelines.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-listPipelines.txt
+++ b/docs/command/atlas-api-dataLakePipelines-listPipelines.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listPipelines
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-pausePipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-pausePipeline.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-pausePipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-pausePipeline.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for pausePipeline
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-resumePipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-resumePipeline.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-resumePipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-resumePipeline.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for resumePipeline
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-triggerSnapshotIngestion.txt
+++ b/docs/command/atlas-api-dataLakePipelines-triggerSnapshotIngestion.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-triggerSnapshotIngestion.txt
+++ b/docs/command/atlas-api-dataLakePipelines-triggerSnapshotIngestion.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for triggerSnapshotIngestion
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-updatePipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-updatePipeline.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-dataLakePipelines-updatePipeline.txt
+++ b/docs/command/atlas-api-dataLakePipelines-updatePipeline.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for updatePipeline
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-createDatabaseUser.txt
+++ b/docs/command/atlas-api-databaseUsers-createDatabaseUser.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createDatabaseUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-createDatabaseUser.txt
+++ b/docs/command/atlas-api-databaseUsers-createDatabaseUser.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-deleteDatabaseUser.txt
+++ b/docs/command/atlas-api-databaseUsers-deleteDatabaseUser.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteDatabaseUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-deleteDatabaseUser.txt
+++ b/docs/command/atlas-api-databaseUsers-deleteDatabaseUser.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-getDatabaseUser.txt
+++ b/docs/command/atlas-api-databaseUsers-getDatabaseUser.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getDatabaseUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-getDatabaseUser.txt
+++ b/docs/command/atlas-api-databaseUsers-getDatabaseUser.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-listDatabaseUsers.txt
+++ b/docs/command/atlas-api-databaseUsers-listDatabaseUsers.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-listDatabaseUsers.txt
+++ b/docs/command/atlas-api-databaseUsers-listDatabaseUsers.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-updateDatabaseUser.txt
+++ b/docs/command/atlas-api-databaseUsers-updateDatabaseUser.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-databaseUsers-updateDatabaseUser.txt
+++ b/docs/command/atlas-api-databaseUsers-updateDatabaseUser.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updateDatabaseUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-createEncryptionAtRestPrivateEndpoint.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-createEncryptionAtRestPrivateEndpoint.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-createEncryptionAtRestPrivateEndpoint.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-createEncryptionAtRestPrivateEndpoint.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for createEncryptionAtRestPrivateEndpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRest.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRest.txt
@@ -62,7 +62,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRest.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRest.txt
@@ -58,11 +58,11 @@ Options
      - 
      - false
      - help for getEncryptionAtRest
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRestPrivateEndpoint.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRestPrivateEndpoint.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for getEncryptionAtRestPrivateEndpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRestPrivateEndpoint.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRestPrivateEndpoint.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRestPrivateEndpointsForCloudProvider.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRestPrivateEndpointsForCloudProvider.txt
@@ -65,11 +65,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRestPrivateEndpointsForCloudProvider.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-getEncryptionAtRestPrivateEndpointsForCloudProvider.txt
@@ -69,7 +69,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-requestEncryptionAtRestPrivateEndpointDeletion.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-requestEncryptionAtRestPrivateEndpointDeletion.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-requestEncryptionAtRestPrivateEndpointDeletion.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-requestEncryptionAtRestPrivateEndpointDeletion.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for requestEncryptionAtRestPrivateEndpointDeletion
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-updateEncryptionAtRest.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-updateEncryptionAtRest.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-updateEncryptionAtRest.txt
+++ b/docs/command/atlas-api-encryptionAtRestUsingCustomerKeyManagement-updateEncryptionAtRest.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for updateEncryptionAtRest
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-getOrganizationEvent.txt
+++ b/docs/command/atlas-api-events-getOrganizationEvent.txt
@@ -64,11 +64,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-getOrganizationEvent.txt
+++ b/docs/command/atlas-api-events-getOrganizationEvent.txt
@@ -68,7 +68,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-getProjectEvent.txt
+++ b/docs/command/atlas-api-events-getProjectEvent.txt
@@ -66,11 +66,11 @@ Options
      - 
      - false
      - Flag that indicates whether to include the raw document in the output. The raw document contains additional meta information about the event.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-getProjectEvent.txt
+++ b/docs/command/atlas-api-events-getProjectEvent.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-listEventTypes.txt
+++ b/docs/command/atlas-api-events-listEventTypes.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-listEventTypes.txt
+++ b/docs/command/atlas-api-events-listEventTypes.txt
@@ -55,11 +55,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-listOrganizationEvents.txt
+++ b/docs/command/atlas-api-events-listOrganizationEvents.txt
@@ -82,11 +82,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-listOrganizationEvents.txt
+++ b/docs/command/atlas-api-events-listOrganizationEvents.txt
@@ -86,7 +86,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-listProjectEvents.txt
+++ b/docs/command/atlas-api-events-listProjectEvents.txt
@@ -98,7 +98,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-events-listProjectEvents.txt
+++ b/docs/command/atlas-api-events-listProjectEvents.txt
@@ -94,11 +94,11 @@ Options
      - string
      - false
      - Date and time from when MongoDB Cloud starts returning events. This parameter uses the ISO 8601 timestamp format in UTC.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-createIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-createIdentityProvider.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-createIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-createIdentityProvider.txt
@@ -60,11 +60,11 @@ Options
      - 
      - false
      - help for createIdentityProvider
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-createRoleMapping.txt
+++ b/docs/command/atlas-api-federatedAuthentication-createRoleMapping.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-createRoleMapping.txt
+++ b/docs/command/atlas-api-federatedAuthentication-createRoleMapping.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-deleteFederationApp.txt
+++ b/docs/command/atlas-api-federatedAuthentication-deleteFederationApp.txt
@@ -49,11 +49,11 @@ Options
      - 
      - false
      - help for deleteFederationApp
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-deleteFederationApp.txt
+++ b/docs/command/atlas-api-federatedAuthentication-deleteFederationApp.txt
@@ -53,7 +53,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-deleteIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-deleteIdentityProvider.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the identity provider to connect.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-deleteIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-deleteIdentityProvider.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-deleteRoleMapping.txt
+++ b/docs/command/atlas-api-federatedAuthentication-deleteRoleMapping.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-deleteRoleMapping.txt
+++ b/docs/command/atlas-api-federatedAuthentication-deleteRoleMapping.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getConnectedOrgConfig.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getConnectedOrgConfig.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getConnectedOrgConfig.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getConnectedOrgConfig.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the connected organization configuration to return.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getFederationSettings.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getFederationSettings.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getFederationSettings.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getFederationSettings.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getIdentityProvider.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique string that identifies the identity provider to connect. If using an API version before 11-15-2023, use the legacy 20-hexadecimal digit id. This id can be found within the Federation Management Console > Identity Providers tab by clicking the info icon in the IdP ID row of a configured identity provider. For all other versions, use the 24-hexadecimal digit id.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getIdentityProvider.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getIdentityProviderMetadata.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getIdentityProviderMetadata.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getIdentityProviderMetadata.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getIdentityProviderMetadata.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Legacy 20-hexadecimal digit string that identifies the identity provider. This id can be found within the Federation Management Console > Identity Providers tab by clicking the info icon in the IdP ID row of a configured identity provider.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getRoleMapping.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getRoleMapping.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-getRoleMapping.txt
+++ b/docs/command/atlas-api-federatedAuthentication-getRoleMapping.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-listConnectedOrgConfigs.txt
+++ b/docs/command/atlas-api-federatedAuthentication-listConnectedOrgConfigs.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-listConnectedOrgConfigs.txt
+++ b/docs/command/atlas-api-federatedAuthentication-listConnectedOrgConfigs.txt
@@ -57,11 +57,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-listIdentityProviders.txt
+++ b/docs/command/atlas-api-federatedAuthentication-listIdentityProviders.txt
@@ -61,11 +61,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-listIdentityProviders.txt
+++ b/docs/command/atlas-api-federatedAuthentication-listIdentityProviders.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-listRoleMappings.txt
+++ b/docs/command/atlas-api-federatedAuthentication-listRoleMappings.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-listRoleMappings.txt
+++ b/docs/command/atlas-api-federatedAuthentication-listRoleMappings.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-removeConnectedOrgConfig.txt
+++ b/docs/command/atlas-api-federatedAuthentication-removeConnectedOrgConfig.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-removeConnectedOrgConfig.txt
+++ b/docs/command/atlas-api-federatedAuthentication-removeConnectedOrgConfig.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the connected organization configuration to remove.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-revokeJwksFromIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-revokeJwksFromIdentityProvider.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the identity provider to connect.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-revokeJwksFromIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-revokeJwksFromIdentityProvider.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-updateConnectedOrgConfig.txt
+++ b/docs/command/atlas-api-federatedAuthentication-updateConnectedOrgConfig.txt
@@ -77,7 +77,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-updateConnectedOrgConfig.txt
+++ b/docs/command/atlas-api-federatedAuthentication-updateConnectedOrgConfig.txt
@@ -73,11 +73,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the connected organization configuration to update.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-updateIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-updateIdentityProvider.txt
@@ -64,11 +64,11 @@ Options
      - string
      - true
      - Unique string that identifies the identity provider to connect. If using an API version before 11-15-2023, use the legacy 20-hexadecimal digit id. This id can be found within the Federation Management Console > Identity Providers tab by clicking the info icon in the IdP ID row of a configured identity provider. For all other versions, use the 24-hexadecimal digit id.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-updateIdentityProvider.txt
+++ b/docs/command/atlas-api-federatedAuthentication-updateIdentityProvider.txt
@@ -68,7 +68,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-updateRoleMapping.txt
+++ b/docs/command/atlas-api-federatedAuthentication-updateRoleMapping.txt
@@ -69,7 +69,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-federatedAuthentication-updateRoleMapping.txt
+++ b/docs/command/atlas-api-federatedAuthentication-updateRoleMapping.txt
@@ -65,11 +65,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-createFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-createFlexCluster.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createFlexCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-createFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-createFlexCluster.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-deleteFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-deleteFlexCluster.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-deleteFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-deleteFlexCluster.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-getFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-getFlexCluster.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-getFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-getFlexCluster.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-listFlexClusters.txt
+++ b/docs/command/atlas-api-flexClusters-listFlexClusters.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-listFlexClusters.txt
+++ b/docs/command/atlas-api-flexClusters-listFlexClusters.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-updateFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-updateFlexCluster.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-updateFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-updateFlexCluster.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-upgradeFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-upgradeFlexCluster.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for upgradeFlexCluster
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexClusters-upgradeFlexCluster.txt
+++ b/docs/command/atlas-api-flexClusters-upgradeFlexCluster.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexRestoreJobs-createFlexBackupRestoreJob.txt
+++ b/docs/command/atlas-api-flexRestoreJobs-createFlexBackupRestoreJob.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster whose snapshot you want to restore.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexRestoreJobs-createFlexBackupRestoreJob.txt
+++ b/docs/command/atlas-api-flexRestoreJobs-createFlexBackupRestoreJob.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexRestoreJobs-getFlexBackupRestoreJob.txt
+++ b/docs/command/atlas-api-flexRestoreJobs-getFlexBackupRestoreJob.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexRestoreJobs-getFlexBackupRestoreJob.txt
+++ b/docs/command/atlas-api-flexRestoreJobs-getFlexBackupRestoreJob.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexRestoreJobs-listFlexBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-flexRestoreJobs-listFlexBackupRestoreJobs.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexRestoreJobs-listFlexBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-flexRestoreJobs-listFlexBackupRestoreJobs.txt
@@ -67,11 +67,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexSnapshots-downloadFlexBackup.txt
+++ b/docs/command/atlas-api-flexSnapshots-downloadFlexBackup.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexSnapshots-downloadFlexBackup.txt
+++ b/docs/command/atlas-api-flexSnapshots-downloadFlexBackup.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexSnapshots-getFlexBackup.txt
+++ b/docs/command/atlas-api-flexSnapshots-getFlexBackup.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexSnapshots-getFlexBackup.txt
+++ b/docs/command/atlas-api-flexSnapshots-getFlexBackup.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexSnapshots-listFlexBackups.txt
+++ b/docs/command/atlas-api-flexSnapshots-listFlexBackups.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-flexSnapshots-listFlexBackups.txt
+++ b/docs/command/atlas-api-flexSnapshots-listFlexBackups.txt
@@ -67,11 +67,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the flex cluster.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-createCustomZoneMapping.txt
+++ b/docs/command/atlas-api-globalClusters-createCustomZoneMapping.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-createCustomZoneMapping.txt
+++ b/docs/command/atlas-api-globalClusters-createCustomZoneMapping.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createCustomZoneMapping
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-createManagedNamespace.txt
+++ b/docs/command/atlas-api-globalClusters-createManagedNamespace.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-createManagedNamespace.txt
+++ b/docs/command/atlas-api-globalClusters-createManagedNamespace.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createManagedNamespace
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-deleteAllCustomZoneMappings.txt
+++ b/docs/command/atlas-api-globalClusters-deleteAllCustomZoneMappings.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-deleteAllCustomZoneMappings.txt
+++ b/docs/command/atlas-api-globalClusters-deleteAllCustomZoneMappings.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteAllCustomZoneMappings
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-deleteManagedNamespace.txt
+++ b/docs/command/atlas-api-globalClusters-deleteManagedNamespace.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-deleteManagedNamespace.txt
+++ b/docs/command/atlas-api-globalClusters-deleteManagedNamespace.txt
@@ -67,11 +67,11 @@ Options
      - 
      - false
      - help for deleteManagedNamespace
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-getManagedNamespace.txt
+++ b/docs/command/atlas-api-globalClusters-getManagedNamespace.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-globalClusters-getManagedNamespace.txt
+++ b/docs/command/atlas-api-globalClusters-getManagedNamespace.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getManagedNamespace
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-createCostExplorerQueryProcess.txt
+++ b/docs/command/atlas-api-invoices-createCostExplorerQueryProcess.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-createCostExplorerQueryProcess.txt
+++ b/docs/command/atlas-api-invoices-createCostExplorerQueryProcess.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-downloadInvoiceCsv.txt
+++ b/docs/command/atlas-api-invoices-downloadInvoiceCsv.txt
@@ -62,7 +62,7 @@ Options
      - string
      - false
      - preferred api format, can be ["csv"] This value defaults to "csv".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-downloadInvoiceCsv.txt
+++ b/docs/command/atlas-api-invoices-downloadInvoiceCsv.txt
@@ -58,11 +58,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["csv"] This value defaults to "csv".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-getCostExplorerQueryProcess.txt
+++ b/docs/command/atlas-api-invoices-getCostExplorerQueryProcess.txt
@@ -57,7 +57,7 @@ Options
      - string
      - true
      - preferred api format, can be ["csv", "json", go-template]
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-getCostExplorerQueryProcess.txt
+++ b/docs/command/atlas-api-invoices-getCostExplorerQueryProcess.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - true
      - preferred api format, can be ["csv", "json", go-template]
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-getInvoice.txt
+++ b/docs/command/atlas-api-invoices-getInvoice.txt
@@ -58,11 +58,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - true
      - preferred api format, can be ["csv", "json", go-template]
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-getInvoice.txt
+++ b/docs/command/atlas-api-invoices-getInvoice.txt
@@ -62,7 +62,7 @@ Options
      - string
      - true
      - preferred api format, can be ["csv", "json", go-template]
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-listInvoices.txt
+++ b/docs/command/atlas-api-invoices-listInvoices.txt
@@ -70,11 +70,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-listInvoices.txt
+++ b/docs/command/atlas-api-invoices-listInvoices.txt
@@ -74,7 +74,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-listPendingInvoices.txt
+++ b/docs/command/atlas-api-invoices-listPendingInvoices.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-listPendingInvoices.txt
+++ b/docs/command/atlas-api-invoices-listPendingInvoices.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-queryLineItemsFromSingleInvoice.txt
+++ b/docs/command/atlas-api-invoices-queryLineItemsFromSingleInvoice.txt
@@ -69,7 +69,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-invoices-queryLineItemsFromSingleInvoice.txt
+++ b/docs/command/atlas-api-invoices-queryLineItemsFromSingleInvoice.txt
@@ -65,11 +65,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-deleteLdapConfiguration.txt
+++ b/docs/command/atlas-api-ldapConfiguration-deleteLdapConfiguration.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-deleteLdapConfiguration.txt
+++ b/docs/command/atlas-api-ldapConfiguration-deleteLdapConfiguration.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for deleteLdapConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-getLdapConfiguration.txt
+++ b/docs/command/atlas-api-ldapConfiguration-getLdapConfiguration.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-getLdapConfiguration.txt
+++ b/docs/command/atlas-api-ldapConfiguration-getLdapConfiguration.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getLdapConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-getLdapConfigurationStatus.txt
+++ b/docs/command/atlas-api-ldapConfiguration-getLdapConfigurationStatus.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-getLdapConfigurationStatus.txt
+++ b/docs/command/atlas-api-ldapConfiguration-getLdapConfigurationStatus.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getLdapConfigurationStatus
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-saveLdapConfiguration.txt
+++ b/docs/command/atlas-api-ldapConfiguration-saveLdapConfiguration.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for saveLdapConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-saveLdapConfiguration.txt
+++ b/docs/command/atlas-api-ldapConfiguration-saveLdapConfiguration.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-verifyLdapConfiguration.txt
+++ b/docs/command/atlas-api-ldapConfiguration-verifyLdapConfiguration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-ldapConfiguration-verifyLdapConfiguration.txt
+++ b/docs/command/atlas-api-ldapConfiguration-verifyLdapConfiguration.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for verifyLdapConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-createLegacyBackupRestoreJob.txt
+++ b/docs/command/atlas-api-legacyBackup-createLegacyBackupRestoreJob.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-createLegacyBackupRestoreJob.txt
+++ b/docs/command/atlas-api-legacyBackup-createLegacyBackupRestoreJob.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createLegacyBackupRestoreJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-deleteLegacySnapshot.txt
+++ b/docs/command/atlas-api-legacyBackup-deleteLegacySnapshot.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteLegacySnapshot
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-deleteLegacySnapshot.txt
+++ b/docs/command/atlas-api-legacyBackup-deleteLegacySnapshot.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-getLegacyBackupCheckpoint.txt
+++ b/docs/command/atlas-api-legacyBackup-getLegacyBackupCheckpoint.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for getLegacyBackupCheckpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-getLegacyBackupCheckpoint.txt
+++ b/docs/command/atlas-api-legacyBackup-getLegacyBackupCheckpoint.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-getLegacyBackupRestoreJob.txt
+++ b/docs/command/atlas-api-legacyBackup-getLegacyBackupRestoreJob.txt
@@ -66,11 +66,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the restore job.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-getLegacyBackupRestoreJob.txt
+++ b/docs/command/atlas-api-legacyBackup-getLegacyBackupRestoreJob.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-getLegacySnapshot.txt
+++ b/docs/command/atlas-api-legacyBackup-getLegacySnapshot.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getLegacySnapshot
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-getLegacySnapshot.txt
+++ b/docs/command/atlas-api-legacyBackup-getLegacySnapshot.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-getLegacySnapshotSchedule.txt
+++ b/docs/command/atlas-api-legacyBackup-getLegacySnapshotSchedule.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-getLegacySnapshotSchedule.txt
+++ b/docs/command/atlas-api-legacyBackup-getLegacySnapshotSchedule.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for getLegacySnapshotSchedule
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-listLegacyBackupCheckpoints.txt
+++ b/docs/command/atlas-api-legacyBackup-listLegacyBackupCheckpoints.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-listLegacyBackupCheckpoints.txt
+++ b/docs/command/atlas-api-legacyBackup-listLegacyBackupCheckpoints.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-listLegacyBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-legacyBackup-listLegacyBackupRestoreJobs.txt
@@ -74,11 +74,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-listLegacyBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-legacyBackup-listLegacyBackupRestoreJobs.txt
@@ -78,7 +78,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-listLegacySnapshots.txt
+++ b/docs/command/atlas-api-legacyBackup-listLegacySnapshots.txt
@@ -71,11 +71,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-listLegacySnapshots.txt
+++ b/docs/command/atlas-api-legacyBackup-listLegacySnapshots.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-updateLegacySnapshotRetention.txt
+++ b/docs/command/atlas-api-legacyBackup-updateLegacySnapshotRetention.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-updateLegacySnapshotRetention.txt
+++ b/docs/command/atlas-api-legacyBackup-updateLegacySnapshotRetention.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updateLegacySnapshotRetention
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-updateLegacySnapshotSchedule.txt
+++ b/docs/command/atlas-api-legacyBackup-updateLegacySnapshotSchedule.txt
@@ -66,11 +66,11 @@ Options
      - 
      - false
      - help for updateLegacySnapshotSchedule
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-legacyBackup-updateLegacySnapshotSchedule.txt
+++ b/docs/command/atlas-api-legacyBackup-updateLegacySnapshotSchedule.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-deferMaintenanceWindow.txt
+++ b/docs/command/atlas-api-maintenanceWindows-deferMaintenanceWindow.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-deferMaintenanceWindow.txt
+++ b/docs/command/atlas-api-maintenanceWindows-deferMaintenanceWindow.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for deferMaintenanceWindow
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-getMaintenanceWindow.txt
+++ b/docs/command/atlas-api-maintenanceWindows-getMaintenanceWindow.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-getMaintenanceWindow.txt
+++ b/docs/command/atlas-api-maintenanceWindows-getMaintenanceWindow.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getMaintenanceWindow
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-resetMaintenanceWindow.txt
+++ b/docs/command/atlas-api-maintenanceWindows-resetMaintenanceWindow.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-resetMaintenanceWindow.txt
+++ b/docs/command/atlas-api-maintenanceWindows-resetMaintenanceWindow.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for resetMaintenanceWindow
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-toggleMaintenanceAutoDefer.txt
+++ b/docs/command/atlas-api-maintenanceWindows-toggleMaintenanceAutoDefer.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-toggleMaintenanceAutoDefer.txt
+++ b/docs/command/atlas-api-maintenanceWindows-toggleMaintenanceAutoDefer.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for toggleMaintenanceAutoDefer
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-updateMaintenanceWindow.txt
+++ b/docs/command/atlas-api-maintenanceWindows-updateMaintenanceWindow.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateMaintenanceWindow
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-maintenanceWindows-updateMaintenanceWindow.txt
+++ b/docs/command/atlas-api-maintenanceWindows-updateMaintenanceWindow.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-addOrganizationRole.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-addOrganizationRole.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-addOrganizationRole.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-addOrganizationRole.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-addProjectRole.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-addProjectRole.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-addProjectRole.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-addProjectRole.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for addProjectRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-addProjectUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-addProjectUser.txt
@@ -73,7 +73,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-addProjectUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-addProjectUser.txt
@@ -69,11 +69,11 @@ Options
      - 
      - false
      - help for addProjectUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-addUserToTeam.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-addUserToTeam.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-addUserToTeam.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-addUserToTeam.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-createOrganizationUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-createOrganizationUser.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-createOrganizationUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-createOrganizationUser.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-createUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-createUser.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-createUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-createUser.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-getOrganizationUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-getOrganizationUser.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-getOrganizationUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-getOrganizationUser.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-getProjectUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-getProjectUser.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for getProjectUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-getProjectUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-getProjectUser.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-getUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-getUser.txt
@@ -49,11 +49,11 @@ Options
      - 
      - false
      - help for getUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-getUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-getUser.txt
@@ -53,7 +53,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-getUserByUsername.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-getUserByUsername.txt
@@ -49,11 +49,11 @@ Options
      - 
      - false
      - help for getUserByUsername
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-getUserByUsername.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-getUserByUsername.txt
@@ -53,7 +53,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-listOrganizationUsers.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-listOrganizationUsers.txt
@@ -71,11 +71,11 @@ Options
      - string
      - false
      - Organization membership status to filter users by. If you exclude this parameter, this resource returns both pending and active users. Not supported in deprecated versions.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-listOrganizationUsers.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-listOrganizationUsers.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-listProjectUsers.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-listProjectUsers.txt
@@ -85,7 +85,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-listProjectUsers.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-listProjectUsers.txt
@@ -81,11 +81,11 @@ Options
      - string
      - false
      - Flag that indicates whether to filter the returned list by users organization membership status. If you exclude this parameter, this resource returns both pending and active users. Not supported in deprecated versions.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-listTeamUsers.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-listTeamUsers.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-listTeamUsers.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-listTeamUsers.txt
@@ -67,11 +67,11 @@ Options
      - string
      - false
      - Organization membership status to filter users by. If you exclude this parameter, this resource returns both pending and active users. Not supported in deprecated versions.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeOrganizationRole.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeOrganizationRole.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeOrganizationRole.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeOrganizationRole.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeOrganizationUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeOrganizationUser.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeOrganizationUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeOrganizationUser.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeProjectRole.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeProjectRole.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for removeProjectRole
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeProjectRole.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeProjectRole.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeProjectUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeProjectUser.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeProjectUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeProjectUser.txt
@@ -61,11 +61,11 @@ Options
      - 
      - false
      - help for removeProjectUser
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeUserFromTeam.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeUserFromTeam.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-removeUserFromTeam.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-removeUserFromTeam.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-updateOrganizationUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-updateOrganizationUser.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-mongoDbCloudUsers-updateOrganizationUser.txt
+++ b/docs/command/atlas-api-mongoDbCloudUsers-updateOrganizationUser.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getAtlasProcess.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getAtlasProcess.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getAtlasProcess.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getAtlasProcess.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getAtlasProcess
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getDatabase.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getDatabase.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getDatabase
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getDatabase.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getDatabase.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getDatabaseMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getDatabaseMeasurements.txt
@@ -71,11 +71,11 @@ Options
      - m
      - false
      - One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for m, repeat the `m` parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getDatabaseMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getDatabaseMeasurements.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getDiskMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getDiskMeasurements.txt
@@ -88,7 +88,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getDiskMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getDiskMeasurements.txt
@@ -84,11 +84,11 @@ Options
      - m
      - false
      - One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for m, repeat the `m` parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getHostLogs.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getHostLogs.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["gzip"] This value defaults to "gzip".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getHostLogs.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getHostLogs.txt
@@ -67,11 +67,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the log file that you want to return. To return audit logs, enable *Database Auditing* for the specified project.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["gzip"] This value defaults to "gzip".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getHostMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getHostMeasurements.txt
@@ -87,11 +87,11 @@ Options
      - m
      - false
      - One or more types of measurement to request for this MongoDB process. If omitted, the resource returns all measurements. To specify multiple values for m, repeat the `m` parameter for each value. Specify measurements that apply to the specified host. MongoDB Cloud returns an error if you specified any invalid measurements.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getHostMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getHostMeasurements.txt
@@ -91,7 +91,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getIndexMetrics.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getIndexMetrics.txt
@@ -79,11 +79,11 @@ Options
      - stringArray
      - true
      - List that contains the measurements that MongoDB Atlas reports for the associated data series.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getIndexMetrics.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getIndexMetrics.txt
@@ -83,7 +83,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getMeasurements.txt
@@ -67,11 +67,11 @@ Options
      - stringArray
      - true
      - List that contains the metrics that you want MongoDB Atlas to report for the associated data series. If you don't set this parameter, this resource returns all hardware and status metrics for the associated data series.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-getMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-getMeasurements.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listAtlasProcesses.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listAtlasProcesses.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listAtlasProcesses.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listAtlasProcesses.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listDatabases.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listDatabases.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listDatabases.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listDatabases.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listDiskMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listDiskMeasurements.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listDiskMeasurements.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listDiskMeasurements.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listDiskMeasurements
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listDiskPartitions.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listDiskPartitions.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listDiskPartitions.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listDiskPartitions.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listIndexMetrics.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listIndexMetrics.txt
@@ -77,7 +77,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listIndexMetrics.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listIndexMetrics.txt
@@ -73,11 +73,11 @@ Options
      - stringArray
      - true
      - List that contains the measurements that MongoDB Atlas reports for the associated data series.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listMetricTypes.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listMetricTypes.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-monitoringAndLogs-listMetricTypes.txt
+++ b/docs/command/atlas-api-monitoringAndLogs-listMetricTypes.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listMetricTypes
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-createPeeringConnection.txt
+++ b/docs/command/atlas-api-networkPeering-createPeeringConnection.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createPeeringConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-createPeeringConnection.txt
+++ b/docs/command/atlas-api-networkPeering-createPeeringConnection.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-createPeeringContainer.txt
+++ b/docs/command/atlas-api-networkPeering-createPeeringContainer.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-createPeeringContainer.txt
+++ b/docs/command/atlas-api-networkPeering-createPeeringContainer.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createPeeringContainer
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-deletePeeringConnection.txt
+++ b/docs/command/atlas-api-networkPeering-deletePeeringConnection.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-deletePeeringConnection.txt
+++ b/docs/command/atlas-api-networkPeering-deletePeeringConnection.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for deletePeeringConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-deletePeeringContainer.txt
+++ b/docs/command/atlas-api-networkPeering-deletePeeringContainer.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deletePeeringContainer
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-deletePeeringContainer.txt
+++ b/docs/command/atlas-api-networkPeering-deletePeeringContainer.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-disablePeering.txt
+++ b/docs/command/atlas-api-networkPeering-disablePeering.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for disablePeering
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-disablePeering.txt
+++ b/docs/command/atlas-api-networkPeering-disablePeering.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-getPeeringConnection.txt
+++ b/docs/command/atlas-api-networkPeering-getPeeringConnection.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-getPeeringConnection.txt
+++ b/docs/command/atlas-api-networkPeering-getPeeringConnection.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getPeeringConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-getPeeringContainer.txt
+++ b/docs/command/atlas-api-networkPeering-getPeeringContainer.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getPeeringContainer
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-getPeeringContainer.txt
+++ b/docs/command/atlas-api-networkPeering-getPeeringContainer.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-listPeeringConnections.txt
+++ b/docs/command/atlas-api-networkPeering-listPeeringConnections.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-listPeeringConnections.txt
+++ b/docs/command/atlas-api-networkPeering-listPeeringConnections.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-listPeeringContainerByCloudProvider.txt
+++ b/docs/command/atlas-api-networkPeering-listPeeringContainerByCloudProvider.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-listPeeringContainerByCloudProvider.txt
+++ b/docs/command/atlas-api-networkPeering-listPeeringContainerByCloudProvider.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-listPeeringContainers.txt
+++ b/docs/command/atlas-api-networkPeering-listPeeringContainers.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-listPeeringContainers.txt
+++ b/docs/command/atlas-api-networkPeering-listPeeringContainers.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-updatePeeringConnection.txt
+++ b/docs/command/atlas-api-networkPeering-updatePeeringConnection.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-updatePeeringConnection.txt
+++ b/docs/command/atlas-api-networkPeering-updatePeeringConnection.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updatePeeringConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-updatePeeringContainer.txt
+++ b/docs/command/atlas-api-networkPeering-updatePeeringContainer.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-updatePeeringContainer.txt
+++ b/docs/command/atlas-api-networkPeering-updatePeeringContainer.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updatePeeringContainer
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-verifyConnectViaPeeringOnlyModeForOneProject.txt
+++ b/docs/command/atlas-api-networkPeering-verifyConnectViaPeeringOnlyModeForOneProject.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-networkPeering-verifyConnectViaPeeringOnlyModeForOneProject.txt
+++ b/docs/command/atlas-api-networkPeering-verifyConnectViaPeeringOnlyModeForOneProject.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for verifyConnectViaPeeringOnlyModeForOneProject
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-createOnlineArchive.txt
+++ b/docs/command/atlas-api-onlineArchive-createOnlineArchive.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-createOnlineArchive.txt
+++ b/docs/command/atlas-api-onlineArchive-createOnlineArchive.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createOnlineArchive
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-deleteOnlineArchive.txt
+++ b/docs/command/atlas-api-onlineArchive-deleteOnlineArchive.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-deleteOnlineArchive.txt
+++ b/docs/command/atlas-api-onlineArchive-deleteOnlineArchive.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for deleteOnlineArchive
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-downloadOnlineArchiveQueryLogs.txt
+++ b/docs/command/atlas-api-onlineArchive-downloadOnlineArchiveQueryLogs.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["gzip"] This value defaults to "gzip".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-downloadOnlineArchiveQueryLogs.txt
+++ b/docs/command/atlas-api-onlineArchive-downloadOnlineArchiveQueryLogs.txt
@@ -67,11 +67,11 @@ Options
      - 
      - false
      - help for downloadOnlineArchiveQueryLogs
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["gzip"] This value defaults to "gzip".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-getOnlineArchive.txt
+++ b/docs/command/atlas-api-onlineArchive-getOnlineArchive.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-getOnlineArchive.txt
+++ b/docs/command/atlas-api-onlineArchive-getOnlineArchive.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for getOnlineArchive
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-listOnlineArchives.txt
+++ b/docs/command/atlas-api-onlineArchive-listOnlineArchives.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-listOnlineArchives.txt
+++ b/docs/command/atlas-api-onlineArchive-listOnlineArchives.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-updateOnlineArchive.txt
+++ b/docs/command/atlas-api-onlineArchive-updateOnlineArchive.txt
@@ -67,11 +67,11 @@ Options
      - 
      - false
      - help for updateOnlineArchive
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-onlineArchive-updateOnlineArchive.txt
+++ b/docs/command/atlas-api-onlineArchive-updateOnlineArchive.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-createOrganization.txt
+++ b/docs/command/atlas-api-organizations-createOrganization.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-createOrganization.txt
+++ b/docs/command/atlas-api-organizations-createOrganization.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for createOrganization
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-createOrganizationInvitation.txt
+++ b/docs/command/atlas-api-organizations-createOrganizationInvitation.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-createOrganizationInvitation.txt
+++ b/docs/command/atlas-api-organizations-createOrganizationInvitation.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-deleteOrganization.txt
+++ b/docs/command/atlas-api-organizations-deleteOrganization.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-deleteOrganization.txt
+++ b/docs/command/atlas-api-organizations-deleteOrganization.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-deleteOrganizationInvitation.txt
+++ b/docs/command/atlas-api-organizations-deleteOrganizationInvitation.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-deleteOrganizationInvitation.txt
+++ b/docs/command/atlas-api-organizations-deleteOrganizationInvitation.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-getOrganization.txt
+++ b/docs/command/atlas-api-organizations-getOrganization.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-getOrganization.txt
+++ b/docs/command/atlas-api-organizations-getOrganization.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-getOrganizationInvitation.txt
+++ b/docs/command/atlas-api-organizations-getOrganizationInvitation.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-getOrganizationInvitation.txt
+++ b/docs/command/atlas-api-organizations-getOrganizationInvitation.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-getOrganizationSettings.txt
+++ b/docs/command/atlas-api-organizations-getOrganizationSettings.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-getOrganizationSettings.txt
+++ b/docs/command/atlas-api-organizations-getOrganizationSettings.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-listOrganizationInvitations.txt
+++ b/docs/command/atlas-api-organizations-listOrganizationInvitations.txt
@@ -56,11 +56,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-listOrganizationInvitations.txt
+++ b/docs/command/atlas-api-organizations-listOrganizationInvitations.txt
@@ -60,7 +60,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-listOrganizationProjects.txt
+++ b/docs/command/atlas-api-organizations-listOrganizationProjects.txt
@@ -82,11 +82,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-listOrganizationProjects.txt
+++ b/docs/command/atlas-api-organizations-listOrganizationProjects.txt
@@ -86,7 +86,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-listOrganizations.txt
+++ b/docs/command/atlas-api-organizations-listOrganizations.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-listOrganizations.txt
+++ b/docs/command/atlas-api-organizations-listOrganizations.txt
@@ -61,11 +61,11 @@ Options
      - string
      - false
      - Human-readable label of the organization to use to filter the returned list. Performs a case-insensitive search for an organization that starts with the specified name.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganization.txt
+++ b/docs/command/atlas-api-organizations-updateOrganization.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganization.txt
+++ b/docs/command/atlas-api-organizations-updateOrganization.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganizationInvitation.txt
+++ b/docs/command/atlas-api-organizations-updateOrganizationInvitation.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganizationInvitation.txt
+++ b/docs/command/atlas-api-organizations-updateOrganizationInvitation.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganizationInvitationById.txt
+++ b/docs/command/atlas-api-organizations-updateOrganizationInvitationById.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganizationInvitationById.txt
+++ b/docs/command/atlas-api-organizations-updateOrganizationInvitationById.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganizationRoles.txt
+++ b/docs/command/atlas-api-organizations-updateOrganizationRoles.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganizationRoles.txt
+++ b/docs/command/atlas-api-organizations-updateOrganizationRoles.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganizationSettings.txt
+++ b/docs/command/atlas-api-organizations-updateOrganizationSettings.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-organizations-updateOrganizationSettings.txt
+++ b/docs/command/atlas-api-organizations-updateOrganizationSettings.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-disableSlowOperationThresholding.txt
+++ b/docs/command/atlas-api-performanceAdvisor-disableSlowOperationThresholding.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-disableSlowOperationThresholding.txt
+++ b/docs/command/atlas-api-performanceAdvisor-disableSlowOperationThresholding.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for disableSlowOperationThresholding
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-enableSlowOperationThresholding.txt
+++ b/docs/command/atlas-api-performanceAdvisor-enableSlowOperationThresholding.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-enableSlowOperationThresholding.txt
+++ b/docs/command/atlas-api-performanceAdvisor-enableSlowOperationThresholding.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for enableSlowOperationThresholding
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-getManagedSlowMs.txt
+++ b/docs/command/atlas-api-performanceAdvisor-getManagedSlowMs.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-getManagedSlowMs.txt
+++ b/docs/command/atlas-api-performanceAdvisor-getManagedSlowMs.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for getManagedSlowMs
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-getServerlessAutoIndexing.txt
+++ b/docs/command/atlas-api-performanceAdvisor-getServerlessAutoIndexing.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getServerlessAutoIndexing
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-getServerlessAutoIndexing.txt
+++ b/docs/command/atlas-api-performanceAdvisor-getServerlessAutoIndexing.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listClusterSuggestedIndexes.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listClusterSuggestedIndexes.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listClusterSuggestedIndexes.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listClusterSuggestedIndexes.txt
@@ -59,11 +59,11 @@ Options
      - .
      - false
      - Namespaces from which to retrieve suggested indexes. A namespace consists of one database and one collection resource written as .: ``<database>.<collection>``. To include multiple namespaces, pass the parameter multiple times delimited with an ampersand (`&`) between each namespace. Omit this parameter to return results for all namespaces.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listDropIndexes.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listDropIndexes.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listDropIndexes.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listDropIndexes.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listDropIndexes
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listSchemaAdvice.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listSchemaAdvice.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listSchemaAdvice.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listSchemaAdvice.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listSchemaAdvice
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listSlowQueries.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listSlowQueries.txt
@@ -74,7 +74,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listSlowQueries.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listSlowQueries.txt
@@ -70,11 +70,11 @@ Options
      - .
      - false
      - Namespaces from which to retrieve slow queries. A namespace consists of one database and one collection resource written as .: ``<database>.<collection>``. To include multiple namespaces, pass the parameter multiple times delimited with an ampersand (`&`) between each namespace. Omit this parameter to return results for all namespaces.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listSlowQueryNamespaces.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listSlowQueryNamespaces.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listSlowQueryNamespaces.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listSlowQueryNamespaces.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for listSlowQueryNamespaces
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listSuggestedIndexes.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listSuggestedIndexes.txt
@@ -82,11 +82,11 @@ Options
      - .
      - false
      - Namespaces from which to retrieve suggested indexes. A namespace consists of one database and one collection resource written as .: ``<database>.<collection>``. To include multiple namespaces, pass the parameter multiple times delimited with an ampersand (`&`) between each namespace. Omit this parameter to return results for all namespaces.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-listSuggestedIndexes.txt
+++ b/docs/command/atlas-api-performanceAdvisor-listSuggestedIndexes.txt
@@ -86,7 +86,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-setServerlessAutoIndexing.txt
+++ b/docs/command/atlas-api-performanceAdvisor-setServerlessAutoIndexing.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for setServerlessAutoIndexing
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-performanceAdvisor-setServerlessAutoIndexing.txt
+++ b/docs/command/atlas-api-performanceAdvisor-setServerlessAutoIndexing.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-createPrivateEndpoint.txt
+++ b/docs/command/atlas-api-privateEndpointServices-createPrivateEndpoint.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-createPrivateEndpoint.txt
+++ b/docs/command/atlas-api-privateEndpointServices-createPrivateEndpoint.txt
@@ -67,11 +67,11 @@ Options
      - 
      - false
      - help for createPrivateEndpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-createPrivateEndpointService.txt
+++ b/docs/command/atlas-api-privateEndpointServices-createPrivateEndpointService.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-createPrivateEndpointService.txt
+++ b/docs/command/atlas-api-privateEndpointServices-createPrivateEndpointService.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createPrivateEndpointService
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-deletePrivateEndpoint.txt
+++ b/docs/command/atlas-api-privateEndpointServices-deletePrivateEndpoint.txt
@@ -67,11 +67,11 @@ Options
      - 
      - false
      - help for deletePrivateEndpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-deletePrivateEndpoint.txt
+++ b/docs/command/atlas-api-privateEndpointServices-deletePrivateEndpoint.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-deletePrivateEndpointService.txt
+++ b/docs/command/atlas-api-privateEndpointServices-deletePrivateEndpointService.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-deletePrivateEndpointService.txt
+++ b/docs/command/atlas-api-privateEndpointServices-deletePrivateEndpointService.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for deletePrivateEndpointService
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-getPrivateEndpoint.txt
+++ b/docs/command/atlas-api-privateEndpointServices-getPrivateEndpoint.txt
@@ -67,11 +67,11 @@ Options
      - 
      - false
      - help for getPrivateEndpoint
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-getPrivateEndpoint.txt
+++ b/docs/command/atlas-api-privateEndpointServices-getPrivateEndpoint.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-getPrivateEndpointService.txt
+++ b/docs/command/atlas-api-privateEndpointServices-getPrivateEndpointService.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-getPrivateEndpointService.txt
+++ b/docs/command/atlas-api-privateEndpointServices-getPrivateEndpointService.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for getPrivateEndpointService
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-getRegionalizedPrivateEndpointSetting.txt
+++ b/docs/command/atlas-api-privateEndpointServices-getRegionalizedPrivateEndpointSetting.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getRegionalizedPrivateEndpointSetting
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-getRegionalizedPrivateEndpointSetting.txt
+++ b/docs/command/atlas-api-privateEndpointServices-getRegionalizedPrivateEndpointSetting.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-listPrivateEndpointServices.txt
+++ b/docs/command/atlas-api-privateEndpointServices-listPrivateEndpointServices.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for listPrivateEndpointServices
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-listPrivateEndpointServices.txt
+++ b/docs/command/atlas-api-privateEndpointServices-listPrivateEndpointServices.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-toggleRegionalizedPrivateEndpointSetting.txt
+++ b/docs/command/atlas-api-privateEndpointServices-toggleRegionalizedPrivateEndpointSetting.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-privateEndpointServices-toggleRegionalizedPrivateEndpointSetting.txt
+++ b/docs/command/atlas-api-privateEndpointServices-toggleRegionalizedPrivateEndpointSetting.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for toggleRegionalizedPrivateEndpointSetting
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-addProjectApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-addProjectApiKey.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-addProjectApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-addProjectApiKey.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for addProjectApiKey
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-createApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-createApiKey.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-createApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-createApiKey.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-createApiKeyAccessList.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-createApiKeyAccessList.txt
@@ -73,7 +73,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-createApiKeyAccessList.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-createApiKeyAccessList.txt
@@ -69,11 +69,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-createProjectApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-createProjectApiKey.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createProjectApiKey
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-createProjectApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-createProjectApiKey.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-deleteApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-deleteApiKey.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-deleteApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-deleteApiKey.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-deleteApiKeyAccessListEntry.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-deleteApiKeyAccessListEntry.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-deleteApiKeyAccessListEntry.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-deleteApiKeyAccessListEntry.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-getApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-getApiKey.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-getApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-getApiKey.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-getApiKeyAccessList.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-getApiKeyAccessList.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-getApiKeyAccessList.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-getApiKeyAccessList.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-listApiKeyAccessListsEntries.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-listApiKeyAccessListsEntries.txt
@@ -69,7 +69,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-listApiKeyAccessListsEntries.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-listApiKeyAccessListsEntries.txt
@@ -65,11 +65,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-listApiKeys.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-listApiKeys.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-listApiKeys.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-listApiKeys.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-listProjectApiKeys.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-listProjectApiKeys.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-listProjectApiKeys.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-listProjectApiKeys.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-removeProjectApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-removeProjectApiKey.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-removeProjectApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-removeProjectApiKey.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for removeProjectApiKey
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-updateApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-updateApiKey.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-updateApiKey.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-updateApiKey.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-updateApiKeyRoles.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-updateApiKeyRoles.txt
@@ -71,11 +71,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-programmaticApiKeys-updateApiKeyRoles.txt
+++ b/docs/command/atlas-api-programmaticApiKeys-updateApiKeyRoles.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-createProjectIpAccessList.txt
+++ b/docs/command/atlas-api-projectIpAccessList-createProjectIpAccessList.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-createProjectIpAccessList.txt
+++ b/docs/command/atlas-api-projectIpAccessList-createProjectIpAccessList.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-deleteProjectIpAccessList.txt
+++ b/docs/command/atlas-api-projectIpAccessList-deleteProjectIpAccessList.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-deleteProjectIpAccessList.txt
+++ b/docs/command/atlas-api-projectIpAccessList-deleteProjectIpAccessList.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for deleteProjectIpAccessList
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-getProjectIpAccessListStatus.txt
+++ b/docs/command/atlas-api-projectIpAccessList-getProjectIpAccessListStatus.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-getProjectIpAccessListStatus.txt
+++ b/docs/command/atlas-api-projectIpAccessList-getProjectIpAccessListStatus.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getProjectIpAccessListStatus
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-getProjectIpList.txt
+++ b/docs/command/atlas-api-projectIpAccessList-getProjectIpList.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getProjectIpList
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-getProjectIpList.txt
+++ b/docs/command/atlas-api-projectIpAccessList-getProjectIpList.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-listProjectIpAccessLists.txt
+++ b/docs/command/atlas-api-projectIpAccessList-listProjectIpAccessLists.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projectIpAccessList-listProjectIpAccessLists.txt
+++ b/docs/command/atlas-api-projectIpAccessList-listProjectIpAccessLists.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-addUserToProject.txt
+++ b/docs/command/atlas-api-projects-addUserToProject.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-addUserToProject.txt
+++ b/docs/command/atlas-api-projects-addUserToProject.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for addUserToProject
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-createProject.txt
+++ b/docs/command/atlas-api-projects-createProject.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-createProject.txt
+++ b/docs/command/atlas-api-projects-createProject.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for createProject
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-createProjectInvitation.txt
+++ b/docs/command/atlas-api-projects-createProjectInvitation.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createProjectInvitation
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-createProjectInvitation.txt
+++ b/docs/command/atlas-api-projects-createProjectInvitation.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-deleteProject.txt
+++ b/docs/command/atlas-api-projects-deleteProject.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-deleteProject.txt
+++ b/docs/command/atlas-api-projects-deleteProject.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for deleteProject
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-deleteProjectInvitation.txt
+++ b/docs/command/atlas-api-projects-deleteProjectInvitation.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-deleteProjectInvitation.txt
+++ b/docs/command/atlas-api-projects-deleteProjectInvitation.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the invitation.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-deleteProjectLimit.txt
+++ b/docs/command/atlas-api-projects-deleteProjectLimit.txt
@@ -76,11 +76,11 @@ Options
        | atlas.project.deployment.privateServiceConnectionsSubnetMask | Subnet mask for GCP PSC Networks. Has lower limit of 20. | 27 | 27|
        | atlas.project.deployment.salesSoldM0s | Limit on the number of M0 clusters in this project if the org is sales-sold | 100 | 100 |
        
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-deleteProjectLimit.txt
+++ b/docs/command/atlas-api-projects-deleteProjectLimit.txt
@@ -80,7 +80,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProject.txt
+++ b/docs/command/atlas-api-projects-getProject.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProject.txt
+++ b/docs/command/atlas-api-projects-getProject.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getProject
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectByName.txt
+++ b/docs/command/atlas-api-projects-getProjectByName.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectByName.txt
+++ b/docs/command/atlas-api-projects-getProjectByName.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for getProjectByName
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectInvitation.txt
+++ b/docs/command/atlas-api-projects-getProjectInvitation.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectInvitation.txt
+++ b/docs/command/atlas-api-projects-getProjectInvitation.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the invitation.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectLimit.txt
+++ b/docs/command/atlas-api-projects-getProjectLimit.txt
@@ -76,11 +76,11 @@ Options
        | atlas.project.deployment.privateServiceConnectionsSubnetMask | Subnet mask for GCP PSC Networks. Has lower limit of 20. | 27 | 27|
        | atlas.project.deployment.salesSoldM0s | Limit on the number of M0 clusters in this project if the org is sales-sold | 100 | 100 |
        
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectLimit.txt
+++ b/docs/command/atlas-api-projects-getProjectLimit.txt
@@ -80,7 +80,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectLtsVersions.txt
+++ b/docs/command/atlas-api-projects-getProjectLtsVersions.txt
@@ -73,7 +73,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectLtsVersions.txt
+++ b/docs/command/atlas-api-projects-getProjectLtsVersions.txt
@@ -69,11 +69,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectSettings.txt
+++ b/docs/command/atlas-api-projects-getProjectSettings.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-getProjectSettings.txt
+++ b/docs/command/atlas-api-projects-getProjectSettings.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getProjectSettings
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-listProjectInvitations.txt
+++ b/docs/command/atlas-api-projects-listProjectInvitations.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-listProjectInvitations.txt
+++ b/docs/command/atlas-api-projects-listProjectInvitations.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listProjectInvitations
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-listProjectLimits.txt
+++ b/docs/command/atlas-api-projects-listProjectLimits.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-listProjectLimits.txt
+++ b/docs/command/atlas-api-projects-listProjectLimits.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for listProjectLimits
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-listProjects.txt
+++ b/docs/command/atlas-api-projects-listProjects.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-listProjects.txt
+++ b/docs/command/atlas-api-projects-listProjects.txt
@@ -57,11 +57,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-migrateProjectToAnotherOrg.txt
+++ b/docs/command/atlas-api-projects-migrateProjectToAnotherOrg.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for migrateProjectToAnotherOrg
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-migrateProjectToAnotherOrg.txt
+++ b/docs/command/atlas-api-projects-migrateProjectToAnotherOrg.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-returnAllIpAddresses.txt
+++ b/docs/command/atlas-api-projects-returnAllIpAddresses.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-returnAllIpAddresses.txt
+++ b/docs/command/atlas-api-projects-returnAllIpAddresses.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for returnAllIpAddresses
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-setProjectLimit.txt
+++ b/docs/command/atlas-api-projects-setProjectLimit.txt
@@ -83,11 +83,11 @@ Options
        | atlas.project.deployment.privateServiceConnectionsSubnetMask | Subnet mask for GCP PSC Networks. Has lower limit of 20. | 27 | 27|
        | atlas.project.deployment.salesSoldM0s | Limit on the number of M0 clusters in this project if the org is sales-sold | 100 | 100 |
        
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-setProjectLimit.txt
+++ b/docs/command/atlas-api-projects-setProjectLimit.txt
@@ -87,7 +87,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProject.txt
+++ b/docs/command/atlas-api-projects-updateProject.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateProject
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProject.txt
+++ b/docs/command/atlas-api-projects-updateProject.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProjectInvitation.txt
+++ b/docs/command/atlas-api-projects-updateProjectInvitation.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateProjectInvitation
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProjectInvitation.txt
+++ b/docs/command/atlas-api-projects-updateProjectInvitation.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProjectInvitationById.txt
+++ b/docs/command/atlas-api-projects-updateProjectInvitationById.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProjectInvitationById.txt
+++ b/docs/command/atlas-api-projects-updateProjectInvitationById.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the invitation.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProjectRoles.txt
+++ b/docs/command/atlas-api-projects-updateProjectRoles.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateProjectRoles
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProjectRoles.txt
+++ b/docs/command/atlas-api-projects-updateProjectRoles.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProjectSettings.txt
+++ b/docs/command/atlas-api-projects-updateProjectSettings.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateProjectSettings
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-projects-updateProjectSettings.txt
+++ b/docs/command/atlas-api-projects-updateProjectSettings.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-pushBasedLogExport-createPushBasedLogConfiguration.txt
+++ b/docs/command/atlas-api-pushBasedLogExport-createPushBasedLogConfiguration.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-pushBasedLogExport-createPushBasedLogConfiguration.txt
+++ b/docs/command/atlas-api-pushBasedLogExport-createPushBasedLogConfiguration.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for createPushBasedLogConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-pushBasedLogExport-deletePushBasedLogConfiguration.txt
+++ b/docs/command/atlas-api-pushBasedLogExport-deletePushBasedLogConfiguration.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-pushBasedLogExport-deletePushBasedLogConfiguration.txt
+++ b/docs/command/atlas-api-pushBasedLogExport-deletePushBasedLogConfiguration.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for deletePushBasedLogConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-pushBasedLogExport-getPushBasedLogConfiguration.txt
+++ b/docs/command/atlas-api-pushBasedLogExport-getPushBasedLogConfiguration.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-pushBasedLogExport-getPushBasedLogConfiguration.txt
+++ b/docs/command/atlas-api-pushBasedLogExport-getPushBasedLogConfiguration.txt
@@ -53,11 +53,11 @@ Options
      - 
      - false
      - help for getPushBasedLogConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-pushBasedLogExport-updatePushBasedLogConfiguration.txt
+++ b/docs/command/atlas-api-pushBasedLogExport-updatePushBasedLogConfiguration.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for updatePushBasedLogConfiguration
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-pushBasedLogExport-updatePushBasedLogConfiguration.txt
+++ b/docs/command/atlas-api-pushBasedLogExport-updatePushBasedLogConfiguration.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-createAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-createAtlasResourcePolicy.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-createAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-createAtlasResourcePolicy.txt
@@ -55,11 +55,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-deleteAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-deleteAtlasResourcePolicy.txt
@@ -55,7 +55,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-deleteAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-deleteAtlasResourcePolicy.txt
@@ -51,11 +51,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-getAtlasResourcePolicies.txt
+++ b/docs/command/atlas-api-resourcePolicies-getAtlasResourcePolicies.txt
@@ -55,7 +55,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-getAtlasResourcePolicies.txt
+++ b/docs/command/atlas-api-resourcePolicies-getAtlasResourcePolicies.txt
@@ -51,11 +51,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-getAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-getAtlasResourcePolicy.txt
@@ -55,7 +55,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-getAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-getAtlasResourcePolicy.txt
@@ -51,11 +51,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-getResourcesNonCompliant.txt
+++ b/docs/command/atlas-api-resourcePolicies-getResourcesNonCompliant.txt
@@ -55,7 +55,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-getResourcesNonCompliant.txt
+++ b/docs/command/atlas-api-resourcePolicies-getResourcesNonCompliant.txt
@@ -51,11 +51,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-updateAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-updateAtlasResourcePolicy.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-updateAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-updateAtlasResourcePolicy.txt
@@ -55,11 +55,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-validateAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-validateAtlasResourcePolicy.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-resourcePolicies-validateAtlasResourcePolicy.txt
+++ b/docs/command/atlas-api-resourcePolicies-validateAtlasResourcePolicy.txt
@@ -55,11 +55,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-rollingIndex-createRollingIndex.txt
+++ b/docs/command/atlas-api-rollingIndex-createRollingIndex.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-rollingIndex-createRollingIndex.txt
+++ b/docs/command/atlas-api-rollingIndex-createRollingIndex.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createRollingIndex
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-root-getSystemStatus.txt
+++ b/docs/command/atlas-api-root-getSystemStatus.txt
@@ -47,11 +47,11 @@ Options
      - 
      - false
      - help for getSystemStatus
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-root-getSystemStatus.txt
+++ b/docs/command/atlas-api-root-getSystemStatus.txt
@@ -51,7 +51,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-root-returnAllControlPlaneIpAddresses.txt
+++ b/docs/command/atlas-api-root-returnAllControlPlaneIpAddresses.txt
@@ -47,11 +47,11 @@ Options
      - 
      - false
      - help for returnAllControlPlaneIpAddresses
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-root-returnAllControlPlaneIpAddresses.txt
+++ b/docs/command/atlas-api-root-returnAllControlPlaneIpAddresses.txt
@@ -51,7 +51,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-createServerlessInstance.txt
+++ b/docs/command/atlas-api-serverlessInstances-createServerlessInstance.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-createServerlessInstance.txt
+++ b/docs/command/atlas-api-serverlessInstances-createServerlessInstance.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for createServerlessInstance
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-deleteServerlessInstance.txt
+++ b/docs/command/atlas-api-serverlessInstances-deleteServerlessInstance.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-deleteServerlessInstance.txt
+++ b/docs/command/atlas-api-serverlessInstances-deleteServerlessInstance.txt
@@ -62,11 +62,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the serverless instance.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-getServerlessInstance.txt
+++ b/docs/command/atlas-api-serverlessInstances-getServerlessInstance.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-getServerlessInstance.txt
+++ b/docs/command/atlas-api-serverlessInstances-getServerlessInstance.txt
@@ -62,11 +62,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the serverless instance.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-listServerlessInstances.txt
+++ b/docs/command/atlas-api-serverlessInstances-listServerlessInstances.txt
@@ -66,11 +66,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-listServerlessInstances.txt
+++ b/docs/command/atlas-api-serverlessInstances-listServerlessInstances.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-updateServerlessInstance.txt
+++ b/docs/command/atlas-api-serverlessInstances-updateServerlessInstance.txt
@@ -66,11 +66,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the serverless instance.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessInstances-updateServerlessInstance.txt
+++ b/docs/command/atlas-api-serverlessInstances-updateServerlessInstance.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-createServerlessPrivateEndpoint.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-createServerlessPrivateEndpoint.txt
@@ -73,7 +73,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-createServerlessPrivateEndpoint.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-createServerlessPrivateEndpoint.txt
@@ -69,11 +69,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the serverless instance for which the tenant endpoint will be created.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-deleteServerlessPrivateEndpoint.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-deleteServerlessPrivateEndpoint.txt
@@ -66,11 +66,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the serverless instance from which the tenant endpoint will be removed.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-deleteServerlessPrivateEndpoint.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-deleteServerlessPrivateEndpoint.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-getServerlessPrivateEndpoint.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-getServerlessPrivateEndpoint.txt
@@ -66,11 +66,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the serverless instance associated with the tenant endpoint.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-getServerlessPrivateEndpoint.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-getServerlessPrivateEndpoint.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-listServerlessPrivateEndpoints.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-listServerlessPrivateEndpoints.txt
@@ -62,11 +62,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the serverless instance associated with the tenant endpoint.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-listServerlessPrivateEndpoints.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-listServerlessPrivateEndpoints.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-updateServerlessPrivateEndpoint.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-updateServerlessPrivateEndpoint.txt
@@ -74,7 +74,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serverlessPrivateEndpoints-updateServerlessPrivateEndpoint.txt
+++ b/docs/command/atlas-api-serverlessPrivateEndpoints-updateServerlessPrivateEndpoint.txt
@@ -70,11 +70,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the serverless instance associated with the tenant endpoint that will be updated.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-addProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-addProjectServiceAccount.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-addProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-addProjectServiceAccount.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for addProjectServiceAccount
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-createProjectServiceAccount.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-createProjectServiceAccount.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createProjectServiceAccount
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createProjectServiceAccountAccessList.txt
+++ b/docs/command/atlas-api-serviceAccounts-createProjectServiceAccountAccessList.txt
@@ -71,11 +71,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createProjectServiceAccountAccessList.txt
+++ b/docs/command/atlas-api-serviceAccounts-createProjectServiceAccountAccessList.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createProjectServiceAccountSecret.txt
+++ b/docs/command/atlas-api-serviceAccounts-createProjectServiceAccountSecret.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createProjectServiceAccountSecret.txt
+++ b/docs/command/atlas-api-serviceAccounts-createProjectServiceAccountSecret.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for createProjectServiceAccountSecret
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-createServiceAccount.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-createServiceAccount.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createServiceAccountAccessList.txt
+++ b/docs/command/atlas-api-serviceAccounts-createServiceAccountAccessList.txt
@@ -73,7 +73,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createServiceAccountAccessList.txt
+++ b/docs/command/atlas-api-serviceAccounts-createServiceAccountAccessList.txt
@@ -69,11 +69,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createServiceAccountSecret.txt
+++ b/docs/command/atlas-api-serviceAccounts-createServiceAccountSecret.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-createServiceAccountSecret.txt
+++ b/docs/command/atlas-api-serviceAccounts-createServiceAccountSecret.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccount.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteProjectServiceAccount
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccount.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccountAccessListEntry.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccountAccessListEntry.txt
@@ -63,11 +63,11 @@ Options
      - string
      - true
      - One IP address or multiple IP addresses represented as one CIDR block. When specifying a CIDR block with a subnet mask, such as 192.0.2.0/24, use the URL-encoded value %2F for the forward slash /.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccountAccessListEntry.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccountAccessListEntry.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccountSecret.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccountSecret.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccountSecret.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteProjectServiceAccountSecret.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteProjectServiceAccountSecret
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteServiceAccount.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteServiceAccount.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteServiceAccountAccessListEntry.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteServiceAccountAccessListEntry.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteServiceAccountAccessListEntry.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteServiceAccountAccessListEntry.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteServiceAccountSecret.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteServiceAccountSecret.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-deleteServiceAccountSecret.txt
+++ b/docs/command/atlas-api-serviceAccounts-deleteServiceAccountSecret.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-getProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-getProjectServiceAccount.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getProjectServiceAccount
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-getProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-getProjectServiceAccount.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-getServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-getServiceAccount.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-getServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-getServiceAccount.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listProjectServiceAccountAccessList.txt
+++ b/docs/command/atlas-api-serviceAccounts-listProjectServiceAccountAccessList.txt
@@ -67,11 +67,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listProjectServiceAccountAccessList.txt
+++ b/docs/command/atlas-api-serviceAccounts-listProjectServiceAccountAccessList.txt
@@ -71,7 +71,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listProjectServiceAccounts.txt
+++ b/docs/command/atlas-api-serviceAccounts-listProjectServiceAccounts.txt
@@ -59,11 +59,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listProjectServiceAccounts.txt
+++ b/docs/command/atlas-api-serviceAccounts-listProjectServiceAccounts.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listServiceAccountAccessList.txt
+++ b/docs/command/atlas-api-serviceAccounts-listServiceAccountAccessList.txt
@@ -69,7 +69,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listServiceAccountAccessList.txt
+++ b/docs/command/atlas-api-serviceAccounts-listServiceAccountAccessList.txt
@@ -65,11 +65,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listServiceAccountProjects.txt
+++ b/docs/command/atlas-api-serviceAccounts-listServiceAccountProjects.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listServiceAccountProjects.txt
+++ b/docs/command/atlas-api-serviceAccounts-listServiceAccountProjects.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listServiceAccounts.txt
+++ b/docs/command/atlas-api-serviceAccounts-listServiceAccounts.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-listServiceAccounts.txt
+++ b/docs/command/atlas-api-serviceAccounts-listServiceAccounts.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-updateProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-updateProjectServiceAccount.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-updateProjectServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-updateProjectServiceAccount.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updateProjectServiceAccount
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-updateServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-updateServiceAccount.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-serviceAccounts-updateServiceAccount.txt
+++ b/docs/command/atlas-api-serviceAccounts-updateServiceAccount.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierRestoreJobs-createSharedClusterBackupRestoreJob.txt
+++ b/docs/command/atlas-api-sharedTierRestoreJobs-createSharedClusterBackupRestoreJob.txt
@@ -66,11 +66,11 @@ Options
      - 
      - false
      - help for createSharedClusterBackupRestoreJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierRestoreJobs-createSharedClusterBackupRestoreJob.txt
+++ b/docs/command/atlas-api-sharedTierRestoreJobs-createSharedClusterBackupRestoreJob.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierRestoreJobs-getSharedClusterBackupRestoreJob.txt
+++ b/docs/command/atlas-api-sharedTierRestoreJobs-getSharedClusterBackupRestoreJob.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierRestoreJobs-getSharedClusterBackupRestoreJob.txt
+++ b/docs/command/atlas-api-sharedTierRestoreJobs-getSharedClusterBackupRestoreJob.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for getSharedClusterBackupRestoreJob
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierRestoreJobs-listSharedClusterBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-sharedTierRestoreJobs-listSharedClusterBackupRestoreJobs.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierRestoreJobs-listSharedClusterBackupRestoreJobs.txt
+++ b/docs/command/atlas-api-sharedTierRestoreJobs-listSharedClusterBackupRestoreJobs.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for listSharedClusterBackupRestoreJobs
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierSnapshots-downloadSharedClusterBackup.txt
+++ b/docs/command/atlas-api-sharedTierSnapshots-downloadSharedClusterBackup.txt
@@ -66,11 +66,11 @@ Options
      - 
      - false
      - help for downloadSharedClusterBackup
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierSnapshots-downloadSharedClusterBackup.txt
+++ b/docs/command/atlas-api-sharedTierSnapshots-downloadSharedClusterBackup.txt
@@ -70,7 +70,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierSnapshots-getSharedClusterBackup.txt
+++ b/docs/command/atlas-api-sharedTierSnapshots-getSharedClusterBackup.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierSnapshots-getSharedClusterBackup.txt
+++ b/docs/command/atlas-api-sharedTierSnapshots-getSharedClusterBackup.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for getSharedClusterBackup
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierSnapshots-listSharedClusterBackups.txt
+++ b/docs/command/atlas-api-sharedTierSnapshots-listSharedClusterBackups.txt
@@ -66,7 +66,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-sharedTierSnapshots-listSharedClusterBackups.txt
+++ b/docs/command/atlas-api-sharedTierSnapshots-listSharedClusterBackups.txt
@@ -62,11 +62,11 @@ Options
      - 
      - false
      - help for listSharedClusterBackups
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-acceptVpcPeeringConnection.txt
+++ b/docs/command/atlas-api-streams-acceptVpcPeeringConnection.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-acceptVpcPeeringConnection.txt
+++ b/docs/command/atlas-api-streams-acceptVpcPeeringConnection.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - The VPC Peering Connection id.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createPrivateLinkConnection.txt
+++ b/docs/command/atlas-api-streams-createPrivateLinkConnection.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createPrivateLinkConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createPrivateLinkConnection.txt
+++ b/docs/command/atlas-api-streams-createPrivateLinkConnection.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createStreamConnection.txt
+++ b/docs/command/atlas-api-streams-createStreamConnection.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createStreamConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createStreamConnection.txt
+++ b/docs/command/atlas-api-streams-createStreamConnection.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createStreamInstance.txt
+++ b/docs/command/atlas-api-streams-createStreamInstance.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createStreamInstance
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createStreamInstance.txt
+++ b/docs/command/atlas-api-streams-createStreamInstance.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createStreamInstanceWithSampleConnections.txt
+++ b/docs/command/atlas-api-streams-createStreamInstanceWithSampleConnections.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createStreamInstanceWithSampleConnections
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createStreamInstanceWithSampleConnections.txt
+++ b/docs/command/atlas-api-streams-createStreamInstanceWithSampleConnections.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-createStreamProcessor.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for createStreamProcessor
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-createStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-createStreamProcessor.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deletePrivateLinkConnection.txt
+++ b/docs/command/atlas-api-streams-deletePrivateLinkConnection.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deletePrivateLinkConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deletePrivateLinkConnection.txt
+++ b/docs/command/atlas-api-streams-deletePrivateLinkConnection.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deleteStreamConnection.txt
+++ b/docs/command/atlas-api-streams-deleteStreamConnection.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for deleteStreamConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deleteStreamConnection.txt
+++ b/docs/command/atlas-api-streams-deleteStreamConnection.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deleteStreamInstance.txt
+++ b/docs/command/atlas-api-streams-deleteStreamInstance.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deleteStreamInstance.txt
+++ b/docs/command/atlas-api-streams-deleteStreamInstance.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for deleteStreamInstance
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deleteStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-deleteStreamProcessor.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for deleteStreamProcessor
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deleteStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-deleteStreamProcessor.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deleteVpcPeeringConnection.txt
+++ b/docs/command/atlas-api-streams-deleteVpcPeeringConnection.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - The VPC Peering Connection id.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-deleteVpcPeeringConnection.txt
+++ b/docs/command/atlas-api-streams-deleteVpcPeeringConnection.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-downloadStreamTenantAuditLogs.txt
+++ b/docs/command/atlas-api-streams-downloadStreamTenantAuditLogs.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["gzip"] This value defaults to "gzip".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-downloadStreamTenantAuditLogs.txt
+++ b/docs/command/atlas-api-streams-downloadStreamTenantAuditLogs.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for downloadStreamTenantAuditLogs
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["gzip"] This value defaults to "gzip".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getAccountDetails.txt
+++ b/docs/command/atlas-api-streams-getAccountDetails.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getAccountDetails.txt
+++ b/docs/command/atlas-api-streams-getAccountDetails.txt
@@ -57,11 +57,11 @@ Options
      - 
      - false
      - help for getAccountDetails
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getActiveVpcPeeringConnections.txt
+++ b/docs/command/atlas-api-streams-getActiveVpcPeeringConnections.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getActiveVpcPeeringConnections.txt
+++ b/docs/command/atlas-api-streams-getActiveVpcPeeringConnections.txt
@@ -57,11 +57,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getPrivateLinkConnection.txt
+++ b/docs/command/atlas-api-streams-getPrivateLinkConnection.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getPrivateLinkConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getPrivateLinkConnection.txt
+++ b/docs/command/atlas-api-streams-getPrivateLinkConnection.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getStreamConnection.txt
+++ b/docs/command/atlas-api-streams-getStreamConnection.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getStreamConnection.txt
+++ b/docs/command/atlas-api-streams-getStreamConnection.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for getStreamConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getStreamInstance.txt
+++ b/docs/command/atlas-api-streams-getStreamInstance.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - Flag to indicate whether connections information should be included in the stream instance.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getStreamInstance.txt
+++ b/docs/command/atlas-api-streams-getStreamInstance.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-getStreamProcessor.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for getStreamProcessor
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-getStreamProcessor.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getVpcPeeringConnections.txt
+++ b/docs/command/atlas-api-streams-getVpcPeeringConnections.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-getVpcPeeringConnections.txt
+++ b/docs/command/atlas-api-streams-getVpcPeeringConnections.txt
@@ -57,11 +57,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-listPrivateLinkConnections.txt
+++ b/docs/command/atlas-api-streams-listPrivateLinkConnections.txt
@@ -59,11 +59,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-listPrivateLinkConnections.txt
+++ b/docs/command/atlas-api-streams-listPrivateLinkConnections.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-listStreamConnections.txt
+++ b/docs/command/atlas-api-streams-listStreamConnections.txt
@@ -59,11 +59,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-listStreamConnections.txt
+++ b/docs/command/atlas-api-streams-listStreamConnections.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-listStreamInstances.txt
+++ b/docs/command/atlas-api-streams-listStreamInstances.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-listStreamInstances.txt
+++ b/docs/command/atlas-api-streams-listStreamInstances.txt
@@ -57,11 +57,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-listStreamProcessors.txt
+++ b/docs/command/atlas-api-streams-listStreamProcessors.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-listStreamProcessors.txt
+++ b/docs/command/atlas-api-streams-listStreamProcessors.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-modifyStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-modifyStreamProcessor.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-modifyStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-modifyStreamProcessor.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for modifyStreamProcessor
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-rejectVpcPeeringConnection.txt
+++ b/docs/command/atlas-api-streams-rejectVpcPeeringConnection.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - The VPC Peering Connection id.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-rejectVpcPeeringConnection.txt
+++ b/docs/command/atlas-api-streams-rejectVpcPeeringConnection.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-startStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-startStreamProcessor.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-startStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-startStreamProcessor.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for startStreamProcessor
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-stopStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-stopStreamProcessor.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-stopStreamProcessor.txt
+++ b/docs/command/atlas-api-streams-stopStreamProcessor.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for stopStreamProcessor
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-updateStreamConnection.txt
+++ b/docs/command/atlas-api-streams-updateStreamConnection.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-updateStreamConnection.txt
+++ b/docs/command/atlas-api-streams-updateStreamConnection.txt
@@ -63,11 +63,11 @@ Options
      - 
      - false
      - help for updateStreamConnection
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-updateStreamInstance.txt
+++ b/docs/command/atlas-api-streams-updateStreamInstance.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateStreamInstance
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-streams-updateStreamInstance.txt
+++ b/docs/command/atlas-api-streams-updateStreamInstance.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-addAllTeamsToProject.txt
+++ b/docs/command/atlas-api-teams-addAllTeamsToProject.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for addAllTeamsToProject
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-addAllTeamsToProject.txt
+++ b/docs/command/atlas-api-teams-addAllTeamsToProject.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-addTeamUser.txt
+++ b/docs/command/atlas-api-teams-addTeamUser.txt
@@ -64,7 +64,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-addTeamUser.txt
+++ b/docs/command/atlas-api-teams-addTeamUser.txt
@@ -60,11 +60,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-createTeam.txt
+++ b/docs/command/atlas-api-teams-createTeam.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-createTeam.txt
+++ b/docs/command/atlas-api-teams-createTeam.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-deleteTeam.txt
+++ b/docs/command/atlas-api-teams-deleteTeam.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-deleteTeam.txt
+++ b/docs/command/atlas-api-teams-deleteTeam.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-getTeamById.txt
+++ b/docs/command/atlas-api-teams-getTeamById.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-getTeamById.txt
+++ b/docs/command/atlas-api-teams-getTeamById.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-getTeamByName.txt
+++ b/docs/command/atlas-api-teams-getTeamByName.txt
@@ -53,11 +53,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-getTeamByName.txt
+++ b/docs/command/atlas-api-teams-getTeamByName.txt
@@ -57,7 +57,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-listOrganizationTeams.txt
+++ b/docs/command/atlas-api-teams-listOrganizationTeams.txt
@@ -65,7 +65,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-listOrganizationTeams.txt
+++ b/docs/command/atlas-api-teams-listOrganizationTeams.txt
@@ -61,11 +61,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-listProjectTeams.txt
+++ b/docs/command/atlas-api-teams-listProjectTeams.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-listProjectTeams.txt
+++ b/docs/command/atlas-api-teams-listProjectTeams.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-removeProjectTeam.txt
+++ b/docs/command/atlas-api-teams-removeProjectTeam.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-removeProjectTeam.txt
+++ b/docs/command/atlas-api-teams-removeProjectTeam.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for removeProjectTeam
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-removeTeamUser.txt
+++ b/docs/command/atlas-api-teams-removeTeamUser.txt
@@ -56,11 +56,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-removeTeamUser.txt
+++ b/docs/command/atlas-api-teams-removeTeamUser.txt
@@ -60,7 +60,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-renameTeam.txt
+++ b/docs/command/atlas-api-teams-renameTeam.txt
@@ -61,7 +61,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-renameTeam.txt
+++ b/docs/command/atlas-api-teams-renameTeam.txt
@@ -57,11 +57,11 @@ Options
      - string
      - true
      - Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-updateTeamRoles.txt
+++ b/docs/command/atlas-api-teams-updateTeamRoles.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-teams-updateTeamRoles.txt
+++ b/docs/command/atlas-api-teams-updateTeamRoles.txt
@@ -59,11 +59,11 @@ Options
      - 
      - false
      - help for updateTeamRoles
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-createThirdPartyIntegration.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-createThirdPartyIntegration.txt
@@ -71,11 +71,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-createThirdPartyIntegration.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-createThirdPartyIntegration.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-deleteThirdPartyIntegration.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-deleteThirdPartyIntegration.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-deleteThirdPartyIntegration.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-deleteThirdPartyIntegration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-getThirdPartyIntegration.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-getThirdPartyIntegration.txt
@@ -59,11 +59,11 @@ Options
      - string
      - true
      - Human-readable label that identifies the service which you want to integrate with MongoDB Cloud.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-getThirdPartyIntegration.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-getThirdPartyIntegration.txt
@@ -63,7 +63,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-listThirdPartyIntegrations.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-listThirdPartyIntegrations.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-listThirdPartyIntegrations.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-listThirdPartyIntegrations.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-updateThirdPartyIntegration.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-updateThirdPartyIntegration.txt
@@ -71,11 +71,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-thirdPartyIntegrations-updateThirdPartyIntegration.txt
+++ b/docs/command/atlas-api-thirdPartyIntegrations-updateThirdPartyIntegration.txt
@@ -75,7 +75,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-x509Authentication-createDatabaseUserCertificate.txt
+++ b/docs/command/atlas-api-x509Authentication-createDatabaseUserCertificate.txt
@@ -69,7 +69,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-x509Authentication-createDatabaseUserCertificate.txt
+++ b/docs/command/atlas-api-x509Authentication-createDatabaseUserCertificate.txt
@@ -65,11 +65,11 @@ Options
      - 
      - false
      - help for createDatabaseUserCertificate
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-x509Authentication-disableCustomerManagedX509.txt
+++ b/docs/command/atlas-api-x509Authentication-disableCustomerManagedX509.txt
@@ -59,7 +59,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-x509Authentication-disableCustomerManagedX509.txt
+++ b/docs/command/atlas-api-x509Authentication-disableCustomerManagedX509.txt
@@ -55,11 +55,11 @@ Options
      - 
      - false
      - help for disableCustomerManagedX509
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-x509Authentication-listDatabaseUserCertificates.txt
+++ b/docs/command/atlas-api-x509Authentication-listDatabaseUserCertificates.txt
@@ -63,11 +63,11 @@ Options
      - int
      - false
      - Number of items that the response returns per page.
-   * - --output
+   * - -o, --output
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - -o, --outputFile
+   * - --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/docs/command/atlas-api-x509Authentication-listDatabaseUserCertificates.txt
+++ b/docs/command/atlas-api-x509Authentication-listDatabaseUserCertificates.txt
@@ -67,7 +67,7 @@ Options
      - string
      - false
      - preferred api format, can be ["json", go-template] This value defaults to "json".
-   * - --output-file
+   * - -o, --outputFile
      - string
      - false
      - file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)

--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -521,7 +521,7 @@ func addOutputFlags(cmd *cobra.Command, apiCommand shared_api.Command, format *s
 
 	// Set the flags
 	cmd.Flags().StringVar(format, flag.Output, *format, fmt.Sprintf("preferred api format, can be [%s]", supportedContentTypesString))
-	cmd.Flags().StringVar(outputFile, flag.OutputFile, "", "file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)")
+	cmd.Flags().StringVarP(outputFile, flag.OutputFile, flag.OutputShort, "", "file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)")
 
 	// If there's multiple content types, mark --format as required
 	if numSupportedContentTypes > 1 {

--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -520,8 +520,8 @@ func addOutputFlags(cmd *cobra.Command, apiCommand shared_api.Command, format *s
 	supportedContentTypesString := strings.Join(supportedContentTypesList, ", ")
 
 	// Set the flags
-	cmd.Flags().StringVar(format, flag.Output, *format, fmt.Sprintf("preferred api format, can be [%s]", supportedContentTypesString))
-	cmd.Flags().StringVarP(outputFile, flag.OutputFile, flag.OutputShort, "", "file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)")
+	cmd.Flags().StringVarP(format, flag.Output, flag.OutputShort, *format, fmt.Sprintf("preferred api format, can be [%s]", supportedContentTypesString))
+	cmd.Flags().StringVar(outputFile, flag.OutputFile, "", "file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)")
 
 	// If there's multiple content types, mark --format as required
 	if numSupportedContentTypes > 1 {

--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -78,7 +78,7 @@ const (
 	Out                                           = "out"                                           // Out flag
 	Output                                        = "output"                                        // Output flag
 	OutputShort                                   = "o"                                             // OutputShort flag
-	OutputFile                                    = "output-file"                                   // OutputFile flag
+	OutputFile                                    = "outputFile"                                    // OutputFile flag
 	Status                                        = "status"                                        // Status flag
 	Start                                         = "start"                                         // Start flag
 	End                                           = "end"                                           // End flag


### PR DESCRIPTION
Ticket: CLOUDP-310107

# Description
This PR renames `--output-file` to `--outputFile` (**breaking change**) and add support for `-o` to the `--output` flag for autogenerated commands.

## How to review this PR
Most of the files are autogenerated. You need to review only `api.go` and `flags.go`.

### Testing
```bash
./bin/atlas api projects listProjects --help

Public Preview: please provide feedback at https://feedback.mongodb.com/forums/930808-atlas-cli.

Returns details about all projects. Projects group clusters into logical collections that support an application environment, workload, or both. Each project can have its own users, teams, security, tags, and alert settings. To use this resource, the requesting Service Account or API Key must have the Organization Read Only role or higher.

This command is autogenerated and corresponds 1:1 with the Atlas API endpoint https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Projects/operation/listProjects.

For more information and examples, see: https://www.mongodb.com/docs/atlas/cli/current/command/atlas-api-projects-listProjects/

Usage:
  atlas api projects listProjects [flags]

Flags:
      --envelope            flag that indicates whether Application wraps the response in an envelope JSON object
  -h, --help                help for listProjects
      --includeCount        flag that indicates whether the response returns the total number of items (totalCount) in the response
      --itemsPerPage int    number of items that the response returns per page
  -o, --output string       preferred api format, can be ["json", go-template] (default "json")
      --outputFile string   file to write the api output to. This flag is required when the output of an endpoint is binary (ex: gzip) and the command is not piped (ex: atlas command > out.zip)
      --pageNum int         number of the page that displays the current set of the total objects that the response returns
      --pretty              flag that indicates whether the response body should be in the prettyprint format
      --version string      api version to use when calling the api call [options: "2023-01-01"], defaults to the latest version or the profiles api_version config value if set (default "2023-01-01")

Global Flags:
  -P, --profile string   Name of the profile to use from your configuration file. To learn about profiles for the Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings.
```

```bash
./bin/atlas api projects listProjects -P dev -o json                                                                                                            
warning: using default API version '2023-01-01'; consider pinning a version to ensure consisentcy when updating the CLI
```
```json
{"links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups?pageNum=1&itemsPerPage=100","rel":"self"}],"results":[{"clusterCount":0,"created":"2023-08-18T13:35:01Z","id":"64df7382ca8f696f6f828ecb","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/64df7382ca8f696f6f828ecb","rel":"self"}],"name":"BCP","orgId":"5e429e7706822c6eac4d5970","tags":[]},{"clusterCount":0,"created":"2023-07-17T14:08:08Z","id":"64b54b47b9429a67128033fa","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/64b54b47b9429a67128033fa","rel":"self"}],"name":"CLI 2 Bianca","orgId":"5e429e7706822c6eac4d5970","tags":[]},{"clusterCount":0,"created":"2020-02-20T10:02:42Z","id":"5e4e593f70dfbf1010295836","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/5e4e593f70dfbf1010295836","rel":"self"}],"name":"CLI ANDREA","orgId":"5e429e7706822c6eac4d5970","tags":[]},{"clusterCount":0,"created":"2022-01-10T16:06:40Z","id":"61dc598fd1f07c7b37ba425d","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/61dc598fd1f07c7b37ba425d","rel":"self"}],"name":"CLI Bianca","orgId":"5e429e7706822c6eac4d5970","tags":[]},{"clusterCount":0,"created":"2020-02-11T12:33:55Z","id":"5e429f2e06822c6eac4d59c9","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/5e429f2e06822c6eac4d59c9","rel":"self"}],"name":"CLI tests","orgId":"5e429e7706822c6eac4d5970","tags":[]},{"clusterCount":0,"created":"2021-08-26T13:25:47Z","id":"61279659d7d1a561be8ab56e","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/61279659d7d1a561be8ab56e","rel":"self"}],"name":"TF GUS","orgId":"5e429e7706822c6eac4d5970","tags":[]},{"clusterCount":0,"created":"2024-11-25T14:59:51Z","id":"674490e57d607746dd153d6a","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/674490e57d607746dd153d6a","rel":"self"}],"name":"TestAAA","orgId":"5e429e7706822c6eac4d5970","tags":[]},{"clusterCount":0,"created":"2024-11-25T14:59:10Z","id":"674490bc7d607746dd153ca7","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/674490bc7d607746dd153ca7","rel":"self"}],"name":"TestAdnrea","orgId":"5e429e7706822c6eac4d5970","tags":[]},{"clusterCount":0,"created":"2023-03-08T11:05:24Z","id":"64086bf3e9f473572ea9392d","links":[{"href":"https://cloud-dev.mongodb.com/api/atlas/v2/groups/64086bf3e9f473572ea9392d","rel":"self"}],"name":"testAndrea","orgId":"5e429e7706822c6eac4d5970","tags":[]}],"totalCount":9}
```