### PR TITLE
CLOUDP-330235: Update config to support service accounts

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -54,14 +54,17 @@ To learn more, see our documentation: https://www.mongodb.com/docs/atlas/cli/sta
 // loadConfig reads in config file and ENV variables if set.
 func loadConfig() (*config.Profile, error) {
 	configStore, initErr := config.NewViperStore(afero.NewOsFs())
-
 	if initErr != nil {
 		return nil, fmt.Errorf("error loading config: %w. Please run `atlas auth login` to reconfigure your profile", initErr)
 	}
 
 	profile := config.NewProfile(config.DefaultProfile, configStore)
-
 	config.SetProfile(profile)
+
+	if err := profile.MigrateVersions(); err != nil {
+		log.Printf("error migrating config versions: %v", err)
+	}
+
 	return profile, nil
 }
 

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/root"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/telemetry"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/validate"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -56,6 +57,10 @@ func loadConfig() (*config.Profile, error) {
 	configStore, initErr := config.NewViperStore(afero.NewOsFs())
 	if initErr != nil {
 		return nil, fmt.Errorf("error loading config: %w. Please run `atlas auth login` to reconfigure your profile", initErr)
+	}
+
+	if err := validate.ValidConfig(configStore); err != nil {
+		return nil, fmt.Errorf("invalid config file: %w", err)
 	}
 
 	profile := config.NewProfile(config.DefaultProfile, configStore)

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -61,7 +61,7 @@ func loadConfig() (*config.Profile, error) {
 	profile := config.NewProfile(config.DefaultProfile, configStore)
 	config.SetProfile(profile)
 
-	if err := profile.MigrateVersions(); err != nil {
+	if err := config.MigrateVersions(configStore); err != nil {
 		log.Printf("error migrating config versions: %v", err)
 	}
 

--- a/internal/cli/auth/login.go
+++ b/internal/cli/auth/login.go
@@ -249,9 +249,11 @@ func (opts *LoginOpts) LoginRun(ctx context.Context) error {
 	}
 
 	if opts.authType == apiKeysAuth {
+		config.SetAuthType(config.APIKeys)
 		return opts.runAPIKeysLogin(ctx)
 	}
 
+	config.SetAuthType(config.UserAccount)
 	return opts.runUserAccountLogin(ctx)
 }
 

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -58,6 +58,9 @@ func (opts *SetOpts) Run() error {
 		value = config.IsTrue(opts.val)
 	}
 	if slices.Contains(config.GlobalProperties(), opts.prop) {
+		if strings.EqualFold(config.Version, opts.prop) {
+			return fmt.Errorf("the %s property cannot be set manually, it is automatically managed by the CLI", config.Version)
+		}
 		opts.store.SetGlobal(opts.prop, value)
 	} else {
 		opts.store.Set(opts.prop, value)

--- a/internal/cli/deployments/list_test.go
+++ b/internal/cli/deployments/list_test.go
@@ -108,7 +108,7 @@ func TestList_Run(t *testing.T) {
 	mockCredentialsGetter.
 		EXPECT().
 		AuthType().
-		Return(config.OAuth).
+		Return(config.UserAccount).
 		Times(2)
 
 	mockContainerEngine.
@@ -201,7 +201,7 @@ func TestList_Run_NoLocal(t *testing.T) {
 	mockCredentialsGetter.
 		EXPECT().
 		AuthType().
-		Return(config.OAuth).
+		Return(config.UserAccount).
 		Times(2)
 
 	mockContainerEngine.
@@ -291,7 +291,7 @@ func TestList_Run_NoAtlas(t *testing.T) {
 	mockCredentialsGetter.
 		EXPECT().
 		AuthType().
-		Return(config.OAuth).
+		Return(config.UserAccount).
 		Times(2)
 
 	mockContainerEngine.
@@ -345,7 +345,7 @@ func TestListOpts_PostRun(t *testing.T) {
 	mockCredentialsGetter.
 		EXPECT().
 		AuthType().
-		Return(config.OAuth).
+		Return(config.UserAccount).
 		Times(1)
 
 	deploymentsTest.MockDeploymentTelemetry.

--- a/internal/cli/deployments/options/deployment_opts.go
+++ b/internal/cli/deployments/options/deployment_opts.go
@@ -231,7 +231,7 @@ func (opts *DeploymentOpts) IsCliAuthenticated() bool {
 	if opts.CredStore == nil {
 		opts.CredStore = config.Default()
 	}
-	return opts.CredStore.AuthType() != config.NotLoggedIn
+	return opts.CredStore.AuthType() != ""
 }
 
 func (opts *DeploymentOpts) GetLocalContainers(ctx context.Context) ([]container.Container, error) {

--- a/internal/cli/deployments/test/fixture/deployment_atlas.go
+++ b/internal/cli/deployments/test/fixture/deployment_atlas.go
@@ -65,7 +65,7 @@ func (m *MockDeploymentOpts) CommonAtlasMocksWithState(projectID string, state s
 	m.MockCredentialsGetter.
 		EXPECT().
 		AuthType().
-		Return(config.OAuth).
+		Return(config.UserAccount).
 		Times(1)
 
 	m.MockAtlasClusterListStore.

--- a/internal/cli/organizations/create.go
+++ b/internal/cli/organizations/create.go
@@ -112,7 +112,7 @@ func (opts *CreateOpts) validateOAuthRequirements() error {
 	}
 	if len(disallowed) > 0 {
 		return fmt.Errorf(
-			"%s are not allowed when using account to authenticate",
+			"%s are not allowed with your authentication method",
 			strings.Join(disallowed, ", "),
 		)
 	}
@@ -123,10 +123,10 @@ func (opts *CreateOpts) validateAuthType() error {
 	switch config.AuthType() {
 	case config.APIKeys:
 		return opts.validateAPIKeyRequirements()
-	case config.OAuth:
+	case config.UserAccount:
 		return opts.validateOAuthRequirements()
-	case config.NotLoggedIn:
-		return nil // should not happen
+	case config.ServiceAccount:
+		return opts.validateOAuthRequirements()
 	default:
 		return nil
 	}

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -25,6 +25,7 @@ import (
 var errUnsupportedService = errors.New("unsupported service")
 
 func InitProfile(profile string) error {
+	initAuthType()
 	if profile != "" {
 		return config.SetName(profile)
 	} else if profile = config.GetString(flag.Profile); profile != "" {
@@ -38,4 +39,22 @@ func InitProfile(profile string) error {
 	}
 
 	return nil
+}
+
+// initAuthType initializes the authentication type based on the current configuration.
+// If the user has set credentials via environment variables and has not set
+// 'MONGODB_ATLAS_AUTH_TYPE', it will set the auth type accordingly.
+func initAuthType() {
+	// If the auth type is already set, we don't need to do anything.
+	authType := config.AuthType()
+	if authType != "" {
+		return
+	}
+	// If the auth type is not set, we try to determine it based on the available credentials.
+	if config.PrivateAPIKey() != "" && config.PublicAPIKey() != "" {
+		config.SetAuthType(config.APIKeys)
+	}
+	if t, _ := config.Token(); t != nil {
+		config.SetAuthType(config.UserAccount)
+	}
 }

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -54,7 +54,10 @@ func initAuthType() {
 	if config.PrivateAPIKey() != "" && config.PublicAPIKey() != "" {
 		config.SetAuthType(config.APIKeys)
 	}
-	if t, _ := config.Token(); t != nil {
+	if config.AccessToken() != "" && config.RefreshToken() != "" {
 		config.SetAuthType(config.UserAccount)
+	}
+	if config.ClientID() != "" && config.ClientSecret() != "" {
+		config.SetAuthType(config.ServiceAccount)
 	}
 }

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -25,18 +25,25 @@ import (
 var errUnsupportedService = errors.New("unsupported service")
 
 func InitProfile(profile string) error {
-	initAuthType()
 	if profile != "" {
-		return config.SetName(profile)
+		if err := config.SetName(profile); err != nil {
+			return err
+		}
 	} else if profile = config.GetString(flag.Profile); profile != "" {
-		return config.SetName(profile)
+		if err := config.SetName(profile); err != nil {
+			return err
+		}
 	} else if availableProfiles := config.List(); len(availableProfiles) == 1 {
-		return config.SetName(availableProfiles[0])
+		if err := config.SetName(availableProfiles[0]); err != nil {
+			return err
+		}
 	}
 
 	if !config.IsCloud() {
 		return fmt.Errorf("%w: %s", errUnsupportedService, config.Service())
 	}
+
+	initAuthType()
 
 	return nil
 }

--- a/internal/cli/setup/setup_cmd.go
+++ b/internal/cli/setup/setup_cmd.go
@@ -589,7 +589,7 @@ func (opts *Opts) PreRun(ctx context.Context) error {
 
 	// if profile has access token and refresh token is valid, we can skip login
 	if _, err := auth.AccountWithAccessToken(); err == nil {
-		if err := opts.login.RefreshAccessToken(ctx); err != nil && !commonerrors.IsInvalidRefreshToken(err) {
+		if err := opts.login.RefreshAccessToken(ctx); !commonerrors.IsInvalidRefreshToken(err) {
 			return nil
 		}
 	}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -14,19 +14,19 @@
 
 package config
 
-const configVersion2 = 2
+const ConfigVersion2 = 2
 
 // MigrateVersions migrates the profile to the latest version.
 // This function can be expanded to support future migrations.
 func MigrateVersions(store Store) error {
-	if GetVersion() >= configVersion2 {
+	if GetVersion() >= ConfigVersion2 {
 		return nil
 	}
 
 	setAuthTypes(store, getAuthType)
 
 	// TODO: Remaining migration steps to move credentials to secure storage will be done as a part of CLOUDP-329802
-	SetVersion(configVersion2)
+	SetVersion(ConfigVersion2)
 
 	return Save()
 }
@@ -53,5 +53,5 @@ func getAuthType(profile *Profile) AuthMechanism {
 	case profile.ClientID() != "" && profile.ClientSecret() != "":
 		return ServiceAccount
 	}
-	return AuthMechanism("")
+	return AuthMechanism("") // This should not happen unless profile is not properly initialized.
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,0 +1,50 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+const configVersion2 = 2
+
+// MigrateVersions migrates the profile to the latest version.
+// This function can be expanded to support future migrations.
+func MigrateVersions() error { return Default().MigrateVersions() }
+func (p *Profile) MigrateVersions() error {
+	if p.GetVersion() >= configVersion2 {
+		return nil
+	}
+
+	p.SetAuthTypes()
+
+	// TODO: Remaining migration steps to move credentials to secure storage will be done as a part of CLOUDP-329802
+	p.SetVersion(configVersion2)
+
+	return p.Save()
+}
+
+// SetAuthTypes sets the auth type for each profile based on the credentials available.
+// "not_logged_in" is used when no or incomplete credentials are present.
+func (p *Profile) SetAuthTypes() {
+	profileNames := p.configStore.GetProfileNames()
+	for _, name := range profileNames {
+		profile := NewProfile(name, p.configStore)
+		switch {
+		case profile.PublicAPIKey() != "" && profile.PrivateAPIKey() != "":
+			profile.SetAuthType(APIKeys)
+		case profile.AccessToken() != "" && profile.RefreshToken() != "":
+			profile.SetAuthType(UserAccount)
+		case profile.ClientID() != "" && profile.ClientSecret() != "":
+			profile.SetAuthType(ServiceAccount)
+		}
+	}
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,190 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_SetAuthTypes(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupExpect      func(mockStore *MockStore)
+		setupProfile     func(p *Profile)
+		expectedAuthType AuthMechanism
+	}{
+		{
+			name: "API Keys",
+			setupExpect: func(mockStore *MockStore) {
+				mockStore.EXPECT().
+					GetProfileNames().
+					Return([]string{"test"}).
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "public_api_key", "public").
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "private_api_key", "private").
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "auth_type", "api_keys").
+					Times(1)
+				mockStore.EXPECT().
+					GetHierarchicalValue("test", "auth_type").
+					Return("api_keys").
+					AnyTimes()
+			},
+			setupProfile: func(p *Profile) {
+				p.SetPublicAPIKey("public")
+				p.SetPrivateAPIKey("private")
+			},
+			expectedAuthType: APIKeys,
+		},
+		{
+			name: "User Account",
+			setupExpect: func(mockStore *MockStore) {
+				mockStore.EXPECT().
+					GetProfileNames().
+					Return([]string{"test"}).
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "access_token", "token").
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "refresh_token", "token").
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "auth_type", "user_account").
+					Times(1)
+				mockStore.EXPECT().
+					GetHierarchicalValue("test", "auth_type").
+					Return("user_account").
+					AnyTimes()
+			},
+			setupProfile: func(p *Profile) {
+				p.SetAccessToken("token")
+				p.SetRefreshToken("token")
+			},
+			expectedAuthType: UserAccount,
+		},
+		{
+			name: "Service Account",
+			setupExpect: func(mockStore *MockStore) {
+				mockStore.EXPECT().
+					GetProfileNames().
+					Return([]string{"test"}).
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "client_id", "id").
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "client_secret", "secret").
+					Times(1)
+				mockStore.EXPECT().
+					SetProfileValue("test", "auth_type", "service_account").
+					Times(1)
+				mockStore.EXPECT().
+					GetHierarchicalValue("test", "auth_type").
+					Return("service_account").
+					AnyTimes()
+			},
+			setupProfile: func(p *Profile) {
+				p.SetClientID("id")
+				p.SetClientSecret("secret")
+			},
+			expectedAuthType: ServiceAccount,
+		},
+		{
+			name: "Empty Profile",
+			setupExpect: func(mockStore *MockStore) {
+				mockStore.EXPECT().
+					GetProfileNames().
+					Return([]string{"test"}).
+					Times(1)
+				mockStore.EXPECT().
+					GetHierarchicalValue("test", "auth_type").
+					Return("").
+					AnyTimes()
+			},
+			setupProfile:     func(*Profile) {},
+			expectedAuthType: AuthMechanism(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockStore := NewMockStore(ctrl)
+			tt.setupExpect(mockStore)
+
+			p := NewProfile("test", mockStore)
+			tt.setupProfile(p)
+			setAuthTypes(mockStore, func(*Profile) AuthMechanism {
+				return tt.expectedAuthType
+			})
+			require.Equal(t, tt.expectedAuthType, p.AuthType())
+		})
+	}
+}
+
+func Test_GetAuthType(t *testing.T) {
+	tests := []struct {
+		name             string
+		setup            func(p *Profile)
+		expectedAuthType AuthMechanism
+	}{
+		{
+			name: "API Keys",
+			setup: func(p *Profile) {
+				p.SetPublicAPIKey("public")
+				p.SetPrivateAPIKey("private")
+			},
+			expectedAuthType: APIKeys,
+		},
+		{
+			name: "User Account",
+			setup: func(p *Profile) {
+				p.SetAccessToken("token")
+				p.SetRefreshToken("refresh")
+			},
+			expectedAuthType: UserAccount,
+		},
+		{
+			name: "Service Account",
+			setup: func(p *Profile) {
+				p.SetClientID("id")
+				p.SetClientSecret("secret")
+			},
+			expectedAuthType: ServiceAccount,
+		},
+		{
+			name:             "Empty Profile",
+			setup:            func(*Profile) {},
+			expectedAuthType: AuthMechanism(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewInMemoryStore()
+			p := NewProfile("test", store)
+			tt.setup(p)
+			require.Equal(t, tt.expectedAuthType, getAuthType(p))
+		})
+	}
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build unit
+
 package config
 
 import (

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -289,25 +289,6 @@ func (p *Profile) AuthType() AuthMechanism {
 	return AuthMechanism(p.GetString(AuthTypeField))
 }
 
-// GetAuthType calculates the auth type for backwards compatibility.
-func GetAuthType() AuthMechanism { return Default().GetAuthType() }
-func (p *Profile) GetAuthType() AuthMechanism {
-	if p.AuthType() != "" {
-		return p.AuthType()
-	}
-	if p.PrivateAPIKey() != "" && p.PublicAPIKey() != "" {
-		return APIKeys
-	}
-	if p.AccessToken() != "" && p.RefreshToken() != "" {
-		return UserAccount
-	}
-	if p.ClientID() != "" && p.ClientSecret() != "" {
-		return ServiceAccount
-	}
-	// If no auth type is set, we assume the user is not logged in.
-	return AuthMechanism("")
-}
-
 // SetAuthType sets the configured auth type.
 func SetAuthType(v AuthMechanism) { Default().SetAuthType(v) }
 func (p *Profile) SetAuthType(v AuthMechanism) {

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -289,6 +289,25 @@ func (p *Profile) AuthType() AuthMechanism {
 	return AuthMechanism(p.GetString(AuthTypeField))
 }
 
+// GetAuthType calculates the auth type for backwards compatibility.
+func GetAuthType() AuthMechanism { return Default().GetAuthType() }
+func (p *Profile) GetAuthType() AuthMechanism {
+	if p.AuthType() != "" {
+		return p.AuthType()
+	}
+	if p.PrivateAPIKey() != "" && p.PublicAPIKey() != "" {
+		return APIKeys
+	}
+	if p.AccessToken() != "" && p.RefreshToken() != "" {
+		return UserAccount
+	}
+	if p.ClientID() != "" && p.ClientSecret() != "" {
+		return ServiceAccount
+	}
+	// If no auth type is set, we assume the user is not logged in.
+	return AuthMechanism("")
+}
+
 // SetAuthType sets the configured auth type.
 func SetAuthType(v AuthMechanism) { Default().SetAuthType(v) }
 func (p *Profile) SetAuthType(v AuthMechanism) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -140,9 +140,9 @@ type CredentialsGetter interface {
 }
 
 // WithAuthentication sets the store credentials.
-func WithAuthentication(c CredentialsGetter, authType config.AuthMechanism) Option {
+func WithAuthentication(c CredentialsGetter) Option {
 	return func(s *Store) error {
-		s.authType = authType
+		s.authType = c.AuthType()
 		if s.authType == config.APIKeys {
 			s.username = c.PublicAPIKey()
 			s.password = c.PrivateAPIKey()
@@ -258,7 +258,7 @@ type AuthenticatedConfig interface {
 
 // AuthenticatedPreset is the default Option when connecting to the public API with authentication.
 func AuthenticatedPreset(c AuthenticatedConfig) Option {
-	options := []Option{Service(c.Service()), WithAuthentication(c, config.GetAuthType())}
+	options := []Option{Service(c.Service()), WithAuthentication(c)}
 	if baseURLOpt := baseURLOption(c); baseURLOpt != nil {
 		options = append(options, baseURLOpt)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -25,9 +25,11 @@ import (
 )
 
 type auth struct {
-	username string
-	password string
-	token    string
+	username     string
+	password     string
+	token        string
+	clientID     string
+	clientSecret string
 }
 
 func (auth) Token() (*atlasauth.Token, error) {
@@ -46,14 +48,25 @@ func (a auth) PrivateAPIKey() string {
 	return a.password
 }
 
+func (a auth) ClientID() string {
+	return a.clientID
+}
+
+func (a auth) ClientSecret() string {
+	return a.clientSecret
+}
+
 func (a auth) AuthType() config.AuthMechanism {
 	if a.username != "" {
 		return config.APIKeys
 	}
 	if a.token != "" {
-		return config.OAuth
+		return config.UserAccount
 	}
-	return config.NotLoggedIn
+	if a.clientID != "" {
+		return config.ServiceAccount
+	}
+	return ""
 }
 
 var _ CredentialsGetter = &auth{}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -121,7 +121,7 @@ func TestWithAuthentication(t *testing.T) {
 		username: "username",
 		password: "password",
 	}
-	c, err := New(Service("cloud"), WithAuthentication(a, config.APIKeys))
+	c, err := New(Service("cloud"), WithAuthentication(a))
 
 	if err != nil {
 		t.Fatalf("New() unexpected error: %v", err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -121,7 +121,7 @@ func TestWithAuthentication(t *testing.T) {
 		username: "username",
 		password: "password",
 	}
-	c, err := New(Service("cloud"), WithAuthentication(a))
+	c, err := New(Service("cloud"), WithAuthentication(a, config.APIKeys))
 
 	if err != nil {
 		t.Fatalf("New() unexpected error: %v", err)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -28,9 +28,22 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 )
 
-const minPasswordLength = 10
-const clusterWideScaling = "clusterWideScaling"
-const independentShardScaling = "independentShardScaling"
+const (
+	minPasswordLength       = 10
+	clusterWideScaling      = "clusterWideScaling"
+	independentShardScaling = "independentShardScaling"
+)
+
+var (
+	ErrAlreadyAuthenticatedAPIKeys = errors.New("already authenticated with an API key")
+	ErrAlreadyAuthenticatedToken   = errors.New("already authenticated with an account")
+	ErrInvalidPath                 = errors.New("invalid path")
+	ErrInvalidClusterName          = errors.New("invalid cluster name")
+	ErrInvalidDBUsername           = errors.New("invalid db username")
+	ErrWeakPassword                = errors.New("the password provided is too common")
+	ErrShortPassword               = errors.New("the password provided is too short")
+	ErrInvalidConfigVersion        = errors.New("version is invalid")
+)
 
 // toString tries to cast an interface to string.
 func toString(val any) (string, error) {
@@ -108,8 +121,6 @@ func Credentials() error {
 	return commonerrors.ErrUnauthorized
 }
 
-var ErrAlreadyAuthenticatedAPIKeys = errors.New("already authenticated with an API key")
-
 // NoAPIKeys there are no API keys in the profile, used for login/register/setup commands.
 func NoAPIKeys() error {
 	if config.PrivateAPIKey() == "" && config.PublicAPIKey() == "" {
@@ -139,8 +150,6 @@ func AutoScalingMode(autoScalingMode string) func() error {
 		return nil
 	}
 }
-
-var ErrAlreadyAuthenticatedToken = errors.New("already authenticated with an account")
 
 // NoAccessToken there is no access token in the profile, used for login/register/setup commands.
 func NoAccessToken() error {
@@ -172,8 +181,6 @@ func ConditionalFlagNotInSlice(conditionalFlag string, conditionalFlagValue stri
 	return fmt.Errorf(`invalid flag "%s" in combination with "%s=%s", not allowed values: "%s"`, flag, conditionalFlag, conditionalFlagValue, strings.Join(invalidFlags, `", "`))
 }
 
-var ErrInvalidPath = errors.New("invalid path")
-
 func Path(val any) error {
 	path, ok := val.(string)
 	if !ok {
@@ -198,8 +205,6 @@ func OptionalPath(val any) error {
 	return Path(val)
 }
 
-var ErrInvalidClusterName = errors.New("invalid cluster name")
-
 func ClusterName(val any) error {
 	name, ok := val.(string)
 	if !ok {
@@ -213,8 +218,6 @@ func ClusterName(val any) error {
 	return fmt.Errorf("%w. Cluster names can only contain ASCII letters, numbers, and hyphens: %s", ErrInvalidClusterName, name)
 }
 
-var ErrInvalidDBUsername = errors.New("invalid db username")
-
 func DBUsername(val any) error {
 	name, ok := val.(string)
 	if !ok {
@@ -227,9 +230,6 @@ func DBUsername(val any) error {
 
 	return fmt.Errorf("%w: %s", ErrInvalidDBUsername, name)
 }
-
-var ErrWeakPassword = errors.New("the password provided is too common")
-var ErrShortPassword = errors.New("the password provided is too short")
 
 func WeakPassword(val any) error {
 	password, ok := val.(string)
@@ -245,5 +245,35 @@ func WeakPassword(val any) error {
 		return ErrWeakPassword
 	}
 
+	return nil
+}
+
+// ValidConfig checks if the config file is valid based on the version and properties.
+func ValidConfig(store config.Store) error {
+	version := int64(0)
+	var ok bool
+	if v := store.GetGlobalValue(config.Version); v != nil {
+		if version, ok = v.(int64); !ok {
+			return errors.New("issue retrieving version")
+		}
+	}
+
+	profileNames := store.GetProfileNames()
+	for _, name := range profileNames {
+		// We do not care if the profile has credentials or not, since all valid profiles should have credentials.
+		auth := store.GetProfileValue(name, "auth_type")
+		hasAuthType := (auth != nil)
+
+		switch version {
+		case config.ConfigVersion2:
+			if !hasAuthType {
+				return ErrInvalidConfigVersion
+			}
+		case 0:
+			if hasAuthType {
+				return ErrInvalidConfigVersion
+			}
+		}
+	}
 	return nil
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -563,7 +563,9 @@ func TestValidConfig(t *testing.T) {
 
 			mockStore.EXPECT().GetGlobalValue("version").Return(tt.expectVersion).Times(1)
 			mockStore.EXPECT().GetProfileNames().Return([]string{"test"}).Times(1)
-			mockStore.EXPECT().GetProfileValue("test", "auth_type").Return(tt.expectAuthType).AnyTimes()
+			mockStore.EXPECT().GetProfileValue("test", "public_api_key").Return("public").Times(1)
+			mockStore.EXPECT().GetProfileValue("test", "private_api_key").Return("private").Times(1)
+			mockStore.EXPECT().GetProfileValue("test", "auth_type").Return(tt.expectAuthType).Times(1)
 
 			err := ValidConfig(mockStore)
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -20,8 +20,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestURL(t *testing.T) {
@@ -517,6 +519,60 @@ func TestWeakPassword(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			wantErr(t, WeakPassword(val))
+		})
+	}
+}
+
+func TestValidConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectVersion  int64
+		expectAuthType any
+		wantError      bool
+	}{
+		{
+			name:           "version 2, profiles with auth_type",
+			expectVersion:  2,
+			expectAuthType: "api_keys",
+			wantError:      false,
+		},
+		{
+			name:           "version 2, profile missing auth_type",
+			expectVersion:  2,
+			expectAuthType: nil,
+			wantError:      true,
+		},
+		{
+			name:           "version 0, profile without auth_type",
+			expectAuthType: nil,
+			wantError:      false,
+		},
+		{
+			name:           "version 0, profile with auth_type",
+			expectVersion:  0,
+			expectAuthType: "api_keys",
+			wantError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockStore := config.NewMockStore(ctrl)
+
+			mockStore.EXPECT().GetGlobalValue("version").Return(tt.expectVersion).Times(1)
+			mockStore.EXPECT().GetProfileNames().Return([]string{"test"}).Times(1)
+			mockStore.EXPECT().GetProfileValue("test", "auth_type").Return(tt.expectAuthType).AnyTimes()
+
+			err := ValidConfig(mockStore)
+
+			if tt.wantError {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidConfigVersion)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Proposed changes

* Adds support for **new profile attributes**:
  * `clientID`: Service Account client ID
  * `clientSecret`: Service Account client secret
  * `authType`: string representing the type of authentication used by the profile
* Adds support for **new global config attribute** `version`.
  * This version is not CLI version but version of the config. This is to support migrations when config logic is changed.
* Added **config migration** to loadConfig. After the config and profile are loaded in:
  * Checks if config is already version == 2
    * Returns
  * Calculates and sets `authType` for every profile
    * Saves config
  * This migration will be expanded in future to migrate credentials to secure storage. There is no concern introducing the migration in two steps as the migration will not be released until fully complete.
* Sets `authType` on `atlas auth login`
* Replaces all instances of checking authentication type by seeing what credentials are available with checking `authType`
  * To avoid breaking users who cannot successfully migrate and users using env vars, on the prerun of the `atlas` cmd,  the authType is set according the credentials available if it is nil.

_Jira ticket:_ [CLOUDP-330235](https://jira.mongodb.org/browse/CLOUDP-330235)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code