### PR TITLE
fix: upgrades core dep and implements

### DIFF
--- a/build/package/purls.txt
+++ b/build/package/purls.txt
@@ -75,7 +75,7 @@ pkg:golang/github.com/mholt/archives@v0.1.3
 pkg:golang/github.com/mikelolasagasti/xz@v1.0.1
 pkg:golang/github.com/minio/minlz@v1.0.0
 pkg:golang/github.com/mongodb-forks/digest@v1.1.0
-pkg:golang/github.com/mongodb/atlas-cli-core@v0.0.0-20250901162552-2e62c5010f93
+pkg:golang/github.com/mongodb/atlas-cli-core@v0.0.0-20250904105537-cdeae83f46e0
 pkg:golang/github.com/montanaflynn/stats@v0.7.1
 pkg:golang/github.com/nwaples/rardecode/v2@v2.1.0
 pkg:golang/github.com/pelletier/go-toml/v2@v2.2.3

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -58,21 +58,7 @@ func loadConfig() (*config.Profile, error) {
 	if err := migrator.Migrate(); err != nil {
 		return nil, fmt.Errorf("error migrating config: %w", err)
 	}
-
-	configStore, initErr := config.NewDefaultStore()
-
-	if initErr != nil {
-		return nil, fmt.Errorf("error loading config: %w. Please run `atlas auth login` to reconfigure your profile", initErr)
-	}
-
-	if !configStore.IsSecure() {
-		fmt.Fprintf(os.Stderr, "Warning: Secure storage is not available, falling back to insecure storage\n")
-	}
-
-	profile := config.NewProfile(config.DefaultProfile, configStore)
-	config.SetProfile(profile)
-
-	return profile, nil
+	return config.LoadAtlasCLIConfig()
 }
 
 func trackInitError(e error, rootCmd *cobra.Command) {

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mholt/archives v0.1.3
 	github.com/mongodb-labs/cobra2snooty v1.19.1
-	github.com/mongodb/atlas-cli-core v0.0.0-20250901162552-2e62c5010f93
+	github.com/mongodb/atlas-cli-core v0.0.0-20250904105537-cdeae83f46e0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/shirou/gopsutil/v4 v4.25.8

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/mongodb-forks/digest v1.1.0 h1:7eUdsR1BtqLv0mdNm4OXs6ddWvR4X2/OsLwdKk
 github.com/mongodb-forks/digest v1.1.0/go.mod h1:rb+EX8zotClD5Dj4NdgxnJXG9nwrlx3NWKJ8xttz1Dg=
 github.com/mongodb-labs/cobra2snooty v1.19.1 h1:GDEQZWy8f/DeJlImNgVvStu6sgNi8nuSOR1Oskcw8BI=
 github.com/mongodb-labs/cobra2snooty v1.19.1/go.mod h1:Hyq4YadN8dwdOiz56MXwTuVN63p0WlkQwxdLxOSGdX8=
-github.com/mongodb/atlas-cli-core v0.0.0-20250901162552-2e62c5010f93 h1:arSkz/kAB+5jgo0efH24UByHsYe7QZ9cHgnAXZPRPeg=
-github.com/mongodb/atlas-cli-core v0.0.0-20250901162552-2e62c5010f93/go.mod h1:QDfVGpdfxXM1httLNXCKsfWTKv6slzCqBZxkkPIktlQ=
+github.com/mongodb/atlas-cli-core v0.0.0-20250904105537-cdeae83f46e0 h1:1g0tih3u0OGiMVmo4R5iBkduFtrNJMZUJD6MwEyWtr4=
+github.com/mongodb/atlas-cli-core v0.0.0-20250904105537-cdeae83f46e0/go.mod h1:QDfVGpdfxXM1httLNXCKsfWTKv6slzCqBZxkkPIktlQ=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/nwaples/rardecode/v2 v2.1.0 h1:JQl9ZoBPDy+nIZGb1mx8+anfHp/LV3NE2MjMiv0ct/U=

--- a/internal/cli/clusters/region_tier_autocomplete.go
+++ b/internal/cli/clusters/region_tier_autocomplete.go
@@ -158,7 +158,7 @@ func (opts *autoCompleteOpts) initStore(ctx context.Context) error {
 func (opts *autoCompleteOpts) parseFlags(cmd *cobra.Command) error {
 	profile := cmd.Flag(flag.Profile).Value.String()
 
-	if err := cli.InitProfile(profile); err != nil {
+	if err := config.InitProfile(profile); err != nil {
 		return err
 	}
 

--- a/internal/cli/processes/process_autocomplete.go
+++ b/internal/cli/processes/process_autocomplete.go
@@ -90,7 +90,7 @@ func (opts *AutoCompleteOpts) initStore(ctx context.Context) error {
 func (opts *AutoCompleteOpts) parseFlags(cmd *cobra.Command) error {
 	profile := cmd.Flag(flag.Profile).Value.String()
 
-	if err := cli.InitProfile(profile); err != nil {
+	if err := config.InitProfile(profile); err != nil {
 		return err
 	}
 

--- a/internal/cli/root/builder.go
+++ b/internal/cli/root/builder.go
@@ -124,7 +124,7 @@ Use the --help flag with any command for more info on that command.`,
 				log.SetLevel(log.DebugLevel)
 			}
 
-			if err := cli.InitProfile(profile); err != nil {
+			if err := config.InitProfile(profile); err != nil {
 				return err
 			}
 

--- a/internal/cli/setup/setup_cmd_test.go
+++ b/internal/cli/setup/setup_cmd_test.go
@@ -48,6 +48,7 @@ func Test_setupOpts_PreRunWithAPIKeys(t *testing.T) {
 	config.SetProfile(profile)
 
 	mockStore.EXPECT().GetHierarchicalValue("test-profile", "auth_type").Return("api_keys").Times(1)
+	mockStore.EXPECT().GetHierarchicalValue("test-profile", "client_id").Return("").Times(1) // This call is AuthType checking if env variables are available
 	require.NoError(t, opts.PreRun(ctx))
 
 	assert.Equal(t, 0, buf.Len())


### PR DESCRIPTION
## Proposed changes

Upgrades AtlasCLICore library and implements use of the new functionality available in the library

#### Manual testing:
1. remove default
2. export SA creds, proj/org IDs, base url
3. run `atlas config list`
  No default profile present 
4. run `atlas config describe <existing api key profile>
  auth type remained "api-keys"
6. run `atlas cluster list`
  Call succeeded
7. run `atlas cluster list --profile <profile for different cloud env>`
  Call succeeded, result from exported cloud env
8. run `atlas login`
  client id was already populated with exported values

Repeated same testing with API keys exported