### PR TITLE
chore: update CODEOWNERS to apix-devtools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Maintained by the MongoDB Atlas CLI team
-*       @mongodb/apix-2
+*       @mongodb/apix-devtools
 
 # Docs maintained by Docs Cloud Team
 /docs/  @mongodb/docs-cloud-team


### PR DESCRIPTION
## Summary
Updates CODEOWNERS to reflect the team rename from `apix-2` to `apix-devtools`.

## Changes
- Replace `@mongodb/apix-2` with `@mongodb/apix-devtools` as the default code owner

## Notes
`@mongodb/apix-devtools` has already been granted `maintain` access to this repository.