### PR TITLE
CLOUDP-329800: Remove force when calling logout

### DIFF
--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -114,6 +114,12 @@ func LogoutBuilder() *cobra.Command {
 			opts.OutWriter = cmd.OutOrStdout()
 			opts.config = config.Default()
 
+			// If the profile is set in the context, use it instead of the default profile
+			profile, ok := config.ProfileFromContext(cmd.Context())
+			if ok {
+				opts.config = profile
+			}
+
 			// Only initialize OAuth flow if we have OAuth-based auth
 			if opts.config.AuthType() == config.UserAccount || opts.config.AuthType() == config.ServiceAccount {
 				return opts.initFlow()

--- a/internal/cli/config/delete.go
+++ b/internal/cli/config/delete.go
@@ -15,14 +15,17 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/auth"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/require"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/workflows"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/config"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/flag"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/log"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
 	"github.com/spf13/cobra"
 )
@@ -31,26 +34,29 @@ type DeleteOpts struct {
 	*cli.DeleteOpts
 }
 
-func (opts *DeleteOpts) executeLogout() error {
-	// Get the current executable path
-	executable, err := os.Executable()
+func (opts *DeleteOpts) Run(ctx context.Context) error {
+	logout := auth.LogoutBuilder()
+
+	var newArgs []string
+	_, _ = log.Debugf("Removing flags and args from original args %s\n", os.Args)
+
+	newArgs, err := workflows.RemoveFlagsAndArgs(nil, map[string]bool{opts.Entry: true}, os.Args)
 	if err != nil {
-		return fmt.Errorf("failed to get executable path: %w", err)
+		return err
 	}
 
-	// Execute: atlas auth logout --profile <profile-name> --force
-	cmd := exec.Command(executable, "auth", "logout", "--profile", opts.Entry, "--force")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	logout.SetArgs(newArgs)
 
-	return cmd.Run()
-}
-
-func (opts *DeleteOpts) Run() error {
-	if !opts.Confirm {
-		return nil
+	// Send profile as a context value to the logout command
+	if err := config.SetName(opts.Entry); err != nil {
+		return err
 	}
-	return opts.executeLogout()
+
+	ctx = config.WithProfile(ctx, config.Default())
+
+	_, _ = log.Debugf("Executing logout with args '%s' and profile '%s'", newArgs, opts.Entry)
+	_, err = logout.ExecuteContextC(ctx)
+	return err
 }
 
 func DeleteBuilder() *cobra.Command {
@@ -78,10 +84,10 @@ func DeleteBuilder() *cobra.Command {
 				return fmt.Errorf("profile %v does not exist", opts.Entry)
 			}
 
-			return opts.Prompt()
+			return nil
 		},
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return opts.Run()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return opts.Run(cmd.Context())
 		},
 	}
 

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -108,6 +108,10 @@ func WithProfile(ctx context.Context, profile *Profile) context.Context {
 
 // Getting a value
 func ProfileFromContext(ctx context.Context) (*Profile, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+
 	profile, ok := ctx.Value(profileContextKey).(*Profile)
 	return profile, ok
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-329800

- Uses the same prompt as logout to run ` config delete` 
- Uses a similar approach to deployments setup to call logout
- Sends profile data on context
- Fixes panic no `ProfileFromContext`

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
