### PR TITLE
chore: Removes serverless e2e tests from update-e2e-tests and evergre…

### DIFF
--- a/.github/workflows/update-e2e-tests.yml
+++ b/.github/workflows/update-e2e-tests.yml
@@ -53,7 +53,6 @@ jobs:
           - atlas/processes
           - atlas/search
           - atlas/search_nodes
-          - atlas/serverless/instance
           - atlas/streams
           - atlas/streams_with_cluster
           - atlas/clusters/iss

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -675,18 +675,6 @@ tasks:
       - func: "e2e test"
         vars:
           E2E_TEST_PACKAGES: ./test/e2e/atlas/interactive/...
-  - name: atlas_serverless_e2e
-    tags: ["e2e","clusters","atlas","foliage_check_task_only"]
-    must_have_test_results: true
-    depends_on:
-      - name: atlas_clusters_flags_e2e
-        variant: "e2e_atlas_clusters"
-        patch_optional: true
-    commands:
-      - func: "install gotestsum"
-      - func: "e2e test"
-        vars:
-          E2E_TEST_PACKAGES: ./test/e2e/atlas/serverless/instance/...
   - name: atlas_service_account_e2e
     tags: ["e2e","generic","atlas"]
     must_have_test_results: true


### PR DESCRIPTION
…en tasks

## Proposed changes

follow-up to #4393.
Removes tasks which run serverless e2e tests, preventing those tasks from failing due to no test files being available.