### PR TITLE
CLOUDP-333521: [AtlasCLI] [Mac] Write e2e test for migration to secure storage

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -1365,6 +1365,25 @@ tasks:
               -e SNYK_CFG_ORG=${SNYK_ORG} \
               -v ${workdir}/src/github.com/mongodb/mongodb-atlas-cli:/app \
               snyk/snyk:golang snyk monitor
+  # 
+  - name: atlas_config_migration_e2e
+    tags: ["e2e","config-migration"]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "install gotestsum"
+      - func: "e2e test"
+        vars:
+          MONGODB_ATLAS_ORG_ID: ${atlas_org_id}
+          MONGODB_ATLAS_PROJECT_ID: ${atlas_project_id}
+          MONGODB_ATLAS_PRIVATE_API_KEY: ${atlas_private_api_key}
+          MONGODB_ATLAS_PUBLIC_API_KEY: ${atlas_public_api_key}
+          MONGODB_ATLAS_OPS_MANAGER_URL: ${mcli_ops_manager_url}
+          MONGODB_ATLAS_SERVICE: cloud
+          E2E_TEST_PACKAGES: ./test/e2e/config/migration/...
 task_groups:
   - name: atlas_deployments_windows_group
     setup_task:
@@ -1683,6 +1702,18 @@ buildvariants:
       - ubuntu2204-small
     tasks:
       - name: ".snyk"
+  - name: e2e_config_migration_macos_14
+    display_name: "E2E Config Migration Tests"
+    allowed_requesters: ["patch", "ad_hoc", "github_pr"]
+    tags:
+      - config-migration
+      - foliage_health
+    run_on:
+      - macos-14-arm64-docker
+    expansions:
+      <<: *go_linux_version
+    tasks:
+      - name: ".e2e .config-migration"
 patch_aliases:
   - alias: "localdev"
     variant_tags: ["localdev cron"]

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -65,6 +65,10 @@ func loadConfig() (*config.Profile, error) {
 		return nil, fmt.Errorf("error loading config: %w. Please run `atlas auth login` to reconfigure your profile", initErr)
 	}
 
+	if !configStore.IsSecure() {
+		fmt.Fprintf(os.Stderr, "Warning: Secure storage is not available, falling back to insecure storage\n")
+	}
+
 	profile := config.NewProfile(config.DefaultProfile, configStore)
 	config.SetProfile(profile)
 

--- a/test/e2e/atlas/search_nodes/searchnodes/search_nodes_test.go
+++ b/test/e2e/atlas/search_nodes/searchnodes/search_nodes_test.go
@@ -66,11 +66,9 @@ func TestSearchNodes(t *testing.T) {
 			internal.ProfileName(),
 		)
 
-		resp, err := cmd.CombinedOutput()
-		respStr := string(resp)
-
-		require.NoError(t, err, respStr)
-		require.Equal(t, "{}\n", respStr)
+		stdout, stderr, err := internal.RunAndGetSeparateStdOutAndErr(cmd)
+		require.NoError(t, err, string(stderr))
+		require.Equal(t, "{}\n", string(stdout))
 	})
 
 	g.Run("Create search node", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run

--- a/test/e2e/config/migration/migration_test.go
+++ b/test/e2e/config/migration/migration_test.go
@@ -1,0 +1,103 @@
+// Copyright 2020 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/test/internal"
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+)
+
+func TestConfigMigration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	// Create a temporary config folder
+	dir := internal.TempConfigFolder(t)
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
+
+	// Initialize the keychain
+	require.NoError(t, internal.InitKeychain(t))
+
+	// Write the old config format that needs to be migrated
+	configPath := path.Join(dir, "config.toml")
+	err := os.WriteFile(configPath, []byte(`[e2e-migration]
+  org_id = "test_id"
+  public_api_key = "test_pub"
+  private_api_key = "test_priv"
+  service = "cloud"
+`), 0600)
+	require.NoError(t, err)
+
+	// Get the CLI path
+	cliPath, err := internal.AtlasCLIBin()
+	require.NoError(t, err)
+
+	// Run the CLI, any command will trigger the migration
+	cmd := exec.Command(cliPath)
+	cmd.Env = os.Environ()
+
+	// Get the output
+	outputBytes, err := cmd.CombinedOutput()
+	output := string(outputBytes)
+	if err != nil {
+		t.Fatalf("failed to run command: %v, output: %s", err, output)
+	}
+
+	// Ensure we're not falling back to insecure storage
+	assert.NotContains(t, output, "Warning: Secure storage is not available, falling back to insecure storage")
+
+	// Read the config file and check that it contains the expected migrated structure
+	configContent, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+
+	// Parse the config file as TOML
+	var config map[string]any
+	require.NoError(t, toml.Unmarshal(configContent, &config))
+
+	// Get the profile that we expect to be migrated
+	migrationProfile, ok := config["e2e-migration"].(map[string]any)
+	if !ok {
+		t.Fatalf("e2e-migration not found in config")
+	}
+
+	// Check that the profile was migrated correctly
+	// Secrets should be removed from the profile
+	assert.Equal(t, "test_id", migrationProfile["org_id"])
+	assert.Nil(t, migrationProfile["public_api_key"])
+	assert.Nil(t, migrationProfile["private_api_key"])
+	assert.Equal(t, "cloud", migrationProfile["service"])
+
+	// Check that the secrets are stored in the keychain
+	publicAPIKey, err := keyring.Get("atlascli_e2e-migration", "public_api_key")
+	require.NoError(t, err)
+	assert.Equal(t, "test_pub", publicAPIKey)
+
+	privateAPIKey, err := keyring.Get("atlascli_e2e-migration", "private_api_key")
+	require.NoError(t, err)
+	assert.Equal(t, "test_priv", privateAPIKey)
+}

--- a/test/e2e/config/migration/migration_test.go
+++ b/test/e2e/config/migration/migration_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/test/internal"
@@ -30,6 +31,10 @@ import (
 func TestConfigMigration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
+	}
+
+	if runtime.GOOS != "darwin" {
+		t.Skip("skipping test on non-macOS")
 	}
 
 	// Create a temporary config folder


### PR DESCRIPTION
## Proposed changes

- Added an e2e test to verify that the config migration is working (MacOS)
    1. Set up a config in legacy format
    2. Set up a temporary keyring independent of the global keyring
    3. Run `atlas`
    4. Verify that the config doesn't contain our secrets anymore
    5. Verify that the keyring contains our secrets
- Print a warning when insecure storage is being used.

_Jira ticket:_ CLOUDP-333521

## Testing
- Manual testing
- Successful [evergreen run](https://spruce.mongodb.com/version/689c673ff909ee000723070f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)