### PR TITLE
CLOUDP-348763: [AtlasCLI] Reduce snapshot interval from daily to weekly

### DIFF
--- a/.github/workflows/update-e2e-tests.yml
+++ b/.github/workflows/update-e2e-tests.yml
@@ -3,7 +3,7 @@ name: Update E2E Tests Snapshots
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 5 * * 1-5 # weekdays at 5:00 AM UTC
+    - cron: 15 2 * * 1 # every Monday at 2:15 AM UTC
   pull_request:
     types: [labeled]
 jobs:


### PR DESCRIPTION
## Proposed changes

Run 'Update E2E Test Snapshots' every Monday at 2:15 am UTC, instead of daily

_Jira ticket:_ CLOUDP-348763