### PR TITLE
CLOUDP-355617: fix breaking changes caused by garasign-cosign image upgrading to v3

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -133,7 +133,7 @@ jobs:
               -v ~/.docker/config.json:/root/.docker/config.json \
               -v "$(pwd):$(pwd)" \
               -w "$(pwd)" \
-              artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign \
+              artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign:2024-10-01 \
               cosign sign --key "${PKCS11_URI}" --sign-container-identity=index.docker.io/mongodb/atlas --tlog-upload=false "${IMAGE}@${DIGEST}"
           done
       - name: Push image to dockerhub public registry


### PR DESCRIPTION
## Proposed changes
The image we use to sign our docker image is upgraded from `v2.x` to `v3.x`, which changes some of the default behaviour.

~~These settings are:~~
- ~~`--use-signing-config=false`~~
- ~~`--new-bundle-format=false`~~

Pinning the image to `2024-10-01` as suggested by devprod until this ticket is resolved: [\[DEVPROD-23584\] Using cosign main repo in garasign cosign image broke it](https://jira.mongodb.org/browse/DEVPROD-23584)

_Jira ticket:_ CLOUDP-355617
