### PR TITLE
CLOUDP-400180: treat Atlas sample data "continuing through error" as success

### DIFF
--- a/internal/cli/setup/setup_cmd.go
+++ b/internal/cli/setup/setup_cmd.go
@@ -277,7 +277,11 @@ func (opts *Opts) sampleDataWatcher() (any, bool, error) {
 		return nil, false, err
 	}
 	if result.GetState() == "FAILED" {
-		return nil, false, fmt.Errorf("failed to load data: %s", result.GetErrorMessage())
+		errMsg := result.GetErrorMessage()
+		if strings.HasPrefix(errMsg, "continuing through error:") {
+			return nil, true, nil
+		}
+		return nil, false, fmt.Errorf("failed to load data: %s", errMsg)
 	}
 	return nil, result.GetState() == "COMPLETED", nil
 }

--- a/internal/cli/setup/setup_cmd_test.go
+++ b/internal/cli/setup/setup_cmd_test.go
@@ -282,3 +282,61 @@ func TestCluster_Run_CheckFlagsSet(t *testing.T) {
 	assert.False(t, opts.shouldAskForValue(flag.Password))
 	assert.False(t, opts.shouldAskForValue(flag.EnableTerminationProtection))
 }
+
+func TestOpts_SampleDataWatcher(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    string
+		errMsg   string
+		wantDone bool
+		wantErr  bool
+	}{
+		{
+			name:     "completed",
+			state:    "COMPLETED",
+			wantDone: true,
+		},
+		{
+			name:     "pending",
+			state:    "WORKING",
+			wantDone: false,
+		},
+		{
+			name:    "failed with hard error",
+			state:   "FAILED",
+			errMsg:  "something went wrong",
+			wantErr: true,
+		},
+		{
+			name:     "failed with continuing through error is treated as completed",
+			state:    "FAILED",
+			errMsg:   "continuing through error: E11000 duplicate key error collection: sample_guides.planets index: _id_ dup key: { _id: ObjectId('621ff30d2a3e781873fcb663') }",
+			wantDone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockStore := NewMockAtlasClusterQuickStarter(ctrl)
+
+			status := &atlasv2.SampleDatasetStatus{}
+			status.State = pointer.Get(tt.state)
+			if tt.errMsg != "" {
+				status.ErrorMessage = pointer.Get(tt.errMsg)
+			}
+
+			mockStore.EXPECT().SampleDataStatus(gomock.Any(), gomock.Any()).Return(status, nil).Times(1)
+
+			opts := &Opts{store: mockStore}
+			_, done, err := opts.sampleDataWatcher()
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantDone, done)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-400180

The Atlas sample data loading API can mark a job as `FAILED` with an error message prefixed `"continuing through error:"` even on a fresh cluster. This happens when Atlas's internal loading service encounters duplicate key errors during its own retry logic — the job completes and `completeDate` is set, but the state is `FAILED`. The CLI was surfacing this as a hard error, causing the `atlas_deployments_atlas_clusters_e2e` task to fail.

The fix detects this prefix in `sampleDataWatcher` and treats it as a successful completion instead of an error.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make fmt` and formatted my code

## Further comments

The four test cases in `TestOpts_SampleDataWatcher` cover: normal completion, still-in-progress, a genuine hard failure, and the `"continuing through error:"` case that was causing the flake.