### PR TITLE
CLOUDP-322905: Fix `update-compliance-report` GitHub action

### DIFF
--- a/.github/workflows/update-ssdlc-report.yaml
+++ b/.github/workflows/update-ssdlc-report.yaml
@@ -40,73 +40,77 @@ jobs:
           VERSION: ${{ steps.extract.outputs.version }}
           AUGMENTED_REPORT: "false"
         run: ./build/package/gen-ssdlc-report.sh
-      # - name: Find JIRA ticket
-      #   id: find
-      #   uses: mongodb/apix-action/find-jira@3024080388613583e3bd119bfb1ab4b4dbf43c42
-      #   with:
-      #     token: ${{ secrets.JIRA_API_TOKEN }}
-      #     jql: project = CLOUDP AND status NOT IN (Closed, Resolved) AND summary ~ "Update Compliance Report"
-      # - name: Set JIRA ticket (find)
-      #   if: steps.find.outputs.found == 'true'
-      #   run: |
-      #     echo "JIRA_KEY=${{steps.find.outputs.issue-key}}" >> "$GITHUB_ENV"
-      # - name: Create JIRA ticket
-      #   uses: mongodb/apix-action/create-jira@3024080388613583e3bd119bfb1ab4b4dbf43c42
-      #   id: create
-      #   if: steps.find.outputs.found == 'false'
-      #   with:
-      #     token: ${{ secrets.JIRA_API_TOKEN }}
-      #     project-key: CLOUDP
-      #     summary: "[AtlasCLI] Update Compliance Report"
-      #     issuetype: Story
-      #     description: Update Compliance Report
-      #     components: AtlasCLI
-      #     assignee: ${{ secrets.ASSIGNEE_JIRA_TICKET }}
-      #     extra-data: |
-      #       {
-      #         "fields": {
-      #           "fixVersions": [
-      #             {
-      #               "id": "41805"
-      #             }
-      #           ],
-      #           "customfield_12751": [
-      #             {
-      #               "id": "22223"
-      #             }
-      #           ],
-      #           "customfield_10257": {
-      #             "id": "11861"
-      #           }
-      #         }
-      #       }
-      # - name: Set JIRA ticket (create)
-      #   if: steps.find.outputs.found == 'false'
-      #   run: |
-      #     echo "JIRA_KEY=${{steps.create.outputs.issue-key}}" >> "$GITHUB_ENV"
       - name: set Apix Bot token
         id: app-token
         uses: mongodb/apix-action/token@3024080388613583e3bd119bfb1ab4b4dbf43c42
         with:
           app-id: ${{ secrets.APIXBOT_APP_ID }}
           private-key: ${{ secrets.APIXBOT_APP_PEM }}
+      - name: Find JIRA ticket
+        id: find
+        uses: mongodb/apix-action/find-jira@3024080388613583e3bd119bfb1ab4b4dbf43c42
+        with:
+          token: ${{ secrets.JIRA_API_TOKEN }}
+          jql: project = CLOUDP AND status NOT IN (Closed, Resolved) AND summary ~ "Update Compliance Report"
+      - name: Set JIRA ticket (find)
+        if: steps.find.outputs.found == 'true'
+        run: |
+          echo "JIRA_KEY=${{steps.find.outputs.issue-key}}" >> "$GITHUB_ENV"
+      - name: Create JIRA ticket
+        uses: mongodb/apix-action/create-jira@3024080388613583e3bd119bfb1ab4b4dbf43c42
+        id: create
+        if: steps.find.outputs.found == 'false'
+        with:
+          token: ${{ secrets.JIRA_API_TOKEN }}
+          project-key: CLOUDP
+          summary: "[AtlasCLI] Update Compliance Report"
+          issuetype: Story
+          description: Update Compliance Report
+          components: AtlasCLI
+          assignee: ${{ secrets.ASSIGNEE_JIRA_TICKET }}
+          extra-data: |
+            {
+              "fields": {
+                "fixVersions": [
+                  {
+                    "id": "41805"
+                  }
+                ],
+                "customfield_12751": [
+                  {
+                    "id": "22223"
+                  }
+                ],
+                "customfield_10257": {
+                  "id": "11861"
+                }
+              }
+            }
+      - name: Set JIRA ticket (create)
+        if: steps.find.outputs.found == 'false'
+        run: |
+          echo "JIRA_KEY=${{steps.create.outputs.issue-key}}" >> "$GITHUB_ENV"
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         id: pr
         with:
           token: ${{ steps.app-token.outputs.token }}
           committer: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
           author: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
-          title: "TEST: Update compliance report for v${{ steps.extract.outputs.version }}"
-          commit-message: "TEST: Update compliance report for v${{ steps.extract.outputs.version }}"
+          title: "${{ env.JIRA_KEY }}: Update compliance report for v${{ steps.extract.outputs.version }}"
+          commit-message: "${{ env.JIRA_KEY }}: Update compliance report for v${{ steps.extract.outputs.version }}"
           delete-branch: true
           base: master
-          branch: test-update-compliance-report
+          branch: ${{ env.JIRA_KEY }}
           labels: |
             compliance
-            auto
             auto_close_jira
           body: |
-            TEST
+            ## Proposed changes
+            Update compliance report for v${{ steps.extract.outputs.version }}
+            _Jira ticket:_ ${{ env.JIRA_KEY }}
+
+            Note: Jira ticket will be closed automatically when this PR is merged.
+
       - name: Set auto merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-ssdlc-report.yaml
+++ b/.github/workflows/update-ssdlc-report.yaml
@@ -40,78 +40,73 @@ jobs:
           VERSION: ${{ steps.extract.outputs.version }}
           AUGMENTED_REPORT: "false"
         run: ./build/package/gen-ssdlc-report.sh
+      # - name: Find JIRA ticket
+      #   id: find
+      #   uses: mongodb/apix-action/find-jira@3024080388613583e3bd119bfb1ab4b4dbf43c42
+      #   with:
+      #     token: ${{ secrets.JIRA_API_TOKEN }}
+      #     jql: project = CLOUDP AND status NOT IN (Closed, Resolved) AND summary ~ "Update Compliance Report"
+      # - name: Set JIRA ticket (find)
+      #   if: steps.find.outputs.found == 'true'
+      #   run: |
+      #     echo "JIRA_KEY=${{steps.find.outputs.issue-key}}" >> "$GITHUB_ENV"
+      # - name: Create JIRA ticket
+      #   uses: mongodb/apix-action/create-jira@3024080388613583e3bd119bfb1ab4b4dbf43c42
+      #   id: create
+      #   if: steps.find.outputs.found == 'false'
+      #   with:
+      #     token: ${{ secrets.JIRA_API_TOKEN }}
+      #     project-key: CLOUDP
+      #     summary: "[AtlasCLI] Update Compliance Report"
+      #     issuetype: Story
+      #     description: Update Compliance Report
+      #     components: AtlasCLI
+      #     assignee: ${{ secrets.ASSIGNEE_JIRA_TICKET }}
+      #     extra-data: |
+      #       {
+      #         "fields": {
+      #           "fixVersions": [
+      #             {
+      #               "id": "41805"
+      #             }
+      #           ],
+      #           "customfield_12751": [
+      #             {
+      #               "id": "22223"
+      #             }
+      #           ],
+      #           "customfield_10257": {
+      #             "id": "11861"
+      #           }
+      #         }
+      #       }
+      # - name: Set JIRA ticket (create)
+      #   if: steps.find.outputs.found == 'false'
+      #   run: |
+      #     echo "JIRA_KEY=${{steps.create.outputs.issue-key}}" >> "$GITHUB_ENV"
       - name: set Apix Bot token
         id: app-token
         uses: mongodb/apix-action/token@3024080388613583e3bd119bfb1ab4b4dbf43c42
         with:
           app-id: ${{ secrets.APIXBOT_APP_ID }}
           private-key: ${{ secrets.APIXBOT_APP_PEM }}
-      - name: Find JIRA ticket
-        id: find
-        uses: mongodb/apix-action/find-jira@3024080388613583e3bd119bfb1ab4b4dbf43c42
-        with:
-          token: ${{ secrets.JIRA_API_TOKEN }}
-          jql: project = CLOUDP AND status NOT IN (Closed, Resolved) AND summary ~ "Update Compliance Report"
-      - name: Set JIRA ticket (find)
-        if: steps.find.outputs.found == 'true'
-        run: |
-          echo "JIRA_KEY=${{steps.find.outputs.issue-key}}" >> "$GITHUB_ENV"
-      - name: Create JIRA ticket
-        uses: mongodb/apix-action/create-jira@3024080388613583e3bd119bfb1ab4b4dbf43c42
-        id: create
-        if: steps.find.outputs.found == 'false'
-        with:
-          token: ${{ secrets.JIRA_API_TOKEN }}
-          project-key: CLOUDP
-          summary: "[AtlasCLI] Update Compliance Report"
-          issuetype: Story
-          description: Update Compliance Report
-          components: AtlasCLI
-          assignee: ${{ secrets.ASSIGNEE_JIRA_TICKET }}
-          extra-data: |
-            {
-              "fields": {
-                "fixVersions": [
-                  {
-                    "id": "41805"
-                  }
-                ],
-                "customfield_12751": [
-                  {
-                    "id": "22223"
-                  }
-                ],
-                "customfield_10257": {
-                  "id": "11861"
-                }
-              }
-            }
-      - name: Set JIRA ticket (create)
-        if: steps.find.outputs.found == 'false'
-        run: |
-          echo "JIRA_KEY=${{steps.create.outputs.issue-key}}" >> "$GITHUB_ENV"
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e
         id: pr
         with:
           token: ${{ steps.app-token.outputs.token }}
           committer: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
           author: "${{ steps.app-token.outputs.user-name }} <${{ steps.app-token.outputs.user-email }}>"
-          title: "${{ env.JIRA_KEY }}: Update compliance report for v${{ steps.extract.outputs.version }}"
-          commit-message: "${{ env.JIRA_KEY }}: Update compliance report for v${{ steps.extract.outputs.version }}"
+          title: "TEST: Update compliance report for v${{ steps.extract.outputs.version }}"
+          commit-message: "TEST: Update compliance report for v${{ steps.extract.outputs.version }}"
           delete-branch: true
           base: master
-          branch: ${{ env.JIRA_KEY }}
+          branch: test-update-compliance-report
           labels: |
             compliance
             auto
             auto_close_jira
           body: |
-            ## Proposed changes
-            Update compliance report for v${{ steps.extract.outputs.version }}
-            _Jira ticket:_ ${{ env.JIRA_KEY }}
-
-            Note: Jira ticket will be closed automatically when this PR is merged.
-
+            TEST
       - name: Set auto merge
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Proposed changes

Fixes `update-compliance-report` GitHub action from failing when applying labels by removing non-existing label and creating new label `compliance`.

Successful run: [action](https://github.com/mongodb/mongodb-atlas-cli/actions/runs/15531716648), [PR](https://github.com/mongodb/mongodb-atlas-cli/pull/3944)

_Jira ticket:_ [CLOUDP-322905](https://jira.mongodb.org/browse/CLOUDP-322905)



## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
