### PR TITLE
CLOUDP-329797: Make `atlas config init` alias of `atlas auth login`

### DIFF
--- a/docs/command/atlas-config-init.txt
+++ b/docs/command/atlas-config-init.txt
@@ -12,7 +12,7 @@ atlas config init
    :depth: 1
    :class: singlecol
 
-Configure a profile to store access settings for your MongoDB deployment.
+Authenticate with MongoDB Atlas.
 
 Public Preview: The atlas api sub-command, automatically generated from the MongoDB Atlas Admin API, offers full coverage of the Admin API and is currently in Public Preview (please provide feedback at https://feedback.mongodb.com/forums/930808-atlas-cli).
 Admin API capabilities have their own release lifecycle, which you can check via the provided API endpoint documentation link.
@@ -45,11 +45,15 @@ Options
    * - --gov
      - 
      - false
-     - Create a default profile for atlas for gov
+     - Log in to Atlas for Government.
    * - -h, --help
      - 
      - false
      - help for init
+   * - --noBrowser
+     - 
+     - false
+     - Don't automatically open a browser session.
 
 Inherited Options
 -----------------

--- a/docs/command/atlas-config.txt
+++ b/docs/command/atlas-config.txt
@@ -64,7 +64,7 @@ Related Commands
 * :ref:`atlas-config-delete` - Delete a profile.
 * :ref:`atlas-config-describe` - Return the profile you specify.
 * :ref:`atlas-config-edit` - Opens the config file with the default text editor.
-* :ref:`atlas-config-init` - Configure a profile to store access settings for your MongoDB deployment.
+* :ref:`atlas-config-init` - Authenticate with MongoDB Atlas.
 * :ref:`atlas-config-list` - Return a list of available profiles by name.
 * :ref:`atlas-config-rename` - Rename a profile.
 * :ref:`atlas-config-set` - Configure specific properties of a profile.

--- a/internal/cli/config/init.go
+++ b/internal/cli/config/init.go
@@ -15,106 +15,17 @@
 package config
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/require"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/prompt"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/telemetry"
-	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/auth"
 	"github.com/spf13/cobra"
 )
 
-const atlas = "atlas"
-
-type initOpts struct {
-	cli.DigestConfigOpts
-	gov bool
-}
-
-func (opts *initOpts) SetUpAccess() {
-	opts.Service = config.CloudService
-	if opts.gov {
-		opts.Service = config.CloudGovService
-	}
-
-	opts.SetUpServiceAndKeys()
-}
-
-func (opts *initOpts) Run(ctx context.Context) error {
-	_, _ = fmt.Fprintf(opts.OutWriter, `You are configuring a profile for %s.
-
-All values are optional and you can use environment variables (MONGODB_ATLAS_*) instead.
-
-Enter [?] on any option to get help.
-
-`, atlas)
-
-	q := prompt.AccessQuestions()
-	if err := telemetry.TrackAsk(q, opts); err != nil {
-		return err
-	}
-	opts.SetUpAccess()
-
-	if err := opts.InitStore(ctx); err != nil {
-		return err
-	}
-
-	if config.IsAccessSet() {
-		if err := opts.AskOrg(); err != nil {
-			return err
-		}
-		if err := opts.AskProject(); err != nil {
-			return err
-		}
-	} else {
-		q := prompt.TenantQuestions()
-		if err := telemetry.TrackAsk(q, opts); err != nil {
-			return err
-		}
-	}
-	opts.SetUpProject()
-	opts.SetUpOrg()
-
-	if err := telemetry.TrackAsk(opts.DefaultQuestions(), opts); err != nil {
-		return err
-	}
-	opts.SetUpOutput()
-
-	if err := config.Save(); err != nil {
-		return err
-	}
-
-	_, _ = fmt.Fprintf(opts.OutWriter, "\nYour profile is now configured.\n")
-	if config.Name() != config.DefaultProfile {
-		_, _ = fmt.Fprintf(opts.OutWriter, "To use this profile, you must set the flag [-%s %s] for every command.\n", flag.ProfileShort, config.Name())
-	}
-	_, _ = fmt.Fprintf(opts.OutWriter, "You can use [%s config set] to change these settings at a later time.\n", atlas)
-	return nil
-}
-
 func InitBuilder() *cobra.Command {
-	opts := &initOpts{}
-	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Configure a profile to store access settings for your MongoDB deployment.",
-		Example: `  # To configure the tool to work with Atlas:
+	cmd := auth.LoginBuilder()
+	cmd.Use = "init"
+	cmd.Example = `  # To configure the tool to work with Atlas:
   atlas config init
 
   # To configure the tool to work with Atlas for Government:
-  atlas config init --gov`,
-		PreRun: func(cmd *cobra.Command, _ []string) {
-			opts.OutWriter = cmd.OutOrStdout()
-		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return opts.Run(cmd.Context())
-		},
-		Args: require.NoArgs,
-	}
-	cmd.Flags().BoolVar(&opts.gov, flag.Gov, false, usage.Gov)
-
+  atlas config init --gov`
 	return cmd
 }


### PR DESCRIPTION
## Proposed changes

As these commands are under different parent commands, this is achieved by calling the Login Builder in the Init Builder and setting different Use and Example values.

This results in `atlas config init` running exactly the same as `atlas auth login` while still referring to the command correctly as `atlas config init` in help text.

_Jira ticket:_ [CLOUDP-329797](https://jira.mongodb.org/browse/CLOUDP-329797)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
