### PR TITLE
chore: Sunset messages should take precident over deprecation messages

### DIFF
--- a/internal/cli/api/api_test.go
+++ b/internal/cli/api/api_test.go
@@ -270,8 +270,9 @@ func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
 			apiCommand: api.Command{
 				Versions: []api.CommandVersion{
 					{
-						Version: api.NewStableVersion(2023, 1, 1),
-						Sunset:  pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Version:    api.NewStableVersion(2023, 1, 1),
+						Sunset:     pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Deprecated: true,
 					},
 					{
 						Version:    api.NewStableVersion(2024, 1, 1),
@@ -289,8 +290,9 @@ func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
 			apiCommand: api.Command{
 				Versions: []api.CommandVersion{
 					{
-						Version: api.NewStableVersion(2023, 1, 1),
-						Sunset:  pointer.Get(time.Date(2020, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Version:    api.NewStableVersion(2023, 1, 1),
+						Sunset:     pointer.Get(time.Date(2020, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Deprecated: true,
 					},
 					{
 						Version:    api.NewStableVersion(2024, 1, 1),
@@ -321,8 +323,9 @@ func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
 			apiCommand: api.Command{
 				Versions: []api.CommandVersion{
 					{
-						Version: api.NewStableVersion(2024, 1, 1),
-						Sunset:  pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Version:    api.NewStableVersion(2024, 1, 1),
+						Sunset:     pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Deprecated: true,
 					},
 				},
 			},
@@ -334,8 +337,9 @@ func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
 			apiCommand: api.Command{
 				Versions: []api.CommandVersion{
 					{
-						Version: api.NewStableVersion(2023, 1, 1),
-						Sunset:  pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Version:    api.NewStableVersion(2023, 1, 1),
+						Sunset:     pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Deprecated: true,
 					},
 				},
 			},
@@ -357,7 +361,7 @@ func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
 			name: "all versions with sunset date and deprecated should not print warning",
 			apiCommand: api.Command{
 				Versions: []api.CommandVersion{
-					{Version: api.NewStableVersion(2023, 1, 1), Deprecated: false, Sunset: pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC))},
+					{Version: api.NewStableVersion(2023, 1, 1), Deprecated: true, Sunset: pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC))},
 					{Version: api.NewStableVersion(2024, 1, 1), Deprecated: true, Sunset: nil},
 				},
 			},


### PR DESCRIPTION
## Proposed changes

Issue: All sunset versions are marked as deprecated. Thus the deprecated message would be printed and return before ever checking if sunset message needs to be printed.

Solution: 
1. Handle sunset message before deprecated
2. Fix unit test to set `Deprecated` to `true` when `Sunset` is set

Before running sunset version of a cmd:
```
➜ bin/atlas api alerts acknowledgeGroupAlert --version 2023-01-01
warning: version '2023-01-01' is deprecated. Consider upgrading to a newer version: 2024-05-30.
Error: required flag(s) "alertId" not set
```

After:
```
➜ bin/atlas api alerts acknowledgeGroupAlert --version 2023-01-01
warning: version '2023-01-01' is deprecated for this command and will be sunset on 2026-11-30. Consider upgrading to a newer version if available.
Error: required flag(s) "alertId" not set
```