### PR TITLE
CLOUDP-342259: fixes search e2e test

### DIFF
--- a/test/e2e/atlas/search/search/search_test.go
+++ b/test/e2e/atlas/search/search/search_test.go
@@ -203,6 +203,30 @@ func TestSearch(t *testing.T) {
 		a.Equal(analyzer, *index.GetLatestDefinition().Analyzer)
 	})
 
+	g.Run("list", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
+		cmd := exec.Command(cliPath,
+			clustersEntity,
+			searchEntity,
+			indexEntity,
+			"list",
+			"--clusterName", g.ClusterName,
+			"--db=sample_mflix",
+			"--collection=movies",
+			"--projectId", g.ProjectID,
+			"-o=json",
+			"-P",
+			internal.ProfileName(),
+		)
+
+		cmd.Env = os.Environ()
+		resp, err := internal.RunAndGetStdOut(cmd)
+		require.NoError(t, err, string(resp))
+
+		var indexes []atlasv2.ClusterSearchIndex
+		require.NoError(t, json.Unmarshal(resp, &indexes))
+		assert.NotEmpty(t, indexes)
+	})
+
 	g.Run("Delete", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
 		cmd := exec.Command(cliPath,
 			clustersEntity,
@@ -459,30 +483,6 @@ func TestSearch(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp, &index))
 		assert.Equal(t, indexName, index.Name)
 	})
-
-	g.Run("list", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
-		cmd := exec.Command(cliPath,
-			clustersEntity,
-			searchEntity,
-			indexEntity,
-			"list",
-			"--clusterName", g.ClusterName,
-			"--db=sample_mflix",
-			"--collection=movies",
-			"--projectId", g.ProjectID,
-			"-o=json",
-			"-P",
-			internal.ProfileName(),
-		)
-
-		cmd.Env = os.Environ()
-		resp, err := internal.RunAndGetStdOut(cmd)
-		require.NoError(t, err, string(resp))
-
-		var indexes []atlasv2.ClusterSearchIndex
-		require.NoError(t, json.Unmarshal(resp, &indexes))
-		assert.NotEmpty(t, indexes)
-	})
 }
 
 func TestSearchDeprecated(t *testing.T) {
@@ -644,6 +644,30 @@ func TestSearchDeprecated(t *testing.T) {
 		a := assert.New(t)
 		a.Equal(indexID, index.GetIndexID())
 		a.Equal(analyzer, index.GetAnalyzer())
+	})
+
+	g.Run("list", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
+		cmd := exec.Command(cliPath,
+			clustersEntity,
+			searchEntity,
+			indexEntity,
+			"list",
+			"--clusterName", g.ClusterName,
+			"--db=sample_mflix",
+			"--collection=movies",
+			"--projectId", g.ProjectID,
+			"-o=json",
+			"-P",
+			internal.ProfileName(),
+		)
+
+		cmd.Env = os.Environ()
+		resp, err := internal.RunAndGetStdOut(cmd)
+		require.NoError(t, err, string(resp))
+
+		var indexes []atlasv2.ClusterSearchIndex
+		require.NoError(t, json.Unmarshal(resp, &indexes))
+		assert.NotEmpty(t, indexes)
 	})
 
 	g.Run("Delete", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
@@ -896,29 +920,5 @@ func TestSearchDeprecated(t *testing.T) {
 		var index atlasv2.ClusterSearchIndex
 		require.NoError(t, json.Unmarshal(resp, &index))
 		assert.Equal(t, indexName, index.Name)
-	})
-
-	g.Run("list", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
-		cmd := exec.Command(cliPath,
-			clustersEntity,
-			searchEntity,
-			indexEntity,
-			"list",
-			"--clusterName", g.ClusterName,
-			"--db=sample_mflix",
-			"--collection=movies",
-			"--projectId", g.ProjectID,
-			"-o=json",
-			"-P",
-			internal.ProfileName(),
-		)
-
-		cmd.Env = os.Environ()
-		resp, err := internal.RunAndGetStdOut(cmd)
-		require.NoError(t, err, string(resp))
-
-		var indexes []atlasv2.ClusterSearchIndex
-		require.NoError(t, json.Unmarshal(resp, &indexes))
-		assert.NotEmpty(t, indexes)
 	})
 }


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-342259

This fixes the search e2e tests, we were trying to list an index that was already deleted. 

[atlas_search_e2e](https://spruce.mongodb.com/task/mongodb_atlas_cli_master_e2e_atlas_clusters_atlas_search_e2e_patch_80d80e776fd2f947a6d183a211a628b635d41ad1_68bef95289fefa00072bd87a_25_09_08_15_42_11?execution=0)

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
