### PR TITLE
CLOUDP-333673 AtlasCLI command `atlas backup restore watch` does not return errors

### DIFF
--- a/internal/cli/backup/exports/jobs/watch.go
+++ b/internal/cli/backup/exports/jobs/watch.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/require"
@@ -58,7 +59,7 @@ func (opts *WatchOpts) watcher() (any, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	return result, result.GetState() == successfulState || result.GetState() == failedState || result.GetState() == cancelledState, nil
+	return result, strings.EqualFold(result.GetState(), successfulState) || strings.EqualFold(result.GetState(), failedState) || strings.EqualFold(result.GetState(), cancelledState), nil
 }
 
 func (opts *WatchOpts) Run() error {
@@ -72,14 +73,15 @@ func (opts *WatchOpts) Run() error {
 		return errExportFailed
 	}
 
-	switch res.GetState() {
-	case failedState:
+	if strings.EqualFold(res.GetState(), failedState) {
 		return errExportFailed
-	case cancelledState:
+	}
+
+	if strings.EqualFold(res.GetState(), cancelledState) {
 		return errExportCancelled
 	}
 
-	return opts.Print(nil)
+	return opts.Print(result)
 }
 
 // WatchBuilder atlas backup(s) export(s) job(s) watch <exportJobId>.

--- a/internal/cli/backup/restores/watch.go
+++ b/internal/cli/backup/restores/watch.go
@@ -17,6 +17,7 @@ package restores
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/require"
@@ -29,6 +30,7 @@ import (
 )
 
 const failedStatus = "FAILED"
+const completedStatus = "COMPLETED"
 
 var watchTemplate = "\nRestore completed.\n"
 var result *atlasv2.DiskBackupSnapshotRestoreJob
@@ -68,7 +70,7 @@ func stopWatcher(result *atlasv2.DiskBackupSnapshotRestoreJob) bool {
 		return true
 	}
 
-	if result.GetDeliveryType() == DeliveryTypeDownload && len(result.GetDeliveryUrl()) > 0 {
+	if strings.EqualFold(result.GetDeliveryType(), DeliveryTypeDownload) && len(result.GetDeliveryUrl()) > 0 {
 		return true
 	}
 
@@ -80,7 +82,7 @@ func (opts *WatchOpts) watcherFlexCluster() (any, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	return result, result.GetStatus() == "COMPLETED" || result.GetStatus() == failedStatus, nil
+	return result, strings.EqualFold(result.GetStatus(), completedStatus) || strings.EqualFold(result.GetStatus(), failedStatus), nil
 }
 
 func (opts *WatchOpts) Run() error {
@@ -102,7 +104,7 @@ func (opts *WatchOpts) RunFlexCluster() error {
 		return errRestoreFailed
 	}
 
-	if res.GetStatus() == failedStatus {
+	if strings.EqualFold(res.GetStatus(), failedStatus) {
 		return errRestoreFailed
 	}
 

--- a/internal/cli/backup/restores/watch_test.go
+++ b/internal/cli/backup/restores/watch_test.go
@@ -18,6 +18,7 @@ package restores
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/pointer"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,8 @@ func TestWatchOpts_Run(t *testing.T) {
 	mockStore := NewMockRestoreJobsDescriber(ctrl)
 
 	expected := &atlasv2.DiskBackupSnapshotRestoreJob{
-		Failed: pointer.Get(true),
+		Failed:     pointer.Get(false),
+		FinishedAt: pointer.Get(time.Now()),
 	}
 
 	describeOpts := &WatchOpts{

--- a/internal/cli/backup/snapshots/watch.go
+++ b/internal/cli/backup/snapshots/watch.go
@@ -59,7 +59,7 @@ func (opts *WatchOpts) watcher() (any, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	return result, strings.ToUpper(result.GetStatus()) == completedStatus || strings.ToUpper(result.GetStatus()) == failedStatus, nil
+	return result, strings.EqualFold(result.GetStatus(), completedStatus) || strings.EqualFold(result.GetStatus(), failedStatus), nil
 }
 
 func (opts *WatchOpts) watcherFlexCluster() (any, bool, error) {
@@ -67,7 +67,7 @@ func (opts *WatchOpts) watcherFlexCluster() (any, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	return result, strings.ToUpper(result.GetStatus()) == completedStatus || strings.ToUpper(result.GetStatus()) == failedStatus, nil
+	return result, strings.EqualFold(result.GetStatus(), completedStatus) || strings.EqualFold(result.GetStatus(), failedStatus), nil
 }
 
 func (opts *WatchOpts) Run() error {
@@ -89,7 +89,7 @@ func (opts *WatchOpts) RunFlexCluster() error {
 		return errSnapshotFailed
 	}
 
-	if strings.ToUpper(res.GetStatus()) == failedStatus {
+	if strings.EqualFold(res.GetStatus(), failedStatus) {
 		return errSnapshotFailed
 	}
 
@@ -107,7 +107,7 @@ func (opts *WatchOpts) RunDedicatedCluster() error {
 		return errSnapshotFailed
 	}
 
-	if strings.ToUpper(res.GetStatus()) == failedStatus {
+	if strings.EqualFold(res.GetStatus(), failedStatus) {
 		return errSnapshotFailed
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes
AtlasCLI command atlas backup restore watch does not return errors
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-333673

<!--
What MongoDB Atlas CLI issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
