### PR TITLE
CLOUDP-323473: Migrate watchers to latest SDK

### DIFF
--- a/internal/cli/clusters/create_test.go
+++ b/internal/cli/clusters/create_test.go
@@ -153,11 +153,17 @@ func TestCreateOpts_PostRun_EnableWatch(t *testing.T) {
 		mocks.NewMockClusterDescriber(ctrl),
 	}
 
-	expected := &atlasClustersPinned.AdvancedClusterDescription{
+	expected := &atlasv2.ClusterDescription20240805{
 		Name:      pointer.Get("ProjectBar"),
 		StateName: pointer.Get("CREATING"),
 	}
-	expectedIdle := &atlasClustersPinned.AdvancedClusterDescription{
+
+	expectedCreatedCluster := &atlasClustersPinned.AdvancedClusterDescription{
+		Name:      expected.Name,
+		StateName: expected.StateName,
+	}
+
+	expectedIdle := &atlasv2.ClusterDescription20240805{
 		Name:      expected.Name,
 		StateName: pointer.Get("IDLE"),
 	}
@@ -184,20 +190,20 @@ func TestCreateOpts_PostRun_EnableWatch(t *testing.T) {
 		MockClusterCreator.
 		EXPECT().
 		CreateCluster(cluster).
-		Return(expected, nil).
+		Return(expectedCreatedCluster, nil).
 		Times(1)
 
 	gomock.InOrder(
 		mockStore.
 			MockClusterDescriber.
 			EXPECT().
-			AtlasCluster(createOpts.ProjectID, expected.GetName()).
+			LatestAtlasCluster(createOpts.ProjectID, expected.GetName()).
 			Return(expected, nil).
 			Times(1),
 		mockStore.
 			MockClusterDescriber.
 			EXPECT().
-			AtlasCluster(createOpts.ProjectID, expected.GetName()).
+			LatestAtlasCluster(createOpts.ProjectID, expected.GetName()).
 			Return(expectedIdle, nil).
 			Times(1),
 	)

--- a/internal/mocks/mock_clusters.go
+++ b/internal/mocks/mock_clusters.go
@@ -70,3 +70,18 @@ func (mr *MockClusterDescriberMockRecorder) FlexCluster(arg0, arg1 any) *gomock.
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlexCluster", reflect.TypeOf((*MockClusterDescriber)(nil).FlexCluster), arg0, arg1)
 }
+
+// LatestAtlasCluster mocks base method.
+func (m *MockClusterDescriber) LatestAtlasCluster(arg0, arg1 string) (*admin0.ClusterDescription20240805, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LatestAtlasCluster", arg0, arg1)
+	ret0, _ := ret[0].(*admin0.ClusterDescription20240805)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LatestAtlasCluster indicates an expected call of LatestAtlasCluster.
+func (mr *MockClusterDescriberMockRecorder) LatestAtlasCluster(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestAtlasCluster", reflect.TypeOf((*MockClusterDescriber)(nil).LatestAtlasCluster), arg0, arg1)
+}

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -25,6 +25,7 @@ import (
 type ClusterDescriber interface { //nolint:iface // right now requires some refactor to deployment commands
 	AtlasCluster(string, string) (*atlasClustersPinned.AdvancedClusterDescription, error)
 	FlexCluster(string, string) (*atlasv2.FlexClusterDescription20241113, error)
+	LatestAtlasCluster(string, string) (*atlasv2.ClusterDescription20240805, error)
 }
 
 // AddSampleData encapsulate the logic to manage different cloud providers.
@@ -140,6 +141,12 @@ func (s *Store) LatestProjectClusters(projectID string, opts *ListOptions) (*atl
 // AtlasCluster encapsulates the logic to manage different cloud providers.
 func (s *Store) AtlasCluster(projectID, name string) (*atlasClustersPinned.AdvancedClusterDescription, error) {
 	result, _, err := s.clientClusters.ClustersApi.GetCluster(s.ctx, projectID, name).Execute()
+	return result, err
+}
+
+// LatestAtlasCluster uses the latest API version to get a cluster.
+func (s *Store) LatestAtlasCluster(projectID, name string) (*atlasv2.ClusterDescription20240805, error) {
+	result, _, err := s.clientv2.ClustersApi.GetCluster(s.ctx, projectID, name).Execute()
 	return result, err
 }
 

--- a/internal/watchers/cluster.go
+++ b/internal/watchers/cluster.go
@@ -45,7 +45,7 @@ type AtlasClusterStateDescriber struct {
 }
 
 func (describer *AtlasClusterStateDescriber) GetState() (string, error) {
-	result, err := describer.store.AtlasCluster(describer.projectID, describer.clusterName)
+	result, err := describer.store.LatestAtlasCluster(describer.projectID, describer.clusterName)
 	if result != nil && result.StateName != nil {
 		return *result.StateName, err
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-323473

- Since watchers only return state and name of the cluster, we can already use the latest SDK for all clusters watchers
- https://spruce.mongodb.com/version/6846d50e01104b0007bd2d5b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
