### PR TITLE
VULN-1034: Fix nil pointer dereference in deployments start

### DIFF
--- a/internal/cli/deployments/start.go
+++ b/internal/cli/deployments/start.go
@@ -88,7 +88,7 @@ func (opts *StartOpts) RunAtlas() error {
 	defer opts.StopSpinner()
 
 	clusterAutoScalingConfig, err := opts.store.GetClusterAutoScalingConfig(opts.ConfigProjectID(), opts.DeploymentName)
-	if err != nil {
+	if err == nil {
 		telemetry.AppendOption(telemetry.WithDetectedAutoScalingMode(clusterAutoScalingConfig.GetAutoScalingMode()))
 	}
 


### PR DESCRIPTION
## Description

Fixes a nil pointer dereference bug in `internal/cli/deployments/start.go`.

The condition `if err != nil` was incorrectly accessing `clusterAutoScalingConfig.GetAutoScalingMode()` when the API call **failed**, which would cause a panic since the config would be nil on error.

Changed to `if err == nil` to only access the config when the API call succeeds.

## JIRA
[VULN-1034](https://jira.mongodb.org/browse/VULN-1034)