### PR TITLE
chore: Removes datalake from test cleanup

### DIFF
--- a/test/internal/cleanup_test.go
+++ b/test/internal/cleanup_test.go
@@ -127,10 +127,6 @@ func TestCleanup(t *testing.T) {
 				t.Parallel()
 				deleteAllClustersForProject(t, cliPath, projectID)
 			})
-			t.Run("delete datapipelines", func(t *testing.T) {
-				t.Parallel()
-				deleteDatapipelinesForProject(t, cliPath, projectID)
-			})
 			t.Run("delete data federations", func(t *testing.T) {
 				t.Parallel()
 				deleteAllDataFederations(t, cliPath, projectID)


### PR DESCRIPTION
## Proposed changes

Cleanup action will fail with `Error: unknown command "datalakepipeline" for "atlas"`
Example fail: https://github.com/mongodb/mongodb-atlas-cli/actions/runs/18453637759/job/52716968298

This PR removes the functions which call to this sunset command.