### PR TITLE
chore: improves logout messaging

### DIFF
--- a/internal/cli/auth/logout.go
+++ b/internal/cli/auth/logout.go
@@ -170,19 +170,18 @@ func LogoutBuilder() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			var message, entry string
-			var err error
+			var message string
 
-			logoutMessage := "Are you sure you want to log out of profile " + opts.config.Name()
+			entry := opts.config.Name()
+			logoutMessage := "Are you sure you want to log out of profile %s"
+
 			switch opts.config.AuthType() {
 			case config.APIKeys:
-				entry = opts.config.PublicAPIKey()
-				message = logoutMessage + " with public API key %s?"
+				message = logoutMessage + " with public API key " + opts.config.PublicAPIKey() + "?"
 			case config.ServiceAccount:
-				entry = opts.config.ClientID()
-				message = logoutMessage + " with service account %s?"
+				message = logoutMessage + " with service account " + opts.config.ClientID() + "?"
 			case config.UserAccount:
-				entry, err = opts.config.AccessTokenSubject()
+				subject, err := opts.config.AccessTokenSubject()
 				if err != nil {
 					return err
 				}
@@ -191,9 +190,8 @@ func LogoutBuilder() *cobra.Command {
 					return ErrUnauthenticated
 				}
 
-				message = logoutMessage + " with user account %s?"
+				message = logoutMessage + " with user account " + subject + "?"
 			case config.NoAuth, "":
-				entry = opts.config.Name()
 				message = logoutMessage + "?"
 			}
 


### PR DESCRIPTION
## Proposed changes

during testing, noticed that logging out of empty default resulted in prompt message 
` ? Are you sure you want to log out of profile default?%!(EXTRA string=default)`

To address this, I changed which parameters are injected by the promptMessage method. 

Success message now says profile name instead of public api key/client id/ user account

See below for changes to messaging
```
// empty default
// before
> bin/atlas logout
? Are you sure you want to log out of profile default?%!(EXTRA string=default) Yes
Successfully logged out of 'default'

// after
> bin/atlas logout
? Are you sure you want to log out of profile default? Yes
Successfully logged out of 'default'
```
```
// service account
// before
> bin/atlas logout
? Are you sure you want to log out of profile sa with service account mdb_sa_id_aaaaaaaa? Yes
Successfully logged out of 'mdb_sa_id_aaaaaaaa'

// after
> bin/atlas logout -P sa
? Are you sure you want to log out of profile sa with service account mdb_sa_id_aaaaaaaa? Yes
Successfully logged out of 'sa'
```
```
// api keys
// before
> bin/atlas logout
? Are you sure you want to log out of profile api with public API key aaaaaaaa? Yes
Successfully logged out of 'aaaaaaaa'

// after
> bin/atlas logout -P api
? Are you sure you want to log out of profile api with public API key aaaaaaaa? Yes
Successfully logged out of 'api'
```
```
// user account
// before
> bin/atlas logout
? Are you sure you want to log out of profile user with user account user.name@mail.com? Yes
Successfully logged out of 'user.name@mail.com'

// after
> bin/atlas logout -P user
? Are you sure you want to log out of profile user with user account user.name@mail.com? Yes
Successfully logged out of 'user'
```