### PR TITLE
CLOUDP-334886: create stub for workspace update command 

### DIFF
--- a/internal/cli/streams/instance/create_test.go
+++ b/internal/cli/streams/instance/create_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	testProjectID = "create-project-id"
+	createTestProjectID = "create-project-id"
 )
 
 func TestCreateOpts_Run(t *testing.T) {
@@ -42,7 +42,7 @@ func TestCreateOpts_Run(t *testing.T) {
 			region:   "VIRGINIA_USA",
 			tier:     "SP30", // Test non default case
 		}
-		opts.ProjectID = testProjectID
+		opts.ProjectID = createTestProjectID
 
 		expected := &atlasv2.StreamsTenant{
 			Name:              &opts.name,
@@ -75,7 +75,7 @@ func TestCreateOpts_Run(t *testing.T) {
 			region:   "VIRGINIA_USA",
 			tier:     "SP10", // Test non default case
 		}
-		opts.ProjectID = testProjectID
+		opts.ProjectID = createTestProjectID
 
 		expected := &atlasv2.StreamsTenant{
 			Name:              &opts.name,
@@ -108,7 +108,7 @@ func TestCreateOpts_Run(t *testing.T) {
 			region:   "VIRGINIA_USA",
 			tier:     "SP30",
 		}
-		opts.ProjectID = testProjectID
+		opts.ProjectID = createTestProjectID
 
 		expected := &atlasv2.StreamsTenant{
 			Name:              &opts.name,
@@ -144,7 +144,7 @@ func TestCreateOpts_Run(t *testing.T) {
 			defaultTier: "SP30",
 			maxTierSize: "SP50",
 		}
-		opts.ProjectID = testProjectID
+		opts.ProjectID = updateTestProjectID
 
 		expected := &atlasv2.StreamsTenant{
 			Name:              &opts.name,

--- a/internal/cli/streams/instance/workspaces.go
+++ b/internal/cli/streams/instance/workspaces.go
@@ -27,7 +27,7 @@ func WorkspaceBuilder() *cobra.Command {
 		Short:   "Manage Atlas Stream Processing workspaces.",
 		Long:    `Create, list, update, and delete your Atlas Stream Processing workspaces.`,
 	}
-	cmd.AddCommand(WorkspaceCreateBuilder())
+	cmd.AddCommand(WorkspaceCreateBuilder(), WorkspaceUpdateBuilder())
 
 	return cmd
 }


### PR DESCRIPTION
## Proposed changes
Create stub for the atlas streams workspaces update command (similar to work done for workspaces create command in [CLOUDP-333877](https://jira.mongodb.org/browse/CLOUDP-333877) 

For context, Atlas Stream Processing is renaming "instances" to "workspaces". We plan to first add new equivalent commands to the existing cli commands so that they can be used as is with "workspaces" substituted for "instances in the commands"

_Jira ticket:_ CLOUDP-334886

## Checklist
- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further Comments
