### PR TITLE
CLOUDP-326352: Fixes backup commands to fallback to flex if not found

### DIFF
--- a/internal/cli/backup/restores/describe.go
+++ b/internal/cli/backup/restores/describe.go
@@ -71,7 +71,7 @@ func (opts *DescribeOpts) Run() error {
 		return err
 	}
 
-	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != featureUnsupported {
+	if apiError.ErrorCode != CannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != FeatureUnsupported && apiError.ErrorCode != ClusterNotFoundErrorCode {
 		return err
 	}
 

--- a/internal/cli/backup/restores/describe_test.go
+++ b/internal/cli/backup/restores/describe_test.go
@@ -41,7 +41,7 @@ func TestDescribeOpts_Run(t *testing.T) {
 	}
 
 	expectedError := &atlasv2.GenericOpenAPIError{}
-	expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
+	expectedError.SetModel(atlasv2.ApiError{ErrorCode: CannotUseNotFlexWithFlexApisErrorCode})
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/backup/restores/list.go
+++ b/internal/cli/backup/restores/list.go
@@ -69,7 +69,7 @@ func (opts *ListOpts) Run() error {
 		return err
 	}
 
-	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != featureUnsupported {
+	if apiError.ErrorCode != CannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != FeatureUnsupported && apiError.ErrorCode != ClusterNotFoundErrorCode {
 		return err
 	}
 

--- a/internal/cli/backup/restores/list_test.go
+++ b/internal/cli/backup/restores/list_test.go
@@ -37,7 +37,7 @@ func TestListOpts_Run(t *testing.T) {
 	}
 
 	expectedError := &atlasv2.GenericOpenAPIError{}
-	expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
+	expectedError.SetModel(atlasv2.ApiError{ErrorCode: CannotUseNotFlexWithFlexApisErrorCode})
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/backup/restores/restores.go
+++ b/internal/cli/backup/restores/restores.go
@@ -20,8 +20,10 @@ import (
 )
 
 const (
-	cannotUseNotFlexWithFlexApisErrorCode = "CANNOT_USE_NON_FLEX_CLUSTER_IN_FLEX_API"
-	featureUnsupported                    = "FEATURE_UNSUPPORTED"
+	CannotUseNotFlexWithFlexApisErrorCode = "CANNOT_USE_NON_FLEX_CLUSTER_IN_FLEX_API"
+	FeatureUnsupported                    = "FEATURE_UNSUPPORTED"
+	ClusterNotFoundErrorCode              = "CLUSTER_NOT_FOUND"
+	DeliveryTypeDownload                  = "download"
 )
 
 func Builder() *cobra.Command {

--- a/internal/cli/backup/restores/watch.go
+++ b/internal/cli/backup/restores/watch.go
@@ -27,7 +27,8 @@ import (
 	atlasv2 "go.mongodb.org/atlas-sdk/v20250312005/admin"
 )
 
-const deliveryTypeDownload = "download"
+var watchTemplate = "\nRestore completed.\n"
+var result *atlasv2.DiskBackupSnapshotRestoreJob
 
 type WatchOpts struct {
 	cli.ProjectOpts
@@ -37,9 +38,6 @@ type WatchOpts struct {
 	isFlexCluster bool
 	store         RestoreJobsDescriber
 }
-
-var watchTemplate = "\nRestore completed.\n"
-var result *atlasv2.DiskBackupSnapshotRestoreJob
 
 func (opts *WatchOpts) initStore(ctx context.Context) func() error {
 	return func() error {
@@ -64,7 +62,7 @@ func stopWatcher(result *atlasv2.DiskBackupSnapshotRestoreJob) bool {
 		return true
 	}
 
-	if result.GetDeliveryType() == deliveryTypeDownload && len(result.GetDeliveryUrl()) > 0 {
+	if result.GetDeliveryType() == DeliveryTypeDownload && len(result.GetDeliveryUrl()) > 0 {
 		return true
 	}
 
@@ -118,7 +116,7 @@ func (opts *WatchOpts) newIsFlexCluster() error {
 		return err
 	}
 
-	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != featureUnsupported {
+	if apiError.ErrorCode != CannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != FeatureUnsupported && apiError.ErrorCode != ClusterNotFoundErrorCode {
 		return err
 	}
 

--- a/internal/cli/backup/snapshots/describe.go
+++ b/internal/cli/backup/snapshots/describe.go
@@ -71,7 +71,7 @@ func (opts *DescribeOpts) Run() error {
 		return err
 	}
 
-	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != featureUnsupported {
+	if apiError.ErrorCode != CannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != FeatureUnsupported && apiError.ErrorCode != ClusterNotFoundErrorCode {
 		return err
 	}
 

--- a/internal/cli/backup/snapshots/describe_test.go
+++ b/internal/cli/backup/snapshots/describe_test.go
@@ -36,7 +36,7 @@ func TestDescribe_Run(t *testing.T) {
 	}
 
 	expectedError := &atlasv2.GenericOpenAPIError{}
-	expectedError.SetModel(atlasv2.ApiError{ErrorCode: cannotUseNotFlexWithFlexApisErrorCode})
+	expectedError.SetModel(atlasv2.ApiError{ErrorCode: CannotUseNotFlexWithFlexApisErrorCode})
 
 	mockStore.
 		EXPECT().

--- a/internal/cli/backup/snapshots/list.go
+++ b/internal/cli/backup/snapshots/list.go
@@ -69,7 +69,7 @@ func (opts *ListOpts) Run() error {
 		return err
 	}
 
-	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != featureUnsupported {
+	if apiError.ErrorCode != CannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != FeatureUnsupported && apiError.ErrorCode != ClusterNotFoundErrorCode {
 		return err
 	}
 

--- a/internal/cli/backup/snapshots/snapshots.go
+++ b/internal/cli/backup/snapshots/snapshots.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	cannotUseNotFlexWithFlexApisErrorCode = "CANNOT_USE_NON_FLEX_CLUSTER_IN_FLEX_API"
-	featureUnsupported                    = "FEATURE_UNSUPPORTED"
+	CannotUseNotFlexWithFlexApisErrorCode = "CANNOT_USE_NON_FLEX_CLUSTER_IN_FLEX_API"
+	FeatureUnsupported                    = "FEATURE_UNSUPPORTED"
+	ClusterNotFoundErrorCode              = "CLUSTER_NOT_FOUND"
 )
 
 func Builder() *cobra.Command {

--- a/internal/cli/backup/snapshots/watch.go
+++ b/internal/cli/backup/snapshots/watch.go
@@ -102,7 +102,7 @@ func (opts *WatchOpts) newIsFlexCluster() error {
 		return err
 	}
 
-	if apiError.ErrorCode != cannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != featureUnsupported {
+	if apiError.ErrorCode != CannotUseNotFlexWithFlexApisErrorCode && apiError.ErrorCode != FeatureUnsupported && apiError.ErrorCode != ClusterNotFoundErrorCode {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-326352

- Fix fallback logic for backup snapshot/restore commands to handle CLUSTER_NOT_FOUND (deleted clusters) by trying the regular API after Flex API fails.
- Error code constants are now defined once per package and exported.
- Removed duplicate constant declarations and import cycles.
- Updated unit tests to use the exported constants.



## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
