### PR TITLE
fix: Deprecated message unit test fix

### DIFF
--- a/internal/cli/api/api.go
+++ b/internal/cli/api/api.go
@@ -518,10 +518,16 @@ func printPreviewWarning(apiCommand shared_api.Command, versionString *string) {
 	}
 }
 
-// printDeprecatedVersionWarning prints a warning if the version is deprecated or has a sunset date.
+// printDeprecatedVersionWarning is a convenience wrapper that calls printDeprecatedVersionWarningWithTime with the current time.
+func printDeprecatedVersionWarning(apiCommand shared_api.Command, versionString *string) {
+	printDeprecatedVersionWarningWithTime(apiCommand, versionString, time.Now())
+}
+
+// printDeprecatedVersionWarningWithTime prints a warning if the version is deprecated or has a sunset date.
 // only warn if the command is not fully deprecated, assume that if all versions are deprecated,
 // then the command will be marked as deprecated in Cobra.
-func printDeprecatedVersionWarning(apiCommand shared_api.Command, versionString *string) {
+// The time parameter `now` allows injection of static date for deterministic testing.
+func printDeprecatedVersionWarningWithTime(apiCommand shared_api.Command, versionString *string, now time.Time) {
 	if allVersionsDeprecated(apiCommand) {
 		return
 	}
@@ -549,7 +555,7 @@ func printDeprecatedVersionWarning(apiCommand shared_api.Command, versionString 
 	if commandVersion.Sunset != nil {
 		sunsetDate := commandVersion.Sunset.Format("2006-01-02")
 		// if date is in the past, warn the user that it will not work
-		if commandVersion.Sunset.Before(time.Now()) {
+		if commandVersion.Sunset.Before(now) {
 			fmt.Fprintf(os.Stderr, "error: version '%s' is deprecated for this command and has already been sunset since %s. Consider upgrading to a newer version if available.\n", *versionString, sunsetDate)
 			return
 		}

--- a/internal/cli/api/api_test.go
+++ b/internal/cli/api/api_test.go
@@ -115,7 +115,9 @@ func TestSetUnTouchedFlags(t *testing.T) {
 	require.True(t, testCmd.Flag("e").Changed)
 }
 
-func TestPrintDeprecatedWarning(t *testing.T) {
+func TestPrintDeprecatedWarningWithTime(t *testing.T) {
+	testTime := time.Date(2025, time.May, 1, 0, 0, 0, 0, time.UTC)
+
 	tests := []struct {
 		name        string
 		apiCommand  api.Command
@@ -243,7 +245,7 @@ func TestPrintDeprecatedWarning(t *testing.T) {
 				outputChan <- output
 			}()
 
-			printDeprecatedVersionWarning(tt.apiCommand, &tt.version)
+			printDeprecatedVersionWarningWithTime(tt.apiCommand, &tt.version, testTime)
 
 			w.Close()
 			os.Stderr = oldStderr
@@ -260,7 +262,9 @@ func TestPrintDeprecatedWarning(t *testing.T) {
 	}
 }
 
-func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
+func TestPrintDeprecatedWarningWithTimeWithSunset(t *testing.T) {
+	testTime := time.Date(2025, time.May, 1, 0, 0, 0, 0, time.UTC)
+
 	tests := []struct {
 		name        string
 		apiCommand  api.Command
@@ -274,7 +278,7 @@ func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
 				Versions: []api.CommandVersion{
 					{
 						Version:    api.NewStableVersion(2023, 1, 1),
-						Sunset:     pointer.Get(time.Date(2045, 1, 15, 0, 0, 0, 0, time.UTC)),
+						Sunset:     pointer.Get(time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)), // Future relative to testTime
 						Deprecated: true,
 					},
 					{
@@ -286,7 +290,7 @@ func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
 			},
 			version:     "2023-01-01",
 			shouldPrint: true,
-			expectedMsg: "warning: version '2023-01-01' is deprecated for this command and will be sunset on 2045-01-15. Consider upgrading to a newer version if available.",
+			expectedMsg: "warning: version '2023-01-01' is deprecated for this command and will be sunset on 2026-01-15. Consider upgrading to a newer version if available.",
 		},
 		{
 			name: "version with past sunset date",
@@ -392,7 +396,7 @@ func TestPrintDeprecatedWarningWithSunset(t *testing.T) {
 				outputChan <- output
 			}()
 
-			printDeprecatedVersionWarning(tt.apiCommand, &tt.version)
+			printDeprecatedVersionWarningWithTime(tt.apiCommand, &tt.version, testTime)
 
 			w.Close()
 			os.Stderr = oldStderr


### PR DESCRIPTION
## Proposed changes

Deprecated Warning message unit tests have been intermittently failing. This was due to:
1. "TestPrintDeprecatedWarning" not processing all lines of the warning
2. "future date" `2026-01-15` was reached today


Solution:
1. Copy warning reading logic from "TestPrintDeprecatedWarningWithSunset"
2. Push future date to `2045-01-15`
