### PR TITLE
CLOUDP-319569: [Local Dev] Container fails to start (intermittently); docker compose, TestContainers & GitHub Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,23 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 ENV MONGODB_ATLAS_IS_CONTAINERIZED=true
 
-COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-6.0.repo
-[mongodb-org-x86_64-6.0]
+COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-8.0.repo
+[mongodb-org-x86_64-8.0]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/8/mongodb-org/6.0/x86_64/
+baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/x86_64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-6.0.asc
+gpgkey=https://www.mongodb.org/static/pgp/server-8.0.asc
 EOF
 
-COPY <<EOF /etc/yum.repos.d/mongodb-org-aarch64-6.0.repo
-[mongodb-org-aarch64-6.0]
+COPY <<EOF /etc/yum.repos.d/mongodb-org-aarch64-8.0.repo
+[mongodb-org-aarch64-8.0]
 name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/8/mongodb-org/6.0/aarch64/
+baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/aarch64/
 gpgcheck=1
 enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-6.0.asc
+gpgkey=https://www.mongodb.org/static/pgp/server-8.0.asc
 EOF
 
 RUN microdnf -y install jq yum &&\


### PR DESCRIPTION
## Proposed changes

Fixed Docker build issues by updating base images + repositories.

Example failure: https://github.com/mongodb/mongodb-atlas-cli/actions/runs/15539188936/job/43745605276?pr=3950

_Jira ticket:_ CLOUDP-319569

