### PR TITLE
CLOUDP-319575: Fixes directory SBOMs are generated into

### DIFF
--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -82,7 +82,7 @@ functions:
           - AWS_SECRET_ACCESS_KEY
           - AWS_SESSION_TOKEN
           - workdir
-        binary: build/package/generate-sbom.sh 
+        binary: build/package/generate-sbom.sh
   "run silkbomb": 
     - command: ec2.assume_role
       params:

--- a/build/package/generate-sbom.sh
+++ b/build/package/generate-sbom.sh
@@ -27,5 +27,5 @@ docker run --rm \
   901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/silkbomb:2.0 \
   update \
   --purls /pwd/build/package/purls.txt \
-  --sbom-out /pwd/sbom.json
+  --sbom-out /pwd/compliance/sbom.json
   


### PR DESCRIPTION
## Proposed changes

Function `run silkbomb` was quietly failing with error `Error: argument --sbom-in/--sbom_in/-i: File not found: /workdir/src/github.com/mongodb/mongodb-atlas-cli/compliance/sbom.json`. This was due to SBOMs being generated into the wrong directory.

_Jira ticket:_ [CLOUDP-319575](https://jira.mongodb.org/browse/CLOUDP-319575)


## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
