### PR TITLE
CLOUDP-354710: upgraded atlas-cli-core library and fixed whoami when auth_token is empty

### DIFF
--- a/build/package/purls.txt
+++ b/build/package/purls.txt
@@ -73,7 +73,7 @@ pkg:golang/github.com/mholt/archives@v0.1.5
 pkg:golang/github.com/mikelolasagasti/xz@v1.0.1
 pkg:golang/github.com/minio/minlz@v1.0.1
 pkg:golang/github.com/mongodb-forks/digest@v1.1.0
-pkg:golang/github.com/mongodb/atlas-cli-core@v0.0.0-20250909113945-ffb322e05f59
+pkg:golang/github.com/mongodb/atlas-cli-core@v0.0.0-20251029131602-d10cd0d198ab
 pkg:golang/github.com/montanaflynn/stats@v0.7.1
 pkg:golang/github.com/nwaples/rardecode/v2@v2.2.0
 pkg:golang/github.com/pelletier/go-toml/v2@v2.2.4

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mholt/archives v0.1.5
 	github.com/mongodb-labs/cobra2snooty v1.19.1
-	github.com/mongodb/atlas-cli-core v0.0.0-20250909113945-ffb322e05f59
+	github.com/mongodb/atlas-cli-core v0.0.0-20251029131602-d10cd0d198ab
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/shirou/gopsutil/v4 v4.25.9

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/mongodb-forks/digest v1.1.0 h1:7eUdsR1BtqLv0mdNm4OXs6ddWvR4X2/OsLwdKk
 github.com/mongodb-forks/digest v1.1.0/go.mod h1:rb+EX8zotClD5Dj4NdgxnJXG9nwrlx3NWKJ8xttz1Dg=
 github.com/mongodb-labs/cobra2snooty v1.19.1 h1:GDEQZWy8f/DeJlImNgVvStu6sgNi8nuSOR1Oskcw8BI=
 github.com/mongodb-labs/cobra2snooty v1.19.1/go.mod h1:Hyq4YadN8dwdOiz56MXwTuVN63p0WlkQwxdLxOSGdX8=
-github.com/mongodb/atlas-cli-core v0.0.0-20250909113945-ffb322e05f59 h1:uIxkUglkDOtrvfzyNsV/FHwGC717mAI0S4/jzFOBvsM=
-github.com/mongodb/atlas-cli-core v0.0.0-20250909113945-ffb322e05f59/go.mod h1:QDfVGpdfxXM1httLNXCKsfWTKv6slzCqBZxkkPIktlQ=
+github.com/mongodb/atlas-cli-core v0.0.0-20251029131602-d10cd0d198ab h1:D62gdi3ztUAf8q0g/6lI+Aff9CePCYyVxeQJVGi/kbI=
+github.com/mongodb/atlas-cli-core v0.0.0-20251029131602-d10cd0d198ab/go.mod h1:692B7OUNots2ODMrjAt2XH44Ss2V+XBsJivqQ6ur8H0=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/nwaples/rardecode/v2 v2.2.0 h1:4ufPGHiNe1rYJxYfehALLjup4Ls3ck42CWwjKiOqu0A=

--- a/internal/cli/auth/whoami.go
+++ b/internal/cli/auth/whoami.go
@@ -46,6 +46,9 @@ func authTypeAndSubject() (string, string, error) {
 		return "service account", config.ClientID(), nil
 	case config.UserAccount:
 		subject, _ := config.AccessTokenSubject()
+		if subject == "" {
+			return "", "", ErrUnauthenticated
+		}
 		return "account", subject, nil
 	case config.NoAuth:
 		return "", "", ErrUnauthenticated


### PR DESCRIPTION
## Proposed changes
- upgraded `atlas-cli-core` library
- fixed `atlas whoami` when `auth_token` is empty

_Jira ticket:_ [CLOUDP-354710](https://jira.mongodb.org/browse/CLOUDP-354710)

Fixed #4283 