### PR TITLE
fix(plugin): sanitize GitHub owner and name values when loading from manifest

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/mongodb/atlas-cli-core/config"
@@ -265,8 +266,8 @@ func createPluginFromManifest(manifest *Manifest) (*Plugin, error) {
 
 	if manifest.Github != nil {
 		plugin.Github = &Github{
-			Owner: manifest.Github.Owner,
-			Name:  manifest.Github.Name,
+			Owner: strings.TrimSuffix(manifest.Github.Owner, "/"),
+			Name:  strings.TrimSuffix(manifest.Github.Name, "/"),
 		}
 	}
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -83,6 +83,21 @@ func Test_createPluginFromManifest(t *testing.T) {
 	assert.Equal(t, plugin.Commands[0].Aliases, manifest.Commands["testCommand"].Aliases)
 }
 
+func Test_createPluginFromManifest_sanitizesGithubValues(t *testing.T) {
+	manifest := getTestManifest()
+	manifest.Github = &ManifestGithubValues{
+		Owner: "mongodb/",         // trailing slash should be removed
+		Name:  "atlas-local-cli/", // trailing slash should be removed
+	}
+
+	plugin, err := createPluginFromManifest(manifest)
+	require.NoError(t, err)
+
+	require.NotNil(t, plugin.Github)
+	assert.Equal(t, "mongodb", plugin.Github.Owner)
+	assert.Equal(t, "atlas-local-cli", plugin.Github.Name)
+}
+
 func TestPluginVersion(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Proposed changes

Trim trailing slashes from the GitHub owner and name fields when creating a plugin from its manifest. This fixes an issue where `atlas plugin update` would fail for first-class plugins (like atlas-local-plugin) when the manifest contained a trailing slash in the GitHub name field, resulting in invalid API URLs like `https://api.github.com/repos/mongodb/atlas-local-cli//releases`.

_Jira ticket:_ CLOUDP-379771