### PR TITLE
DEVPROD-16721: switch role used for writes to new bucket

### DIFF
--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -418,7 +418,7 @@ tasks:
           display_name: downloads-center-
       - command: s3.put
         params:
-          role_arn: "arn:aws:iam::119629040606:role/s3-access.cdn-origin-atlascli"
+          role_arn: "arn:aws:iam::119629040606:role/s3-access.cdn-origin-mongocli"
           local_files_include_filter:
             - src/github.com/mongodb/mongodb-atlas-cli/dist/*.tar.gz
             - src/github.com/mongodb/mongodb-atlas-cli/dist/*.zip


### PR DESCRIPTION
This commit adjusts the role we use to write to our new bucket. The previous role will only work when we separate out Atlas CLI from Mongo CLI's infrastructure. Because the two share a common bucket for now, I've swapped over to the appropriate role with access to that bucket.