### PR TITLE
feat(plugin): add MinVersion field to first-class plugins for auto-update

### DIFF
--- a/internal/cli/plugin/first_class_test.go
+++ b/internal/cli/plugin/first_class_test.go
@@ -17,8 +17,11 @@ package plugin
 import (
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/plugin"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_IsFirstClassPluginCmd(t *testing.T) {
@@ -65,30 +68,85 @@ func Test_IsFirstClassPluginCmd(t *testing.T) {
 	}
 }
 
-func Test_isAlreadyInstalled(t *testing.T) {
+func Test_getInstalledPlugin(t *testing.T) {
 	plugins := getTestPlugins(t)
 
 	tests := []struct {
 		name             string
 		firstClassPlugin *FirstClassPlugin
-		expected         bool
+		expectFound      bool
 	}{
 		{
 			name:             "Is already installed",
 			firstClassPlugin: &FirstClassPlugin{Name: "plugin2"},
-			expected:         true,
+			expectFound:      true,
 		},
 		{
 			name:             "Is not installed",
 			firstClassPlugin: &FirstClassPlugin{Name: "plugin4"},
-			expected:         false,
+			expectFound:      false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Call the method and check the result
-			result := tt.firstClassPlugin.isAlreadyInstalled(plugins)
+			result := tt.firstClassPlugin.getInstalledPlugin(plugins)
+			if tt.expectFound {
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.firstClassPlugin.Name, result.Name)
+			} else {
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func Test_needsUpdate(t *testing.T) {
+	version123, err := semver.NewVersion("1.2.3")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		firstClassPlugin *FirstClassPlugin
+		installedPlugin  *plugin.Plugin
+		expected         bool
+	}{
+		{
+			name:             "No MinVersion specified",
+			firstClassPlugin: &FirstClassPlugin{Name: "test", MinVersion: ""},
+			installedPlugin:  &plugin.Plugin{Name: "test", Version: version123},
+			expected:         false,
+		},
+		{
+			name:             "Installed version equals MinVersion",
+			firstClassPlugin: &FirstClassPlugin{Name: "test", MinVersion: "1.2.3"},
+			installedPlugin:  &plugin.Plugin{Name: "test", Version: version123},
+			expected:         false,
+		},
+		{
+			name:             "Installed version greater than MinVersion",
+			firstClassPlugin: &FirstClassPlugin{Name: "test", MinVersion: "1.0.0"},
+			installedPlugin:  &plugin.Plugin{Name: "test", Version: version123},
+			expected:         false,
+		},
+		{
+			name:             "Installed version less than MinVersion",
+			firstClassPlugin: &FirstClassPlugin{Name: "test", MinVersion: "2.0.0"},
+			installedPlugin:  &plugin.Plugin{Name: "test", Version: version123},
+			expected:         true,
+		},
+		{
+			name:             "Invalid MinVersion format",
+			firstClassPlugin: &FirstClassPlugin{Name: "test", MinVersion: "invalid"},
+			installedPlugin:  &plugin.Plugin{Name: "test", Version: version123},
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.firstClassPlugin.needsUpdate(tt.installedPlugin)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/cli/plugin/plugin.go
+++ b/internal/cli/plugin/plugin.go
@@ -130,7 +130,15 @@ func (opts *Opts) findPluginWithName(name string) (*plugin.Plugin, error) {
 func RegisterCommands(rootCmd *cobra.Command) {
 	plugins := plugin.GetAllPluginsValidated(createExistingCommandsSet(rootCmd.Commands()))
 
+	// Get set of first-class plugins that need updating
+	firstClassPluginsNeedingUpdate := getFirstClassPluginsNeedingUpdate(plugins)
+
 	for _, p := range plugins.GetValidPlugins() {
+		// Skip installed plugins that are first-class plugins needing update
+		// Their commands will be handled by the first-class plugin mechanism
+		if _, needsUpdate := firstClassPluginsNeedingUpdate[p.Name]; needsUpdate {
+			continue
+		}
 		rootCmd.AddCommand(p.GetCobraCommands()...)
 	}
 

--- a/internal/cli/plugin/plugin_github_asset.go
+++ b/internal/cli/plugin/plugin_github_asset.go
@@ -289,7 +289,6 @@ func (g *GithubAsset) verifyAssetSignature(ghClient *github.Client, asset []byte
 		return fmt.Errorf("signature verification unsuccessful: %w", err)
 	}
 
-	fmt.Println("PGP signature verification successful!")
 	return nil
 }
 


### PR DESCRIPTION
## Proposed changes

First-class plugins now support a MinVersion field that triggers automatic updates when the installed version is below the specified minimum.

Changes:
- Add MinVersion field to FirstClassPlugin struct
- Implement needsUpdate() to compare installed version against MinVersion
- Auto-update plugins before execution when version is below minimum
- Skip installed plugin commands in favor of first-class handlers when update is needed
- Add getFirstClassPluginsNeedingUpdate() helper for command registration

Set initial MinVersion values:
- atlas-cli-plugin-kubernetes: 1.2.4
- atlas-local-plugin: 0.0.10

_Jira ticket:_ CLOUDP-379821
