### PR TITLE
Revert "build(deps): bump sigstore/cosign-installer from 3.10.0 to 4.0.0"

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -176,7 +176,7 @@ jobs:
           username: "${{ secrets.DOCKERHUB_USER }}"
           password: "${{ secrets.DOCKERHUB_SECRET }}"
       - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62
         with:
           cosign-release: 'v2.2.3'
       - name: Verify Signature Docker Image
@@ -215,7 +215,7 @@ jobs:
           username: "${{ secrets.QUAY_USER }}"
           password: "${{ secrets.QUAY_TOKEN }}"
       - name: Install Cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62
         with:
           cosign-release: 'v2.2.3'
       - name: Verify Signature Quay Image


### PR DESCRIPTION
Reverts mongodb/mongodb-atlas-cli#4267

It seems like this PR is breaking our `Daily Release AtlasCLI Docker Image` workflow:
https://github.com/mongodb/mongodb-atlas-cli/actions/workflows/docker-release.yml

Reverting, if this works, I'll stop dependabot from updating us to `4.0`