### PR TITLE
chore: Adds silence_storage_warning=true to e2e tests and profiles

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -341,6 +341,7 @@ jobs:
           CONFIG_PATH: ${{ steps.config-path.outputs.CONFIG_PATH }}
           CONFIG_CONTENT: |
             skip_update_check = true
+            silence_storage_warning = true
             telemetry_enabled = false
 
             [__e2e]

--- a/.github/workflows/update-e2e-tests.yml
+++ b/.github/workflows/update-e2e-tests.yml
@@ -84,6 +84,7 @@ jobs:
           CONFIG_PATH: ${{ steps.config-path.outputs.CONFIG_PATH }}
           CONFIG_CONTENT: |
             skip_update_check = true
+            silence_storage_warning = true
             telemetry_enabled = false
 
             [__e2e]
@@ -174,6 +175,7 @@ jobs:
           CONFIG_PATH: ${{ steps.config-path.outputs.CONFIG_PATH }}
           CONFIG_CONTENT: |
             skip_update_check = true
+            silence_storage_warning = true
             telemetry_enabled = false
 
             [__e2e]

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -129,6 +129,7 @@ functions:
           CONFIG_PATH=$(./bin/atlas config edit 2>/dev/null)
           cat <<EOF > "$CONFIG_PATH"
           skip_update_check = true
+          silence_storage_warning = true
           telemetry_enabled = false
 
           [__e2e]
@@ -188,6 +189,7 @@ functions:
         env:
           <<: *go_env
           MONGODB_ATLAS_SKIP_UPDATE_CHECK: "yes"
+          MONGODB_ATLAS_SILENCE_STORAGE_WARNING: "true"
           DO_NOT_TRACK: "1"
           TEST_MODE: live
           TEST_CMD: gotestsum --junitfile e2e-tests.xml --format standard-verbose --

--- a/scripts/add-e2e-profiles.sh
+++ b/scripts/add-e2e-profiles.sh
@@ -46,7 +46,6 @@ cat <<EOF >> "$CONFIG_PATH"
   private_api_key = '12345678-abcd-ef01-2345-6789abcdef01'
   ops_manager_url = 'http://localhost:8080/'
   service = 'cloud'
-  silence_storage_warning = true 
   telemetry_enabled = false
   output = 'plaintext'
 EOF

--- a/scripts/add-e2e-profiles.sh
+++ b/scripts/add-e2e-profiles.sh
@@ -30,6 +30,7 @@ fi
 ./bin/atlas config init -P __e2e
 ./bin/atlas config set output plaintext -P __e2e
 ./bin/atlas config set telemetry_enabled false -P __e2e
+./bin/atlas config set silence_storage_warning true -P __e2e
 
 ./bin/atlas config delete __e2e_snapshot --force >/dev/null 2>&1 || true
 
@@ -45,6 +46,7 @@ cat <<EOF >> "$CONFIG_PATH"
   private_api_key = '12345678-abcd-ef01-2345-6789abcdef01'
   ops_manager_url = 'http://localhost:8080/'
   service = 'cloud'
+  silence_storage_warning = true 
   telemetry_enabled = false
   output = 'plaintext'
 EOF

--- a/test/e2e/config/config/config_test.go
+++ b/test/e2e/config/config/config_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path"
@@ -168,17 +169,16 @@ func TestConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
-		// unbloakcing work, will fix in #4195
-		// var config map[string]any
-		// if err := json.Unmarshal(resp, &config); err != nil {
-		// 	t.Fatalf("unexpected error: %v", err)
-		// }
-		// if _, ok := config["org_id"]; !ok {
-		// 	t.Errorf("expected %v, to have key %s\n", config, "org_id")
-		// }
-		// if _, ok := config["service"]; !ok {
-		// 	t.Errorf("expected %v, to have key %s\n", config, "service")
-		// }
+		var config map[string]any
+		if err := json.Unmarshal(resp, &config); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := config["org_id"]; !ok {
+			t.Errorf("expected %v, to have key %s\n", config, "org_id")
+		}
+		if _, ok := config["service"]; !ok {
+			t.Errorf("expected %v, to have key %s\n", config, "service")
+		}
 	})
 	t.Run("Rename", func(t *testing.T) {
 		cmd := exec.Command(

--- a/test/e2e/config/config/config_test.go
+++ b/test/e2e/config/config/config_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"encoding/json"
 	"os"
 	"os/exec"
 	"path"
@@ -169,16 +168,17 @@ func TestConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v, resp: %v", err, string(resp))
 		}
-		var config map[string]any
-		if err := json.Unmarshal(resp, &config); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if _, ok := config["org_id"]; !ok {
-			t.Errorf("expected %v, to have key %s\n", config, "org_id")
-		}
-		if _, ok := config["service"]; !ok {
-			t.Errorf("expected %v, to have key %s\n", config, "service")
-		}
+		// unbloakcing work, will fix in #4195
+		// var config map[string]any
+		// if err := json.Unmarshal(resp, &config); err != nil {
+		// 	t.Fatalf("unexpected error: %v", err)
+		// }
+		// if _, ok := config["org_id"]; !ok {
+		// 	t.Errorf("expected %v, to have key %s\n", config, "org_id")
+		// }
+		// if _, ok := config["service"]; !ok {
+		// 	t.Errorf("expected %v, to have key %s\n", config, "service")
+		// }
 	})
 	t.Run("Rename", func(t *testing.T) {
 		cmd := exec.Command(

--- a/test/internal/helper.go
+++ b/test/internal/helper.go
@@ -606,6 +606,9 @@ func TempConfigFolder(t *testing.T) string {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("AppData", tmpDir)
 
+	// Silence storage warning for e2e tests to reduce noise in the output.
+	t.Setenv("MONGODB_ATLAS_SILENCE_STORAGE_WARNING", "true")
+
 	dir, err := os.UserConfigDir()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Proposed changes

Removes warning `Warning: Secure storage is not available, falling back to insecure storage [...]` by adding global config property `silence_storage_warning`

### Evergreen tests:
* [before](https://parsley.mongodb.com/evergreen/mongodb_atlas_cli_master_e2e_generic_atlas_generic_e2e_feaebe104365505f810ce40822e87803706c3fcf_25_09_09_10_03_08/0/task?bookmarks=0,498) 
<img width="1096" height="744" alt="image" src="https://github.com/user-attachments/assets/ea3f19cc-1fae-4811-b34a-81f6dda0aed8" />

* [after](https://parsley.mongodb.com/evergreen/mongodb_atlas_cli_master_e2e_generic_atlas_generic_e2e_patch_feaebe104365505f810ce40822e87803706c3fcf_68c018b42e90580007ce7057_25_09_09_12_08_22/0/task) 
<img width="916" height="488" alt="image" src="https://github.com/user-attachments/assets/b8c60fa1-a599-4c74-93cd-69dab87c8383" />


### Github action e2e test:
* [before](https://github.com/mongodb/mongodb-atlas-cli/actions/runs/17579058771/job/49930970919)
<img width="269" height="61" alt="image" src="https://github.com/user-attachments/assets/c22ab5da-51a5-45d1-b939-fe911237ebb7" />

* [after](https://github.com/mongodb/mongodb-atlas-cli/actions/runs/17582061233/job/49940589778?pr=4208)
<img width="263" height="56" alt="image" src="https://github.com/user-attachments/assets/6043b327-acce-4345-9256-da805741dc09" />
