### PR TITLE
refactor: docs team notification to use review_requested event

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,7 @@
 
 # Docs maintained by Docs Cloud Team
 /docs/  @mongodb/docs-cloud-team
+
+# Auto-generated API command docs are not reviewed by the Docs team
+/docs/command/atlas-api-*  @mongodb/apix-devtools
+/docs/command/includes/    @mongodb/apix-devtools

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -4,15 +4,3 @@ labels:
   - label: "kubernetes"
     type: "issue"
     body: "kubernetes*"
-  - label: "need-doc-review"
-    type: "pull_request"
-    draft: False
-    files:
-      - "docs\\/command\\/.*\\.txt"
-  - label: "mongocli"
-    type: "pull_request"
-    draft: False
-    base-branch: mongocli-master
-  - label: "atlascli"
-    type: "pull_request"
-    base-branch: master

--- a/.github/workflows/docs-notification.yaml
+++ b/.github/workflows/docs-notification.yaml
@@ -1,0 +1,38 @@
+name: Docs Team Notification
+on:
+  pull_request:
+    types:
+      - review_requested
+jobs:
+  slack-notification-doc-team:
+    name: Notify Docs Team on Slack
+    runs-on: ubuntu-latest
+    if: github.event.requested_team.slug == 'docs-cloud-team'
+    permissions:
+      pull-requests: write # Needed by sticky-pull-request-comment
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        id: append_comment
+        with:
+          header: pr-title-slack-doc
+          message: "APIx Bot :bowtie:: a message has been sent to Docs Slack channel :rocket:."
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
+        if: steps.append_comment.outputs.previous_comment_id == ''
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_DOCS }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "hey ${{ secrets.SLACK_DOCS_TAG }}, this is APIx Bot :aileafy:, could you please review <${{ github.event.pull_request.html_url }}|PR ${{ github.event.pull_request.number }}> :pretty-please:? thanks a lot!"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -2,12 +2,6 @@ name: Issue and PRs Labeler
 on:
   issues:
     types: [opened, edited]
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
 jobs:
   labeler:
     name: Add Label to PRs and Issues
@@ -29,47 +23,3 @@ jobs:
         with:
           config_path: .github/labeler.yaml
           use_local_config: true
-  slack-notification-doc-team:
-    needs: labeler
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # Needed by sticky-pull-request-comment
-    steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-      - name: Get PR labels
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          labels=$(gh api repos/"$OWNER"/"$REPO_NAME"/pulls/"$PULL_REQUEST_NUMBER" --jq '.labels.[].name')
-          echo "Labels: $labels"
-          if echo "$labels" | grep -q "need-doc-review"; then
-            echo "review_needed=true" >> "$GITHUB_ENV"
-          fi
-      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
-        id: append_comment
-        if: env.review_needed == 'true'
-        with:
-          header: pr-title-slack-doc
-          message: "APIx Bot :bowtie:: a message has been sent to Docs Slack channel :rocket:."
-      - uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c
-        if: env.review_needed == 'true' && steps.append_comment.outputs.previous_comment_id == ''
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_DOCS }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "hey ${{ secrets.SLACK_DOCS_TAG }}, this is APIx Bot :aileafy:, could you please review <${{ github.event.pull_request.html_url }}|PR ${{ github.event.pull_request.number }}> :pretty-please:? thanks a lot!"
-                  }
-                }
-              ]
-            }


### PR DESCRIPTION
## Proposed changes

Refactors how the docs team gets notified on Slack when a PR touches docs files.

Previously, the `labeler.yaml` workflow would apply a `need-doc-review` label when `docs/command/*.txt` files changed, then a second job would poll the GitHub API for that label and send a Slack ping. This had a bug where the job also ran on `issues` events, causing a jq type error, and was fragile since it depended on label state rather than the event itself.

The new approach uses the `review_requested` event and checks `github.event.requested_team.slug` directly — no API call needed. Since CODEOWNERS already requests `@mongodb/docs-cloud-team` on docs changes, this is a cleaner and more reliable trigger. Verified with two test PRs (non-draft open and draft → ready) that `review_requested` fires correctly in both cases.

Also updates CODEOWNERS to exclude auto-generated `atlas-api-*` command docs from `@mongodb/docs-cloud-team` ownership, per the discussion in #cloud-apix-devtools.

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

## Further comments

Tested by opening dummy PRs against this repo:
- #4555 — non-draft PR with docs changes → `review_requested` fired for `docs-cloud-team` ✅
- #4556 — draft PR with docs changes → no event on open, `review_requested` fired after marking ready for review ✅