### PR TITLE
CLOUDP-337696: Enable logout from Service Account

### DIFF
--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -27,7 +27,7 @@ import (
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/transport"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/usage"
 	"github.com/spf13/cobra"
-	"go.mongodb.org/atlas-sdk/v20250312005/auth/clientcredentials"
+	"go.mongodb.org/atlas-sdk/v20250312006/auth/clientcredentials"
 	atlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -80,8 +80,8 @@ func revokeServiceAccountToken(ctx context.Context, clientID, clientSecret strin
 	cfg := clientcredentials.NewConfig(clientID, clientSecret)
 	if config.OpsManagerURL() != "" {
 		// TokenURL and RevokeURL points to "https://cloud.mongodb.com/api/oauth/<token/revoke>". Modify TokenURL and RevokeURL if OpsManagerURL does not point to cloud.mongodb.com
-		cfg.TokenURL = config.OpsManagerURL() + "api/oauth/token"
-		cfg.RevokeURL = config.OpsManagerURL() + "api/oauth/revoke"
+		cfg.TokenURL = config.OpsManagerURL() + clientcredentials.TokenAPIPath
+		cfg.RevokeURL = config.OpsManagerURL() + clientcredentials.RevokeAPIPath
 	}
 	token, err := cfg.Token(ctx)
 	if err != nil {

--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -48,6 +48,8 @@ type ConfigDeleter interface {
 	PublicAPIKey() string
 	ClientID() string
 	ClientSecret() string
+	AccessTokenSubject() (string, error)
+	RefreshToken() string
 	Save() error
 }
 
@@ -170,12 +172,12 @@ func LogoutBuilder() *cobra.Command {
 				entry = opts.config.ClientID()
 				message = "Are you sure you want to log out of service account %s?"
 			case config.UserAccount:
-				entry, err = config.AccessTokenSubject()
+				entry, err = opts.config.AccessTokenSubject()
 				if err != nil {
 					return err
 				}
 
-				if config.RefreshToken() == "" {
+				if opts.config.RefreshToken() == "" {
 					return ErrUnauthenticated
 				}
 

--- a/internal/cli/auth/logout_mock_test.go
+++ b/internal/cli/auth/logout_mock_test.go
@@ -42,6 +42,45 @@ func (m *MockConfigDeleter) EXPECT() *MockConfigDeleterMockRecorder {
 	return m.recorder
 }
 
+// AccessTokenSubject mocks base method.
+func (m *MockConfigDeleter) AccessTokenSubject() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AccessTokenSubject")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AccessTokenSubject indicates an expected call of AccessTokenSubject.
+func (mr *MockConfigDeleterMockRecorder) AccessTokenSubject() *MockConfigDeleterAccessTokenSubjectCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccessTokenSubject", reflect.TypeOf((*MockConfigDeleter)(nil).AccessTokenSubject))
+	return &MockConfigDeleterAccessTokenSubjectCall{Call: call}
+}
+
+// MockConfigDeleterAccessTokenSubjectCall wrap *gomock.Call
+type MockConfigDeleterAccessTokenSubjectCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterAccessTokenSubjectCall) Return(arg0 string, arg1 error) *MockConfigDeleterAccessTokenSubjectCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterAccessTokenSubjectCall) Do(f func() (string, error)) *MockConfigDeleterAccessTokenSubjectCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterAccessTokenSubjectCall) DoAndReturn(f func() (string, error)) *MockConfigDeleterAccessTokenSubjectCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // AuthType mocks base method.
 func (m *MockConfigDeleter) AuthType() config.AuthMechanism {
 	m.ctrl.T.Helper()
@@ -266,6 +305,44 @@ func (c *MockConfigDeleterPublicAPIKeyCall) Do(f func() string) *MockConfigDelet
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigDeleterPublicAPIKeyCall) DoAndReturn(f func() string) *MockConfigDeleterPublicAPIKeyCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RefreshToken mocks base method.
+func (m *MockConfigDeleter) RefreshToken() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshToken")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// RefreshToken indicates an expected call of RefreshToken.
+func (mr *MockConfigDeleterMockRecorder) RefreshToken() *MockConfigDeleterRefreshTokenCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshToken", reflect.TypeOf((*MockConfigDeleter)(nil).RefreshToken))
+	return &MockConfigDeleterRefreshTokenCall{Call: call}
+}
+
+// MockConfigDeleterRefreshTokenCall wrap *gomock.Call
+type MockConfigDeleterRefreshTokenCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterRefreshTokenCall) Return(arg0 string) *MockConfigDeleterRefreshTokenCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterRefreshTokenCall) Do(f func() string) *MockConfigDeleterRefreshTokenCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterRefreshTokenCall) DoAndReturn(f func() string) *MockConfigDeleterRefreshTokenCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/cli/auth/logout_mock_test.go
+++ b/internal/cli/auth/logout_mock_test.go
@@ -80,6 +80,82 @@ func (c *MockConfigDeleterAuthTypeCall) DoAndReturn(f func() config.AuthMechanis
 	return c
 }
 
+// ClientID mocks base method.
+func (m *MockConfigDeleter) ClientID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClientID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClientID indicates an expected call of ClientID.
+func (mr *MockConfigDeleterMockRecorder) ClientID() *MockConfigDeleterClientIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientID", reflect.TypeOf((*MockConfigDeleter)(nil).ClientID))
+	return &MockConfigDeleterClientIDCall{Call: call}
+}
+
+// MockConfigDeleterClientIDCall wrap *gomock.Call
+type MockConfigDeleterClientIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterClientIDCall) Return(arg0 string) *MockConfigDeleterClientIDCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterClientIDCall) Do(f func() string) *MockConfigDeleterClientIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterClientIDCall) DoAndReturn(f func() string) *MockConfigDeleterClientIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ClientSecret mocks base method.
+func (m *MockConfigDeleter) ClientSecret() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClientSecret")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ClientSecret indicates an expected call of ClientSecret.
+func (mr *MockConfigDeleterMockRecorder) ClientSecret() *MockConfigDeleterClientSecretCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientSecret", reflect.TypeOf((*MockConfigDeleter)(nil).ClientSecret))
+	return &MockConfigDeleterClientSecretCall{Call: call}
+}
+
+// MockConfigDeleterClientSecretCall wrap *gomock.Call
+type MockConfigDeleterClientSecretCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterClientSecretCall) Return(arg0 string) *MockConfigDeleterClientSecretCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterClientSecretCall) Do(f func() string) *MockConfigDeleterClientSecretCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterClientSecretCall) DoAndReturn(f func() string) *MockConfigDeleterClientSecretCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Delete mocks base method.
 func (m *MockConfigDeleter) Delete() error {
 	m.ctrl.T.Helper()
@@ -264,6 +340,78 @@ func (c *MockConfigDeleterSetAccessTokenCall) Do(f func(string)) *MockConfigDele
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockConfigDeleterSetAccessTokenCall) DoAndReturn(f func(string)) *MockConfigDeleterSetAccessTokenCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetClientID mocks base method.
+func (m *MockConfigDeleter) SetClientID(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetClientID", arg0)
+}
+
+// SetClientID indicates an expected call of SetClientID.
+func (mr *MockConfigDeleterMockRecorder) SetClientID(arg0 any) *MockConfigDeleterSetClientIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClientID", reflect.TypeOf((*MockConfigDeleter)(nil).SetClientID), arg0)
+	return &MockConfigDeleterSetClientIDCall{Call: call}
+}
+
+// MockConfigDeleterSetClientIDCall wrap *gomock.Call
+type MockConfigDeleterSetClientIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterSetClientIDCall) Return() *MockConfigDeleterSetClientIDCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterSetClientIDCall) Do(f func(string)) *MockConfigDeleterSetClientIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterSetClientIDCall) DoAndReturn(f func(string)) *MockConfigDeleterSetClientIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetClientSecret mocks base method.
+func (m *MockConfigDeleter) SetClientSecret(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetClientSecret", arg0)
+}
+
+// SetClientSecret indicates an expected call of SetClientSecret.
+func (mr *MockConfigDeleterMockRecorder) SetClientSecret(arg0 any) *MockConfigDeleterSetClientSecretCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClientSecret", reflect.TypeOf((*MockConfigDeleter)(nil).SetClientSecret), arg0)
+	return &MockConfigDeleterSetClientSecretCall{Call: call}
+}
+
+// MockConfigDeleterSetClientSecretCall wrap *gomock.Call
+type MockConfigDeleterSetClientSecretCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockConfigDeleterSetClientSecretCall) Return() *MockConfigDeleterSetClientSecretCall {
+	c.Call = c.Call.Return()
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockConfigDeleterSetClientSecretCall) Do(f func(string)) *MockConfigDeleterSetClientSecretCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockConfigDeleterSetClientSecretCall) DoAndReturn(f func(string)) *MockConfigDeleterSetClientSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -267,9 +267,10 @@ func Test_logoutOpts_Run_NoAuth(t *testing.T) {
 		Return(config.NoAuth).
 		Times(1)
 
-	mockTokenCleanUp(mockConfig)
-	mockProjectAndOrgCleanUp(mockConfig)
 	mockAPIKeysCleanUp(mockConfig)
+	mockTokenCleanUp(mockConfig)
+	mockServiceAccountCleanUp(mockConfig)
+	mockProjectAndOrgCleanUp(mockConfig)
 
 	mockConfig.
 		EXPECT().

--- a/internal/cli/auth/logout_test.go
+++ b/internal/cli/auth/logout_test.go
@@ -111,6 +111,9 @@ func Test_logoutOpts_Run_ServiceAccount(t *testing.T) {
 		DeleteOpts: &cli.DeleteOpts{
 			Confirm: true,
 		},
+		revokeServiceAccountToken: func() error {
+			return nil
+		},
 	}
 	ctx := t.Context()
 	mockConfig.
@@ -118,18 +121,15 @@ func Test_logoutOpts_Run_ServiceAccount(t *testing.T) {
 		AuthType().
 		Return(config.ServiceAccount).
 		Times(1)
+
+	mockServiceAccountCleanUp(mockConfig)
+	mockProjectAndOrgCleanUp(mockConfig)
 	mockConfig.
 		EXPECT().
 		Delete().
 		Return(nil).
 		Times(1)
-	mockFlow.
-		EXPECT().
-		RevokeToken(ctx, gomock.Any(), gomock.Any()).
-		Return(nil, nil).
-		Times(1)
-	mockTokenCleanUp(mockConfig)
-	mockProjectAndOrgCleanUp(mockConfig)
+
 	require.NoError(t, opts.Run(ctx))
 }
 
@@ -222,6 +222,9 @@ func Test_logoutOpts_Run_Keep_ServiceAccount(t *testing.T) {
 			Confirm: true,
 		},
 		keepConfig: true,
+		revokeServiceAccountToken: func() error {
+			return nil
+		},
 	}
 	ctx := t.Context()
 	mockConfig.
@@ -230,13 +233,7 @@ func Test_logoutOpts_Run_Keep_ServiceAccount(t *testing.T) {
 		Return(config.ServiceAccount).
 		Times(1)
 
-	mockFlow.
-		EXPECT().
-		RevokeToken(ctx, gomock.Any(), gomock.Any()).
-		Return(nil, nil).
-		Times(1)
-
-	mockTokenCleanUp(mockConfig)
+	mockServiceAccountCleanUp(mockConfig)
 	mockProjectAndOrgCleanUp(mockConfig)
 	mockConfig.
 		EXPECT().
@@ -302,6 +299,17 @@ func mockTokenCleanUp(mockConfig *MockConfigDeleter) {
 	mockConfig.
 		EXPECT().
 		SetAccessToken("").
+		Times(1)
+}
+
+func mockServiceAccountCleanUp(mockConfig *MockConfigDeleter) {
+	mockConfig.
+		EXPECT().
+		SetClientID("").
+		Times(1)
+	mockConfig.
+		EXPECT().
+		SetClientSecret("").
 		Times(1)
 }
 

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -118,8 +118,8 @@ func (tr *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func NewServiceAccountClient(clientID, clientSecret string) *http.Client {
 	cfg := clientcredentials.NewConfig(clientID, clientSecret)
 	if config.OpsManagerURL() != "" {
-		cfg.RevokeURL = config.OpsManagerURL() + "api/oauth/revoke"
-		cfg.TokenURL = config.OpsManagerURL() + "api/oauth/token"
+		cfg.TokenURL = config.OpsManagerURL() + clientcredentials.TokenAPIPath
+		cfg.RevokeURL = config.OpsManagerURL() + clientcredentials.RevokeAPIPath
 	}
 	return cfg.Client(context.Background())
 }


### PR DESCRIPTION
## Proposed changes

* Logs out of SA profile
  * Revokes token 
  * Sets SA credentials to ""
* Adjust SA logout unit tests


```
$ bin/atlas logout -P oauth2
? Are you sure you want to log out of service account <clientID>? Yes
Successfully logged out of '<clientID>'
```

_Jira ticket:_ [CLOUDP-337696](https://jira.mongodb.org/browse/CLOUDP-337696)


## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code