### PR TITLE
CLOUDP-350267: accept updating state while creating a cluster

### DIFF
--- a/internal/watchers/cluster.go
+++ b/internal/watchers/cluster.go
@@ -34,8 +34,9 @@ var ClusterDeleted = &StateTransition{
 }
 
 var ClusterCreated = &StateTransition{
-	StartState: pointer.Get(clusterCreating),
-	EndState:   pointer.Get(clusterIdle),
+	StartState:      pointer.Get(clusterCreating),
+	EndState:        pointer.Get(clusterIdle),
+	RetryableStates: []string{clusterUpdating},
 }
 
 type AtlasClusterStateDescriber struct {

--- a/internal/watchers/watcher.go
+++ b/internal/watchers/watcher.go
@@ -49,9 +49,9 @@ func (err *InvalidStateError) Error() string {
 	}
 
 	if err.State != nil {
-		expected = fmt.Sprintf(expectedTemplate, *err.State)
+		expected = fmt.Sprintf(expectedTemplate, *err.ExpectedState)
 	} else {
-		expected = fmt.Sprintf(expectedErrorCode, *err.ErrorCode)
+		expected = fmt.Sprintf(expectedErrorCode, *err.ExpectedErrorCode)
 	}
 
 	return fmt.Sprintf("%s %s", got, expected)


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-350267

- Fixes the ISS issue where it would fail with `Error: Invalid state reached: UPDATING. Expected state: UPDATING.`. Probably because ISS goes into `UPDATING` after creation. This should be OK to happen after a cluster creation.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
