### PR TITLE
Chore: Fixes `make gen-purls` to use 64-bit windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ gen-purls: # Generate purls
 		LC_ALL=C sort > build/package/purls-darwin.txt
 
 	@echo "==> Generating Windows purls"
-	GOOS=windows GOARCH=386 go build -trimpath -mod=readonly -o bin/atlas-win ./cmd/atlas
+	GOOS=windows GOARCH=amd64 go build -trimpath -mod=readonly -o bin/atlas-win ./cmd/atlas
 	go version -m ./bin/atlas-win | \
 		awk '$$1 == "dep" || $$1 == "=>" { print "pkg:golang/" $$2 "@" $$3 }' | \
 		LC_ALL=C sort > build/package/purls-win.txt


### PR DESCRIPTION
## Proposed changes

Changes windows build for the `gen-purls` make task from 32-bit to 64-bit. 

### Why?
This is to avoid int overflow issues that have arisen with a bump to a dependency: https://github.com/mongodb/mongodb-atlas-cli/pull/4169

### Concerns?
None.
This change to windows build should not be a concern as we do not release for 32-bit win.
Also, this does not change the existing purls.txt.