### PR TITLE
CLOUDP-324051: customize L2 cluster commands to specify that users sh…

### DIFF
--- a/internal/cli/commonerrors/errors.go
+++ b/internal/cli/commonerrors/errors.go
@@ -21,8 +21,9 @@ import (
 )
 
 var (
-	errClusterUnsupported = errors.New("atlas supports this command only for M10+ clusters. You can upgrade your cluster by running the 'atlas cluster upgrade' command")
-	errOutsideVPN         = errors.New("forbidden action outside access allow list, if you are a MongoDB employee double check your VPN connection")
+	errClusterUnsupported         = errors.New("atlas supports this command only for M10+ clusters. You can upgrade your cluster by running the 'atlas cluster upgrade' command")
+	errOutsideVPN                 = errors.New("forbidden action outside access allow list, if you are a MongoDB employee double check your VPN connection")
+	errAsymmetricShardUnsupported = errors.New("trying to run a cluster wide scaling command on an independent shard scaling cluster. Use --autoScalingMode 'independentShardScaling' instead")
 )
 
 func Check(err error) error {
@@ -37,6 +38,8 @@ func Check(err error) error {
 			return errClusterUnsupported
 		case "GLOBAL_USER_OUTSIDE_SUBNET":
 			return errOutsideVPN
+		case "ASYMMETRIC_SHARD_UNSUPPORTED":
+			return errAsymmetricShardUnsupported
 		}
 	}
 	return err

--- a/internal/cli/commonerrors/errors_test.go
+++ b/internal/cli/commonerrors/errors_test.go
@@ -28,6 +28,10 @@ func TestCheck(t *testing.T) {
 
 	skderr := &admin.GenericOpenAPIError{}
 	skderr.SetModel(admin.ApiError{ErrorCode: "TENANT_CLUSTER_UPDATE_UNSUPPORTED"})
+
+	asymmetricShardErr := &admin.GenericOpenAPIError{}
+	asymmetricShardErr.SetModel(admin.ApiError{ErrorCode: "ASYMMETRIC_SHARD_UNSUPPORTED"})
+
 	testCases := []struct {
 		name string
 		err  error
@@ -47,6 +51,11 @@ func TestCheck(t *testing.T) {
 			name: "arbitrary error",
 			err:  dummyErr,
 			want: dummyErr,
+		},
+		{
+			name: "asymmetric shard unsupported",
+			err:  asymmetricShardErr,
+			want: errAsymmetricShardUnsupported,
 		},
 	}
 


### PR DESCRIPTION
…ould use the -autoScalingMode independentShardScaling flag

<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-324051

Warn user to use `--autoScalingMode independentShardCluster` if `ASYMMETRIC_SHARD_UNSUPPORTED` is thrown by the API

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
