### PR TITLE
CLOUDP-316626: createSearchIndex command is marshaled incorrectly

### DIFF
--- a/internal/cli/deployments/search/indexes/create.go
+++ b/internal/cli/deployments/search/indexes/create.go
@@ -120,7 +120,10 @@ func (opts *CreateOpts) RunLocal(ctx context.Context) error {
 		opts.indexID.Collection = index.CollectionName
 		opts.indexID.Name = index.Name
 
-		definition = index.Definition
+		definition, err = buildIndexDefinition(index.Definition)
+		if err != nil {
+			return err
+		}
 	case *atlasv2.ClusterSearchIndex:
 		_, _ = log.Warningln("you're using an old search index definition")
 		idxType = index.Type
@@ -163,7 +166,7 @@ func (opts *CreateOpts) RunLocal(ctx context.Context) error {
 	return nil
 }
 
-func buildIndexDefinition(idx *atlasv2.ClusterSearchIndex) (any, error) {
+func buildIndexDefinition(idx any) (any, error) {
 	// To maintain formatting of the SDK, marshal object into JSON and then unmarshal into BSON
 	jsonIndex, err := json.Marshal(idx)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-316626

### Bug:
The CLI is marshing directly the SDK struct into Bson for the `createSearchIndex` this cause fields in the structs such as `charFilters` to be transformed in their lowercase version `charfilters`.
```bash
atlas deployments search indexes create --deploymentName local9975 --type LOCAL -f search-index.json --watch
Error: (UnknownError) "userCommand.indexes[0].analyzers[0]" unrecognized fields ["charfilters", "tokenfilters"]
```

### Fix:
As we are doing with other index such as `ClusterSearchIndex`, we first marsh the struct into json and then marsh into Bson to keep the same field names of the original SDK struct.
```bash
./bin/atlas deployments search indexes create --deploymentName local9975 --type LOCAL -f search-index.json --watch
Search index created with ID: 682dce72481bfa62cd0cb969

atlas deployments search indexes ls                                            
? Database sample_mflix
? Collection movies
ID                         NAME                 DATABASE       COLLECTION   STATUS   TYPE
682dce72481bfa62cd0cb969   custom_movie_index   sample_mflix   movies       READY    search
```