### PR TITLE
Fix: Prioritises env var authentication over profile authentication

### DIFF
--- a/build/package/purls.txt
+++ b/build/package/purls.txt
@@ -75,7 +75,7 @@ pkg:golang/github.com/mholt/archives@v0.1.3
 pkg:golang/github.com/mikelolasagasti/xz@v1.0.1
 pkg:golang/github.com/minio/minlz@v1.0.0
 pkg:golang/github.com/mongodb-forks/digest@v1.1.0
-pkg:golang/github.com/mongodb/atlas-cli-core@v0.0.0-20250901162552-2e62c5010f93
+pkg:golang/github.com/mongodb/atlas-cli-core@v0.0.0-20250903130314-af1597538b48
 pkg:golang/github.com/montanaflynn/stats@v0.7.1
 pkg:golang/github.com/nwaples/rardecode/v2@v2.1.0
 pkg:golang/github.com/pelletier/go-toml/v2@v2.2.3

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mholt/archives v0.1.3
 	github.com/mongodb-labs/cobra2snooty v1.19.1
-	github.com/mongodb/atlas-cli-core v0.0.0-20250901162552-2e62c5010f93
+	github.com/mongodb/atlas-cli-core v0.0.0-20250903130314-af1597538b48
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/shirou/gopsutil/v4 v4.25.7

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/mongodb-forks/digest v1.1.0 h1:7eUdsR1BtqLv0mdNm4OXs6ddWvR4X2/OsLwdKk
 github.com/mongodb-forks/digest v1.1.0/go.mod h1:rb+EX8zotClD5Dj4NdgxnJXG9nwrlx3NWKJ8xttz1Dg=
 github.com/mongodb-labs/cobra2snooty v1.19.1 h1:GDEQZWy8f/DeJlImNgVvStu6sgNi8nuSOR1Oskcw8BI=
 github.com/mongodb-labs/cobra2snooty v1.19.1/go.mod h1:Hyq4YadN8dwdOiz56MXwTuVN63p0WlkQwxdLxOSGdX8=
-github.com/mongodb/atlas-cli-core v0.0.0-20250901162552-2e62c5010f93 h1:arSkz/kAB+5jgo0efH24UByHsYe7QZ9cHgnAXZPRPeg=
-github.com/mongodb/atlas-cli-core v0.0.0-20250901162552-2e62c5010f93/go.mod h1:QDfVGpdfxXM1httLNXCKsfWTKv6slzCqBZxkkPIktlQ=
+github.com/mongodb/atlas-cli-core v0.0.0-20250903130314-af1597538b48 h1:2wM7bULO03UWRzzE5uxKThdyJ9VFSeM+GeZP7T2P3tk=
+github.com/mongodb/atlas-cli-core v0.0.0-20250903130314-af1597538b48/go.mod h1:QDfVGpdfxXM1httLNXCKsfWTKv6slzCqBZxkkPIktlQ=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/nwaples/rardecode/v2 v2.1.0 h1:JQl9ZoBPDy+nIZGb1mx8+anfHp/LV3NE2MjMiv0ct/U=

--- a/internal/cli/auth/login_test.go
+++ b/internal/cli/auth/login_test.go
@@ -32,6 +32,8 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+const jsonOutput = "json"
+
 func Test_loginOpts_SyncWithOAuthAccessProfile(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -284,7 +286,7 @@ func TestLoginOpts_setUpProfile_Success(t *testing.T) {
 		TrackAsk(gomock.Any(), opts).
 		DoAndReturn(func(_ []*survey.Question, answer any, _ ...survey.AskOpt) error {
 			if o, ok := answer.(*LoginOpts); ok {
-				o.Output = "json" //nolint:goconst
+				o.Output = jsonOutput
 			}
 			return nil
 		})

--- a/internal/cli/auth/register_test.go
+++ b/internal/cli/auth/register_test.go
@@ -114,7 +114,7 @@ func Test_registerOpts_Run(t *testing.T) {
 		TrackAsk(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ []*survey.Question, answer any, _ ...survey.AskOpt) error {
 			if o, ok := answer.(*LoginOpts); ok {
-				o.Output = "json"
+				o.Output = jsonOutput
 			}
 			return nil
 		})


### PR DESCRIPTION
## Proposed changes

Before, if authType was already set, we would not check to see if another auth type is available, this would cause env vars to be ignored in the case:
* profile you run the command with is of different auth type to credentials you are setting with env vars

Caveat: 
We still have the issue of default showing when default profile does not exist and env vars are set when running `atlas config list` as the auth type will be set
`atlas config describe default` shows that only auth tpye is set, and is set to the auth type of the credentials provided through env vars.