### PR TITLE
CLOUDP-400334: refactor docs team notification to use review_requested event

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,7 @@
 
 # Docs maintained by Docs Cloud Team
 /docs/  @mongodb/docs-cloud-team
+
+# Auto-generated API command docs are not reviewed by the Docs team
+/docs/command/atlas-api-*  @mongodb/apix-devtools
+/docs/command/includes/    @mongodb/apix-devtools

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -4,15 +4,3 @@ labels:
   - label: "kubernetes"
     type: "issue"
     body: "kubernetes*"
-  - label: "need-doc-review"
-    type: "pull_request"
-    draft: False
-    files:
-      - "docs\\/command\\/.*\\.txt"
-  - label: "mongocli"
-    type: "pull_request"
-    draft: False
-    base-branch: mongocli-master
-  - label: "atlascli"
-    type: "pull_request"
-    base-branch: master

--- a/.github/workflows/docs-notification.yaml
+++ b/.github/workflows/docs-notification.yaml
@@ -1,0 +1,38 @@
+name: Docs Team Notification
+on:
+  pull_request:
+    types:
+      - review_requested
+jobs:
+  slack-notification-doc-team:
+    name: Notify Docs Team on Slack
+    runs-on: ubuntu-latest
+    if: github.event.requested_team.slug == 'docs-cloud-team'
+    permissions:
+      pull-requests: write # Needed by sticky-pull-request-comment
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        id: append_comment
+        with:
+          header: pr-title-slack-doc
+          message: "APIx Bot :bowtie:: a message has been sent to Docs Slack channel :rocket:."
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
+        if: steps.append_comment.outputs.previous_comment_id == ''
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_DOCS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "hey ${{ secrets.SLACK_DOCS_TAG }}, this is APIx Bot :aileafy:, could you please review <${{ github.event.pull_request.html_url }}|PR ${{ github.event.pull_request.number }}> :pretty-please:? thanks a lot!"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -2,12 +2,6 @@ name: Issue and PRs Labeler
 on:
   issues:
     types: [opened, edited]
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 jobs:
   labeler:
     name: Add Label to PRs and Issues
@@ -29,47 +23,3 @@ jobs:
         with:
           config_path: .github/labeler.yaml
           use_local_config: true
-  slack-notification-doc-team:
-    needs: labeler
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Needed by sticky-pull-request-comment
-    steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-      - name: Get PR labels
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          labels=$(gh api repos/"$OWNER"/"$REPO_NAME"/pulls/"$PULL_REQUEST_NUMBER" --jq '.labels.[].name')
-          echo "Labels: $labels"
-          if echo "$labels" | grep -q "need-doc-review"; then
-            echo "review_needed=true" >> "$GITHUB_ENV"
-          fi
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
-        id: append_comment
-        if: env.review_needed == 'true'
-        with:
-          header: pr-title-slack-doc
-          message: "APIx Bot :bowtie:: a message has been sent to Docs Slack channel :rocket:."
-      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
-        if: env.review_needed == 'true' && steps.append_comment.outputs.previous_comment_id == ''
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_DOCS }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "hey ${{ secrets.SLACK_DOCS_TAG }}, this is APIx Bot :aileafy:, could you please review <${{ github.event.pull_request.html_url }}|PR ${{ github.event.pull_request.number }}> :pretty-please:? thanks a lot!"
-                  }
-                }
-              ]
-            }

--- a/internal/cli/plugin/update.go
+++ b/internal/cli/plugin/update.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -50,6 +50,10 @@ type UpdateOpts struct {
 	pluginUpdateVersion       *semver.Version
 	ghClient                  *github.Client
 	skipSignatureVerification bool
+}
+
+func pluginTargetDirectory(existingPluginPath, newDirectoryName string) string {
+	return filepath.Join(filepath.Dir(existingPluginPath), newDirectoryName)
 }
 
 func printPluginUpdateWarning(p *plugin.Plugin, err error) {
@@ -188,14 +192,9 @@ func (opts *UpdateOpts) updatePlugin(ctx context.Context, githubAssetRelease *Gi
 	}
 	defer os.RemoveAll(oldPluginDirectoryPath)
 
-	// rename temp plugin directory to actual name
-	// if anything goes wrong, rollback the old version of the directory
-	pluginsDefaultDirectory, err := plugin.GetDefaultPluginDirectory()
-	if err != nil {
-		err = os.Rename(oldPluginDirectoryPath, existingPlugin.PluginDirectoryPath)
-		return err
-	}
-	pluginDirectoryPath := path.Join(pluginsDefaultDirectory, githubAssetRelease.getPluginDirectoryName())
+	// rename temp plugin directory to actual name in the same parent directory as the existing plugin,
+	// so plugins installed in ATLAS_CLI_EXTRA_PLUGIN_DIRECTORY are updated in place.
+	pluginDirectoryPath := pluginTargetDirectory(existingPlugin.PluginDirectoryPath, githubAssetRelease.getPluginDirectoryName())
 	err = os.Rename(tempPluginDirectoryPath, pluginDirectoryPath)
 	if err != nil {
 		err = os.Rename(oldPluginDirectoryPath, existingPlugin.PluginDirectoryPath)

--- a/internal/cli/plugin/update_test.go
+++ b/internal/cli/plugin/update_test.go
@@ -15,6 +15,7 @@
 package plugin
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -31,21 +32,21 @@ func Test_pluginTargetDirectory(t *testing.T) {
 	}{
 		{
 			name:               "plugin in custom directory is updated in place",
-			existingPluginPath: "/custom/plugins/my-plugin",
+			existingPluginPath: filepath.FromSlash("/custom/plugins/my-plugin"),
 			newDirectoryName:   "my-plugin",
-			want:               "/custom/plugins/my-plugin",
+			want:               filepath.FromSlash("/custom/plugins/my-plugin"),
 		},
 		{
 			name:               "plugin in extra dir with new version directory name stays in extra dir",
-			existingPluginPath: "/extra/plugins/owner-repo-1.0.0",
+			existingPluginPath: filepath.FromSlash("/extra/plugins/owner-repo-1.0.0"),
 			newDirectoryName:   "owner-repo-2.0.0",
-			want:               "/extra/plugins/owner-repo-2.0.0",
+			want:               filepath.FromSlash("/extra/plugins/owner-repo-2.0.0"),
 		},
 		{
 			name:               "plugin in default directory stays in default directory",
-			existingPluginPath: "/home/user/.config/atlascli/plugins/my-plugin",
+			existingPluginPath: filepath.FromSlash("/home/user/.config/atlascli/plugins/my-plugin"),
 			newDirectoryName:   "my-plugin",
-			want:               "/home/user/.config/atlascli/plugins/my-plugin",
+			want:               filepath.FromSlash("/home/user/.config/atlascli/plugins/my-plugin"),
 		},
 	}
 

--- a/internal/cli/plugin/update_test.go
+++ b/internal/cli/plugin/update_test.go
@@ -22,6 +22,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_pluginTargetDirectory(t *testing.T) {
+	tests := []struct {
+		name               string
+		existingPluginPath string
+		newDirectoryName   string
+		want               string
+	}{
+		{
+			name:               "plugin in custom directory is updated in place",
+			existingPluginPath: "/custom/plugins/my-plugin",
+			newDirectoryName:   "my-plugin",
+			want:               "/custom/plugins/my-plugin",
+		},
+		{
+			name:               "plugin in extra dir with new version directory name stays in extra dir",
+			existingPluginPath: "/extra/plugins/owner-repo-1.0.0",
+			newDirectoryName:   "owner-repo-2.0.0",
+			want:               "/extra/plugins/owner-repo-2.0.0",
+		},
+		{
+			name:               "plugin in default directory stays in default directory",
+			existingPluginPath: "/home/user/.config/atlascli/plugins/my-plugin",
+			newDirectoryName:   "my-plugin",
+			want:               "/home/user/.config/atlascli/plugins/my-plugin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := pluginTargetDirectory(tt.existingPluginPath, tt.newDirectoryName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Test_extractPluginSpecifierAndVersionFromArg(t *testing.T) {
 	var (
 		v1, _       = semver.NewVersion("1.0.0")


### PR DESCRIPTION
## Summary

- Splits `labeler.yaml` into two focused workflows: `labeler.yaml` (issues-only labeling) and `docs-notification.yaml` (docs team Slack notification)
- Replaces the label-based notification flow with a `review_requested` event trigger — no API call needed, `github.event.requested_team.slug` carries the team directly
- Fixes a bug where the old `slack-notification-doc-team` job ran on `issues` events, causing a jq type error from an empty `PULL_REQUEST_NUMBER`
- Removes the `need-doc-review` label rule from the labeler config
- Updates CODEOWNERS to exclude auto-generated `atlas-api-*` docs from `@mongodb/docs-cloud-team` ownership (`docs/command/atlas-api-*` and `docs/command/includes/`)

## How it was tested

Opened two test PRs against this repo to observe actual GitHub event behavior:
- Non-draft PR touching `docs/` → `review_requested` fired for `docs-cloud-team` ✅
- Draft PR touching `docs/` → no `review_requested` on open (by design) ✅
- Draft → ready for review → `review_requested` fired for `docs-cloud-team` ✅