### PR TITLE
CLOUDP-312241: [AtlasCLI] Podman local seed tests fail with Podman issue

### DIFF
--- a/internal/container/podman.go
+++ b/internal/container/podman.go
@@ -113,6 +113,7 @@ func (e *podmanImpl) ContainerRun(ctx context.Context, image string, flags *RunF
 			podmanOpts.HealthRetries = flags.HealthRetries
 		}
 		if flags.Volumes != nil {
+			podmanOpts.Volumes = map[string]string{}
 			for _, volume := range flags.Volumes {
 				podmanOpts.Volumes[volume.HostPath] = volume.ContainerPath
 			}


### PR DESCRIPTION
## Proposed changes

The seed tests are not the cause; they revealed another issue due to the increased test coverage.
There's an issue with passing volumes to the Podman implementation.

_Jira ticket:_ CLOUDP-312241

## Testing
I queued the following tasks on Evergreen as part of this PR (which were failing)


Task name | Build variant
-- | --
atlas_deployments_local_seed | E2E Local Deployments Tests (rhel8/podman)
atlas_deployments_local_seed | E2E Local Deployments Tests (rhel9/podman)