### PR TITLE
task: move mockgen to use go tool

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -245,8 +245,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: Install go-mock
-        run: go install go.uber.org/mock/mockgen@latest
       - name: Generate mocks
         run: make gen-mocks
       - name: Check for uncommitted files

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ deps:  ## Download go module dependencies
 .PHONY: devtools
 devtools:  ## Install dev tools
 	@echo "==> Installing dev tools..."
-	go install go.uber.org/mock/mockgen@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
 
 .PHONY: setup

--- a/go.mod
+++ b/go.mod
@@ -195,4 +195,5 @@ tool (
 	github.com/google/addlicense
 	github.com/google/go-licenses
 	github.com/icholy/gomajor
+	go.uber.org/mock/mockgen
 )

--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/tools/shared/api"
 )
 
-//go:generate mockgen -destination=./mocks.go -package=api github.com/mongodb/mongodb-atlas-cli/atlascli/internal/api CommandExecutor,Doer,ConfigProvider,CommandConverter,Logger,ResponseFormatter
+//go:generate go tool go.uber.org/mock/mockgen -destination=./mocks.go -package=api github.com/mongodb/mongodb-atlas-cli/atlascli/internal/api CommandExecutor,Doer,ConfigProvider,CommandConverter,Logger,ResponseFormatter
 
 type CommandExecutor interface {
 	ExecuteCommand(ctx context.Context, commandRequest CommandRequest) (*CommandResponse, error)

--- a/internal/cli/accesslists/create.go
+++ b/internal/cli/accesslists/create.go
@@ -38,7 +38,7 @@ const (
 	createTemplate   = "Created a new IP access list.\n"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=accesslists . ProjectIPAccessListCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=accesslists . ProjectIPAccessListCreator
 
 type ProjectIPAccessListCreator interface {
 	CreateProjectIPAccessList([]*atlasv2.NetworkPermissionEntry) (*atlasv2.PaginatedNetworkAccess, error)

--- a/internal/cli/accesslists/delete.go
+++ b/internal/cli/accesslists/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=accesslists . ProjectIPAccessListDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=accesslists . ProjectIPAccessListDeleter
 
 type ProjectIPAccessListDeleter interface {
 	DeleteProjectIPAccessList(string, string) error

--- a/internal/cli/accesslists/describe.go
+++ b/internal/cli/accesslists/describe.go
@@ -31,7 +31,7 @@ const describeTemplate = `CIDR BLOCK	SECURITY GROUP
 {{.CidrBlock}}	{{if .AwsSecurityGroup}}{{.AwsSecurityGroup}} {{else}}N/A{{end}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=accesslists . ProjectIPAccessListDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=accesslists . ProjectIPAccessListDescriber
 
 type ProjectIPAccessListDescriber interface {
 	IPAccessList(string, string) (*atlasv2.NetworkPermissionEntry, error)

--- a/internal/cli/accesslists/list.go
+++ b/internal/cli/accesslists/list.go
@@ -31,7 +31,7 @@ const listTemplate = `CIDR BLOCK	AWS SECURITY GROUP{{range valueOrEmptySlice .Re
 {{.CidrBlock}}	{{if .AwsSecurityGroup}}{{.AwsSecurityGroup}} {{else}}N/A{{end}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=accesslists . ProjectIPAccessListLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=accesslists . ProjectIPAccessListLister
 
 type ProjectIPAccessListLister interface {
 	ProjectIPAccessLists(string, *store.ListOptions) (*atlasv2.PaginatedNetworkAccess, error)

--- a/internal/cli/accesslogs/list.go
+++ b/internal/cli/accesslogs/list.go
@@ -38,7 +38,7 @@ const (
 	invalidValueAuthResultErrorMessage = "you must set --%s to %q or %q"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=accesslogs . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=accesslogs . Lister
 
 type Lister interface {
 	AccessLogsByHostname(string, string, *store.AccessLogOptions) (*atlasv2.MongoDBAccessLogsList, error)

--- a/internal/cli/alerts/acknowledge.go
+++ b/internal/cli/alerts/acknowledge.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=acknowledge_mock_test.go -package=alerts . AlertAcknowledger
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=acknowledge_mock_test.go -package=alerts . AlertAcknowledger
 
 type AlertAcknowledger interface {
 	AcknowledgeAlert(*atlasv2.AcknowledgeAlertApiParams) (*atlasv2.AlertViewForNdsGroup, error)

--- a/internal/cli/alerts/describe.go
+++ b/internal/cli/alerts/describe.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=alerts . AlertDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=alerts . AlertDescriber
 
 type AlertDescriber interface {
 	Alert(*atlasv2.GetAlertApiParams) (*atlasv2.AlertViewForNdsGroup, error)

--- a/internal/cli/alerts/list.go
+++ b/internal/cli/alerts/list.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=alerts . AlertLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=alerts . AlertLister
 
 type AlertLister interface {
 	Alerts(*atlasv2.ListAlertsApiParams) (*atlasv2.PaginatedAlert, error)

--- a/internal/cli/alerts/settings/create.go
+++ b/internal/cli/alerts/settings/create.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=settings . AlertConfigurationCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=settings . AlertConfigurationCreator
 
 type AlertConfigurationCreator interface {
 	CreateAlertConfiguration(*atlasv2.GroupAlertsConfig) (*atlasv2.GroupAlertsConfig, error)

--- a/internal/cli/alerts/settings/delete.go
+++ b/internal/cli/alerts/settings/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=settings . AlertConfigurationDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=settings . AlertConfigurationDeleter
 
 type AlertConfigurationDeleter interface {
 	DeleteAlertConfiguration(string, string) error

--- a/internal/cli/alerts/settings/describe.go
+++ b/internal/cli/alerts/settings/describe.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=settings . AlertConfigurationDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=settings . AlertConfigurationDescriber
 
 type AlertConfigurationDescriber interface {
 	AlertConfiguration(string, string) (*atlasv2.GroupAlertsConfig, error)

--- a/internal/cli/alerts/settings/disable.go
+++ b/internal/cli/alerts/settings/disable.go
@@ -25,7 +25,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=disable_mock_test.go -package=settings . AlertConfigurationDisabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=disable_mock_test.go -package=settings . AlertConfigurationDisabler
 
 type AlertConfigurationDisabler interface {
 	DisableAlertConfiguration(string, string) (*atlasv2.GroupAlertsConfig, error)

--- a/internal/cli/alerts/settings/enable.go
+++ b/internal/cli/alerts/settings/enable.go
@@ -25,7 +25,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=enable_mock_test.go -package=settings . AlertConfigurationEnabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=enable_mock_test.go -package=settings . AlertConfigurationEnabler
 
 type AlertConfigurationEnabler interface {
 	EnableAlertConfiguration(string, string) (*atlasv2.GroupAlertsConfig, error)

--- a/internal/cli/alerts/settings/fields_type.go
+++ b/internal/cli/alerts/settings/fields_type.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=fields_type_mock_test.go -package=settings . MatcherFieldsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=fields_type_mock_test.go -package=settings . MatcherFieldsLister
 
 type MatcherFieldsLister interface {
 	MatcherFields() ([]string, error)

--- a/internal/cli/alerts/settings/list.go
+++ b/internal/cli/alerts/settings/list.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=settings . AlertConfigurationLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=settings . AlertConfigurationLister
 
 type AlertConfigurationLister interface {
 	AlertConfigurations(*atlasv2.ListAlertConfigurationsApiParams) (*atlasv2.PaginatedAlertConfig, error)

--- a/internal/cli/alerts/settings/update.go
+++ b/internal/cli/alerts/settings/update.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=settings . AlertConfigurationUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=settings . AlertConfigurationUpdater
 
 type AlertConfigurationUpdater interface {
 	UpdateAlertConfiguration(*atlasv2.GroupAlertsConfig) (*atlasv2.GroupAlertsConfig, error)

--- a/internal/cli/auditing/describe.go
+++ b/internal/cli/auditing/describe.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=auditing . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=auditing . Describer
 
 type Describer interface {
 	Auditing(string) (*atlasv2.AuditLog, error)

--- a/internal/cli/auditing/update.go
+++ b/internal/cli/auditing/update.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=auditing . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=auditing . Updater
 
 type Updater interface {
 	UpdateAuditingConfig(string, *atlasv2.AuditLog) (*atlasv2.AuditLog, error)

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -34,7 +34,7 @@ import (
 	"go.mongodb.org/atlas/auth"
 )
 
-//go:generate mockgen -typed -destination=login_mock_test.go -package=auth . LoginConfig
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=login_mock_test.go -package=auth . LoginConfig
 
 type SetSaver interface {
 	Set(string, any)

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -30,7 +30,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -typed -destination=logout_mock_test.go -package=auth . ConfigDeleter,Revoker
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=logout_mock_test.go -package=auth . ConfigDeleter,Revoker
 
 type ConfigDeleter interface {
 	Delete() error

--- a/internal/cli/backup/compliancepolicy/copyprotection/disable.go
+++ b/internal/cli/backup/compliancepolicy/copyprotection/disable.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=disable_mock_test.go -package=copyprotection . CompliancePolicyCopyProtectionDisabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=disable_mock_test.go -package=copyprotection . CompliancePolicyCopyProtectionDisabler
 
 type CompliancePolicyCopyProtectionDisabler interface {
 	DisableCopyProtection(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/copyprotection/enable.go
+++ b/internal/cli/backup/compliancepolicy/copyprotection/enable.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=enable_mock_test.go -package=copyprotection . CompliancePolicyCopyProtectionEnabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=enable_mock_test.go -package=copyprotection . CompliancePolicyCopyProtectionEnabler
 
 type CompliancePolicyCopyProtectionEnabler interface {
 	EnableCopyProtection(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/describe.go
+++ b/internal/cli/backup/compliancepolicy/describe.go
@@ -24,7 +24,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=compliancepolicy . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=compliancepolicy . Describer
 
 type Describer interface {
 	DescribeCompliancePolicy(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/enable.go
+++ b/internal/cli/backup/compliancepolicy/enable.go
@@ -31,7 +31,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=enable_mock_test.go -package=compliancepolicy . Enabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=enable_mock_test.go -package=compliancepolicy . Enabler
 
 type Enabler interface {
 	EnableCompliancePolicy(projectID, authorizedEmail, authorizedFirstName, authorizedLastName string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/encryptionatrest/disable.go
+++ b/internal/cli/backup/compliancepolicy/encryptionatrest/disable.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=disable_mock_test.go -package=encryptionatrest . CompliancePolicyEncryptionAtRestDisabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=disable_mock_test.go -package=encryptionatrest . CompliancePolicyEncryptionAtRestDisabler
 
 type CompliancePolicyEncryptionAtRestDisabler interface {
 	DisableEncryptionAtRest(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/encryptionatrest/enable.go
+++ b/internal/cli/backup/compliancepolicy/encryptionatrest/enable.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=enable_mock_test.go -package=encryptionatrest . CompliancePolicyEncryptionAtRestEnabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=enable_mock_test.go -package=encryptionatrest . CompliancePolicyEncryptionAtRestEnabler
 
 type CompliancePolicyEncryptionAtRestEnabler interface {
 	EnableEncryptionAtRest(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/pointintimerestore/enable.go
+++ b/internal/cli/backup/compliancepolicy/pointintimerestore/enable.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=enable_mock_test.go -package=pointintimerestore . CompliancePolicyPointInTimeRestoresEnabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=enable_mock_test.go -package=pointintimerestore . CompliancePolicyPointInTimeRestoresEnabler
 
 type CompliancePolicyPointInTimeRestoresEnabler interface {
 	EnablePointInTimeRestore(projectID string, restoreWindowDays int) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/policies/describe.go
+++ b/internal/cli/backup/compliancepolicy/policies/describe.go
@@ -24,7 +24,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=policies . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=policies . Describer
 
 type Describer interface {
 	DescribeCompliancePolicy(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/policies/ondemand/create.go
+++ b/internal/cli/backup/compliancepolicy/policies/ondemand/create.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=ondemand . CompliancePolicyOnDemandPolicyCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=ondemand . CompliancePolicyOnDemandPolicyCreator
 
 type CompliancePolicyOnDemandPolicyCreator interface {
 	CreateOnDemandPolicy(projectID string, policy *atlasv2.BackupComplianceOnDemandPolicyItem) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/policies/ondemand/describe.go
+++ b/internal/cli/backup/compliancepolicy/policies/ondemand/describe.go
@@ -24,7 +24,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=ondemand . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=ondemand . Describer
 
 type Describer interface {
 	DescribeCompliancePolicy(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/policies/scheduled/create.go
+++ b/internal/cli/backup/compliancepolicy/policies/scheduled/create.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=scheduled . CompliancePolicyScheduledPolicyCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=scheduled . CompliancePolicyScheduledPolicyCreator
 
 type CompliancePolicyScheduledPolicyCreator interface {
 	CreateScheduledPolicy(projectID string, policy *atlasv2.BackupComplianceScheduledPolicyItem) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/policies/scheduled/describe.go
+++ b/internal/cli/backup/compliancepolicy/policies/scheduled/describe.go
@@ -24,7 +24,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=scheduled . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=scheduled . Describer
 
 type Describer interface {
 	DescribeCompliancePolicy(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/compliancepolicy/setup.go
+++ b/internal/cli/backup/compliancepolicy/setup.go
@@ -32,7 +32,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=setup_mock_test.go -package=compliancepolicy . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=setup_mock_test.go -package=compliancepolicy . Updater
 
 type Updater interface {
 	DescribeCompliancePolicy(projectID string) (*atlasv2.DataProtectionSettings20231001, error)

--- a/internal/cli/backup/exports/buckets/create.go
+++ b/internal/cli/backup/exports/buckets/create.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=buckets . ExportBucketsCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=buckets . ExportBucketsCreator
 
 type ExportBucketsCreator interface {
 	CreateExportBucket(string, *atlasv2.DiskBackupSnapshotExportBucketRequest) (*atlasv2.DiskBackupSnapshotExportBucketResponse, error)

--- a/internal/cli/backup/exports/buckets/delete.go
+++ b/internal/cli/backup/exports/buckets/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=buckets . ExportBucketsDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=buckets . ExportBucketsDeleter
 
 type ExportBucketsDeleter interface {
 	DeleteExportBucket(string, string) error

--- a/internal/cli/backup/exports/buckets/describe.go
+++ b/internal/cli/backup/exports/buckets/describe.go
@@ -32,7 +32,7 @@ var describeTemplate = `ID	BUCKET NAME	CLOUD PROVIDER	IAM ROLE ID
 {{.Id}}	{{.BucketName}}	{{.CloudProvider}}	{{.IamRoleId}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=buckets . ExportBucketsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=buckets . ExportBucketsDescriber
 
 type ExportBucketsDescriber interface {
 	DescribeExportBucket(string, string) (*atlasv2.DiskBackupSnapshotExportBucketResponse, error)

--- a/internal/cli/backup/exports/buckets/list.go
+++ b/internal/cli/backup/exports/buckets/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=buckets . ExportBucketsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=buckets . ExportBucketsLister
 
 type ExportBucketsLister interface {
 	ExportBuckets(string, *store.ListOptions) (*atlasv2.PaginatedBackupSnapshotExportBuckets, error)

--- a/internal/cli/backup/exports/jobs/create.go
+++ b/internal/cli/backup/exports/jobs/create.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=jobs . ExportJobsCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=jobs . ExportJobsCreator
 
 type ExportJobsCreator interface {
 	CreateExportJob(string, string, *atlasv2.DiskBackupExportJobRequest) (*atlasv2.DiskBackupExportJob, error)

--- a/internal/cli/backup/exports/jobs/describe.go
+++ b/internal/cli/backup/exports/jobs/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=jobs . ExportJobsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=jobs . ExportJobsDescriber
 
 type ExportJobsDescriber interface {
 	ExportJob(string, string, string) (*atlasv2.DiskBackupExportJob, error)

--- a/internal/cli/backup/exports/jobs/list.go
+++ b/internal/cli/backup/exports/jobs/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=jobs . ExportJobsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=jobs . ExportJobsLister
 
 type ExportJobsLister interface {
 	ExportJobs(string, string, *store.ListOptions) (*atlasv2.PaginatedApiAtlasDiskBackupExportJob, error)

--- a/internal/cli/backup/restores/describe.go
+++ b/internal/cli/backup/restores/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=restores . RestoreJobsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=restores . RestoreJobsDescriber
 
 type RestoreJobsDescriber interface {
 	RestoreJob(string, string, string) (*atlasv2.DiskBackupSnapshotRestoreJob, error)

--- a/internal/cli/backup/restores/list.go
+++ b/internal/cli/backup/restores/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=restores . RestoreJobsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=restores . RestoreJobsLister
 
 type RestoreJobsLister interface {
 	RestoreJobs(string, string, *store.ListOptions) (*atlasv2.PaginatedCloudBackupRestoreJob, error)

--- a/internal/cli/backup/restores/start.go
+++ b/internal/cli/backup/restores/start.go
@@ -37,7 +37,7 @@ const (
 	cannotUseFlexWithClusterApisErrorCode = "CANNOT_USE_FLEX_CLUSTER_IN_CLUSTER_API"
 )
 
-//go:generate mockgen -typed -destination=start_mock_test.go -package=restores . RestoreJobsCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=start_mock_test.go -package=restores . RestoreJobsCreator
 
 type RestoreJobsCreator interface {
 	CreateRestoreJobs(string, string, *atlasv2.DiskBackupSnapshotRestoreJob) (*atlasv2.DiskBackupSnapshotRestoreJob, error)

--- a/internal/cli/backup/schedule/delete.go
+++ b/internal/cli/backup/schedule/delete.go
@@ -31,7 +31,7 @@ const (
 	confirmationMessage = "Are you sure you want to delete all backup schedules for cluster: %s"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=schedule . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=schedule . Deleter
 
 type Deleter interface {
 	DeleteSchedule(string, string) error

--- a/internal/cli/backup/schedule/describe.go
+++ b/internal/cli/backup/schedule/describe.go
@@ -27,7 +27,7 @@ import (
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=schedule . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=schedule . Describer
 
 type Describer interface {
 	DescribeSchedule(string, string) (*atlasClustersPinned.DiskBackupSnapshotSchedule, error)

--- a/internal/cli/backup/schedule/update.go
+++ b/internal/cli/backup/schedule/update.go
@@ -47,7 +47,7 @@ const (
 	backupPolicyLength = 6
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=schedule . DescribeUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=schedule . DescribeUpdater
 
 type DescribeUpdater interface {
 	DescribeSchedule(string, string) (*atlasClustersPinned.DiskBackupSnapshotSchedule, error)

--- a/internal/cli/backup/snapshots/create.go
+++ b/internal/cli/backup/snapshots/create.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=snapshots . Creator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=snapshots . Creator
 
 type Creator interface {
 	CreateSnapshot(string, string, *atlasv2.DiskBackupOnDemandSnapshotRequest) (*atlasv2.DiskBackupSnapshot, error)

--- a/internal/cli/backup/snapshots/delete.go
+++ b/internal/cli/backup/snapshots/delete.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=snapshots . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=snapshots . Deleter
 
 type Deleter interface {
 	DeleteSnapshot(string, string, string) error

--- a/internal/cli/backup/snapshots/describe.go
+++ b/internal/cli/backup/snapshots/describe.go
@@ -36,7 +36,7 @@ const describeTemplateFlex = `ID	STATUS	MONGODB VERSION	START TIME	FINISH TIME	E
 {{.Id}}	{{.Status}}	{{.MongoDBVersion}}	{{.StartTime}}	{{.FinishTime}}	{{.Expiration}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=snapshots . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=snapshots . Describer
 
 type Describer interface {
 	Snapshot(string, string, string) (*atlasv2.DiskBackupReplicaSet, error)

--- a/internal/cli/backup/snapshots/download.go
+++ b/internal/cli/backup/snapshots/download.go
@@ -33,7 +33,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=download_mock_test.go -package=snapshots . Downloader
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=download_mock_test.go -package=snapshots . Downloader
 
 type Downloader interface {
 	DownloadFlexClusterSnapshot(string, string, *atlasv2.FlexBackupSnapshotDownloadCreate20241113) (*atlasv2.FlexBackupRestoreJob20241113, error)

--- a/internal/cli/backup/snapshots/list.go
+++ b/internal/cli/backup/snapshots/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=snapshots . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=snapshots . Lister
 
 type Lister interface {
 	Snapshots(string, string, *store.ListOptions) (*atlasv2.PaginatedCloudBackupReplicaSet, error)

--- a/internal/cli/cloudproviders/accessroles/aws/authorize.go
+++ b/internal/cli/cloudproviders/accessroles/aws/authorize.go
@@ -29,7 +29,7 @@ import (
 
 const authorizeTemplate = "AWS IAM role '{{.RoleId}} successfully authorized.\n"
 
-//go:generate mockgen -typed -destination=authorize_mock_test.go -package=aws . CloudProviderAccessRoleAuthorizer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=authorize_mock_test.go -package=aws . CloudProviderAccessRoleAuthorizer
 
 // CloudProviderAccessRoleAuthorizer encapsulates the logic to manage different cloud providers.
 type CloudProviderAccessRoleAuthorizer interface {

--- a/internal/cli/cloudproviders/accessroles/aws/create.go
+++ b/internal/cli/cloudproviders/accessroles/aws/create.go
@@ -35,7 +35,7 @@ Unique External ID: {{.AtlasAssumedRoleExternalId}}
 `
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=aws . CloudProviderAccessRoleCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=aws . CloudProviderAccessRoleCreator
 
 type CloudProviderAccessRoleCreator interface {
 	CreateCloudProviderAccessRole(string, string) (*atlasv2.CloudProviderAccessRole, error)

--- a/internal/cli/cloudproviders/accessroles/aws/deauthorize.go
+++ b/internal/cli/cloudproviders/accessroles/aws/deauthorize.go
@@ -33,7 +33,7 @@ const (
 	confirmationMessage = "Are you sure you want to deauthorize: %s"
 )
 
-//go:generate mockgen -typed -destination=deauthorize_mock_test.go -package=aws . CloudProviderAccessRoleDeauthorizer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=deauthorize_mock_test.go -package=aws . CloudProviderAccessRoleDeauthorizer
 
 type CloudProviderAccessRoleDeauthorizer interface {
 	DeauthorizeCloudProviderAccessRoles(string, string, string) error

--- a/internal/cli/cloudproviders/accessroles/list.go
+++ b/internal/cli/cloudproviders/accessroles/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=accessroles . CloudProviderAccessRoleLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=accessroles . CloudProviderAccessRoleLister
 
 type CloudProviderAccessRoleLister interface {
 	CloudProviderAccessRoles(string) (*atlasv2.CloudProviderAccessRoles, error)

--- a/internal/cli/clusters/advancedsettings/describe.go
+++ b/internal/cli/clusters/advancedsettings/describe.go
@@ -31,7 +31,7 @@ var describeTemplate = `MINIMUM TLS	JAVASCRIPT ENABLED	OPLOG SIZE MB
 {{.MinimumEnabledTlsProtocol}}	{{.JavascriptEnabled}}	{{if .GetOplogSizeMB}}{{.GetOplogSizeMB}} {{else}}N/A{{end}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=advancedsettings . AtlasClusterConfigurationOptionsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=advancedsettings . AtlasClusterConfigurationOptionsDescriber
 
 type AtlasClusterConfigurationOptionsDescriber interface {
 	AtlasClusterConfigurationOptions(string, string) (*atlasClustersPinned.ClusterDescriptionProcessArgs, error)

--- a/internal/cli/clusters/advancedsettings/update.go
+++ b/internal/cli/clusters/advancedsettings/update.go
@@ -30,7 +30,7 @@ import (
 
 const updateTmpl = "Updating advanced configuration settings of your cluster'.\n"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=advancedsettings . AtlasClusterConfigurationOptionsUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=advancedsettings . AtlasClusterConfigurationOptionsUpdater
 
 type AtlasClusterConfigurationOptionsUpdater interface {
 	UpdateAtlasClusterConfigurationOptions(string, string, *atlasClustersPinned.ClusterDescriptionProcessArgs) (*atlasClustersPinned.ClusterDescriptionProcessArgs, error)

--- a/internal/cli/clusters/availableregions/list.go
+++ b/internal/cli/clusters/availableregions/list.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_autocomplete_mock_test.go -package=availableregions . CloudProviderRegionsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_autocomplete_mock_test.go -package=availableregions . CloudProviderRegionsLister
 
 type CloudProviderRegionsLister interface {
 	CloudProviderRegions(string, string, []string) (*atlasv2.PaginatedApiAtlasProviderRegions, error)

--- a/internal/cli/clusters/connectionstring/describe.go
+++ b/internal/cli/clusters/connectionstring/describe.go
@@ -29,7 +29,7 @@ import (
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=connectionstring . ClusterDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=connectionstring . ClusterDescriber
 
 type ClusterDescriber interface {
 	AtlasCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/clusters/create.go
+++ b/internal/cli/clusters/create.go
@@ -50,7 +50,7 @@ const (
 	regionName                    = "regionName"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=clusters . ClusterCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=clusters . ClusterCreator
 
 type ClusterCreator interface {
 	CreateCluster(v15 *atlasClustersPinned.AdvancedClusterDescription) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/clusters/delete.go
+++ b/internal/cli/clusters/delete.go
@@ -30,7 +30,7 @@ import (
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=clusters . ClusterDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=clusters . ClusterDeleter
 
 type ClusterDeleter interface {
 	DeleteCluster(string, string) error

--- a/internal/cli/clusters/describe.go
+++ b/internal/cli/clusters/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=clusters . ClusterDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=clusters . ClusterDescriber
 
 type ClusterDescriber interface {
 	AtlasCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/clusters/failover.go
+++ b/internal/cli/clusters/failover.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=failover_mock_test.go -package=clusters . ClusterTester
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=failover_mock_test.go -package=clusters . ClusterTester
 
 type ClusterTester interface {
 	TestClusterFailover(string, string) error

--- a/internal/cli/clusters/indexes/create.go
+++ b/internal/cli/clusters/indexes/create.go
@@ -31,7 +31,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=indexes . IndexCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=indexes . IndexCreator
 
 type IndexCreator interface {
 	CreateIndex(string, string, *atlasv2.DatabaseRollingIndexRequest) error

--- a/internal/cli/clusters/list.go
+++ b/internal/cli/clusters/list.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=clusters . ClusterLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=clusters . ClusterLister
 
 type ClusterLister interface {
 	ProjectClusters(string, *store.ListOptions) (*atlasClustersPinned.PaginatedAdvancedClusterDescription, error)

--- a/internal/cli/clusters/load_sample_data.go
+++ b/internal/cli/clusters/load_sample_data.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=load_sample_data_mock_test.go -package=clusters . SampleDataAdder
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=load_sample_data_mock_test.go -package=clusters . SampleDataAdder
 
 type SampleDataAdder interface {
 	AddSampleData(string, string) (*atlasv2.SampleDatasetStatus, error)

--- a/internal/cli/clusters/onlinearchive/create.go
+++ b/internal/cli/clusters/onlinearchive/create.go
@@ -31,7 +31,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=onlinearchive . Creator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=onlinearchive . Creator
 
 type Creator interface {
 	CreateOnlineArchive(string, string, *atlasv2.BackupOnlineArchiveCreate) (*atlasv2.BackupOnlineArchive, error)

--- a/internal/cli/clusters/onlinearchive/delete.go
+++ b/internal/cli/clusters/onlinearchive/delete.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=onlinearchive . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=onlinearchive . Deleter
 
 type Deleter interface {
 	DeleteOnlineArchive(string, string, string) error

--- a/internal/cli/clusters/onlinearchive/describe.go
+++ b/internal/cli/clusters/onlinearchive/describe.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=onlinearchive . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=onlinearchive . Describer
 
 type Describer interface {
 	OnlineArchive(string, string, string) (*atlasv2.BackupOnlineArchive, error)

--- a/internal/cli/clusters/onlinearchive/list.go
+++ b/internal/cli/clusters/onlinearchive/list.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=onlinearchive . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=onlinearchive . Lister
 
 type Lister interface {
 	OnlineArchives(string, string, *store.ListOptions) (*atlasv2.PaginatedOnlineArchive, error)

--- a/internal/cli/clusters/onlinearchive/update.go
+++ b/internal/cli/clusters/onlinearchive/update.go
@@ -31,7 +31,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=onlinearchive . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=onlinearchive . Updater
 
 type Updater interface {
 	UpdateOnlineArchive(string, string, *atlasv2.BackupOnlineArchive) (*atlasv2.BackupOnlineArchive, error)

--- a/internal/cli/clusters/pause.go
+++ b/internal/cli/clusters/pause.go
@@ -28,7 +28,7 @@ import (
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 )
 
-//go:generate mockgen -typed -destination=pause_mock_test.go -package=clusters . ClusterPauser
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=pause_mock_test.go -package=clusters . ClusterPauser
 
 type ClusterPauser interface {
 	PauseCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/clusters/region_tier_autocomplete.go
+++ b/internal/cli/clusters/region_tier_autocomplete.go
@@ -31,7 +31,7 @@ import (
 
 const storeErrMsg = "store error: "
 
-//go:generate mockgen -typed -destination=region_tier_autocomplete_mock_test.go -package=clusters . CloudProviderRegionsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=region_tier_autocomplete_mock_test.go -package=clusters . CloudProviderRegionsLister
 
 type CloudProviderRegionsLister interface {
 	CloudProviderRegions(string, string, []string) (*atlasv2.PaginatedApiAtlasProviderRegions, error)

--- a/internal/cli/clusters/sampledata/describe.go
+++ b/internal/cli/clusters/sampledata/describe.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=sampledata . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=sampledata . Describer
 
 type Describer interface {
 	SampleDataStatus(string, string) (*atlasv2.SampleDatasetStatus, error)

--- a/internal/cli/clusters/sampledata/load.go
+++ b/internal/cli/clusters/sampledata/load.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=load_mock_test.go -package=sampledata . Adder
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=load_mock_test.go -package=sampledata . Adder
 
 type Adder interface {
 	AddSampleData(string, string) (*atlasv2.SampleDatasetStatus, error)

--- a/internal/cli/clusters/start.go
+++ b/internal/cli/clusters/start.go
@@ -28,7 +28,7 @@ import (
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 )
 
-//go:generate mockgen -typed -destination=start_mock_test.go -package=clusters . ClusterStarter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=start_mock_test.go -package=clusters . ClusterStarter
 
 type ClusterStarter interface {
 	StartCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/clusters/update.go
+++ b/internal/cli/clusters/update.go
@@ -39,7 +39,7 @@ const (
 	updateTmpl = "Updating cluster '{{.Name}}'.\n"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=clusters . AtlasClusterGetterUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=clusters . AtlasClusterGetterUpdater
 
 type AtlasClusterGetterUpdater interface {
 	AtlasCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/clusters/upgrade.go
+++ b/internal/cli/clusters/upgrade.go
@@ -38,7 +38,7 @@ const (
 	replicaSetPriority  = 7
 )
 
-//go:generate mockgen -typed -destination=upgrade_mock_test.go -package=clusters . AtlasSharedClusterGetterUpgrader
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=upgrade_mock_test.go -package=clusters . AtlasSharedClusterGetterUpgrader
 
 type AtlasSharedClusterGetterUpgrader interface {
 	AtlasSharedCluster(string, string) (*atlas.Cluster, error)

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=set_mock_test.go -package=config . SetSaver
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=set_mock_test.go -package=config . SetSaver
 
 type SetSaver interface {
 	Set(string, any)

--- a/internal/cli/customdbroles/create.go
+++ b/internal/cli/customdbroles/create.go
@@ -32,7 +32,7 @@ import (
 
 const createTemplate = "Custom database role '{{.RoleName}}' successfully created.\n"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=customdbroles . DatabaseRoleCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=customdbroles . DatabaseRoleCreator
 
 type DatabaseRoleCreator interface {
 	CreateDatabaseRole(string, *atlasv2.UserCustomDBRole) (*atlasv2.UserCustomDBRole, error)

--- a/internal/cli/customdbroles/delete.go
+++ b/internal/cli/customdbroles/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=customdbroles . DatabaseRoleDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=customdbroles . DatabaseRoleDeleter
 
 type DatabaseRoleDeleter interface {
 	DeleteDatabaseRole(string, string) error

--- a/internal/cli/customdbroles/describe.go
+++ b/internal/cli/customdbroles/describe.go
@@ -31,7 +31,7 @@ const describeTemplate = `NAME	ACTION	DB	COLLECTION	CLUSTER {{- $roleName := .Ro
 {{ $roleName }}	{{ $actionName }}{{if .Db }}	{{ .Db }}{{else}}	N/A{{end}}{{if .Collection }}	{{ .Collection }}{{else if .Cluster}}	N/A{{else}}	ALL COLLECTIONS{{end}}{{if .Cluster}}	{{ .Cluster }}{{else}}	N/A	{{end}}{{end}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=customdbroles . DatabaseRoleDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=customdbroles . DatabaseRoleDescriber
 
 type DatabaseRoleDescriber interface {
 	DatabaseRole(string, string) (*atlasv2.UserCustomDBRole, error)

--- a/internal/cli/customdbroles/list.go
+++ b/internal/cli/customdbroles/list.go
@@ -36,7 +36,7 @@ const listTemplate = `NAME	ACTION	INHERITED ROLES	DB	COLLECTION	CLUSTER{{range v
 
 const deprecatedFlagMessage = "--pageNum and --ItemsPerPage are not supported by customdbroles list"
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=customdbroles . DatabaseRoleLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=customdbroles . DatabaseRoleLister
 
 type DatabaseRoleLister interface {
 	DatabaseRoles(string) ([]atlasv2.UserCustomDBRole, error)

--- a/internal/cli/customdbroles/update.go
+++ b/internal/cli/customdbroles/update.go
@@ -32,7 +32,7 @@ import (
 
 const updateTemplate = "Custom database role '{{.RoleName}}' successfully updated.\n"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=customdbroles . DatabaseRoleUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=customdbroles . DatabaseRoleUpdater
 
 type DatabaseRoleUpdater interface {
 	UpdateDatabaseRole(string, string, *atlasv2.UserCustomDBRole) (*atlasv2.UserCustomDBRole, error)

--- a/internal/cli/customdns/aws/describe.go
+++ b/internal/cli/customdns/aws/describe.go
@@ -26,7 +26,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=aws . CustomDNSDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=aws . CustomDNSDescriber
 
 type CustomDNSDescriber interface {
 	DescribeCustomDNS(string) (*atlasv2.AWSCustomDNSEnabled, error)

--- a/internal/cli/customdns/aws/disable.go
+++ b/internal/cli/customdns/aws/disable.go
@@ -26,7 +26,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=disable_mock_test.go -package=aws . CustomDNSDisabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=disable_mock_test.go -package=aws . CustomDNSDisabler
 
 type CustomDNSDisabler interface {
 	DisableCustomDNS(string) (*atlasv2.AWSCustomDNSEnabled, error)

--- a/internal/cli/customdns/aws/enable.go
+++ b/internal/cli/customdns/aws/enable.go
@@ -26,7 +26,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=enable_mock_test.go -package=aws . CustomDNSEnabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=enable_mock_test.go -package=aws . CustomDNSEnabler
 
 type CustomDNSEnabler interface {
 	EnableCustomDNS(string) (*atlasv2.AWSCustomDNSEnabled, error)

--- a/internal/cli/datafederation/create.go
+++ b/internal/cli/datafederation/create.go
@@ -32,7 +32,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=datafederation . Creator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=datafederation . Creator
 
 type Creator interface {
 	CreateDataFederation(string, *atlasv2.DataLakeTenant) (*atlasv2.DataLakeTenant, error)

--- a/internal/cli/datafederation/delete.go
+++ b/internal/cli/datafederation/delete.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=datafederation . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=datafederation . Deleter
 
 type Deleter interface {
 	DeleteDataFederation(string, string) error

--- a/internal/cli/datafederation/describe.go
+++ b/internal/cli/datafederation/describe.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=datafederation . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=datafederation . Describer
 
 type Describer interface {
 	DataFederation(string, string) (*atlasv2.DataLakeTenant, error)

--- a/internal/cli/datafederation/list.go
+++ b/internal/cli/datafederation/list.go
@@ -35,7 +35,7 @@ var listTemplate = `NAME	STATE{{range valueOrEmptySlice .}}
 {{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=datafederation . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=datafederation . Lister
 
 type Lister interface {
 	DataFederationList(string) ([]atlasv2.DataLakeTenant, error)

--- a/internal/cli/datafederation/logs.go
+++ b/internal/cli/datafederation/logs.go
@@ -31,7 +31,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=logs_mock_test.go -package=datafederation . LogDownloader
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=logs_mock_test.go -package=datafederation . LogDownloader
 
 type LogDownloader interface {
 	DataFederationLogs(string, string, int64, int64) (io.ReadCloser, error)

--- a/internal/cli/datafederation/privateendpoints/create.go
+++ b/internal/cli/datafederation/privateendpoints/create.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=privateendpoints . DataFederationPrivateEndpointCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=privateendpoints . DataFederationPrivateEndpointCreator
 
 type DataFederationPrivateEndpointCreator interface {
 	CreateDataFederationPrivateEndpoint(string, *atlasv2.PrivateNetworkEndpointIdEntry) (*atlasv2.PaginatedPrivateNetworkEndpointIdEntry, error)

--- a/internal/cli/datafederation/privateendpoints/delete.go
+++ b/internal/cli/datafederation/privateendpoints/delete.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=privateendpoints . DataFederationPrivateEndpointDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=privateendpoints . DataFederationPrivateEndpointDeleter
 
 type DataFederationPrivateEndpointDeleter interface {
 	DeleteDataFederationPrivateEndpoint(string, string) error

--- a/internal/cli/datafederation/privateendpoints/describe.go
+++ b/internal/cli/datafederation/privateendpoints/describe.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=privateendpoints . DataFederationPrivateEndpointDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=privateendpoints . DataFederationPrivateEndpointDescriber
 
 type DataFederationPrivateEndpointDescriber interface {
 	DataFederationPrivateEndpoint(string, string) (*atlasv2.PrivateNetworkEndpointIdEntry, error)

--- a/internal/cli/datafederation/privateendpoints/list.go
+++ b/internal/cli/datafederation/privateendpoints/list.go
@@ -34,7 +34,7 @@ var listTemplate = `ENDPOINT ID	COMMENT	TYPE{{range valueOrEmptySlice .Results}}
 {{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=privateendpoints . DataFederationPrivateEndpointLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=privateendpoints . DataFederationPrivateEndpointLister
 
 type DataFederationPrivateEndpointLister interface {
 	DataFederationPrivateEndpoints(string) (*atlasv2.PaginatedPrivateNetworkEndpointIdEntry, error)

--- a/internal/cli/datafederation/querylimits/create.go
+++ b/internal/cli/datafederation/querylimits/create.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=querylimits . DataFederationQueryLimitCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=querylimits . DataFederationQueryLimitCreator
 
 type DataFederationQueryLimitCreator interface {
 	CreateDataFederationQueryLimit(string, string, string, *atlasv2.DataFederationTenantQueryLimit) (*atlasv2.DataFederationTenantQueryLimit, error)

--- a/internal/cli/datafederation/querylimits/delete.go
+++ b/internal/cli/datafederation/querylimits/delete.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=querylimits . DataFederationQueryLimitDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=querylimits . DataFederationQueryLimitDeleter
 
 type DataFederationQueryLimitDeleter interface {
 	DeleteDataFederationQueryLimit(string, string, string) error

--- a/internal/cli/datafederation/querylimits/describe.go
+++ b/internal/cli/datafederation/querylimits/describe.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=querylimits . DataFederationQueryLimitDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=querylimits . DataFederationQueryLimitDescriber
 
 type DataFederationQueryLimitDescriber interface {
 	DataFederationQueryLimit(string, string, string) (*atlasv2.DataFederationTenantQueryLimit, error)

--- a/internal/cli/datafederation/querylimits/list.go
+++ b/internal/cli/datafederation/querylimits/list.go
@@ -35,7 +35,7 @@ var listTemplate = `TENANT NAME	NAME	VALUE{{range valueOrEmptySlice .}}
 {{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=querylimits . DataFederationQueryLimitLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=querylimits . DataFederationQueryLimitLister
 
 type DataFederationQueryLimitLister interface {
 	DataFederationQueryLimits(string, string) ([]atlasv2.DataFederationTenantQueryLimit, error)

--- a/internal/cli/datafederation/update.go
+++ b/internal/cli/datafederation/update.go
@@ -32,7 +32,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=datafederation . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=datafederation . Updater
 
 type Updater interface {
 	UpdateDataFederation(string, string, *atlasv2.DataLakeTenant) (*atlasv2.DataLakeTenant, error)

--- a/internal/cli/datalake/create.go
+++ b/internal/cli/datalake/create.go
@@ -27,7 +27,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=datalake . Creator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=datalake . Creator
 
 type Creator interface {
 	CreateDataLake(string, *atlas.DataLakeCreateRequest) (*atlas.DataLake, error)

--- a/internal/cli/datalake/delete.go
+++ b/internal/cli/datalake/delete.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=datalake . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=datalake . Deleter
 
 type Deleter interface {
 	DeleteDataLake(string, string) error

--- a/internal/cli/datalake/describe.go
+++ b/internal/cli/datalake/describe.go
@@ -25,7 +25,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=datalake . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=datalake . Describer
 
 type Describer interface {
 	DataLake(string, string) (*atlas.DataLake, error)

--- a/internal/cli/datalake/list.go
+++ b/internal/cli/datalake/list.go
@@ -25,7 +25,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=datalake . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=datalake . Lister
 
 type Lister interface {
 	DataLakes(string) ([]atlas.DataLake, error)

--- a/internal/cli/datalake/update.go
+++ b/internal/cli/datalake/update.go
@@ -30,7 +30,7 @@ import (
 
 const aws = "AWS"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=datalake . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=datalake . Updater
 
 type Updater interface {
 	UpdateDataLake(string, string, *atlas.DataLakeUpdateRequest) (*atlas.DataLake, error)

--- a/internal/cli/datalakepipelines/availableschedules/list.go
+++ b/internal/cli/datalakepipelines/availableschedules/list.go
@@ -33,7 +33,7 @@ import (
 var listTemplate = `ID	FREQUENCY INTERVAL	FREQUENCY TYPE	RETENTION UNIT	RETENTION VALUE{{range valueOrEmptySlice .}}
 {{ .Id }}	{{ .FrequencyInterval }}	{{ .FrequencyType }}	{{ .RetentionUnit }}	{{ .RetentionValue }}{{end}}`
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=availableschedules . PipelineAvailableSchedulesLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=availableschedules . PipelineAvailableSchedulesLister
 
 type PipelineAvailableSchedulesLister interface {
 	PipelineAvailableSchedules(string, string) ([]atlasv2.DiskBackupApiPolicyItem, error)

--- a/internal/cli/datalakepipelines/availablesnapshots/list.go
+++ b/internal/cli/datalakepipelines/availablesnapshots/list.go
@@ -36,7 +36,7 @@ import (
 var listTemplate = `ID	DESCRIPTION	STATUS{{range valueOrEmptySlice .Results}}
 {{.Id}}	{{.Description}}	{{.Status}}{{end}}`
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=availablesnapshots . PipelineAvailableSnapshotsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=availablesnapshots . PipelineAvailableSnapshotsLister
 
 type PipelineAvailableSnapshotsLister interface {
 	PipelineAvailableSnapshots(string, string, *time.Time, *store.ListOptions) (*atlasv2.PaginatedBackupSnapshot, error)

--- a/internal/cli/datalakepipelines/create.go
+++ b/internal/cli/datalakepipelines/create.go
@@ -34,7 +34,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=datalakepipelines . PipelinesCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=datalakepipelines . PipelinesCreator
 
 type PipelinesCreator interface {
 	CreatePipeline(string, atlasv2.DataLakeIngestionPipeline) (*atlasv2.DataLakeIngestionPipeline, error)

--- a/internal/cli/datalakepipelines/datasets/delete.go
+++ b/internal/cli/datalakepipelines/datasets/delete.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=datasets . PipelineDatasetDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=datasets . PipelineDatasetDeleter
 
 type PipelineDatasetDeleter interface {
 	DeletePipelineDataset(string, string, string) error

--- a/internal/cli/datalakepipelines/delete.go
+++ b/internal/cli/datalakepipelines/delete.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=datalakepipelines . PipelinesDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=datalakepipelines . PipelinesDeleter
 
 type PipelinesDeleter interface {
 	DeletePipeline(string, string) error

--- a/internal/cli/datalakepipelines/describe.go
+++ b/internal/cli/datalakepipelines/describe.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=datalakepipelines . PipelinesDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=datalakepipelines . PipelinesDescriber
 
 type PipelinesDescriber interface {
 	Pipeline(string, string) (*atlasv2.DataLakeIngestionPipeline, error)

--- a/internal/cli/datalakepipelines/list.go
+++ b/internal/cli/datalakepipelines/list.go
@@ -34,7 +34,7 @@ var listTemplate = `ID	NAME	STATE{{range valueOrEmptySlice .}}
 {{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=datalakepipelines . PipelinesLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=datalakepipelines . PipelinesLister
 
 type PipelinesLister interface {
 	Pipelines(string) ([]atlasv2.DataLakeIngestionPipeline, error)

--- a/internal/cli/datalakepipelines/pause.go
+++ b/internal/cli/datalakepipelines/pause.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=pause_mock_test.go -package=datalakepipelines . PipelinesPauser
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=pause_mock_test.go -package=datalakepipelines . PipelinesPauser
 
 type PipelinesPauser interface {
 	PipelinePause(string, string) (*atlasv2.DataLakeIngestionPipeline, error)

--- a/internal/cli/datalakepipelines/runs/describe.go
+++ b/internal/cli/datalakepipelines/runs/describe.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=runs . PipelineRunsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=runs . PipelineRunsDescriber
 
 type PipelineRunsDescriber interface {
 	PipelineRun(string, string, string) (*atlasv2.IngestionPipelineRun, error)

--- a/internal/cli/datalakepipelines/runs/list.go
+++ b/internal/cli/datalakepipelines/runs/list.go
@@ -35,7 +35,7 @@ var listTemplate = `ID	DATASET NAME	STATE{{range valueOrEmptySlice .Results}}
 {{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=runs . PipelineRunsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=runs . PipelineRunsLister
 
 type PipelineRunsLister interface {
 	PipelineRuns(string, string) (*atlasv2.PaginatedPipelineRun, error)

--- a/internal/cli/datalakepipelines/start.go
+++ b/internal/cli/datalakepipelines/start.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=start_mock_test.go -package=datalakepipelines . PipelinesResumer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=start_mock_test.go -package=datalakepipelines . PipelinesResumer
 
 type PipelinesResumer interface {
 	PipelineResume(string, string) (*atlasv2.DataLakeIngestionPipeline, error)

--- a/internal/cli/datalakepipelines/trigger.go
+++ b/internal/cli/datalakepipelines/trigger.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=trigger_mock_test.go -package=datalakepipelines . PipelinesTriggerer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=trigger_mock_test.go -package=datalakepipelines . PipelinesTriggerer
 
 type PipelinesTriggerer interface {
 	PipelineTrigger(string, string, string) (*atlasv2.IngestionPipelineRun, error)

--- a/internal/cli/datalakepipelines/update.go
+++ b/internal/cli/datalakepipelines/update.go
@@ -33,7 +33,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=datalakepipelines . PipelinesUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=datalakepipelines . PipelinesUpdater
 
 type PipelinesUpdater interface {
 	UpdatePipeline(string, string, atlasv2.DataLakeIngestionPipeline) (*atlasv2.DataLakeIngestionPipeline, error)

--- a/internal/cli/dbusers/certs/create.go
+++ b/internal/cli/dbusers/certs/create.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=certs . DBUserCertificateCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=certs . DBUserCertificateCreator
 
 type DBUserCertificateCreator interface {
 	CreateDBUserCertificate(string, string, int) (string, error)

--- a/internal/cli/dbusers/certs/list.go
+++ b/internal/cli/dbusers/certs/list.go
@@ -25,7 +25,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=certs . DBUserCertificateLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=certs . DBUserCertificateLister
 
 type DBUserCertificateLister interface {
 	DBUserCertificates(string, string, *store.ListOptions) (*atlasv2.PaginatedUserCert, error)

--- a/internal/cli/dbusers/create.go
+++ b/internal/cli/dbusers/create.go
@@ -32,7 +32,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=dbusers . DatabaseUserCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=dbusers . DatabaseUserCreator
 
 type DatabaseUserCreator interface {
 	CreateDatabaseUser(*atlasv2.CloudDatabaseUser) (*atlasv2.CloudDatabaseUser, error)

--- a/internal/cli/dbusers/delete.go
+++ b/internal/cli/dbusers/delete.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=dbusers . DatabaseUserDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=dbusers . DatabaseUserDeleter
 
 type DatabaseUserDeleter interface {
 	DeleteDatabaseUser(string, string, string) error

--- a/internal/cli/dbusers/describe.go
+++ b/internal/cli/dbusers/describe.go
@@ -34,7 +34,7 @@ const describeTemplate = `USERNAME	DATABASE
 {{.Username}}	{{.DatabaseName}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=dbusers . DatabaseUserDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=dbusers . DatabaseUserDescriber
 
 type DatabaseUserDescriber interface {
 	DatabaseUser(string, string, string) (*atlasv2.CloudDatabaseUser, error)

--- a/internal/cli/dbusers/list.go
+++ b/internal/cli/dbusers/list.go
@@ -32,7 +32,7 @@ const listTemplate = `USERNAME	DATABASE{{range valueOrEmptySlice .Results}}
 {{.Username}}	{{.DatabaseName}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=dbusers . DatabaseUserLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=dbusers . DatabaseUserLister
 
 type DatabaseUserLister interface {
 	DatabaseUsers(groupID string, opts *store.ListOptions) (*atlasv2.PaginatedApiAtlasDatabaseUser, error)

--- a/internal/cli/dbusers/update.go
+++ b/internal/cli/dbusers/update.go
@@ -32,7 +32,7 @@ import (
 
 const updateTemplate = "Successfully updated database user '{{.Username}}'.\n"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=dbusers . DatabaseUserUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=dbusers . DatabaseUserUpdater
 
 type DatabaseUserUpdater interface {
 	UpdateDatabaseUser(*atlasv2.UpdateDatabaseUserApiParams) (*atlasv2.CloudDatabaseUser, error)

--- a/internal/cli/default_setter_opts.go
+++ b/internal/cli/default_setter_opts.go
@@ -33,7 +33,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -destination=../mocks/mock_default_opts.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli ProjectOrgsLister
+//go:generate go tool go.uber.org/mock/mockgen -destination=../mocks/mock_default_opts.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli ProjectOrgsLister
 
 type ProjectOrgsLister interface {
 	Project(id string) (*atlasv2.Group, error)

--- a/internal/cli/deployments/connect.go
+++ b/internal/cli/deployments/connect.go
@@ -239,7 +239,7 @@ func (opts *ConnectOpts) connectToLocal(ctx context.Context) error {
 	return opts.connectToDeployment(connectionString)
 }
 
-//go:generate mockgen -typed -destination=connect_mock_test.go -package=deployments . ClusterDescriberStarter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=connect_mock_test.go -package=deployments . ClusterDescriberStarter
 
 type ClusterDescriberStarter interface {
 	AtlasCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/deployments/delete.go
+++ b/internal/cli/deployments/delete.go
@@ -36,7 +36,7 @@ const (
 	deleteFailMessage    = "Deployment not deleted"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=deployments . ClusterDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=deployments . ClusterDeleter
 
 type ClusterDeleter interface {
 	DeleteCluster(string, string) error

--- a/internal/cli/deployments/logs.go
+++ b/internal/cli/deployments/logs.go
@@ -37,7 +37,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=logs_mock_test.go -package=deployments . LogsDownloader
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=logs_mock_test.go -package=deployments . LogsDownloader
 
 type LogsDownloader interface {
 	DownloadLog(*atlasv2.GetHostLogsApiParams) (io.ReadCloser, error)

--- a/internal/cli/deployments/options/deployment_opts_telemetry.go
+++ b/internal/cli/deployments/options/deployment_opts_telemetry.go
@@ -35,7 +35,7 @@ var (
 	errEmptyUUID                  = errors.New("error uuid is empty")
 )
 
-//go:generate mockgen -destination=../../../mocks/mock_deployment_opts_telemetry.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/options DeploymentTelemetry
+//go:generate go tool go.uber.org/mock/mockgen -destination=../../../mocks/mock_deployment_opts_telemetry.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/options DeploymentTelemetry
 type DeploymentTelemetry interface {
 	AppendDeploymentType()
 	AppendDeploymentUUID()

--- a/internal/cli/deployments/pause.go
+++ b/internal/cli/deployments/pause.go
@@ -30,7 +30,7 @@ import (
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 )
 
-//go:generate mockgen -typed -destination=pause_mock_test.go -package=deployments . ClusterPauser
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=pause_mock_test.go -package=deployments . ClusterPauser
 
 type ClusterPauser interface {
 	PauseCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/deployments/search/indexes/create.go
+++ b/internal/cli/deployments/search/indexes/create.go
@@ -57,7 +57,7 @@ type IndexID struct {
 	Index      any
 }
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=indexes . SearchIndexCreatorDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=indexes . SearchIndexCreatorDescriber
 
 type SearchIndexCreatorDescriber interface {
 	SearchIndexDeprecated(string, string, string) (*atlasv2.ClusterSearchIndex, error)

--- a/internal/cli/deployments/search/indexes/delete.go
+++ b/internal/cli/deployments/search/indexes/delete.go
@@ -34,7 +34,7 @@ const (
 	deleteMessageFailed = "Index not deleted"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=indexes . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=indexes . Deleter
 
 type Deleter interface {
 	DeleteSearchIndex(string, string, string) error

--- a/internal/cli/deployments/search/indexes/describe.go
+++ b/internal/cli/deployments/search/indexes/describe.go
@@ -35,7 +35,7 @@ var describeTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE
 {{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{if .Type}}{{.Type}}{{else}}` + search.DefaultType + `{{end}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=indexes . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=indexes . Describer
 
 type Describer interface {
 	SearchIndexDeprecated(string, string, string) (*atlasv2.ClusterSearchIndex, error)

--- a/internal/cli/deployments/search/indexes/list.go
+++ b/internal/cli/deployments/search/indexes/list.go
@@ -34,7 +34,7 @@ var listTemplate = `ID	NAME	DATABASE	COLLECTION	STATUS	TYPE{{range valueOrEmptyS
 {{.IndexID}}	{{.Name}}	{{.Database}}	{{.CollectionName}}	{{.Status}}	{{if .Type}}{{.Type}}{{else}}` + search.DefaultType + `{{end}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=indexes . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=indexes . Lister
 
 type Lister interface {
 	SearchIndexesDeprecated(string, string, string, string) ([]atlasv2.ClusterSearchIndex, error)

--- a/internal/cli/deployments/start.go
+++ b/internal/cli/deployments/start.go
@@ -28,7 +28,7 @@ import (
 	atlasClustersPinned "go.mongodb.org/atlas-sdk/v20240530005/admin"
 )
 
-//go:generate mockgen -typed -destination=start_mock_test.go -package=deployments . ClusterStarter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=start_mock_test.go -package=deployments . ClusterStarter
 
 type ClusterStarter interface {
 	StartCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)

--- a/internal/cli/events/list.go
+++ b/internal/cli/events/list.go
@@ -38,7 +38,7 @@ type EventListOpts struct {
 	MaxDate   string
 }
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=events . EventLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=events . EventLister
 
 type EventLister interface {
 	OrganizationEvents(opts *atlasv2.ListOrganizationEventsApiParams) (*atlasv2.OrgPaginatedEvent, error)

--- a/internal/cli/events/orgs_list.go
+++ b/internal/cli/events/orgs_list.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=orgs_list_mock_test.go -package=events . OrganizationEventLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=orgs_list_mock_test.go -package=events . OrganizationEventLister
 
 type OrganizationEventLister interface {
 	OrganizationEvents(opts *atlasv2.ListOrganizationEventsApiParams) (*atlasv2.OrgPaginatedEvent, error)

--- a/internal/cli/events/projects_list.go
+++ b/internal/cli/events/projects_list.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=projects_list_mock_test.go -package=events . ProjectEventLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=projects_list_mock_test.go -package=events . ProjectEventLister
 
 type ProjectEventLister interface {
 	ProjectEvents(opts *atlasv2.ListProjectEventsApiParams) (*atlasv2.GroupPaginatedEvent, error)

--- a/internal/cli/federatedauthentication/federationsettings/connectedorgsconfigs/delete.go
+++ b/internal/cli/federatedauthentication/federationsettings/connectedorgsconfigs/delete.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=connectedorgsconfigs . ConnectedOrgConfigsDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=connectedorgsconfigs . ConnectedOrgConfigsDeleter
 
 type ConnectedOrgConfigsDeleter interface {
 	DeleteConnectedOrgConfig(federationSettingsID string, orgID string) error

--- a/internal/cli/federatedauthentication/federationsettings/connectedorgsconfigs/describe_org_config_opts.go
+++ b/internal/cli/federatedauthentication/federationsettings/connectedorgsconfigs/describe_org_config_opts.go
@@ -22,7 +22,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=connectedorgsconfigs . ConnectedOrgConfigsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=connectedorgsconfigs . ConnectedOrgConfigsDescriber
 
 type ConnectedOrgConfigsDescriber interface {
 	GetConnectedOrgConfig(opts *atlasv2.GetConnectedOrgConfigApiParams) (*atlasv2.ConnectedOrgConfig, error)

--- a/internal/cli/federatedauthentication/federationsettings/connectedorgsconfigs/list.go
+++ b/internal/cli/federatedauthentication/federationsettings/connectedorgsconfigs/list.go
@@ -26,7 +26,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=connectedorgsconfigs . ConnectedOrgConfigsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=connectedorgsconfigs . ConnectedOrgConfigsLister
 
 type ConnectedOrgConfigsLister interface {
 	ListConnectedOrgConfigs(opts *atlasv2.ListConnectedOrgConfigsApiParams) (*atlasv2.PaginatedConnectedOrgConfigs, error)

--- a/internal/cli/federatedauthentication/federationsettings/connectedorgsconfigs/update.go
+++ b/internal/cli/federatedauthentication/federationsettings/connectedorgsconfigs/update.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=connectedorgsconfigs . ConnectedOrgConfigsUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=connectedorgsconfigs . ConnectedOrgConfigsUpdater
 
 type ConnectedOrgConfigsUpdater interface {
 	UpdateConnectedOrgConfig(opts *atlasv2.UpdateConnectedOrgConfigApiParams) (*atlasv2.ConnectedOrgConfig, error)

--- a/internal/cli/federatedauthentication/federationsettings/describe.go
+++ b/internal/cli/federatedauthentication/federationsettings/describe.go
@@ -31,7 +31,7 @@ const describeTemplate = `ID	IDENTITY PROVIDER ID	IDENTITY PROVIDER STATUS
 {{.Id}}	{{.IdentityProviderId}}	{{.IdentityProviderStatus}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=federationsettings . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=federationsettings . Describer
 
 type Describer interface {
 	FederationSetting(opts *atlasv2.GetFederationSettingsApiParams) (*atlasv2.OrgFederationSettings, error)

--- a/internal/cli/federatedauthentication/federationsettings/identityprovider/create/oidc.go
+++ b/internal/cli/federatedauthentication/federationsettings/identityprovider/create/oidc.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=oidc_mock_test.go -package=create . IdentityProviderCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=oidc_mock_test.go -package=create . IdentityProviderCreator
 
 type IdentityProviderCreator interface {
 	CreateIdentityProvider(*atlasv2.CreateIdentityProviderApiParams) (*atlasv2.FederationOidcIdentityProvider, error)

--- a/internal/cli/federatedauthentication/federationsettings/identityprovider/delete.go
+++ b/internal/cli/federatedauthentication/federationsettings/identityprovider/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=identityprovider . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=identityprovider . Deleter
 
 type Deleter interface {
 	DeleteIdentityProvider(string, string) error

--- a/internal/cli/federatedauthentication/federationsettings/identityprovider/describe.go
+++ b/internal/cli/federatedauthentication/federationsettings/identityprovider/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=identityprovider . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=identityprovider . Describer
 
 type Describer interface {
 	IdentityProvider(opts *atlasv2.GetIdentityProviderApiParams) (*atlasv2.FederationIdentityProvider, error)

--- a/internal/cli/federatedauthentication/federationsettings/identityprovider/list.go
+++ b/internal/cli/federatedauthentication/federationsettings/identityprovider/list.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=identityprovider . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=identityprovider . Lister
 
 type Lister interface {
 	IdentityProviders(opts *atlasv2.ListIdentityProvidersApiParams) (*atlasv2.PaginatedFederationIdentityProvider, error)

--- a/internal/cli/federatedauthentication/federationsettings/identityprovider/revokejwk.go
+++ b/internal/cli/federatedauthentication/federationsettings/identityprovider/revokejwk.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=revokejwk_mock_test.go -package=identityprovider . JwkRevoker
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=revokejwk_mock_test.go -package=identityprovider . JwkRevoker
 
 type JwkRevoker interface {
 	RevokeJwksFromIdentityProvider(string, string) error

--- a/internal/cli/federatedauthentication/federationsettings/identityprovider/update/oidc.go
+++ b/internal/cli/federatedauthentication/federationsettings/identityprovider/update/oidc.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=oidc_mock_test.go -package=update . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=oidc_mock_test.go -package=update . Updater
 
 type Updater interface {
 	UpdateIdentityProvider(opts *atlasv2.UpdateIdentityProviderApiParams) (*atlasv2.FederationIdentityProvider, error)

--- a/internal/cli/integrations/create/create.go
+++ b/internal/cli/integrations/create/create.go
@@ -19,7 +19,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=create . IntegrationCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=create . IntegrationCreator
 
 type IntegrationCreator interface {
 	CreateIntegration(string, string, *atlasv2.ThirdPartyIntegration) (*atlasv2.PaginatedIntegration, error)

--- a/internal/cli/integrations/delete.go
+++ b/internal/cli/integrations/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=integrations . IntegrationDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=integrations . IntegrationDeleter
 
 type IntegrationDeleter interface {
 	DeleteIntegration(string, string) error

--- a/internal/cli/integrations/describe.go
+++ b/internal/cli/integrations/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=integrations . IntegrationDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=integrations . IntegrationDescriber
 
 type IntegrationDescriber interface {
 	Integration(string, string) (*atlasv2.ThirdPartyIntegration, error)

--- a/internal/cli/integrations/list.go
+++ b/internal/cli/integrations/list.go
@@ -31,7 +31,7 @@ const listTemplate = `TYPE{{range valueOrEmptySlice .Results}}
 {{.Type}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=integrations . IntegrationLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=integrations . IntegrationLister
 
 type IntegrationLister interface {
 	Integrations(string) (*atlasv2.PaginatedIntegration, error)

--- a/internal/cli/livemigrations/create.go
+++ b/internal/cli/livemigrations/create.go
@@ -24,7 +24,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=livemigrations . LiveMigrationCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=livemigrations . LiveMigrationCreator
 
 type LiveMigrationCreator interface {
 	LiveMigrationCreate(string, *atlasv2.LiveMigrationRequest20240530) (*atlasv2.LiveMigrationResponse, error)

--- a/internal/cli/livemigrations/cutover.go
+++ b/internal/cli/livemigrations/cutover.go
@@ -27,7 +27,7 @@ import (
 
 var cutoverTemplate = "Cutover process successfully started.\n"
 
-//go:generate mockgen -typed -destination=cutover_mock_test.go -package=livemigrations . LiveMigrationCutoverCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=cutover_mock_test.go -package=livemigrations . LiveMigrationCutoverCreator
 
 type LiveMigrationCutoverCreator interface {
 	CreateLiveMigrationCutover(string, string) error

--- a/internal/cli/livemigrations/describe.go
+++ b/internal/cli/livemigrations/describe.go
@@ -26,7 +26,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=livemigrations . LiveMigrationDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=livemigrations . LiveMigrationDescriber
 
 type LiveMigrationDescriber interface {
 	LiveMigrationDescribe(string, string) (*atlasv2.LiveMigrationResponse, error)

--- a/internal/cli/livemigrations/link/create.go
+++ b/internal/cli/livemigrations/link/create.go
@@ -28,7 +28,7 @@ import (
 
 var createTemplate = "Link-token '{{.LinkToken}}' successfully created.\n"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=link . TokenCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=link . TokenCreator
 
 type TokenCreator interface {
 	CreateLinkToken(string, *atlasv2.TargetOrgRequest) (*atlasv2.TargetOrg, error)

--- a/internal/cli/livemigrations/link/delete.go
+++ b/internal/cli/livemigrations/link/delete.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=link . TokenDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=link . TokenDeleter
 
 type TokenDeleter interface {
 	DeleteLinkToken(string) error

--- a/internal/cli/livemigrations/validation/create.go
+++ b/internal/cli/livemigrations/validation/create.go
@@ -24,7 +24,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=validation . LiveMigrationValidationsCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=validation . LiveMigrationValidationsCreator
 
 type LiveMigrationValidationsCreator interface {
 	CreateValidation(string, *atlasv2.LiveMigrationRequest20240530) (*atlasv2.LiveImportValidation, error)

--- a/internal/cli/livemigrations/validation/describe.go
+++ b/internal/cli/livemigrations/validation/describe.go
@@ -26,7 +26,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=validation . LiveMigrationValidationsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=validation . LiveMigrationValidationsDescriber
 
 type LiveMigrationValidationsDescriber interface {
 	GetValidationStatus(string, string) (*atlasv2.LiveImportValidation, error)

--- a/internal/cli/logs/download.go
+++ b/internal/cli/logs/download.go
@@ -37,7 +37,7 @@ import (
 
 var errEmptyLog = errors.New("log is empty")
 
-//go:generate mockgen -typed -destination=download_mock_test.go -package=logs . Downloader
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=download_mock_test.go -package=logs . Downloader
 
 type Downloader interface {
 	DownloadLog(*atlasv2.GetHostLogsApiParams) (io.ReadCloser, error)

--- a/internal/cli/maintenance/clear.go
+++ b/internal/cli/maintenance/clear.go
@@ -32,7 +32,7 @@ const longDesc = `To learn more about maintenance windows, see https://www.mongo
 
 `
 
-//go:generate mockgen -typed -destination=clear_mock_test.go -package=maintenance . Clearer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=clear_mock_test.go -package=maintenance . Clearer
 
 type Clearer interface {
 	ClearMaintenanceWindow(string) error

--- a/internal/cli/maintenance/defer.go
+++ b/internal/cli/maintenance/defer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=defer_mock_test.go -package=maintenance . Deferrer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=defer_mock_test.go -package=maintenance . Deferrer
 
 type Deferrer interface {
 	DeferMaintenanceWindow(string) error

--- a/internal/cli/maintenance/describe.go
+++ b/internal/cli/maintenance/describe.go
@@ -30,7 +30,7 @@ var describeTemplate = `DAY OF THE WEEK	HOUR OF DAY	START ASAP
 {{.DayOfWeek}}	{{.HourOfDay}}	{{.StartASAP}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=maintenance . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=maintenance . Describer
 
 type Describer interface {
 	MaintenanceWindow(string) (*atlasv2.GroupMaintenanceWindow, error)

--- a/internal/cli/maintenance/update.go
+++ b/internal/cli/maintenance/update.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=maintenance . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=maintenance . Updater
 
 type Updater interface {
 	UpdateMaintenanceWindow(string, *atlasv2.GroupMaintenanceWindow) error

--- a/internal/cli/metrics/databases/describe.go
+++ b/internal/cli/metrics/databases/describe.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=databases . ProcessDatabaseMeasurementsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=databases . ProcessDatabaseMeasurementsLister
 
 type ProcessDatabaseMeasurementsLister interface {
 	ProcessDatabaseMeasurements(*atlasv2.GetDatabaseMeasurementsApiParams) (*atlasv2.ApiMeasurementsGeneralViewAtlas, error)

--- a/internal/cli/metrics/databases/list.go
+++ b/internal/cli/metrics/databases/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=databases . ProcessDatabaseLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=databases . ProcessDatabaseLister
 
 type ProcessDatabaseLister interface {
 	ProcessDatabases(string, string, int, *store.ListOptions) (*atlasv2.PaginatedDatabase, error)

--- a/internal/cli/metrics/disks/describe.go
+++ b/internal/cli/metrics/disks/describe.go
@@ -31,7 +31,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=disks . ProcessDiskMeasurementsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=disks . ProcessDiskMeasurementsLister
 
 type ProcessDiskMeasurementsLister interface {
 	ProcessDiskMeasurements(*atlasv2.GetDiskMeasurementsApiParams) (*atlasv2.ApiMeasurementsGeneralViewAtlas, error)

--- a/internal/cli/metrics/disks/list.go
+++ b/internal/cli/metrics/disks/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=disks . ProcessDisksLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=disks . ProcessDisksLister
 
 type ProcessDisksLister interface {
 	ProcessDisks(string, string, int, *store.ListOptions) (*atlasv2.PaginatedDiskPartition, error)

--- a/internal/cli/metrics/processes/processes.go
+++ b/internal/cli/metrics/processes/processes.go
@@ -31,7 +31,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=processes_mock_test.go -package=processes . ProcessMeasurementLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=processes_mock_test.go -package=processes . ProcessMeasurementLister
 
 type ProcessMeasurementLister interface {
 	ProcessMeasurements(*atlasv2.GetHostMeasurementsApiParams) (*atlasv2.ApiMeasurementsGeneralViewAtlas, error)

--- a/internal/cli/networking/containers/delete.go
+++ b/internal/cli/networking/containers/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=containers . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=containers . Deleter
 
 type Deleter interface {
 	DeleteContainer(string, string) error

--- a/internal/cli/networking/containers/list.go
+++ b/internal/cli/networking/containers/list.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=containers . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=containers . Lister
 
 type Lister interface {
 	ContainersByProvider(string, *store.ContainersListOptions) ([]atlasv2.CloudProviderContainer, error)

--- a/internal/cli/networking/peering/create/aws.go
+++ b/internal/cli/networking/peering/create/aws.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=aws_mock_test.go -package=create . AWSPeeringConnectionCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=aws_mock_test.go -package=create . AWSPeeringConnectionCreator
 
 type AWSPeeringConnectionCreator interface {
 	AWSContainers(string) ([]atlasv2.CloudProviderContainer, error)

--- a/internal/cli/networking/peering/create/azure.go
+++ b/internal/cli/networking/peering/create/azure.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=azure_mock_test.go -package=create . AzurePeeringConnectionCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=azure_mock_test.go -package=create . AzurePeeringConnectionCreator
 
 type AzurePeeringConnectionCreator interface {
 	AzureContainers(string) ([]atlasv2.CloudProviderContainer, error)

--- a/internal/cli/networking/peering/create/gcp.go
+++ b/internal/cli/networking/peering/create/gcp.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=gcp_mock_test.go -package=create . GCPPeeringConnectionCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=gcp_mock_test.go -package=create . GCPPeeringConnectionCreator
 
 type GCPPeeringConnectionCreator interface {
 	GCPContainers(string) ([]atlasv2.CloudProviderContainer, error)

--- a/internal/cli/networking/peering/delete.go
+++ b/internal/cli/networking/peering/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=peering . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=peering . Deleter
 
 type Deleter interface {
 	DeletePeeringConnection(string, string) error

--- a/internal/cli/networking/peering/list.go
+++ b/internal/cli/networking/peering/list.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=peering . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=peering . Lister
 
 type Lister interface {
 	PeeringConnections(string, *store.ContainersListOptions) ([]atlasv2.BaseNetworkPeeringConnectionSettings, error)

--- a/internal/cli/networking/peering/watch.go
+++ b/internal/cli/networking/peering/watch.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=watch_mock_test.go -package=peering . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=watch_mock_test.go -package=peering . Describer
 
 type Describer interface {
 	PeeringConnection(string, string) (*atlasv2.BaseNetworkPeeringConnectionSettings, error)

--- a/internal/cli/organizations/apikeys/accesslists/create.go
+++ b/internal/cli/organizations/apikeys/accesslists/create.go
@@ -30,7 +30,7 @@ import (
 
 const createTemplate = "Created new access list entry(s).\n"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=accesslists . OrganizationAPIKeyAccessListCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=accesslists . OrganizationAPIKeyAccessListCreator
 
 type OrganizationAPIKeyAccessListCreator interface {
 	CreateOrganizationAPIKeyAccessList(*admin.CreateApiKeyAccessListApiParams) (*admin.PaginatedApiUserAccessListResponse, error)

--- a/internal/cli/organizations/apikeys/accesslists/delete.go
+++ b/internal/cli/organizations/apikeys/accesslists/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=accesslists . OrganizationAPIKeyAccessListDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=accesslists . OrganizationAPIKeyAccessListDeleter
 
 type OrganizationAPIKeyAccessListDeleter interface {
 	DeleteOrganizationAPIKeyAccessList(string, string, string) error

--- a/internal/cli/organizations/apikeys/accesslists/list.go
+++ b/internal/cli/organizations/apikeys/accesslists/list.go
@@ -31,7 +31,7 @@ const listTemplate = `IP ADDRESS	CIDR BLOCK	CREATED AT{{range valueOrEmptySlice 
 {{.IpAddress}}	{{.CidrBlock}}	{{.Created}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=accesslists . OrganizationAPIKeyAccessListLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=accesslists . OrganizationAPIKeyAccessListLister
 
 type OrganizationAPIKeyAccessListLister interface {
 	OrganizationAPIKeyAccessLists(*admin.ListApiKeyAccessListsEntriesApiParams) (*admin.PaginatedApiUserAccessListResponse, error)

--- a/internal/cli/organizations/apikeys/create.go
+++ b/internal/cli/organizations/apikeys/create.go
@@ -33,7 +33,7 @@ Public API Key {{.PublicKey}}
 Private API Key {{.PrivateKey}}
 `
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=apikeys . OrganizationAPIKeyCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=apikeys . OrganizationAPIKeyCreator
 
 type OrganizationAPIKeyCreator interface {
 	CreateOrganizationAPIKey(string, *atlasv2.CreateAtlasOrganizationApiKey) (*atlasv2.ApiKeyUserDetails, error)

--- a/internal/cli/organizations/apikeys/delete.go
+++ b/internal/cli/organizations/apikeys/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=apikeys . OrganizationAPIKeyDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=apikeys . OrganizationAPIKeyDeleter
 
 type OrganizationAPIKeyDeleter interface {
 	DeleteOrganizationAPIKey(string, string) error

--- a/internal/cli/organizations/apikeys/describe.go
+++ b/internal/cli/organizations/apikeys/describe.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=apikeys . OrganizationAPIKeyDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=apikeys . OrganizationAPIKeyDescriber
 
 type OrganizationAPIKeyDescriber interface {
 	OrganizationAPIKey(string, string) (*atlasv2.ApiKeyUserDetails, error)

--- a/internal/cli/organizations/apikeys/list.go
+++ b/internal/cli/organizations/apikeys/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	DESCRIPTION	PUBLIC KEY	PRIVATE KEY{{range valueOrEmptyS
 {{.Id}}	{{.Desc}}	{{.PublicKey}}	{{.PrivateKey}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=apikeys . OrganizationAPIKeyLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=apikeys . OrganizationAPIKeyLister
 
 type OrganizationAPIKeyLister interface {
 	OrganizationAPIKeys(string, *store.ListOptions) (*atlasv2.PaginatedApiApiUser, error)

--- a/internal/cli/organizations/apikeys/update.go
+++ b/internal/cli/organizations/apikeys/update.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=apikeys . OrganizationAPIKeyUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=apikeys . OrganizationAPIKeyUpdater
 
 type OrganizationAPIKeyUpdater interface {
 	UpdateOrganizationAPIKey(string, string, *atlasv2.UpdateAtlasOrganizationApiKey) (*atlasv2.ApiKeyUserDetails, error)

--- a/internal/cli/organizations/create.go
+++ b/internal/cli/organizations/create.go
@@ -32,7 +32,7 @@ import (
 
 var createAtlasTemplate = "Organization '{{.Organization.Id}}' created.\n"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=organizations . OrganizationCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=organizations . OrganizationCreator
 
 type OrganizationCreator interface {
 	CreateAtlasOrganization(*atlasv2.CreateOrganizationRequest) (*atlasv2.CreateOrganizationResponse, error)

--- a/internal/cli/organizations/delete.go
+++ b/internal/cli/organizations/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=organizations . OrganizationDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=organizations . OrganizationDeleter
 
 type OrganizationDeleter interface {
 	DeleteOrganization(string) error

--- a/internal/cli/organizations/describe.go
+++ b/internal/cli/organizations/describe.go
@@ -31,7 +31,7 @@ const describeTemplate = `ID	NAME
 {{.Id}}	{{.Name}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=organizations . OrganizationDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=organizations . OrganizationDescriber
 
 type OrganizationDescriber interface {
 	Organization(string) (*atlasv2.AtlasOrganization, error)

--- a/internal/cli/organizations/invitations/delete.go
+++ b/internal/cli/organizations/invitations/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=invitations . OrganizationInvitationDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=invitations . OrganizationInvitationDeleter
 
 type OrganizationInvitationDeleter interface {
 	DeleteInvitation(string, string) error

--- a/internal/cli/organizations/invitations/describe.go
+++ b/internal/cli/organizations/invitations/describe.go
@@ -31,7 +31,7 @@ const describeTemplate = `ID	USERNAME	CREATED AT	EXPIRES AT
 {{.Id}}	{{.Username}}	{{.CreatedAt}}	{{.ExpiresAt}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=invitations . OrganizationInvitationDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=invitations . OrganizationInvitationDescriber
 
 type OrganizationInvitationDescriber interface {
 	OrganizationInvitation(string, string) (*atlasv2.OrganizationInvitation, error)

--- a/internal/cli/organizations/invitations/invite.go
+++ b/internal/cli/organizations/invitations/invite.go
@@ -32,7 +32,7 @@ import (
 
 const createTemplate = "User '{{.Username}}' invited.\n"
 
-//go:generate mockgen -typed -destination=invite_mock_test.go -package=invitations . OrganizationInviter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=invite_mock_test.go -package=invitations . OrganizationInviter
 
 type OrganizationInviter interface {
 	InviteUser(string, *atlasv2.OrganizationInvitationRequest) (*atlasv2.OrganizationInvitation, error)

--- a/internal/cli/organizations/invitations/list.go
+++ b/internal/cli/organizations/invitations/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	USERNAME	CREATED AT	EXPIRES AT{{range valueOrEmptySlice
 {{.Id}}	{{.Username}}	{{.CreatedAt}}	{{.ExpiresAt}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=invitations . OrganizationInvitationLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=invitations . OrganizationInvitationLister
 
 type OrganizationInvitationLister interface {
 	OrganizationInvitations(*atlasv2.ListOrganizationInvitationsApiParams) ([]atlasv2.OrganizationInvitation, error)

--- a/internal/cli/organizations/invitations/update.go
+++ b/internal/cli/organizations/invitations/update.go
@@ -32,7 +32,7 @@ import (
 
 const updateTemplate = "Invitation {{.Id}} updated.\n"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=invitations . OrganizationInvitationUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=invitations . OrganizationInvitationUpdater
 
 type OrganizationInvitationUpdater interface {
 	UpdateOrganizationInvitation(string, string, *atlasv2.OrganizationInvitationRequest) (*atlasv2.OrganizationInvitation, error)

--- a/internal/cli/organizations/list.go
+++ b/internal/cli/organizations/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	NAME{{range valueOrEmptySlice .Results}}
 {{.Id}}	{{.Name}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=organizations . OrganizationLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=organizations . OrganizationLister
 
 type OrganizationLister interface {
 	Organizations(*atlasv2.ListOrganizationsApiParams) (*atlasv2.PaginatedOrganization, error)

--- a/internal/cli/organizations/users/list.go
+++ b/internal/cli/organizations/users/list.go
@@ -31,7 +31,7 @@ const listTemplate = `ID	FIRST NAME	LAST NAME	USERNAME{{range valueOrEmptySlice 
 {{.Id}}	{{.FirstName}}	{{.LastName}}	{{.Username}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=users . UserLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=users . UserLister
 
 type UserLister interface {
 	OrganizationUsers(string, *store.ListOptions) (*atlasv2.PaginatedOrgUser, error)

--- a/internal/cli/performanceadvisor/namespaces/list.go
+++ b/internal/cli/performanceadvisor/namespaces/list.go
@@ -32,7 +32,7 @@ const listTemplate = `NAMESPACE	TYPE{{range valueOrEmptySlice .Namespaces}}
 {{.Namespace}}	{{.Type}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=namespaces . PerformanceAdvisorNamespacesLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=namespaces . PerformanceAdvisorNamespacesLister
 
 type PerformanceAdvisorNamespacesLister interface {
 	PerformanceAdvisorNamespaces(opts *atlasv2.ListSlowQueryNamespacesApiParams) (*atlasv2.Namespaces, error)

--- a/internal/cli/performanceadvisor/slowoperationthreshold/disable.go
+++ b/internal/cli/performanceadvisor/slowoperationthreshold/disable.go
@@ -29,7 +29,7 @@ import (
 const DisableTemplate = `Atlas management of the slow operation disabled
 `
 
-//go:generate mockgen -typed -destination=disable_mock_test.go -package=slowoperationthreshold . PerformanceAdvisorSlowOperationThresholdDisabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=disable_mock_test.go -package=slowoperationthreshold . PerformanceAdvisorSlowOperationThresholdDisabler
 
 type PerformanceAdvisorSlowOperationThresholdDisabler interface {
 	DisablePerformanceAdvisorSlowOperationThreshold(string) error

--- a/internal/cli/performanceadvisor/slowoperationthreshold/enable.go
+++ b/internal/cli/performanceadvisor/slowoperationthreshold/enable.go
@@ -29,7 +29,7 @@ import (
 const EnableTemplate = `Atlas management of the slow operation enabled
 `
 
-//go:generate mockgen -typed -destination=enable_mock_test.go -package=slowoperationthreshold . PerformanceAdvisorSlowOperationThresholdEnabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=enable_mock_test.go -package=slowoperationthreshold . PerformanceAdvisorSlowOperationThresholdEnabler
 
 type PerformanceAdvisorSlowOperationThresholdEnabler interface {
 	EnablePerformanceAdvisorSlowOperationThreshold(string) error

--- a/internal/cli/performanceadvisor/slowquerylogs/list.go
+++ b/internal/cli/performanceadvisor/slowquerylogs/list.go
@@ -33,7 +33,7 @@ const listTemplate = `NAMESPACE	LINE{{range valueOrEmptySlice .SlowQueries}}
 {{.Namespace}}	{{.Line}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=slowquerylogs . PerformanceAdvisorSlowQueriesLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=slowquerylogs . PerformanceAdvisorSlowQueriesLister
 
 type PerformanceAdvisorSlowQueriesLister interface {
 	PerformanceAdvisorSlowQueries(*atlasv2.ListSlowQueriesApiParams) (*atlasv2.PerformanceAdvisorSlowQueryList, error)

--- a/internal/cli/performanceadvisor/suggestedindexes/list.go
+++ b/internal/cli/performanceadvisor/suggestedindexes/list.go
@@ -33,7 +33,7 @@ const listTemplate = `ID	NAMESPACE	SUGGESTED INDEX{{range valueOrEmptySlice .Sug
 {{ .Id }}	{{ .Namespace}}	{ {{range $i, $element := valueOrEmptySlice .Index}}{{range $key, $value := .}}{{if $i}}, {{end}}{{ $key }}: {{ $value }}{{end}}{{end}} }{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=suggestedindexes . PerformanceAdvisorIndexesLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=suggestedindexes . PerformanceAdvisorIndexesLister
 
 type PerformanceAdvisorIndexesLister interface {
 	PerformanceAdvisorIndexes(*atlasv2.ListSuggestedIndexesApiParams) (*atlasv2.PerformanceAdvisorResponse, error)

--- a/internal/cli/privateendpoints/aws/create.go
+++ b/internal/cli/privateendpoints/aws/create.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=aws . PrivateEndpointCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=aws . PrivateEndpointCreator
 
 type PrivateEndpointCreator interface {
 	CreatePrivateEndpoint(string, *atlasv2.CloudProviderEndpointServiceRequest) (*atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/aws/delete.go
+++ b/internal/cli/privateendpoints/aws/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=aws . PrivateEndpointDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=aws . PrivateEndpointDeleter
 
 type PrivateEndpointDeleter interface {
 	DeletePrivateEndpoint(string, string, string) error

--- a/internal/cli/privateendpoints/aws/describe.go
+++ b/internal/cli/privateendpoints/aws/describe.go
@@ -32,7 +32,7 @@ var describeTemplate = `ID	ENDPOINT SERVICE	STATUS	ERROR
 {{.Id}}	{{.EndpointServiceName}}	{{.Status}}	{{.ErrorMessage}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=aws . PrivateEndpointDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=aws . PrivateEndpointDescriber
 
 type PrivateEndpointDescriber interface {
 	PrivateEndpoint(string, string, string) (*atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/aws/interfaces/create.go
+++ b/internal/cli/privateendpoints/aws/interfaces/create.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=interfaces . InterfaceEndpointCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=interfaces . InterfaceEndpointCreator
 
 type InterfaceEndpointCreator interface {
 	CreateInterfaceEndpoint(string, string, string, *atlasv2.CreateEndpointRequest) (*atlasv2.PrivateLinkEndpoint, error)

--- a/internal/cli/privateendpoints/aws/interfaces/delete.go
+++ b/internal/cli/privateendpoints/aws/interfaces/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=interfaces . InterfaceEndpointDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=interfaces . InterfaceEndpointDeleter
 
 type InterfaceEndpointDeleter interface {
 	DeleteInterfaceEndpoint(string, string, string, string) error

--- a/internal/cli/privateendpoints/aws/interfaces/describe.go
+++ b/internal/cli/privateendpoints/aws/interfaces/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=interfaces . InterfaceEndpointDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=interfaces . InterfaceEndpointDescriber
 
 type InterfaceEndpointDescriber interface {
 	InterfaceEndpoint(projectID, cloudProvider, privateEndpointID, endpointServiceID string) (*atlasv2.PrivateLinkEndpoint, error)

--- a/internal/cli/privateendpoints/aws/list.go
+++ b/internal/cli/privateendpoints/aws/list.go
@@ -34,7 +34,7 @@ var listTemplate = `ID	ENDPOINT SERVICE	STATUS	ERROR{{range valueOrEmptySlice .}
 
 const deprecatedFlagMessage = "--page and --limit are not supported by privateendpoint aws list"
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=aws . PrivateEndpointLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=aws . PrivateEndpointLister
 
 type PrivateEndpointLister interface {
 	PrivateEndpoints(string, string) ([]atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/azure/create.go
+++ b/internal/cli/privateendpoints/azure/create.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=azure . PrivateEndpointCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=azure . PrivateEndpointCreator
 
 type PrivateEndpointCreator interface {
 	CreatePrivateEndpoint(string, *atlasv2.CloudProviderEndpointServiceRequest) (*atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/azure/delete.go
+++ b/internal/cli/privateendpoints/azure/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=azure . PrivateEndpointDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=azure . PrivateEndpointDeleter
 
 type PrivateEndpointDeleter interface {
 	DeletePrivateEndpoint(string, string, string) error

--- a/internal/cli/privateendpoints/azure/describe.go
+++ b/internal/cli/privateendpoints/azure/describe.go
@@ -31,7 +31,7 @@ var describeTemplate = `ID	ENDPOINT SERVICE	STATUS	ERROR
 {{.Id}}	{{.PrivateLinkServiceName}}	{{.Status}}	{{.ErrorMessage}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=azure . PrivateEndpointDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=azure . PrivateEndpointDescriber
 
 type PrivateEndpointDescriber interface {
 	PrivateEndpoint(string, string, string) (*atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/azure/interfaces/create.go
+++ b/internal/cli/privateendpoints/azure/interfaces/create.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=interfaces . InterfaceEndpointCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=interfaces . InterfaceEndpointCreator
 
 type InterfaceEndpointCreator interface {
 	CreateInterfaceEndpoint(string, string, string, *atlasv2.CreateEndpointRequest) (*atlasv2.PrivateLinkEndpoint, error)

--- a/internal/cli/privateendpoints/azure/interfaces/delete.go
+++ b/internal/cli/privateendpoints/azure/interfaces/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=interfaces . InterfaceEndpointDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=interfaces . InterfaceEndpointDeleter
 
 type InterfaceEndpointDeleter interface {
 	DeleteInterfaceEndpoint(string, string, string, string) error

--- a/internal/cli/privateendpoints/azure/interfaces/describe.go
+++ b/internal/cli/privateendpoints/azure/interfaces/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=interfaces . InterfaceEndpointDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=interfaces . InterfaceEndpointDescriber
 
 type InterfaceEndpointDescriber interface {
 	InterfaceEndpoint(projectID, cloudProvider, privateEndpointID, endpointServiceID string) (*atlasv2.PrivateLinkEndpoint, error)

--- a/internal/cli/privateendpoints/azure/list.go
+++ b/internal/cli/privateendpoints/azure/list.go
@@ -34,7 +34,7 @@ var listTemplate = `ID	ENDPOINT SERVICE	STATUS	ERROR{{range valueOrEmptySlice .}
 
 const deprecatedFlagMessage = "--page and --limit are not supported by privateendpoint azure list"
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=azure . PrivateEndpointLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=azure . PrivateEndpointLister
 
 type PrivateEndpointLister interface {
 	PrivateEndpoints(string, string) ([]atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/create.go
+++ b/internal/cli/privateendpoints/create.go
@@ -27,7 +27,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=privateendpoints . PrivateEndpointCreatorDeprecated
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=privateendpoints . PrivateEndpointCreatorDeprecated
 
 type PrivateEndpointCreatorDeprecated interface {
 	CreatePrivateEndpointDeprecated(string, *atlas.PrivateEndpointConnectionDeprecated) (*atlas.PrivateEndpointConnectionDeprecated, error)

--- a/internal/cli/privateendpoints/datalake/aws/create.go
+++ b/internal/cli/privateendpoints/datalake/aws/create.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=aws . DataLakePrivateEndpointCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=aws . DataLakePrivateEndpointCreator
 
 type DataLakePrivateEndpointCreator interface {
 	DataLakeCreatePrivateEndpoint(string, *atlasv2.PrivateNetworkEndpointIdEntry) (*atlasv2.PaginatedPrivateNetworkEndpointIdEntry, error)

--- a/internal/cli/privateendpoints/datalake/aws/delete.go
+++ b/internal/cli/privateendpoints/datalake/aws/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=aws . DataLakePrivateEndpointDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=aws . DataLakePrivateEndpointDeleter
 
 type DataLakePrivateEndpointDeleter interface {
 	DataLakeDeletePrivateEndpoint(string, string) error

--- a/internal/cli/privateendpoints/datalake/aws/describe.go
+++ b/internal/cli/privateendpoints/datalake/aws/describe.go
@@ -31,7 +31,7 @@ var describeTemplate = `ID	ENDPOINT PROVIDER	TYPE	COMMENT
 {{.EndpointId}}	{{.Provider}}	{{.Type}}	{{.Comment}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=aws . DataLakePrivateEndpointDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=aws . DataLakePrivateEndpointDescriber
 
 type DataLakePrivateEndpointDescriber interface {
 	DataLakePrivateEndpoint(string, string) (*atlasv2.PrivateNetworkEndpointIdEntry, error)

--- a/internal/cli/privateendpoints/datalake/aws/list.go
+++ b/internal/cli/privateendpoints/datalake/aws/list.go
@@ -32,7 +32,7 @@ var listTemplate = `ID	ENDPOINT PROVIDER	TYPE	COMMENT{{range valueOrEmptySlice .
 {{.EndpointId}}	{{.Provider}}	{{.Type}}	{{.Comment}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=aws . DataLakePrivateEndpointLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=aws . DataLakePrivateEndpointLister
 
 type DataLakePrivateEndpointLister interface {
 	DataLakePrivateEndpoints(*atlasv2.ListDataFederationPrivateEndpointsApiParams) (*atlasv2.PaginatedPrivateNetworkEndpointIdEntry, error)

--- a/internal/cli/privateendpoints/delete.go
+++ b/internal/cli/privateendpoints/delete.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=privateendpoints . PrivateEndpointDeleterDeprecated
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=privateendpoints . PrivateEndpointDeleterDeprecated
 
 type PrivateEndpointDeleterDeprecated interface {
 	DeletePrivateEndpointDeprecated(string, string) error

--- a/internal/cli/privateendpoints/describe.go
+++ b/internal/cli/privateendpoints/describe.go
@@ -29,7 +29,7 @@ var describeTemplate = `ID	ENDPOINT SERVICE	STATUS	ERROR
 {{.ID}}	{{.EndpointServiceName}}	{{.Status}}	{{.ErrorMessage}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=privateendpoints . PrivateEndpointDescriberDeprecated
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=privateendpoints . PrivateEndpointDescriberDeprecated
 
 type PrivateEndpointDescriberDeprecated interface {
 	PrivateEndpointDeprecated(string, string) (*atlas.PrivateEndpointConnectionDeprecated, error)

--- a/internal/cli/privateendpoints/gcp/create.go
+++ b/internal/cli/privateendpoints/gcp/create.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=gcp . PrivateEndpointCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=gcp . PrivateEndpointCreator
 
 type PrivateEndpointCreator interface {
 	CreatePrivateEndpoint(string, *atlasv2.CloudProviderEndpointServiceRequest) (*atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/gcp/delete.go
+++ b/internal/cli/privateendpoints/gcp/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=gcp . PrivateEndpointDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=gcp . PrivateEndpointDeleter
 
 type PrivateEndpointDeleter interface {
 	DeletePrivateEndpoint(string, string, string) error

--- a/internal/cli/privateendpoints/gcp/describe.go
+++ b/internal/cli/privateendpoints/gcp/describe.go
@@ -32,7 +32,7 @@ var describeTemplate = `ID	GROUP NAME	REGION	STATUS	ERROR{{if .EndpointGroupName
 {{$.Id}}	N/A	{{$.RegionName}}	{{$.Status}}	{{$.ErrorMessage}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=gcp . PrivateEndpointDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=gcp . PrivateEndpointDescriber
 
 type PrivateEndpointDescriber interface {
 	PrivateEndpoint(string, string, string) (*atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/gcp/interfaces/create.go
+++ b/internal/cli/privateendpoints/gcp/interfaces/create.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=interfaces . InterfaceEndpointCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=interfaces . InterfaceEndpointCreator
 
 type InterfaceEndpointCreator interface {
 	CreateInterfaceEndpoint(string, string, string, *atlasv2.CreateEndpointRequest) (*atlasv2.PrivateLinkEndpoint, error)

--- a/internal/cli/privateendpoints/gcp/interfaces/delete.go
+++ b/internal/cli/privateendpoints/gcp/interfaces/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=interfaces . InterfaceEndpointDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=interfaces . InterfaceEndpointDeleter
 
 type InterfaceEndpointDeleter interface {
 	DeleteInterfaceEndpoint(string, string, string, string) error

--- a/internal/cli/privateendpoints/gcp/interfaces/describe.go
+++ b/internal/cli/privateendpoints/gcp/interfaces/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=interfaces . InterfaceEndpointDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=interfaces . InterfaceEndpointDescriber
 
 type InterfaceEndpointDescriber interface {
 	InterfaceEndpoint(projectID, cloudProvider, privateEndpointID, endpointServiceID string) (*atlasv2.PrivateLinkEndpoint, error)

--- a/internal/cli/privateendpoints/gcp/list.go
+++ b/internal/cli/privateendpoints/gcp/list.go
@@ -34,7 +34,7 @@ var listTemplate = `ID	REGION	STATUS	ERROR{{range valueOrEmptySlice .}}
 
 const deprecatedFlagMessage = "--page and --limit are not supported by privateendpoint aws list"
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=gcp . PrivateEndpointLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=gcp . PrivateEndpointLister
 
 type PrivateEndpointLister interface {
 	PrivateEndpoints(string, string) ([]atlasv2.EndpointService, error)

--- a/internal/cli/privateendpoints/interfaces/create.go
+++ b/internal/cli/privateendpoints/interfaces/create.go
@@ -27,7 +27,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=interfaces . InterfaceEndpointCreatorDeprecated
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=interfaces . InterfaceEndpointCreatorDeprecated
 
 type InterfaceEndpointCreatorDeprecated interface {
 	CreateInterfaceEndpointDeprecated(string, string, string) (*atlas.InterfaceEndpointConnectionDeprecated, error)

--- a/internal/cli/privateendpoints/interfaces/delete.go
+++ b/internal/cli/privateendpoints/interfaces/delete.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=interfaces . InterfaceEndpointDeleterDeprecated
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=interfaces . InterfaceEndpointDeleterDeprecated
 
 type InterfaceEndpointDeleterDeprecated interface {
 	DeleteInterfaceEndpointDeprecated(string, string, string) error

--- a/internal/cli/privateendpoints/interfaces/describe.go
+++ b/internal/cli/privateendpoints/interfaces/describe.go
@@ -27,7 +27,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=interfaces . InterfaceEndpointDescriberDeprecated
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=interfaces . InterfaceEndpointDescriberDeprecated
 
 type InterfaceEndpointDescriberDeprecated interface {
 	InterfaceEndpointDeprecated(string, string, string) (*atlas.InterfaceEndpointConnectionDeprecated, error)

--- a/internal/cli/privateendpoints/list.go
+++ b/internal/cli/privateendpoints/list.go
@@ -29,7 +29,7 @@ var listTemplate = `ID	ENDPOINT SERVICE	STATUS	ERROR{{range valueOrEmptySlice .}
 {{.ID}}	{{.EndpointServiceName}}	{{.Status}}	{{.ErrorMessage}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=privateendpoints . PrivateEndpointListerDeprecated
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=privateendpoints . PrivateEndpointListerDeprecated
 
 type PrivateEndpointListerDeprecated interface {
 	PrivateEndpointsDeprecated(string, *store.ListOptions) ([]atlas.PrivateEndpointConnectionDeprecated, error)

--- a/internal/cli/privateendpoints/regionalmodes/describe.go
+++ b/internal/cli/privateendpoints/regionalmodes/describe.go
@@ -30,7 +30,7 @@ var describeTemplate = `ENABLED
 {{.Enabled}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=regionalmodes . RegionalizedPrivateEndpointSettingDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=regionalmodes . RegionalizedPrivateEndpointSettingDescriber
 
 type RegionalizedPrivateEndpointSettingDescriber interface {
 	RegionalizedPrivateEndpointSetting(string) (*atlasv2.ProjectSettingItem, error)

--- a/internal/cli/privateendpoints/regionalmodes/disable.go
+++ b/internal/cli/privateendpoints/regionalmodes/disable.go
@@ -26,7 +26,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=disable_mock_test.go -package=regionalmodes . RegionalizedPrivateEndpointSettingUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=disable_mock_test.go -package=regionalmodes . RegionalizedPrivateEndpointSettingUpdater
 
 type RegionalizedPrivateEndpointSettingUpdater interface {
 	UpdateRegionalizedPrivateEndpointSetting(string, bool) (*atlasv2.ProjectSettingItem, error)

--- a/internal/cli/processes/describe.go
+++ b/internal/cli/processes/describe.go
@@ -30,7 +30,7 @@ const describeTemplate = `ID	REPLICA SET NAME	SHARD NAME	VERSION
 {{.Id}}	{{.ReplicaSetName}}	{{.ShardName}}	{{.Version}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=processes . ProcessDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=processes . ProcessDescriber
 
 type ProcessDescriber interface {
 	Process(*atlasv2.GetAtlasProcessApiParams) (*atlasv2.ApiHostViewAtlas, error)

--- a/internal/cli/processes/list.go
+++ b/internal/cli/processes/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	REPLICA SET NAME	SHARD NAME	VERSION{{range valueOrEmpty
 {{.Id}}	{{.ReplicaSetName}}	{{.ShardName}}	{{.Version}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=processes . ProcessLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=processes . ProcessLister
 
 type ProcessLister interface {
 	Processes(*atlasv2.ListAtlasProcessesApiParams) (*atlasv2.PaginatedHostViewAtlas, error)

--- a/internal/cli/projects/apikeys/assign.go
+++ b/internal/cli/projects/apikeys/assign.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=assign_mock_test.go -package=apikeys . ProjectAPIKeyAssigner
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=assign_mock_test.go -package=apikeys . ProjectAPIKeyAssigner
 
 type ProjectAPIKeyAssigner interface {
 	AssignProjectAPIKey(string, string, *atlasv2.UpdateAtlasProjectApiKey) error

--- a/internal/cli/projects/apikeys/create.go
+++ b/internal/cli/projects/apikeys/create.go
@@ -33,7 +33,7 @@ Public API Key {{.PublicKey}}
 Private API Key {{.PrivateKey}}
 `
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=apikeys . ProjectAPIKeyCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=apikeys . ProjectAPIKeyCreator
 
 type ProjectAPIKeyCreator interface {
 	CreateProjectAPIKey(string, *atlasv2.CreateAtlasProjectApiKey) (*atlasv2.ApiKeyUserDetails, error)

--- a/internal/cli/projects/apikeys/delete.go
+++ b/internal/cli/projects/apikeys/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=apikeys . ProjectAPIKeyDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=apikeys . ProjectAPIKeyDeleter
 
 type ProjectAPIKeyDeleter interface {
 	DeleteProjectAPIKey(string, string) error

--- a/internal/cli/projects/apikeys/list.go
+++ b/internal/cli/projects/apikeys/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	PUBLIC KEY	DESCRIPTION{{range valueOrEmptySlice .Result
 {{.Id}}	{{.PublicKey}}	{{.Desc}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=apikeys . ProjectAPIKeyLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=apikeys . ProjectAPIKeyLister
 
 type ProjectAPIKeyLister interface {
 	ProjectAPIKeys(string, *store.ListOptions) (*atlasv2.PaginatedApiApiUser, error)

--- a/internal/cli/projects/create.go
+++ b/internal/cli/projects/create.go
@@ -31,7 +31,7 @@ import (
 
 const atlasCreateTemplate = "Project '{{.Id}}' created.\n"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=projects . ProjectCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=projects . ProjectCreator
 
 type ProjectCreator interface {
 	CreateProject(*atlasv2.CreateProjectApiParams) (*atlasv2.Group, error)

--- a/internal/cli/projects/delete.go
+++ b/internal/cli/projects/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=projects . ProjectDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=projects . ProjectDeleter
 
 type ProjectDeleter interface {
 	DeleteProject(string) error

--- a/internal/cli/projects/describe.go
+++ b/internal/cli/projects/describe.go
@@ -31,7 +31,7 @@ const describeTemplate = `ID	NAME
 {{.Id}}	{{.Name}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=projects . ProjectDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=projects . ProjectDescriber
 
 type ProjectDescriber interface {
 	Project(string) (*atlasv2.Group, error)

--- a/internal/cli/projects/invitations/delete.go
+++ b/internal/cli/projects/invitations/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=invitations . ProjectInvitationDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=invitations . ProjectInvitationDeleter
 
 type ProjectInvitationDeleter interface {
 	DeleteProjectInvitation(string, string) error

--- a/internal/cli/projects/invitations/describe.go
+++ b/internal/cli/projects/invitations/describe.go
@@ -31,7 +31,7 @@ const describeTemplate = `ID	USERNAME	CREATED AT	EXPIRES AT
 {{.Id}}	{{.Username}}	{{.CreatedAt}}	{{.ExpiresAt}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=invitations . ProjectInvitationDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=invitations . ProjectInvitationDescriber
 
 type ProjectInvitationDescriber interface {
 	ProjectInvitation(string, string) (*atlasv2.GroupInvitation, error)

--- a/internal/cli/projects/invitations/invite.go
+++ b/internal/cli/projects/invitations/invite.go
@@ -30,7 +30,7 @@ import (
 
 const createTemplate = "User '{{.Username}}' invited.\n"
 
-//go:generate mockgen -typed -destination=invite_mock_test.go -package=invitations . ProjectInviter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=invite_mock_test.go -package=invitations . ProjectInviter
 
 type ProjectInviter interface {
 	InviteUserToProject(string, *atlasv2.GroupInvitationRequest) (*atlasv2.GroupInvitation, error)

--- a/internal/cli/projects/invitations/list.go
+++ b/internal/cli/projects/invitations/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	USERNAME	CREATED AT	EXPIRES AT{{range valueOrEmptySlice
 {{.Id}}	{{.Username}}	{{.CreatedAt}}	{{.ExpiresAt}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=invitations . ProjectInvitationLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=invitations . ProjectInvitationLister
 
 type ProjectInvitationLister interface {
 	ProjectInvitations(*atlasv2.ListProjectInvitationsApiParams) ([]atlasv2.GroupInvitation, error)

--- a/internal/cli/projects/invitations/update.go
+++ b/internal/cli/projects/invitations/update.go
@@ -30,7 +30,7 @@ import (
 
 const updateTemplate = "Invitation {{.Id}} updated.\n"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=invitations . ProjectInvitationUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=invitations . ProjectInvitationUpdater
 
 type ProjectInvitationUpdater interface {
 	UpdateProjectInvitation(string, string, *atlasv2.GroupInvitationRequest) (*atlasv2.GroupInvitation, error)

--- a/internal/cli/projects/list.go
+++ b/internal/cli/projects/list.go
@@ -31,7 +31,7 @@ const listTemplate = `ID	NAME{{range valueOrEmptySlice .Results}}
 {{.Id}}	{{.Name}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=projects . OrgProjectLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=projects . OrgProjectLister
 
 type OrgProjectLister interface {
 	Projects(*store.ListOptions) (*atlasv2.PaginatedAtlasGroup, error)

--- a/internal/cli/projects/settings/describe.go
+++ b/internal/cli/projects/settings/describe.go
@@ -25,7 +25,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=settings . ProjectSettingsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=settings . ProjectSettingsDescriber
 
 type ProjectSettingsDescriber interface {
 	ProjectSettings(string) (*atlasv2.GroupSettings, error)

--- a/internal/cli/projects/settings/update.go
+++ b/internal/cli/projects/settings/update.go
@@ -28,7 +28,7 @@ import (
 
 const updateTemplate = "Project settings updated.\n"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=settings . ProjectSettingsUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=settings . ProjectSettingsUpdater
 
 type ProjectSettingsUpdater interface {
 	UpdateProjectSettings(string, *atlasv2.GroupSettings) (*atlasv2.GroupSettings, error)

--- a/internal/cli/projects/teams/add.go
+++ b/internal/cli/projects/teams/add.go
@@ -30,7 +30,7 @@ import (
 
 const addTemplate = "Team added to the project.\n"
 
-//go:generate mockgen -typed -destination=add_mock_test.go -package=teams . ProjectTeamAdder
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=add_mock_test.go -package=teams . ProjectTeamAdder
 
 type ProjectTeamAdder interface {
 	AddTeamsToProject(string, []atlasv2.TeamRole) (*atlasv2.PaginatedTeamRole, error)

--- a/internal/cli/projects/teams/delete.go
+++ b/internal/cli/projects/teams/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=teams . ProjectTeamDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=teams . ProjectTeamDeleter
 
 type ProjectTeamDeleter interface {
 	DeleteTeamFromProject(string, string) error

--- a/internal/cli/projects/teams/list.go
+++ b/internal/cli/projects/teams/list.go
@@ -31,7 +31,7 @@ const listTemplate = `ID{{range valueOrEmptySlice .Results}}
 {{.TeamId}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=teams . ProjectTeamLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=teams . ProjectTeamLister
 
 type ProjectTeamLister interface {
 	ProjectTeams(string, *store.ListOptions) (*atlasv2.PaginatedTeamRole, error)

--- a/internal/cli/projects/teams/update.go
+++ b/internal/cli/projects/teams/update.go
@@ -30,7 +30,7 @@ import (
 
 const updateTemplate = "Team's roles updated.\n"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=teams . TeamRolesUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=teams . TeamRolesUpdater
 
 type TeamRolesUpdater interface {
 	UpdateProjectTeamRoles(string, string, *atlasv2.TeamRole) (*atlasv2.PaginatedTeamRole, error)

--- a/internal/cli/projects/update.go
+++ b/internal/cli/projects/update.go
@@ -34,7 +34,7 @@ import (
 
 const updateTemplate = "Project '{{.Id}}' updated.\n"
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=projects . ProjectUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=projects . ProjectUpdater
 
 type ProjectUpdater interface {
 	UpdateProject(*atlasv2.UpdateProjectApiParams) (*atlasv2.Group, error)

--- a/internal/cli/projects/users/delete.go
+++ b/internal/cli/projects/users/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=users . ProjectUserDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=users . ProjectUserDeleter
 
 type ProjectUserDeleter interface {
 	DeleteUserFromProject(string, string) error

--- a/internal/cli/projects/users/list.go
+++ b/internal/cli/projects/users/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	FIRST NAME	LAST NAME	USERNAME{{range valueOrEmptySlice 
 {{.Id}}	{{.FirstName}}	{{.LastName}}	{{.Username}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=users . ProjectUsersLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=users . ProjectUsersLister
 
 type ProjectUsersLister interface {
 	ProjectUsers(string, *store.ListOptions) (*atlasv2.PaginatedGroupUser, error)

--- a/internal/cli/refresher_opts.go
+++ b/internal/cli/refresher_opts.go
@@ -33,7 +33,7 @@ type RefresherOpts struct {
 	flow Refresher
 }
 
-//go:generate mockgen -destination=../mocks/mock_refresher.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli Refresher
+//go:generate go tool go.uber.org/mock/mockgen -destination=../mocks/mock_refresher.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli Refresher
 type Refresher interface {
 	RequestCode(context.Context) (*atlasauth.DeviceCode, *atlas.Response, error)
 	PollToken(context.Context, *atlasauth.DeviceCode) (*atlasauth.Token, *atlas.Response, error)

--- a/internal/cli/search/create.go
+++ b/internal/cli/search/create.go
@@ -34,7 +34,7 @@ import (
 
 var errInvalidIndex = errors.New("invalid index")
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=search . Creator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=search . Creator
 
 type Creator interface {
 	CreateSearchIndexesDeprecated(string, string, *atlasv2.ClusterSearchIndex) (*atlasv2.ClusterSearchIndex, error)

--- a/internal/cli/search/delete.go
+++ b/internal/cli/search/delete.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=search . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=search . Deleter
 
 type Deleter interface {
 	DeleteSearchIndex(string, string, string) error

--- a/internal/cli/search/describe.go
+++ b/internal/cli/search/describe.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=search . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=search . Describer
 
 type Describer interface {
 	SearchIndexDeprecated(string, string, string) (*atlasv2.ClusterSearchIndex, error)

--- a/internal/cli/search/list.go
+++ b/internal/cli/search/list.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=search . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=search . Lister
 
 type Lister interface {
 	SearchIndexesDeprecated(string, string, string, string) ([]atlasv2.ClusterSearchIndex, error)

--- a/internal/cli/search/nodes/create.go
+++ b/internal/cli/search/nodes/create.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=nodes . SearchNodesCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=nodes . SearchNodesCreator
 
 type SearchNodesCreator interface {
 	CreateSearchNodes(string, string, *atlasv2.ApiSearchDeploymentRequest) (*atlasv2.ApiSearchDeploymentResponse, error)

--- a/internal/cli/search/nodes/delete.go
+++ b/internal/cli/search/nodes/delete.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=nodes . SearchNodesDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=nodes . SearchNodesDeleter
 
 type SearchNodesDeleter interface {
 	DeleteSearchNodes(string, string) error

--- a/internal/cli/search/nodes/list.go
+++ b/internal/cli/search/nodes/list.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=nodes . SearchNodesLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=nodes . SearchNodesLister
 
 type SearchNodesLister interface {
 	SearchNodes(string, string) (*atlasv2.ApiSearchDeploymentResponse, error)

--- a/internal/cli/search/nodes/update.go
+++ b/internal/cli/search/nodes/update.go
@@ -29,7 +29,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=nodes . SearchNodesUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=nodes . SearchNodesUpdater
 
 type SearchNodesUpdater interface {
 	UpdateSearchNodes(string, string, *atlasv2.ApiSearchDeploymentRequest) (*atlasv2.ApiSearchDeploymentResponse, error)

--- a/internal/cli/search/update.go
+++ b/internal/cli/search/update.go
@@ -31,7 +31,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=search . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=search . Updater
 
 type Updater interface {
 	UpdateSearchIndexesDeprecated(string, string, string, *atlasv2.ClusterSearchIndex) (*atlasv2.ClusterSearchIndex, error)

--- a/internal/cli/security/customercerts/create.go
+++ b/internal/cli/security/customercerts/create.go
@@ -31,7 +31,7 @@ import (
 
 const createTemplate = "Certificate successfully created.\n"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=customercerts . X509CertificateConfSaver
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=customercerts . X509CertificateConfSaver
 
 type X509CertificateConfSaver interface {
 	SaveX509Configuration(string, string) (*atlasv2.UserSecurity, error)

--- a/internal/cli/security/customercerts/describe.go
+++ b/internal/cli/security/customercerts/describe.go
@@ -29,7 +29,7 @@ import (
 
 const describeTemplate = "{{if .CustomerX509}}{{.CustomerX509.Cas}}{{end}}\n"
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=customercerts . X509CertificateConfDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=customercerts . X509CertificateConfDescriber
 
 type X509CertificateConfDescriber interface {
 	X509Configuration(string) (*atlasv2.UserSecurity, error)

--- a/internal/cli/security/customercerts/disable.go
+++ b/internal/cli/security/customercerts/disable.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=disable_mock_test.go -package=customercerts . X509CertificateConfDisabler
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=disable_mock_test.go -package=customercerts . X509CertificateConfDisabler
 
 type X509CertificateConfDisabler interface {
 	DisableX509Configuration(string) error

--- a/internal/cli/security/ldap/delete.go
+++ b/internal/cli/security/ldap/delete.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=ldap . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=ldap . Deleter
 
 type Deleter interface {
 	DeleteLDAPConfiguration(string) error

--- a/internal/cli/security/ldap/get.go
+++ b/internal/cli/security/ldap/get.go
@@ -30,7 +30,7 @@ var getTemplate = `HOSTNAME	PORT	AUTHENTICATION	AUTHORIZATION
 {{.Ldap.Hostname}}	{{.Ldap.Port}}	{{.Ldap.AuthenticationEnabled}}	{{.Ldap.AuthorizationEnabled}}
 `
 
-//go:generate mockgen -typed -destination=get_mock_test.go -package=ldap . Getter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=get_mock_test.go -package=ldap . Getter
 
 type Getter interface {
 	GetLDAPConfiguration(string) (*atlasv2.UserSecurity, error)

--- a/internal/cli/security/ldap/save.go
+++ b/internal/cli/security/ldap/save.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=save_mock_test.go -package=ldap . Saver
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=save_mock_test.go -package=ldap . Saver
 
 type Saver interface {
 	SaveLDAPConfiguration(string, *atlasv2.UserSecurity) (*atlasv2.UserSecurity, error)

--- a/internal/cli/security/ldap/status.go
+++ b/internal/cli/security/ldap/status.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=status_mock_test.go -package=ldap . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=status_mock_test.go -package=ldap . Describer
 
 type Describer interface {
 	GetStatusLDAPConfiguration(string, string) (*atlasv2.LDAPVerifyConnectivityJobRequest, error)

--- a/internal/cli/security/ldap/verify.go
+++ b/internal/cli/security/ldap/verify.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=verify_mock_test.go -package=ldap . ConfigurationVerifier
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=verify_mock_test.go -package=ldap . ConfigurationVerifier
 
 type ConfigurationVerifier interface {
 	VerifyLDAPConfiguration(string, *atlasv2.LDAPVerifyConnectivityJobRequestParams) (*atlasv2.LDAPVerifyConnectivityJobRequest, error)

--- a/internal/cli/serverless/backup/restores/create.go
+++ b/internal/cli/serverless/backup/restores/create.go
@@ -36,7 +36,7 @@ const (
 	pointInTimeRestore = "pointInTime"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=restores . ServerlessRestoreJobsCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=restores . ServerlessRestoreJobsCreator
 
 type ServerlessRestoreJobsCreator interface {
 	ServerlessCreateRestoreJobs(string, string, *atlasv2.ServerlessBackupRestoreJob) (*atlasv2.ServerlessBackupRestoreJob, error)

--- a/internal/cli/serverless/backup/restores/describe.go
+++ b/internal/cli/serverless/backup/restores/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=restores . ServerlessRestoreJobsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=restores . ServerlessRestoreJobsDescriber
 
 type ServerlessRestoreJobsDescriber interface {
 	ServerlessRestoreJob(string, string, string) (*atlasv2.ServerlessBackupRestoreJob, error)

--- a/internal/cli/serverless/backup/restores/list.go
+++ b/internal/cli/serverless/backup/restores/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=restores . ServerlessRestoreJobsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=restores . ServerlessRestoreJobsLister
 
 type ServerlessRestoreJobsLister interface {
 	ServerlessRestoreJobs(string, string, *store.ListOptions) (*atlasv2.PaginatedApiAtlasServerlessBackupRestoreJob, error)

--- a/internal/cli/serverless/backup/snapshots/describe.go
+++ b/internal/cli/serverless/backup/snapshots/describe.go
@@ -32,7 +32,7 @@ const describeTemplate = `ID	SNAPSHOT TYPE	EXPIRES AT
 {{.Id}}	{{.SnapshotType}}	{{.ExpiresAt}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=snapshots . ServerlessSnapshotsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=snapshots . ServerlessSnapshotsDescriber
 
 type ServerlessSnapshotsDescriber interface {
 	ServerlessSnapshot(string, string, string) (*atlasv2.ServerlessBackupSnapshot, error)

--- a/internal/cli/serverless/backup/snapshots/list.go
+++ b/internal/cli/serverless/backup/snapshots/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=snapshots . ServerlessSnapshotsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=snapshots . ServerlessSnapshotsLister
 
 type ServerlessSnapshotsLister interface {
 	ServerlessSnapshots(string, string, *store.ListOptions) (*atlasv2.PaginatedApiAtlasServerlessBackupSnapshot, error)

--- a/internal/cli/serverless/create.go
+++ b/internal/cli/serverless/create.go
@@ -31,7 +31,7 @@ import (
 
 const providerName = "SERVERLESS"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=serverless . Creator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=serverless . Creator
 
 type Creator interface {
 	CreateServerlessInstance(string, *atlasv2.ServerlessInstanceDescriptionCreate) (*atlasv2.ServerlessInstanceDescription, error)

--- a/internal/cli/serverless/delete.go
+++ b/internal/cli/serverless/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=serverless . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=serverless . Deleter
 
 type Deleter interface {
 	DeleteServerlessInstance(string, string) error

--- a/internal/cli/serverless/describe.go
+++ b/internal/cli/serverless/describe.go
@@ -31,7 +31,7 @@ var describeTemplate = `ID	NAME	MDB VER	STATE
 {{.Id}}	{{.Name}}	{{.MongoDBVersion}}	{{.StateName}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=serverless . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=serverless . Describer
 
 type Describer interface {
 	GetServerlessInstance(string, string) (*atlasv2.ServerlessInstanceDescription, error)

--- a/internal/cli/serverless/list.go
+++ b/internal/cli/serverless/list.go
@@ -31,7 +31,7 @@ var listTemplate = `ID	NAME	MDB VER	STATE{{range valueOrEmptySlice .Results}}
 {{.Id}}	{{.Name}}	{{.MongoDBVersion}}	{{.StateName}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=serverless . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=serverless . Lister
 
 type Lister interface {
 	ServerlessInstances(string, *store.ListOptions) (*atlasv2.PaginatedServerlessInstanceDescription, error)

--- a/internal/cli/serverless/update.go
+++ b/internal/cli/serverless/update.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=serverless . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=serverless . Updater
 
 type Updater interface {
 	UpdateServerlessInstance(string, string, *atlasv2.ServerlessInstanceDescriptionUpdate) (*atlasv2.ServerlessInstanceDescription, error)

--- a/internal/cli/setup/setup_cmd.go
+++ b/internal/cli/setup/setup_cmd.go
@@ -109,7 +109,7 @@ We could not find your public IP address. To add your IP address run:
 
 `
 
-//go:generate mockgen -typed -destination=setup_mock_test.go -package=setup . AtlasClusterQuickStarter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=setup_mock_test.go -package=setup . AtlasClusterQuickStarter
 
 type profileReader interface {
 	ProjectID() string

--- a/internal/cli/streams/connection/create.go
+++ b/internal/cli/streams/connection/create.go
@@ -33,7 +33,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=connection . Creator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=connection . Creator
 
 type Creator interface {
 	CreateConnection(string, string, *atlasv2.StreamsConnection) (*atlasv2.StreamsConnection, error)

--- a/internal/cli/streams/connection/delete.go
+++ b/internal/cli/streams/connection/delete.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=connection . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=connection . Deleter
 
 type Deleter interface {
 	DeleteConnection(string, string, string) error

--- a/internal/cli/streams/connection/describe.go
+++ b/internal/cli/streams/connection/describe.go
@@ -30,7 +30,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=connection . StreamsConnectionDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=connection . StreamsConnectionDescriber
 
 type StreamsConnectionDescriber interface {
 	StreamConnection(string, string, string) (*atlasv2.StreamsConnection, error)

--- a/internal/cli/streams/connection/list.go
+++ b/internal/cli/streams/connection/list.go
@@ -34,7 +34,7 @@ var listTemplate = `NAME	TYPE	SERVERS{{range valueOrEmptySlice .Results}}
 {{.Name}}	{{.Type}}	{{if .ClusterName}}{{.ClusterName}}{{else if .BootstrapServers}}{{.BootstrapServers}}{{else}}nil{{end}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=connection . StreamsConnectionLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=connection . StreamsConnectionLister
 
 type StreamsConnectionLister interface {
 	StreamsConnections(string, string) (*atlasv2.PaginatedApiStreamsConnection, error)

--- a/internal/cli/streams/connection/update.go
+++ b/internal/cli/streams/connection/update.go
@@ -32,7 +32,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=connection . Updater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=connection . Updater
 
 type Updater interface {
 	UpdateConnection(string, string, string, *atlasv2.StreamsConnection) (*atlasv2.StreamsConnection, error)

--- a/internal/cli/streams/instance/create.go
+++ b/internal/cli/streams/instance/create.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=instance . StreamsCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=instance . StreamsCreator
 
 type StreamsCreator interface {
 	CreateStream(string, *atlasv2.StreamsTenant) (*atlasv2.StreamsTenant, error)

--- a/internal/cli/streams/instance/delete.go
+++ b/internal/cli/streams/instance/delete.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=instance . StreamsDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=instance . StreamsDeleter
 
 type StreamsDeleter interface {
 	DeleteStream(string, string) error

--- a/internal/cli/streams/instance/describe.go
+++ b/internal/cli/streams/instance/describe.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=instance . StreamsDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=instance . StreamsDescriber
 
 type StreamsDescriber interface {
 	AtlasStream(string, string) (*atlasv2.StreamsTenant, error)

--- a/internal/cli/streams/instance/download.go
+++ b/internal/cli/streams/instance/download.go
@@ -32,7 +32,7 @@ import (
 
 var downloadMessage = "Download of %s completed.\n"
 
-//go:generate mockgen -typed -destination=download_mock_test.go -package=instance . StreamsDownloader
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=download_mock_test.go -package=instance . StreamsDownloader
 
 type StreamsDownloader interface {
 	DownloadAuditLog(*atlasv2.DownloadStreamTenantAuditLogsApiParams) (io.ReadCloser, error)

--- a/internal/cli/streams/instance/list.go
+++ b/internal/cli/streams/instance/list.go
@@ -27,7 +27,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=instance . StreamsLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=instance . StreamsLister
 
 type StreamsLister interface {
 	ProjectStreams(*atlasv2.ListStreamInstancesApiParams) (*atlasv2.PaginatedApiStreamsTenant, error)

--- a/internal/cli/streams/instance/update.go
+++ b/internal/cli/streams/instance/update.go
@@ -28,7 +28,7 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
-//go:generate mockgen -typed -destination=update_mock_test.go -package=instance . StreamsUpdater
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=update_mock_test.go -package=instance . StreamsUpdater
 
 type StreamsUpdater interface {
 	UpdateStream(string, string, *atlasv2.StreamsDataProcessRegion) (*atlasv2.StreamsTenant, error)

--- a/internal/cli/streams/privatelink/create.go
+++ b/internal/cli/streams/privatelink/create.go
@@ -33,7 +33,7 @@ import (
 
 var createTemplate = "Atlas Stream Processing PrivateLink endpoint {{.InterfaceEndpointId}} created.\n"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=privatelink . Creator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=privatelink . Creator
 
 type Creator interface {
 	CreatePrivateLinkEndpoint(projectID string, connection *atlasv2.StreamsPrivateLinkConnection) (*atlasv2.StreamsPrivateLinkConnection, error)

--- a/internal/cli/streams/privatelink/delete.go
+++ b/internal/cli/streams/privatelink/delete.go
@@ -32,7 +32,7 @@ var (
 	failDeleteTemplate    = "Atlas Stream Processing PrivateLink endpoint not deleted"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=privatelink . Deleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=privatelink . Deleter
 
 type Deleter interface {
 	DeletePrivateLinkEndpoint(projectID, connectionID string) error

--- a/internal/cli/streams/privatelink/describe.go
+++ b/internal/cli/streams/privatelink/describe.go
@@ -32,7 +32,7 @@ var describeTemplate = `ID  PROVIDER  REGION  VENDOR  STATE  INTERFACE_ENDPOINT_
 {{.Id}}  {{.Provider}}  {{.Region}}  {{.Vendor}}  {{.State}}  {{.InterfaceEndpointId}}  {{.ServiceEndpointId}}  {{.DnsDomain}}  {{.DnsSubDomain}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=privatelink . Describer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=privatelink . Describer
 
 type Describer interface {
 	DescribePrivateLinkEndpoint(projectID, connectionID string) (*atlasv2.StreamsPrivateLinkConnection, error)

--- a/internal/cli/streams/privatelink/list.go
+++ b/internal/cli/streams/privatelink/list.go
@@ -31,7 +31,7 @@ var listTemplate = `ID  PROVIDER  REGION  VENDOR  STATE  INTERFACE_ENDPOINT_ID  
 {{.Id}}  {{.Provider}}  {{.Region}}  {{.Vendor}}  {{.State}}  {{.InterfaceEndpointId}}  {{.ServiceEndpointId}}  {{.DnsDomain}}  {{.DnsSubDomain}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=privatelink . Lister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=privatelink . Lister
 
 type Lister interface {
 	ListPrivateLinkEndpoints(projectID string) (*atlasv2.PaginatedApiStreamsPrivateLink, error)

--- a/internal/cli/teams/create.go
+++ b/internal/cli/teams/create.go
@@ -30,7 +30,7 @@ import (
 
 var createTemplate = "Team '{{.Name}}' created.\n"
 
-//go:generate mockgen -typed -destination=create_mock_test.go -package=teams . TeamCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=create_mock_test.go -package=teams . TeamCreator
 
 type TeamCreator interface {
 	CreateTeam(string, *atlasv2.Team) (*atlasv2.Team, error)

--- a/internal/cli/teams/delete.go
+++ b/internal/cli/teams/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=teams . TeamDeleter
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=teams . TeamDeleter
 
 type TeamDeleter interface {
 	DeleteTeam(string, string) error

--- a/internal/cli/teams/describe.go
+++ b/internal/cli/teams/describe.go
@@ -32,7 +32,7 @@ const describeTemplate = `ID	NAME
 {{.Id}}	{{.Name}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=teams . TeamDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=teams . TeamDescriber
 
 type TeamDescriber interface {
 	TeamByID(string, string) (*atlasv2.TeamResponse, error)

--- a/internal/cli/teams/list.go
+++ b/internal/cli/teams/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	NAME{{range valueOrEmptySlice .Results}}
 {{.Id}}	{{.Name}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=teams . TeamLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=teams . TeamLister
 
 type TeamLister interface {
 	Teams(string, *store.ListOptions) (*atlasv2.PaginatedTeam, error)

--- a/internal/cli/teams/rename.go
+++ b/internal/cli/teams/rename.go
@@ -30,7 +30,7 @@ import (
 
 var renameTemplate = "Team '{{.Name}}' updated.\n"
 
-//go:generate mockgen -typed -destination=rename_mock_test.go -package=teams . TeamRenamer
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=rename_mock_test.go -package=teams . TeamRenamer
 
 type TeamRenamer interface {
 	RenameTeam(string, string, *atlasv2.TeamUpdate) (*atlasv2.TeamResponse, error)

--- a/internal/cli/teams/users/add.go
+++ b/internal/cli/teams/users/add.go
@@ -30,7 +30,7 @@ import (
 
 const addTemplate = "User(s) added to the team.\n"
 
-//go:generate mockgen -typed -destination=add_mock_test.go -package=users . TeamAdder
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=add_mock_test.go -package=users . TeamAdder
 
 type TeamAdder interface {
 	AddUsersToTeam(string, string, []atlasv2.AddUserToTeam) (*atlasv2.PaginatedApiAppUser, error)

--- a/internal/cli/teams/users/delete.go
+++ b/internal/cli/teams/users/delete.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:generate mockgen -typed -destination=delete_mock_test.go -package=users . TeamUserRemover
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=delete_mock_test.go -package=users . TeamUserRemover
 
 type TeamUserRemover interface {
 	RemoveUserFromTeam(string, string, string) error

--- a/internal/cli/teams/users/list.go
+++ b/internal/cli/teams/users/list.go
@@ -32,7 +32,7 @@ const listTemplate = `ID	FIRST NAME	LAST NAME	USERNAME	EMAIL{{range valueOrEmpty
 {{.Id}}	{{.FirstName}}	{{.LastName}}	{{.Username}}	{{.EmailAddress}}{{end}}
 `
 
-//go:generate mockgen -typed -destination=list_mock_test.go -package=users . TeamUserLister
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=list_mock_test.go -package=users . TeamUserLister
 
 type TeamUserLister interface {
 	TeamUsers(string, string) (*atlasv2.PaginatedOrgUser, error)

--- a/internal/cli/users/describe.go
+++ b/internal/cli/users/describe.go
@@ -32,7 +32,7 @@ const describeTemplate = `ID	FIRST NAME	LAST NAME	USERNAME	EMAIL
 {{.Id}}	{{.FirstName}}	{{.LastName}}	{{.Username}}	{{.EmailAddress}}
 `
 
-//go:generate mockgen -typed -destination=describe_mock_test.go -package=users . UserDescriber
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=describe_mock_test.go -package=users . UserDescriber
 
 type UserDescriber interface {
 	UserByID(string) (*atlasv2.CloudAppUser, error)

--- a/internal/cli/users/invite.go
+++ b/internal/cli/users/invite.go
@@ -37,7 +37,7 @@ var inviteTemplate = `The user '{{.Username}}' has been invited.
 Invited users do not have access to the project until they accept the invitation.
 `
 
-//go:generate mockgen -typed -destination=invite_mock_test.go -package=users . UserCreator
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=invite_mock_test.go -package=users . UserCreator
 
 type UserCreator interface {
 	CreateUser(user *atlasv2.CloudAppUser) (*atlasv2.CloudAppUser, error)

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -53,7 +53,7 @@ type RunFlags struct {
 	HealthRetries     *int
 }
 
-//go:generate mockgen -destination=../mocks/mock_container.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/container Engine
+//go:generate go tool go.uber.org/mock/mockgen -destination=../mocks/mock_container.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/container Engine
 
 type Engine interface {
 	Name() string

--- a/internal/mongodbclient/client.go
+++ b/internal/mongodbclient/client.go
@@ -28,7 +28,7 @@ import (
 var errConnectFailed = errors.New("failed to connect to mongodb server")
 var errPingFailed = errors.New("failed to ping mongodb server")
 
-//go:generate mockgen -destination=../mocks/mock_mongodb_client.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mongodbclient MongoDBClient,Database,Collection
+//go:generate go tool go.uber.org/mock/mockgen -destination=../mocks/mock_mongodb_client.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/mongodbclient MongoDBClient,Database,Collection
 
 type MongoDBClient interface {
 	Connect(ctx context.Context, connectionString string, waitSeconds int64) error

--- a/internal/podman/client.go
+++ b/internal/podman/client.go
@@ -75,7 +75,7 @@ type Image struct {
 	Digest     string `json:"digest"`
 }
 
-//go:generate mockgen -destination=../mocks/mock_podman.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/podman Client
+//go:generate go tool go.uber.org/mock/mockgen -destination=../mocks/mock_podman.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/podman Client
 
 type Client interface {
 	Ready(ctx context.Context) error

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -20,7 +20,7 @@ import (
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
-//go:generate mockgen -destination=../mocks/mock_clusters.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store ClusterLister,ClusterDescriber
+//go:generate go tool go.uber.org/mock/mockgen -destination=../mocks/mock_clusters.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store ClusterLister,ClusterDescriber
 
 type ClusterLister interface { //nolint:iface // right now requires some refactor to deployment commands
 	ProjectClusters(string, *ListOptions) (*atlasClustersPinned.PaginatedAdvancedClusterDescription, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@
 
 package store
 
-//go:generate mockgen -destination=../mocks/mock_store.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store CredentialsGetter
+//go:generate go tool go.uber.org/mock/mockgen -destination=../mocks/mock_store.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/store CredentialsGetter
 
 import (
 	"context"

--- a/internal/telemetry/tracker.go
+++ b/internal/telemetry/tracker.go
@@ -41,7 +41,7 @@ const (
 	promptEventType = "prompt"
 )
 
-//go:generate mockgen -typed -destination=tracker_mock_test.go -package=telemetry . EventsSender,UnauthEventsSender
+//go:generate go tool go.uber.org/mock/mockgen -typed -destination=tracker_mock_test.go -package=telemetry . EventsSender,UnauthEventsSender
 
 type EventsSender interface {
 	SendEvents(body any) error

--- a/internal/version/release_version.go
+++ b/internal/version/release_version.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/go-github/v61/github"
 )
 
-//go:generate mockgen -destination=../mocks/mock_release_version.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version ReleaseVersionDescriber
+//go:generate go tool go.uber.org/mock/mockgen -destination=../mocks/mock_release_version.go -package=mocks github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version ReleaseVersionDescriber
 
 const (
 	maxWaitTime = 500 * time.Millisecond


### PR DESCRIPTION
## Proposed changes

Move mockgen to use the new go tool directive 

Mainly replace `//go:generate mockgen` with `//go:generate go tool go.uber.org/mock/mockgen`

