### PR TITLE
CLOUDP-329788: Send telemetry property auth_method = service_account when using SA

### DIFF
--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -207,18 +207,19 @@ func withOS() EventOpt {
 }
 
 type Authenticator interface {
-	PublicAPIKey() string
-	PrivateAPIKey() string
-	AccessToken() string
+	AuthType() config.AuthMechanism
 }
 
 func withAuthMethod(c Authenticator) EventOpt {
 	return func(event Event) {
-		if c.PublicAPIKey() != "" && c.PrivateAPIKey() != "" {
+		switch c.AuthType() {
+		case config.APIKeys:
 			event.Properties["auth_method"] = "api_key"
 			return
-		} else if c.AccessToken() != "" {
+		case config.UserAccount:
 			event.Properties["auth_method"] = "oauth"
+		case config.ServiceAccount:
+			event.Properties["auth_method"] = "service_account"
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes
* Refactors method `withAuthMethod()` to use switch with `AuthType()`
* Sets telemetry property `auth_method` to `service_account` if authentication is through SA

_Jira ticket:_ [CLOUDP-329788](https://jira.mongodb.org/browse/CLOUDP-329788)

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code
