### PR TITLE
CLOUDP-371592: ignores breaking changes if the default version is upd…

### DIFF
--- a/tools/cmd/breakvalidator/validate.go
+++ b/tools/cmd/breakvalidator/validate.go
@@ -52,7 +52,8 @@ func compareFlags(cmdPath string, mainFlags, changedFlags map[string]flagData) [
 			changes = append(changes, fmt.Errorf("%w: %s --%s", errFlagTypeChanged, cmdPath, flagName))
 		}
 
-		if flagValue.Default != changedFlagValue.Default {
+		// Ignore default value changes for the --version flag as this is allowed
+		if flagValue.Default != changedFlagValue.Default && flagName != "version" {
 			changes = append(changes, fmt.Errorf("%w: %s --%s", errFlagDefaultChanged, cmdPath, flagName))
 		}
 


### PR DESCRIPTION
…ated

<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-371592

Ignores breaking changes to the `--version` default  if a new version of an endpoint is released, this is the default CLI behaviour and users always get a warning:

```shell
warning: using default API version '2023-01-01'; consider pinning a version to ensure consisentcy when updating the CLI
```

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
