### PR TITLE
CLOUDP-317690: [AtlasCLI] Drop ubuntu20.04 support

### DIFF
--- a/tools/cmd/genevergreen/generate/generate.go
+++ b/tools/cmd/genevergreen/generate/generate.go
@@ -45,7 +45,6 @@ var (
 		"rhel9",
 		"debian11",
 		"debian12",
-		"ubuntu20.04",
 		"ubuntu22.04",
 		"ubuntu24.04",
 	}
@@ -54,7 +53,6 @@ var (
 		"suse15":      "suse15-rpm",
 		"centos8":     "centos8-rpm",
 		"rhel9":       "rhel9-rpm",
-		"ubuntu20.04": "ubuntu20.04-deb",
 		"ubuntu22.04": "ubuntu22.04-deb",
 		"ubuntu24.04": "ubuntu24.04-deb",
 		"debian11":    "debian11-deb",
@@ -64,7 +62,6 @@ var (
 		"suse15":          "suse15",
 		"centos8":         "rhel80",
 		"rhel9":           "rhel90",
-		"ubuntu20.04":     "ubuntu2004",
 		"ubuntu22.04":     "ubuntu2204",
 		"ubuntu24.04":     "ubuntu2404",
 		"debian11":        "debian11",

--- a/tools/cmd/genevergreen/generate/generate_test.go
+++ b/tools/cmd/genevergreen/generate/generate_test.go
@@ -94,7 +94,7 @@ func TestPostPkgMetaTasks(t *testing.T) {
 		}
 	}
 	assert.Len(t, c.Variants, 1)
-	assert.Len(t, c.Tasks, 21)
+	assert.Len(t, c.Tasks, 18)
 }
 
 func TestRepoTasks(t *testing.T) {
@@ -115,5 +115,5 @@ func TestRepoTasks(t *testing.T) {
 	}
 
 	assert.Len(t, c.Variants, 3)
-	assert.Len(t, c.Tasks, 42)
+	assert.Len(t, c.Tasks, 36)
 }

--- a/tools/cmd/release/main.go
+++ b/tools/cmd/release/main.go
@@ -99,8 +99,8 @@ func generateFile(name, version string) error {
 		Platform: []*Platform{
 			newPlatform(version, "x86_64", "linux", "Linux (x86_64)", []string{"tar.gz"}),
 			newPlatform(version, "arm64", "linux", "Linux (arm64)", []string{"tar.gz"}),
-			newPlatform(version, "x86_64", "linux", "Debian 11, 12 / Ubuntu 20.04, 22.04, 24.04 (x86_64)", []string{"deb"}),
-			newPlatform(version, "arm64", "linux", "Debian 11, 12 / Ubuntu 20.04, 22.04, 24.04 (arm64)", []string{"deb"}),
+			newPlatform(version, "x86_64", "linux", "Debian 11, 12 / Ubuntu 22.04, 24.04 (x86_64)", []string{"deb"}),
+			newPlatform(version, "arm64", "linux", "Debian 11, 12 / Ubuntu 22.04, 24.04 (arm64)", []string{"deb"}),
 			newPlatform(version, "x86_64", "linux", "Red Hat + CentOS 8, 9 / SUSE 12 + 15 / Amazon Linux 2023 (x86_64)", []string{"rpm"}),
 			newPlatform(version, "arm64", "linux", "Red Hat + CentOS 8, 9 / SUSE 12 + 15 / Amazon Linux 2023 (arm64)", []string{"rpm"}),
 			newPlatform(version, "x86_64", "windows", "Microsoft Windows", []string{"msi", "zip"}),


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-317690

Ubuntu20.04 has reached EOL
