### PR TITLE
CLOUDP-378338: Fix sharded cluster test for Gov

### DIFF
--- a/test/e2e/atlas/clusters/sharded/clusterssharded/clusters_sharded_test.go
+++ b/test/e2e/atlas/clusters/sharded/clusterssharded/clusters_sharded_test.go
@@ -53,7 +53,7 @@ func TestShardedCluster(t *testing.T) {
 
 	shardedClusterName := g.Memory("shardedClusterName", internal.Must(internal.RandClusterName())).(string)
 	dbUserUsername := g.Memory("dbUserUsername", internal.Must(internal.RandUsername())).(string)
-	dbUserPassword := dbUserUsername + "~PwD"
+	dbUserPassword := dbUserUsername + "~PassWord"
 
 	var client *mongo.Client
 	ctx := t.Context()


### PR DESCRIPTION
Failing test `TestShardedCluster/Create_sharded_cluster` but only on Gov clusters and [Parsley logs](https://parsley.corp.mongodb.com/test/mongodb_atlas_cli_master_e2e_atlas_gov_clusters_atlas_gov_clusters_sharded_e2e_3931f967fa5d780860714a4f058c0146e2980498_26_02_04_14_17_58/6/3ce0e7ae33424488c133c98d88f3c313?bookmarks=0,2,4&shareLine=0)  show failure with `(Error code: "SHORT_PASSWORD") Detail: The specified password is too short`.

This is because Gov has a [minimum password length of 14 characters](https://www.mongodb.com/docs/atlas/government/atlas-access/#passwords) rather than 8. 

`dbUserPassword ` was generated in the form `user-{d}~PwD`, where d is a random number between 0 and 1000. Resulting in a password length between 10 and 12.
Now it will be in the form `user-{d}~PassWord` and has a length between 15 and 17


[Evergreen link of passing atlas gov test](https://spruce.mongodb.com/version/698b13882798030007d3c28b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Ee2e_atlas_gov_clusters%24) 