### PR TITLE
CLOUDP-385889: Fix Go stdlib CVEs by building atlas CLI from source in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+bin/
+cov/
+docs/
+test/
+*.md
+!go.md
+LICENSE

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - name: Check out code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: Set date
         id: set-date
         run: |
@@ -33,6 +31,10 @@ jobs:
         run: |
           release_tag=${{ steps.get-latest-tag.outputs.tag }}
           echo "LATEST_VERSION=${release_tag#*/}" >> "$GITHUB_ENV"
+      - name: Check out release tag
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          ref: ${{ steps.get-latest-tag.outputs.tag }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Login to Docker Hub
@@ -50,6 +52,9 @@ jobs:
             ${{ env.STAGING_IMAGE_REPOSITORY }}:${{ env.LATEST_VERSION }}-${{ env.DATE }}
           file: Dockerfile
           push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            ATLAS_VERSION=${{ env.LATEST_VERSION }}
       - name: Create Issue
         if: ${{ failure() }}
         uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,31 @@
-# syntax=docker/dockerfile:1.3-labs
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+# Build stage: compile atlas CLI from source with current Go toolchain
+FROM golang:1.26 AS builder
+
+ARG TARGETARCH
+ARG GIT_SHA=""
+ARG ATLAS_VERSION=""
+
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build \
+    -trimpath -mod=readonly \
+    -ldflags "-s -w \
+      -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version.GitCommit=${GIT_SHA} \
+      -X github.com/mongodb/mongodb-atlas-cli/atlascli/internal/version.Version=${ATLAS_VERSION}" \
+    -o /atlas ./cmd/atlas
+
+# Runtime stage
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
+
 ENV MONGODB_ATLAS_IS_CONTAINERIZED=true
 
-COPY <<EOF /etc/yum.repos.d/mongodb-org-x86_64-8.0.repo
-[mongodb-org-x86_64-8.0]
-name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/x86_64/
-gpgcheck=1
-enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-8.0.asc
-EOF
-
-COPY <<EOF /etc/yum.repos.d/mongodb-org-aarch64-8.0.repo
-[mongodb-org-aarch64-8.0]
-name=MongoDB Repository
-baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/aarch64/
-gpgcheck=1
-enabled=1
-gpgkey=https://www.mongodb.org/static/pgp/server-8.0.asc
-EOF
-
-RUN microdnf -y install jq yum &&\
-    yum -y update &&\
-    yum install -y mongodb-atlas &&\
-    yum clean all &&\
-    microdnf clean all &&\
+RUN microdnf -y install jq && \
+    microdnf clean all && \
     rm -rf /var/cache
+
+COPY --from=builder /atlas /usr/bin/atlas
 
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
## Summary

* Switch Dockerfile from yum-based `mongodb-atlas` install to a multi-stage build that compiles the atlas CLI from source with Go 1.26, eliminating Go stdlib 1.24.0 CVEs (2 critical, 11 high)
* Bump base image from `ubi9/ubi-minimal:9.5` to `9.7`
* Remove yum, MongoDB yum repos, and gnupg2 from the final image, reducing attack surface
* Update `docker-release.yml` to checkout the release tag and pass `GIT_SHA`/`ATLAS_VERSION` build args

## CVE Triage

`docker scout cves mongodb/mongodb-atlas-local` found 36 vulnerabilities (3C, 33H) across 9 packages:

| Package | Severity | Fixable? | Action |
|---------|----------|----------|--------|
| Go stdlib 1.24.0 | 2C + 11H | Yes | **Fixed** - building with Go 1.26 |
| Go stdlib 1.25.0 | 1C + 10H | Yes | Not from this repo (likely atlas-local-cli plugin) |
| basic-ftp 5.2.0 (npm) | 3H | Yes | Not from this repo (likely mongosh) |
| path-to-regexp 8.3.0 (npm) | 1H | Yes | Not from this repo (likely mongosh) |
| lodash 4.17.23 (npm) | 1H | Yes | Not from this repo (likely mongosh) |
| gnupg2 2.3.3-5 (rpm) | 3H | No fix from Red Hat | **Removed** from image (no longer installed) |
| glibc 2.34 (rpm) | 2H | No fix from Red Hat | Base image package, not fixable |
| zlib 1.2.11 (rpm) | 1H | No fix from Red Hat | Base image package, not fixable |
| libarchive 3.5.3 (rpm) | 1H | No fix from Red Hat | Base image package, not fixable |

This PR directly addresses 13 CVEs (Go stdlib 1.24.0) and removes gnupg2 (3 more), for a net reduction of 16 vulnerabilities. The remaining 20 are either from other repos (npm packages, Go stdlib 1.25.0) or have no vendor fix available (glibc, zlib, libarchive).

## Test plan

* [ ] Verify CI Dockerfile lint (hadolint) passes
* [ ] Verify CI Docker build succeeds for linux/amd64 and linux/arm64
* [ ] Build image locally and confirm `atlas --version` works
* [ ] Run `docker scout cves` against the new image to confirm Go stdlib 1.24.0 CVEs are gone