### PR TITLE
CLOUDP-329791: Refactor auth check

### DIFF
--- a/internal/cli/root/builder.go
+++ b/internal/cli/root/builder.go
@@ -67,13 +67,11 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/homebrew"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/latestrelease"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/log"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/plugin"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/prerun"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/sighandle"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/telemetry"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/terminal"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/validate"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -87,18 +85,6 @@ type Notifier struct {
 	filesystem     afero.Fs
 	writer         io.Writer
 }
-
-type AuthRequirements int64
-
-const (
-	// NoAuth command does not require authentication.
-	NoAuth AuthRequirements = 0
-	// RequiredAuth command requires authentication.
-	RequiredAuth AuthRequirements = 1
-	// OptionalAuth command can work with or without authentication,
-	// and if access token is found, try to refresh it.
-	OptionalAuth AuthRequirements = 2
-)
 
 func handleSignal() {
 	sighandle.Notify(func(sig os.Signal) {
@@ -149,29 +135,7 @@ Use the --help flag with any command for more info on that command.`,
 				config.SetService(config.CloudService)
 			}
 
-			authReq := shouldCheckCredentials(cmd)
-			if authReq == NoAuth {
-				return nil
-			}
-
-			if err := prerun.ExecuteE(
-				opts.InitFlow(config.Default()),
-				func() error {
-					err := opts.RefreshAccessToken(cmd.Context())
-					if err != nil && authReq == RequiredAuth {
-						return err
-					}
-					return nil
-				},
-			); err != nil {
-				return err
-			}
-
-			if authReq == RequiredAuth {
-				return validate.Credentials()
-			}
-
-			return nil
+			return prerun.ExecuteE(opts.InitFlow(config.Default()))
 		},
 		// PersistentPostRun only runs if the command is successful
 		PersistentPostRun: func(cmd *cobra.Command, _ []string) {
@@ -287,43 +251,6 @@ func shouldSetService(cmd *cobra.Command) bool {
 	}
 
 	return true
-}
-
-func shouldCheckCredentials(cmd *cobra.Command) AuthRequirements {
-	searchByName := []string{
-		"__complete",
-		"help",
-	}
-	for _, n := range searchByName {
-		if cmd.Name() == n {
-			return NoAuth
-		}
-	}
-	customRequirements := map[string]AuthRequirements{
-		fmt.Sprintf("%s %s", atlas, "completion"):  NoAuth,       // completion commands do not require credentials
-		fmt.Sprintf("%s %s", atlas, "config"):      NoAuth,       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "auth"):        NoAuth,       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "register"):    NoAuth,       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "login"):       NoAuth,       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "logout"):      NoAuth,       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "whoami"):      NoAuth,       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "setup"):       NoAuth,       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "register"):    NoAuth,       // user wants to set credentials
-		fmt.Sprintf("%s %s", atlas, "plugin"):      NoAuth,       // plugin functionality requires no authentication
-		fmt.Sprintf("%s %s", atlas, "quickstart"):  NoAuth,       // command supports login
-		fmt.Sprintf("%s %s", atlas, "deployments"): OptionalAuth, // command supports local and Atlas
-	}
-	for p, r := range customRequirements {
-		if strings.HasPrefix(cmd.CommandPath(), p) {
-			return r
-		}
-	}
-
-	if plugin.IsPluginCmd(cmd) || pluginCmd.IsFirstClassPluginCmd(cmd) {
-		return OptionalAuth
-	}
-
-	return RequiredAuth
 }
 
 func formattedVersion() string {

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -15,6 +15,7 @@
 package transport
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/mongodb-forks/digest"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/oauth"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/validate"
 	atlasauth "go.mongodb.org/atlas/auth"
 )
 
@@ -109,4 +111,25 @@ func (tr *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	tr.token.SetAuthHeader(req)
 
 	return tr.base.RoundTrip(req)
+}
+
+type AuthRequiredRoundTripper struct {
+	Base http.RoundTripper
+}
+
+func (tr *AuthRequiredRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := tr.Base.RoundTrip(req)
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf(
+			`%w
+
+To log in using your Atlas username and password, run: atlas auth login
+To set credentials using API keys, run: atlas config init`,
+			validate.ErrMissingCredentials,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }

--- a/test/e2e/brew/brew_test.go
+++ b/test/e2e/brew/brew_test.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	profileString = "PROFILE NAME"
-	errorMessage  = "Error: this action requires authentication"
+	errorMessage  = "this action requires authentication"
 )
 
 func TestAtlasCLIConfig(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

This change migrates the auth check logic to run during transport instead of in the prerun of the root command.


### Main Changes
**1. Remove validation from `atlas` prerun**
Now the default transport client has a wrapper which calls the default RoundTrip and, on response status 401: Unauthorized, the following error is bubbled up:
```
Error: Get "https://cloud.mongodb.com/api/atlas/v2/groups?includeCount=true&itemsPerPage=100&pageNum=1": this action requires authentication

To log in using your Atlas username and password, run: atlas auth login
To set credentials using API keys, run: atlas config init
```

The same behaviour is preserved as, if neither API Keys or Access Token are present, the default transport will be used and, if used to call a cmd that requires auth, it will error with similar messaging.

**Note:**
The unauthorized error now takes a slightly different form, with the response wrapped in the error. (E.g. `Get "https://cloud.mongodb.com/api/atlas/v2/groups?includeCount=true&itemsPerPage=100&pageNum=1":`) To my understanding, this is the standard behaviour of Go http clients & cobra. Removing this would require additional code to catch and format the error at the command level. As I believe this is not a breaking change, I have left this addition to the error messaging.

**2. Remove token refresh from `atlas` prerun**
The access token Round Tripper already verifies if the token is expired and refreshes if it is not.

_Jira ticket:_ [CLOUDP-329791](https://jira.mongodb.org/browse/CLOUDP-329791)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code
