### PR TITLE
CLOUDP-390810: Fall back to major.minor image tag when major-only tag is unavailable

### DIFF
--- a/internal/cli/deployments/options/deployment_opts.go
+++ b/internal/cli/deployments/options/deployment_opts.go
@@ -105,6 +105,7 @@ type DeploymentOpts struct {
 	Config                ProfileReader
 	DeploymentTelemetry   DeploymentTelemetry
 	DeploymentUUID        string
+	resolvedImageName     string
 }
 
 type Deployment struct {
@@ -152,8 +153,20 @@ func getLocalDevImage() string {
 }
 
 func (opts *DeploymentOpts) MongodDockerImageName() string {
+	if opts.resolvedImageName != "" {
+		return opts.resolvedImageName
+	}
 	v, _ := semver.NewVersion(opts.MdbVersion)
 	return getLocalDevImage() + ":" + strconv.FormatUint(v.Major(), 10)
+}
+
+func (opts *DeploymentOpts) MongodDockerImageNameFallback() string {
+	v, _ := semver.NewVersion(opts.MdbVersion)
+	return getLocalDevImage() + ":" + strconv.FormatUint(v.Major(), 10) + ".0"
+}
+
+func (opts *DeploymentOpts) SetResolvedImageName(name string) {
+	opts.resolvedImageName = name
 }
 
 func (opts *DeploymentOpts) Spin(funcs ...func() error) error {

--- a/internal/cli/deployments/setup.go
+++ b/internal/cli/deployments/setup.go
@@ -145,23 +145,45 @@ func (opts *SetupOpts) downloadImage(ctx context.Context, currentStep int) error
 	opts.logStepStarted("Downloading the latest MongoDB image to your local environment...", currentStep, steps)
 	defer opts.stop()
 
-	err := opts.ContainerEngine.ImagePull(ctx, opts.MongodDockerImageName())
-	if err == nil {
-		return nil
+	candidates := []string{
+		opts.MongodDockerImageName(),
+		opts.MongodDockerImageNameFallback(),
 	}
-	_, _ = log.Debugf("Error encountered while pulling image '%s': %s\n", opts.MongodDockerImageName(), err.Error())
-	if opts.isDiskSpaceError(err) {
-		return errInsufficientDiskSpace
-	}
-	_, _ = log.Debugf("Checking if image exists locally\n")
-	// In case we already have an image present and the download fails, we can continue with the existing image
-	images, _ := opts.ContainerEngine.ImageList(ctx, opts.MongodDockerImageName())
-	if len(images) != 0 {
-		_, _ = log.Debugf("Image '%s' exists locally, continuing with the existing image\n", opts.MongodDockerImageName())
-		return nil
-	}
-	_, _ = log.Debugf("Failed to find image '%s' locally\n", opts.MongodDockerImageName())
 
+	prevImage := ""
+	for _, image := range candidates {
+		if prevImage != "" {
+			_, _ = log.Debugf("Image '%s' not available, trying to download fallback image '%s'\n", prevImage, image)
+		}
+		err := opts.ContainerEngine.ImagePull(ctx, image)
+		if err == nil {
+			_, _ = log.Debugf("Successfully pulled image '%s'\n", image)
+			opts.SetResolvedImageName(image)
+			return nil
+		}
+		_, _ = log.Debugf("Error encountered while pulling image '%s': %s\n", image, err.Error())
+		if opts.isDiskSpaceError(err) {
+			return errInsufficientDiskSpace
+		}
+		prevImage = image
+	}
+
+	_, _ = log.Debugf("Could not pull images, checking if any candidate exists locally\n")
+	prevImage = ""
+	for _, image := range candidates {
+		if prevImage != "" {
+			_, _ = log.Debugf("Image '%s' not found locally, looking for fallback image '%s'\n", prevImage, image)
+		}
+		images, _ := opts.ContainerEngine.ImageList(ctx, image)
+		if len(images) != 0 {
+			_, _ = log.Debugf("Found image '%s' locally, continuing with existing image\n", image)
+			opts.SetResolvedImageName(image)
+			return nil
+		}
+		prevImage = image
+	}
+
+	_, _ = log.Debugf("Failed to find any of %v locally\n", candidates)
 	return errFailedToDownloadImage
 }
 

--- a/internal/cli/deployments/setup_test.go
+++ b/internal/cli/deployments/setup_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli"
+	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/options"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/cli/deployments/test/fixture"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/container"
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/internal/log"
@@ -29,6 +30,7 @@ import (
 )
 
 const dockerImageName = "docker.io/mongodb/mongodb-atlas-local:8"
+const dockerImageNameFallback = "docker.io/mongodb/mongodb-atlas-local:8.0"
 
 func TestSetupOpts_PostRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -138,10 +140,13 @@ func TestSetupOpts_LocalDev_HappyPathOfflinePull(t *testing.T) {
 	// Verify version should always succeed
 	deploymentTest.MockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
 
-	// Image gets pulled
+	// Primary image pull fails
 	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageName).Return(errors.New("image pull failed")).Times(1)
 
-	// The image was downloaded before
+	// Fallback image pull also fails
+	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageNameFallback).Return(errors.New("image pull failed")).Times(1)
+
+	// The primary image was downloaded before
 	deploymentTest.MockContainerEngine.EXPECT().ImageList(ctx, dockerImageName).Return([]container.Image{{ID: dockerImageName}}, nil).Times(1)
 
 	// No local dev container exists yet
@@ -204,14 +209,18 @@ func TestSetupOpts_LocalDev_UnhappyPathOfflinePull(t *testing.T) {
 	// Verify version should always succeed
 	deploymentTest.MockContainerEngine.EXPECT().VerifyVersion(ctx).Return(nil).Times(1)
 
-	// Image gets pulled
+	// Primary image pull fails
 	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageName).Return(errors.New("image pull failed")).Times(1)
+
+	// Fallback image pull also fails
+	deploymentTest.MockContainerEngine.EXPECT().ImagePull(ctx, dockerImageNameFallback).Return(errors.New("image pull failed")).Times(1)
 
 	// No local dev container exists yet
 	deploymentTest.MockContainerEngine.EXPECT().ContainerList(ctx, "mongodb-atlas-local=container").Return([]container.Container{}, nil).Times(1)
 
-	// The image was downloaded before
+	// Neither image exists locally
 	deploymentTest.MockContainerEngine.EXPECT().ImageList(ctx, dockerImageName).Return([]container.Image{}, nil).Times(1)
+	deploymentTest.MockContainerEngine.EXPECT().ImageList(ctx, dockerImageNameFallback).Return([]container.Image{}, nil).Times(1)
 
 	// Container is removed
 	deploymentTest.MockContainerEngine.EXPECT().ContainerRm(ctx, deploymentName).Return(nil).Times(1)
@@ -394,6 +403,41 @@ func TestSetupOpts_MongodDockerImageName(t *testing.T) {
 	}
 }
 
+func TestSetupOpts_MongodDockerImageNameFallback(t *testing.T) {
+	testCases := []struct {
+		name          string
+		version       string
+		customImage   string
+		expectedImage string
+	}{
+		{name: "mdb70", version: mdb70, expectedImage: "docker.io/mongodb/mongodb-atlas-local:7.0"},
+		{name: "mdb80", version: mdb80, expectedImage: "docker.io/mongodb/mongodb-atlas-local:8.0"},
+		{name: "mdb8", version: mdb8, expectedImage: "docker.io/mongodb/mongodb-atlas-local:8.0"},
+		{name: "mdb7", version: mdb7, expectedImage: "docker.io/mongodb/mongodb-atlas-local:7.0"},
+		{name: "custom_mdb7", version: mdb7, customImage: "my-registry.example.com/mongo", expectedImage: "my-registry.example.com/mongo:7.0"},
+		{name: "custom_mdb8", version: mdb8, customImage: "my-registry.example.com/mongo", expectedImage: "my-registry.example.com/mongo:8.0"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if testCase.customImage != "" {
+				original := options.LocalDevImage
+				options.LocalDevImage = testCase.customImage
+				t.Cleanup(func() { options.LocalDevImage = original })
+			}
+			opts := &SetupOpts{}
+			opts.MdbVersion = testCase.version
+			assert.Equal(t, testCase.expectedImage, opts.MongodDockerImageNameFallback())
+		})
+	}
+}
+
+func TestSetupOpts_MongodDockerImageName_UsesResolvedName(t *testing.T) {
+	opts := &SetupOpts{}
+	opts.MdbVersion = mdb8
+	opts.SetResolvedImageName("override/mongodb-atlas-local:8.0")
+	assert.Equal(t, "override/mongodb-atlas-local:8.0", opts.MongodDockerImageName())
+}
+
 func TestSetupOpts_isDiskSpaceError(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -456,19 +500,24 @@ func TestSetupOpts_downloadImage_ErrorPulling_ImageExists(t *testing.T) {
 	}
 	opts.MdbVersion = "8"
 
-	// Image fails to pull
+	// Primary image fails to pull
 	deploymentTest.MockContainerEngine.EXPECT().
 		ImagePull(ctx, dockerImageName).
 		Return(errors.New("network timeout")).
 		Times(1)
 
-	// Image exists locally
+	// Fallback image also fails to pull
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, dockerImageNameFallback).
+		Return(errors.New("network timeout")).
+		Times(1)
+
+	// Primary image exists locally
 	deploymentTest.MockContainerEngine.EXPECT().
 		ImageList(ctx, dockerImageName).
 		Return([]container.Image{{ID: dockerImageName}}, nil).
 		Times(1)
 
-	// Should return nil when image exists locally
 	err := opts.downloadImage(ctx, 1)
 	require.NoError(t, err, "Expected no error when image exists locally")
 }
@@ -483,19 +532,28 @@ func TestSetupOpts_downloadImage_FailedToDownloadImageError(t *testing.T) {
 	}
 	opts.MdbVersion = "8"
 
-	// Image fails to pull
+	// Primary image fails to pull
 	deploymentTest.MockContainerEngine.EXPECT().
 		ImagePull(ctx, dockerImageName).
 		Return(errors.New("network timeout")).
 		Times(1)
 
-	// Image does not exist locally
+	// Fallback image also fails to pull
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, dockerImageNameFallback).
+		Return(errors.New("network timeout")).
+		Times(1)
+
+	// Neither image exists locally
 	deploymentTest.MockContainerEngine.EXPECT().
 		ImageList(ctx, dockerImageName).
 		Return([]container.Image{}, nil).
 		Times(1)
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImageList(ctx, dockerImageNameFallback).
+		Return([]container.Image{}, nil).
+		Times(1)
 
-	// Should return errFailedToDownloadImage when no image exists
 	err := opts.downloadImage(ctx, 1)
 	require.ErrorIs(t, err, errFailedToDownloadImage, "Expected errFailedToDownloadImage when no local image exists")
 }
@@ -519,4 +577,132 @@ func TestSetupOpts_downloadImage_DiskSpaceError(t *testing.T) {
 	// Should return errInsufficientDiskSpace directly
 	err := opts.downloadImage(ctx, 1)
 	require.ErrorIs(t, err, errInsufficientDiskSpace, "Expected errInsufficientDiskSpace for disk space error")
+}
+
+func TestSetupOpts_downloadImage_FallbackPullSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := t.Context()
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+
+	opts := &SetupOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+	}
+	opts.MdbVersion = "8"
+
+	// Primary pull fails
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, dockerImageName).
+		Return(errors.New("not found")).
+		Times(1)
+
+	// Fallback pull succeeds
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, dockerImageNameFallback).
+		Return(nil).
+		Times(1)
+
+	err := opts.downloadImage(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, dockerImageNameFallback, opts.MongodDockerImageName(),
+		"MongodDockerImageName should return the fallback image after fallback pull succeeds")
+}
+
+func TestSetupOpts_downloadImage_FallbackImageExistsLocally(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := t.Context()
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+
+	opts := &SetupOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+	}
+	opts.MdbVersion = "8"
+
+	// Both pulls fail
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, dockerImageName).
+		Return(errors.New("not found")).
+		Times(1)
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, dockerImageNameFallback).
+		Return(errors.New("not found")).
+		Times(1)
+
+	// Primary image not found locally
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImageList(ctx, dockerImageName).
+		Return([]container.Image{}, nil).
+		Times(1)
+
+	// Fallback image exists locally
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImageList(ctx, dockerImageNameFallback).
+		Return([]container.Image{{ID: dockerImageNameFallback}}, nil).
+		Times(1)
+
+	err := opts.downloadImage(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, dockerImageNameFallback, opts.MongodDockerImageName(),
+		"MongodDockerImageName should return the fallback image when only fallback exists locally")
+}
+
+func TestSetupOpts_downloadImage_FallbackDiskSpaceError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := t.Context()
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+
+	opts := &SetupOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+	}
+	opts.MdbVersion = "8"
+
+	// Primary pull fails with non-disk-space error
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, dockerImageName).
+		Return(errors.New("not found")).
+		Times(1)
+
+	// Fallback pull fails with disk space error
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, dockerImageNameFallback).
+		Return(errors.New("no space left on device")).
+		Times(1)
+
+	err := opts.downloadImage(ctx, 1)
+	require.ErrorIs(t, err, errInsufficientDiskSpace)
+}
+
+// HELP-90753: customer uses a custom registry that only has the major.minor tag (e.g., "7.0"), not the major-only tag ("7").
+func TestSetupOpts_downloadImage_CustomRegistryOnlyHasFallbackTag(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := t.Context()
+	deploymentTest := fixture.NewMockLocalDeploymentOpts(ctrl, deploymentName)
+
+	originalImage := options.LocalDevImage
+	options.LocalDevImage = "my-registry.example.com/mongodb-atlas-local"
+	t.Cleanup(func() { options.LocalDevImage = originalImage })
+
+	opts := &SetupOpts{
+		DeploymentOpts: *deploymentTest.Opts,
+	}
+	opts.MdbVersion = "7"
+
+	primaryImage := "my-registry.example.com/mongodb-atlas-local:7"
+	fallbackImage := "my-registry.example.com/mongodb-atlas-local:7.0"
+
+	// Primary tag does not exist in the custom registry
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, primaryImage).
+		Return(errors.New("manifest unknown")).
+		Times(1)
+
+	// Fallback tag exists
+	deploymentTest.MockContainerEngine.EXPECT().
+		ImagePull(ctx, fallbackImage).
+		Return(nil).
+		Times(1)
+
+	err := opts.downloadImage(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, fallbackImage, opts.MongodDockerImageName(),
+		"MongodDockerImageName should return the fallback image from the custom registry")
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-390810

Customers using private/mirrored container registries via `MONGODB_ATLAS_LOCAL_DEPLOYMENT_IMAGE` can experience deployment failures after Atlas CLI 1.48.0. That release changed the Docker image tag format from `major.minor` (e.g., `7.0`) to `major`-only (e.g., `7`). Registries that only mirror the `major.minor` tag now fail with "failed to download the MongoDB image".

This change makes `downloadImage` try both tag formats in order: first the `major` tag (e.g., `:7`), then the `major.minor` tag (e.g., `:7.0`). Whichever succeeds is remembered and used for all subsequent operations (health check, container run). The same fallback applies when checking for locally cached images.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

The fallback mechanism iterates over a candidates list (`[":7", ":7.0"]`), trying to pull each in order. If all pulls fail, it checks for locally cached images using the same candidate order. The resolved image name is stored so that subsequent operations (`ImageHealthCheck`, `ContainerRun`) use the correct tag.

Test coverage includes: primary success, fallback pull success, fallback local image, disk space errors on both primary and fallback, and a custom registry scenario reproducing HELP-90753.