### PR TITLE
VULN-1041: Fix GO-2022-0493 by forcing golang.org/x/sys to v0.41.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/mongodb/mongodb-atlas-cli/atlascli
 go 1.26
 
 replace (
+	// Security fix for VULN-1041 (GO-2022-0493): force vulnerable golang.org/x/sys to fixed version
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 => golang.org/x/sys v0.41.0
 	// Security fix for VULN-1042: Update golang.org/x/text v0.3.0 to v0.33.0
 	golang.org/x/text v0.3.0 => golang.org/x/text v0.33.0
 	// Security fix for VULN-1044: Update protobuf v1.22.0 to v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -641,7 +641,6 @@ golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
## Summary
Security fix for [VULN-1041](https://jira.mongodb.org/browse/VULN-1041) (GO-2022-0493, Medium). The vulnerable `golang.org/x/sys@v0.0.0-20201119102817-f84b799fce68` appears in the module graph via transitive deps; this change adds a replace directive so it resolves to the fixed v0.41.0.


Made with [Cursor](https://cursor.com)