### PR TITLE
Fix: Release fails in git dirty state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ cov/
 # We don't want to commit the 3rd party notices
 third_party_notices/
 
+# File generated during release process
+sbom.json
+
 # Evergreen generated files
 .gocache/
 gon_x86_64.json

--- a/build/package/generate-sbom.sh
+++ b/build/package/generate-sbom.sh
@@ -28,4 +28,9 @@ podman run --rm \
   update \
   --purls /pwd/build/package/purls.txt \
   --sbom-out /pwd/sbom.json
+
+echo "Cleaning up..."
+rm -f \
+  ${workdir}/src/github.com/mongodb/mongodb-atlas-cli/build/ci/hosts.json \
+  ${workdir}/src/github.com/mongodb/mongodb-atlas-cli/ssh_id
   


### PR DESCRIPTION
## Proposed changes

Since sbom generation creates some new files, the release workflow fails with `git is in a dirty state`. Sbom is added to .gitignore as to not trigger this state and remaining artifacts are removed after sbom generation.

_Jira ticket:_ CLOUDP-#

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code