### PR TITLE
chore: Minor fix to update SDK

### DIFF
--- a/.github/workflows/autoupdate-sdk.yaml
+++ b/.github/workflows/autoupdate-sdk.yaml
@@ -26,8 +26,6 @@ jobs:
              ./internal/**/*
              go.mod
              go.sum
-      - run:  make gen-purls
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
       - name: Find JIRA ticket
         id: find
         if: steps.verify-changed-files.outputs.files_changed == 'true'
@@ -103,6 +101,25 @@ jobs:
             _Jira ticket:_ ${{ env.JIRA_KEY }}
 
             Note: Jira ticket will be closed automatically when this PR is merged.
+      - name: Checkout PR branch
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: |
+          git fetch origin ${{ env.JIRA_KEY }}
+          git checkout ${{ env.JIRA_KEY }}
+      - name: Generate and commit purls.txt
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: |
+          make gen-purls
+          echo "Changes to purls.txt:"
+          if git diff --exit-code build/package/purls.txt; then
+            echo "No changes to purls.txt"
+          else 
+            git config --global user.name "${{ steps.app-token.outputs.user-name }}"
+            git config --global user.email "${{ steps.app-token.outputs.user-email }}"
+            git add build/package/purls.txt
+            git commit -m "chore: update purls.txt"
+            git push origin ${{ env.JIRA_KEY }}
+          fi
       - name: Set auto merge
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         env:


### PR DESCRIPTION
## Proposed changes

- Issue 1: 
  - If no SDK update, action always fails on task `auto merge`
  Solution:
    - Add caveat that auto-merge is only set if there is an sdk update
- Issue 2:
  - If sdk update results in changes that cause build failures, task `make gen-purls` will fail, preventing the PR from being opened
  Solution:
    - Move this task to after PR is opened. This provides greater visual that an SDK update is available but has changes that cause failure.
