### PR TITLE
CLOUDP-336714: [AtlasCLI] atlas_deployments_local_nocli_e2e fails

### DIFF
--- a/internal/cli/deployments/diagnostics.go
+++ b/internal/cli/deployments/diagnostics.go
@@ -112,7 +112,9 @@ func (opts *diagnosticsOpts) Run(ctx context.Context) error {
 		})
 	}
 
-	d.Err = errors.Join(errs...).Error()
+	if len(errs) > 0 {
+		d.Err = errors.Join(errs...).Error()
+	}
 
 	return opts.Print(d)
 }


### PR DESCRIPTION
## Proposed changes

Fixed nil pointer dereference error when there are no errors
_Jira ticket:_ CLOUDP-336714