### PR TITLE
CLOUDP-329808: Adds service account e2e test

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -685,6 +685,18 @@ tasks:
       - func: "e2e test"
         vars:
           E2E_TEST_PACKAGES: ./test/e2e/atlas/serverless/instance/...
+  - name: atlas_service_account_e2e
+    tags: ["e2e","generic","atlas"]
+    must_have_test_results: true
+    depends_on:
+      - name: compile
+        variant: "code_health"
+        patch_optional: true
+    commands:
+      - func: "install gotestsum"
+      - func: "e2e test"
+        vars:
+          E2E_TEST_PACKAGES: ./test/e2e/atlas/serviceAccount/...
   - name: atlas_gov_clusters_flags_e2e
     tags: ["e2e","clusters","atlasgov"]
     must_have_test_results: true

--- a/internal/cli/commonerrors/errors.go
+++ b/internal/cli/commonerrors/errors.go
@@ -30,7 +30,7 @@ var (
 	errAsymmetricShardUnsupported = errors.New("trying to run a cluster wide scaling command on an independent shard scaling cluster. Use --autoScalingMode 'independentShardScaling' instead")
 	ErrUnauthorized               = errors.New(`this action requires authentication
 	
-To log in using your Atlas username and password or to set credentials using API keys, run: atlas auth login`)
+To log in using your Atlas username and password or to set credentials using a Service account or API keys, run: atlas auth login`)
 	ErrInvalidRefreshToken = errors.New(`session expired
 
 Please note that your session expires periodically. 

--- a/internal/cli/config/set.go
+++ b/internal/cli/config/set.go
@@ -48,7 +48,7 @@ func (opts *SetOpts) Run() error {
 			return err
 		}
 	} else if strings.HasSuffix(opts.prop, "_id") {
-		if err := validate.ObjectID(opts.val); err != nil {
+		if err := validate.ObjectIDByType(opts.prop, opts.val); err != nil {
 			return err
 		}
 	}

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -138,6 +138,8 @@ func ProfileProperties() []string {
 		privateAPIKey,
 		projectID,
 		publicAPIKey,
+		ClientIDField,
+		ClientSecretField,
 		RefreshTokenField,
 		service,
 	}

--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/mongodb-forks/digest"
@@ -118,8 +119,9 @@ func (tr *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 func NewServiceAccountClient(clientID, clientSecret string) *http.Client {
 	cfg := clientcredentials.NewConfig(clientID, clientSecret)
 	if config.OpsManagerURL() != "" {
-		cfg.TokenURL = config.OpsManagerURL() + clientcredentials.TokenAPIPath
-		cfg.RevokeURL = config.OpsManagerURL() + clientcredentials.RevokeAPIPath
+		baseURL := strings.TrimSuffix(config.OpsManagerURL(), "/")
+		cfg.TokenURL = baseURL + clientcredentials.TokenAPIPath
+		cfg.RevokeURL = baseURL + clientcredentials.RevokeAPIPath
 	}
 	return cfg.Client(context.Background())
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -32,6 +32,7 @@ const (
 	minPasswordLength       = 10
 	clusterWideScaling      = "clusterWideScaling"
 	independentShardScaling = "independentShardScaling"
+	clientIDLength          = 34
 )
 
 var (
@@ -106,6 +107,17 @@ func ObjectID(s string) error {
 		return fmt.Errorf("the provided value '%s' is not a valid ID", s)
 	}
 	return nil
+}
+
+func ObjectIDByType(name, s string) error {
+	if strings.HasPrefix(name, "client_") {
+		if len(s) != clientIDLength {
+			return fmt.Errorf("the provided value '%s' is not a valid client ID", s)
+		}
+		return nil
+	}
+
+	return ObjectID(s)
 }
 
 // Credentials validates public and private API keys have been set.

--- a/test/e2e/atlas/serviceAccount/service_account_test.go
+++ b/test/e2e/atlas/serviceAccount/service_account_test.go
@@ -30,6 +30,12 @@ func TestCreateOrgServiceAccount(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
+	mode, err := internal.TestRunMode()
+	require.NoError(t, err)
+	if mode != internal.TestModeLive {
+		t.Skip("skipping test in snapshot mode")
+	}
+
 	cliPath, err := internal.AtlasCLIBin()
 	require.NoError(t, err)
 
@@ -49,7 +55,7 @@ func TestCreateOrgServiceAccount(t *testing.T) {
 
 	resp, err := internal.RunAndGetStdOut(cmd)
 	require.NoError(t, err, string(resp))
-	t.Logf("Service account authentication successful. Projects output: %s", string(resp))
+	t.Logf("Service account authentication successful: Command executed using service account profile. Command output: %s", string(resp))
 
 	// Logout from the service account profile
 	err = logoutServiceAccountProfile(t, cliPath, saProfileName)
@@ -81,7 +87,7 @@ func setupServiceAccountProfile(t *testing.T, cliPath, profileName, clientID, cl
 	}
 
 	// Set ops manager URL
-	opsManagerURL := getOpsManagerURL()
+	opsManagerURL := "https://cloud-dev.mongodb.com/"
 	cmd = exec.Command(cliPath, "config", "set", "ops_manager_url", opsManagerURL, "-P", profileName)
 	cmd.Env = os.Environ()
 	if _, err := internal.RunAndGetStdOut(cmd); err != nil {
@@ -89,17 +95,6 @@ func setupServiceAccountProfile(t *testing.T, cliPath, profileName, clientID, cl
 	}
 
 	return nil
-}
-
-// getOpsManagerURL returns a URL depending on the profile name.
-func getOpsManagerURL() string {
-	profileName := internal.ProfileName()
-	switch profileName {
-	case "__e2e_snapshot":
-		return "http://localhost:8080/"
-	default:
-		return "https://cloud-dev.mongodb.com/"
-	}
 }
 
 func logoutServiceAccountProfile(t *testing.T, cliPath, profileName string) error {

--- a/test/e2e/atlas/serviceAccount/service_account_test.go
+++ b/test/e2e/atlas/serviceAccount/service_account_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceaccount
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/test/internal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateOrgServiceAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	cliPath, err := internal.AtlasCLIBin()
+	require.NoError(t, err)
+
+	// Create a new Service Account
+	g := internal.NewAtlasE2ETestGenerator(t)
+	name := "test-service-account"
+	g.GenerateOrgServiceAccount(cliPath, name)
+
+	// Set up a Service Account profile
+	saProfileName := fmt.Sprintf("sa-test-%d", time.Now().Unix())
+	err = setupServiceAccountProfile(t, cliPath, saProfileName, g.ClientID, g.ClientSecret)
+	require.NoError(t, err)
+
+	// Run some command with the Service Account profile
+	cmd := exec.Command(cliPath, "projects", "ls", "-P", saProfileName)
+	cmd.Env = os.Environ()
+
+	resp, err := internal.RunAndGetStdOut(cmd)
+	require.NoError(t, err, string(resp))
+	t.Logf("Service account authentication successful. Projects output: %s", string(resp))
+
+	// Logout from the service account profile
+	err = logoutServiceAccountProfile(t, cliPath, saProfileName)
+	require.NoError(t, err)
+}
+
+func setupServiceAccountProfile(t *testing.T, cliPath, profileName, clientID, clientSecret string) error {
+	t.Helper()
+
+	// Set client ID
+	cmd := exec.Command(cliPath, "config", "set", "client_id", clientID, "-P", profileName)
+	cmd.Env = os.Environ()
+	if _, err := internal.RunAndGetStdOut(cmd); err != nil {
+		return fmt.Errorf("failed to set client_id: %w", err)
+	}
+
+	// Set client secret
+	cmd = exec.Command(cliPath, "config", "set", "client_secret", clientSecret, "-P", profileName)
+	cmd.Env = os.Environ()
+	if _, err := internal.RunAndGetStdOut(cmd); err != nil {
+		return fmt.Errorf("failed to set client_secret: %w", err)
+	}
+
+	// Set service
+	cmd = exec.Command(cliPath, "config", "set", "service", "cloud", "-P", profileName)
+	cmd.Env = os.Environ()
+	if _, err := internal.RunAndGetStdOut(cmd); err != nil {
+		return fmt.Errorf("failed to set service: %w", err)
+	}
+
+	// Set ops manager URL
+	opsManagerURL := getOpsManagerURL()
+	cmd = exec.Command(cliPath, "config", "set", "ops_manager_url", opsManagerURL, "-P", profileName)
+	cmd.Env = os.Environ()
+	if _, err := internal.RunAndGetStdOut(cmd); err != nil {
+		return fmt.Errorf("failed to set ops_manager_url: %w", err)
+	}
+
+	return nil
+}
+
+// getOpsManagerURL returns a URL depending on the profile name.
+func getOpsManagerURL() string {
+	profileName := internal.ProfileName()
+	switch profileName {
+	case "__e2e_snapshot":
+		return "http://localhost:8080/"
+	default:
+		return "https://cloud-dev.mongodb.com/"
+	}
+}
+
+func logoutServiceAccountProfile(t *testing.T, cliPath, profileName string) error {
+	t.Helper()
+
+	cmd := exec.Command(cliPath, "auth", "logout", "--force", "-P", profileName)
+	cmd.Env = os.Environ()
+	if _, err := internal.RunAndGetStdOut(cmd); err != nil {
+		return fmt.Errorf("failed to logout service account: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Proposed changes

Adds e2e test for service account. this test:
* Provisions an SA using existing e2e profile
* Sets up new profile with SA credentials
* Runs basic command with SA profile
* Logs out of SA profile
* Deletes SA

#### How SA is provisioned:
SA is provisioned using `atlas api` cmds. This approach was chosen over direct curl calls as use of existing CLI cmds to provision resources is precedent in e2e testing and greatly simplifies retrieving digest credentials for making the call.

#### Drive-by work:
* Logout will ignore oauth2 error "This specific service account doesn't exist" when revoking SA token and proceed with logout.
* Fix to setting TokenURL & RevokeURL
* Amend ErrUnauthorized to mention SA

_Jira ticket:_ [CLOUDP-329808](https://jira.mongodb.org/browse/CLOUDP-329808)
