### PR TITLE
CLOUDP-360661: [atlas-cli] atlas auth token prints token surrounded by quotes, remove quotes

### DIFF
--- a/internal/cli/auth/token.go
+++ b/internal/cli/auth/token.go
@@ -40,7 +40,9 @@ func (opts *tokenOpts) Run() error {
 	if accessToken == "" {
 		return fmt.Errorf("no access token found for profile %s", opts.config.Name())
 	}
-	return opts.Print(accessToken)
+	// Use fmt.Fprintln directly to output the raw token regardless of output settings.
+	_, err := fmt.Fprintln(opts.ConfigWriter(), accessToken)
+	return err
 }
 
 func TokenBuilder() *cobra.Command {


### PR DESCRIPTION
## Proposed changes
`atlas login auth` prints token with quotes (`"`) around it (behavior introduced by the `cli.OutputOpts`.

Fix:
- Use`fmt.Fprintln` directly to avoid formatting

_Jira ticket:_ CLOUDP-360661
