### PR TITLE
 CLOUDP-333260: Delete api key from profile on logout (#4094) 

### DIFF
--- a/internal/cli/auth/logout_mock_test.go
+++ b/internal/cli/auth/logout_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	config "github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -39,6 +40,44 @@ func NewMockConfigDeleter(ctrl *gomock.Controller) *MockConfigDeleter {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConfigDeleter) EXPECT() *MockConfigDeleterMockRecorder {
 	return m.recorder
+}
+
+// AuthType mocks base method.
+func (m *MockConfigDeleter) AuthType() config.AuthMechanism {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthType")
+	ret0, _ := ret[0].(config.AuthMechanism)
+	return ret0
+}
+
+// AuthType indicates an expected call of AuthType.
+func (mr *MockConfigDeleterMockRecorder) AuthType() *MockConfigDeleterAuthTypeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthType", reflect.TypeOf((*MockConfigDeleter)(nil).AuthType))
+	return &MockConfigDeleterAuthTypeCall{Call: call}
+}
+
+// MockConfigDeleterAuthTypeCall wrap *gomock.Call
+type MockConfigDeleterAuthTypeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterAuthTypeCall) Return(arg0 config.AuthMechanism) *MockConfigDeleterAuthTypeCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterAuthTypeCall) Do(f func() config.AuthMechanism) *MockConfigDeleterAuthTypeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterAuthTypeCall) DoAndReturn(f func() config.AuthMechanism) *MockConfigDeleterAuthTypeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // Delete mocks base method.
@@ -189,6 +228,42 @@ func (c *MockConfigDeleterSetOrgIDCall) DoAndReturn(f func(string)) *MockConfigD
 	return c
 }
 
+// SetPrivateAPIKey mocks base method.
+func (m *MockConfigDeleter) SetPrivateAPIKey(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPrivateAPIKey", arg0)
+}
+
+// SetPrivateAPIKey indicates an expected call of SetPrivateAPIKey.
+func (mr *MockConfigDeleterMockRecorder) SetPrivateAPIKey(arg0 any) *MockConfigDeleterSetPrivateAPIKeyCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPrivateAPIKey", reflect.TypeOf((*MockConfigDeleter)(nil).SetPrivateAPIKey), arg0)
+	return &MockConfigDeleterSetPrivateAPIKeyCall{Call: call}
+}
+
+// MockConfigDeleterSetPrivateAPIKeyCall wrap *gomock.Call
+type MockConfigDeleterSetPrivateAPIKeyCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterSetPrivateAPIKeyCall) Return() *MockConfigDeleterSetPrivateAPIKeyCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterSetPrivateAPIKeyCall) Do(f func(string)) *MockConfigDeleterSetPrivateAPIKeyCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterSetPrivateAPIKeyCall) DoAndReturn(f func(string)) *MockConfigDeleterSetPrivateAPIKeyCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetProjectID mocks base method.
 func (m *MockConfigDeleter) SetProjectID(arg0 string) {
 	m.ctrl.T.Helper()
@@ -221,6 +296,42 @@ func (c *MockConfigDeleterSetProjectIDCall) Do(f func(string)) *MockConfigDelete
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigDeleterSetProjectIDCall) DoAndReturn(f func(string)) *MockConfigDeleterSetProjectIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetPublicAPIKey mocks base method.
+func (m *MockConfigDeleter) SetPublicAPIKey(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPublicAPIKey", arg0)
+}
+
+// SetPublicAPIKey indicates an expected call of SetPublicAPIKey.
+func (mr *MockConfigDeleterMockRecorder) SetPublicAPIKey(arg0 any) *MockConfigDeleterSetPublicAPIKeyCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPublicAPIKey", reflect.TypeOf((*MockConfigDeleter)(nil).SetPublicAPIKey), arg0)
+	return &MockConfigDeleterSetPublicAPIKeyCall{Call: call}
+}
+
+// MockConfigDeleterSetPublicAPIKeyCall wrap *gomock.Call
+type MockConfigDeleterSetPublicAPIKeyCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterSetPublicAPIKeyCall) Return() *MockConfigDeleterSetPublicAPIKeyCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterSetPublicAPIKeyCall) Do(f func(string)) *MockConfigDeleterSetPublicAPIKeyCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterSetPublicAPIKeyCall) DoAndReturn(f func(string)) *MockConfigDeleterSetPublicAPIKeyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -21,11 +21,12 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
-func Test_logoutOpts_Run(t *testing.T) {
+func Test_logoutOpts_Run_OAuth(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockFlow := NewMockRevoker(ctrl)
 	mockConfig := NewMockConfigDeleter(ctrl)
@@ -41,6 +42,12 @@ func Test_logoutOpts_Run(t *testing.T) {
 		},
 	}
 	ctx := t.Context()
+
+	mockConfig.
+		EXPECT().
+		AuthType().
+		Return(config.OAuth).
+		Times(1)
 	mockFlow.
 		EXPECT().
 		RevokeToken(ctx, gomock.Any(), gomock.Any()).
@@ -54,7 +61,38 @@ func Test_logoutOpts_Run(t *testing.T) {
 	require.NoError(t, opts.Run(ctx))
 }
 
-func Test_logoutOpts_Run_Keep(t *testing.T) {
+func Test_logoutOpts_Run_APIKeys(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockFlow := NewMockRevoker(ctrl)
+	mockConfig := NewMockConfigDeleter(ctrl)
+
+	buf := new(bytes.Buffer)
+
+	opts := logoutOpts{
+		OutWriter: buf,
+		config:    mockConfig,
+		flow:      mockFlow,
+		DeleteOpts: &cli.DeleteOpts{
+			Confirm: true,
+		},
+	}
+	ctx := t.Context()
+
+	mockConfig.
+		EXPECT().
+		AuthType().
+		Return(config.APIKeys).
+		Times(1)
+	// No token revocation expected for API keys
+	mockConfig.
+		EXPECT().
+		Delete().
+		Return(nil).
+		Times(1)
+	require.NoError(t, opts.Run(ctx))
+}
+
+func Test_logoutOpts_Run_Keep_OAuth(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockFlow := NewMockRevoker(ctrl)
 	mockConfig := NewMockConfigDeleter(ctrl)
@@ -71,6 +109,12 @@ func Test_logoutOpts_Run_Keep(t *testing.T) {
 		keepConfig: true,
 	}
 	ctx := t.Context()
+
+	mockConfig.
+		EXPECT().
+		AuthType().
+		Return(config.OAuth).
+		Times(1)
 	mockFlow.
 		EXPECT().
 		RevokeToken(ctx, gomock.Any(), gomock.Any()).
@@ -84,6 +128,56 @@ func Test_logoutOpts_Run_Keep(t *testing.T) {
 	mockConfig.
 		EXPECT().
 		SetRefreshToken("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		SetProjectID("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		SetOrgID("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		Save().
+		Return(nil).
+		Times(1)
+
+	require.NoError(t, opts.Run(ctx))
+}
+
+func Test_logoutOpts_Run_Keep_APIKeys(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockFlow := NewMockRevoker(ctrl)
+	mockConfig := NewMockConfigDeleter(ctrl)
+
+	buf := new(bytes.Buffer)
+
+	opts := logoutOpts{
+		OutWriter: buf,
+		config:    mockConfig,
+		flow:      mockFlow,
+		DeleteOpts: &cli.DeleteOpts{
+			Confirm: true,
+		},
+		keepConfig: true,
+	}
+	ctx := t.Context()
+
+	mockConfig.
+		EXPECT().
+		AuthType().
+		Return(config.APIKeys).
+		Times(1)
+	// No token revocation for API keys
+
+	mockConfig.
+		EXPECT().
+		SetPublicAPIKey("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		SetPrivateAPIKey("").
 		Times(1)
 	mockConfig.
 		EXPECT().


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

Cherry picking ` CLOUDP-333260: Delete api key from profile on logout (#4094) ` 

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
