### PR TITLE
Revert "build(deps): bump crazy-max/ghaction-setup-docker from 4.3.0 to 4.4.0…"

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -85,7 +85,7 @@ jobs:
           release_tag=${{ steps.get-latest-tag.outputs.tag }}
           echo "LATEST_VERSION=${release_tag#*/}" >> "$GITHUB_ENV"
       - name: Enable containerd image store # See https://github.com/docker/setup-buildx-action/issues/257#issuecomment-1722284952
-        uses: crazy-max/ghaction-setup-docker@3fb92d6d9c634363128c8cce4bc3b2826526370a
+        uses: crazy-max/ghaction-setup-docker@b60f85385d03ac8acfca6d9996982511d8620a19
         with:
           version: v24.0.6
           daemon-config: |


### PR DESCRIPTION
Reverting since it appears that it might break our [Daily Release AtlasCLI Docker Image](https://github.com/mongodb/mongodb-atlas-cli/actions/workflows/docker-release.yml) workflow