### PR TITLE
CLOUDP-341161: accesslogs list did not pass opts to apiRequest

### DIFF
--- a/internal/store/access_logs.go
+++ b/internal/store/access_logs.go
@@ -35,23 +35,23 @@ func (s *Store) AccessLogsByHostname(groupID, hostname string, opts *AccessLogOp
 	if opts != nil {
 		if opts.Start != "" {
 			startTime, _ := strconv.ParseInt(opts.Start, 10, 64)
-			result.Start(startTime)
+			result = result.Start(startTime)
 		}
 		if opts.End != "" {
 			endTime, _ := strconv.ParseInt(opts.End, 10, 64)
-			result.End(endTime)
+			result = result.End(endTime)
 		}
 
 		if opts.NLogs > 0 {
-			result.NLogs(opts.NLogs)
+			result = result.NLogs(opts.NLogs)
 		}
 
 		if opts.IPAddress != "" {
-			result.IpAddress(opts.IPAddress)
+			result = result.IpAddress(opts.IPAddress)
 		}
 
 		if opts.AuthResult != nil {
-			result.AuthResult(*opts.AuthResult)
+			result = result.AuthResult(*opts.AuthResult)
 		}
 	}
 
@@ -66,23 +66,23 @@ func (s *Store) AccessLogsByClusterName(groupID, clusterName string, opts *Acces
 	if opts != nil {
 		if opts.Start != "" {
 			startTime, _ := strconv.ParseInt(opts.Start, 10, 64)
-			result.Start(startTime)
+			result = result.Start(startTime)
 		}
 		if opts.End != "" {
 			endTime, _ := strconv.ParseInt(opts.End, 10, 64)
-			result.End(endTime)
+			result = result.End(endTime)
 		}
 
 		if opts.NLogs > 0 {
-			result.NLogs(opts.NLogs)
+			result = result.NLogs(opts.NLogs)
 		}
 
 		if opts.IPAddress != "" {
-			result.IpAddress(opts.IPAddress)
+			result = result.IpAddress(opts.IPAddress)
 		}
 
 		if opts.AuthResult != nil {
-			result.AuthResult(*opts.AuthResult)
+			result = result.AuthResult(*opts.AuthResult)
 		}
 	}
 	res, _, err := result.Execute()


### PR DESCRIPTION

## Proposed changes

This PR addresses a bug in accesslogs list in which the apiRequest was not being correctly populated with flag opts. This results in flags like `--start` and `--end` to be ignored. This is because the setter functions the SDK provides don't modify the apiRequest calling the setter, but instead returns a new apiRequest which is teh calling apiRequest + the opts set.

This fix has been tested manually.

**Behaviour before:**
  All logs would be printed, regardless of flags set.

**Behaviour after:**
  Logs are printed in accordance to flags set.

_Jira ticket:_ [CLOUDP-341161](https://jira.mongodb.org/browse/CLOUDP-341161)
