### PR TITLE
chore: address followup review of service account tutorial

### DIFF
--- a/guides/tutorials/authenticate_with_service_account.md
+++ b/guides/tutorials/authenticate_with_service_account.md
@@ -2,7 +2,7 @@
 
 This tutorial provides step-by-step instructions for authenticating your MongoDB Atlas CLI profile using Service Accounts, allowing you to automate and and manage MongoDB resources. Service Accounts, also referred to as OAuth Applications, allows programmatic access through a secure Client ID and Secret—ideal for scripting use cases and CI/CD workflows.
 
-__Note:__ This process is interactive. For programmatic authentication, set enviroment variables `MONGODB_ATLAS_*` before using the AtlasCLI. See [Atlas CLI Environment Variables](https://www.mongodb.com/docs/atlas/cli/stable/atlas-cli-env-variables/) for all supported environment variables.
+__Note:__ This process is interactive. For programmatic authentication, set enviroment variables `MONGODB_ATLAS_CLIENT_ID` and `MONGODB_ATLAS_CLIENT_SECRET` before using the AtlasCLI. See [Atlas CLI Environment Variables](https://www.mongodb.com/docs/atlas/cli/stable/atlas-cli-env-variables/) for all supported environment variables.
 
 ---
 
@@ -23,7 +23,7 @@ Open your terminal and run the following command:
 atlas auth login --profile myProfile
 ```
 
-This command initiates the interactive authentication setup guide for a Atlas CLI profile 'myProfile'.
+This command initiates the interactive authentication setup guide for a Atlas CLI profile called 'myProfile'.
 
 ---
 ### Step 2: Select the Authentication Method


### PR DESCRIPTION
## Proposed changes

Followup to #4184 addressing a review by:
1. Making clear this process is interactive
2. Providing a programmatic alternative
3. Adding `--profile` flag to the example for clarity
4. Adding an example of how to use the profile to use auth-required atlasCLI commands