### PR TITLE
CLOUDP-400902: Extend agent env var telemetry with Codex, Augment, Cline, OpenCode, TRAE AI and Devin

### DIFF
--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -164,6 +164,8 @@ var agentEnvVars = []struct {
 	{"CLINE_ACTIVE", "true", "cline"},
 	{"OPENCODE_CLIENT", "1", "opencode_client"},
 	{"TRAE_AI_SHELL_ID", "", "trae_ai"},
+	{"AMP_AGENT", "1", "amp"},
+	{"GOOSE_AGENT", "1", "goose"},
 }
 
 func withAgent() EventOpt {

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -160,7 +160,7 @@ var agentEnvVars = []struct {
 	{"CURSOR_AGENT", "1", "cursor"},
 	{"GEMINI_CLI", "1", "gemini_cli"},
 	{"CODEX_SANDBOX", "seatbelt", "codex_cli"},
-	{"AUGMENT_AGENT", "1", "augment"},
+	{"AUGMENT_AGENT", "1", "auggie_cli"},
 	{"CLINE_ACTIVE", "true", "cline"},
 	{"OPENCODE_CLIENT", "1", "opencode_client"},
 	{"TRAE_AI_SHELL_ID", "", "trae_ai"},

--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -153,20 +153,34 @@ func withCI() EventOpt {
 
 var agentEnvVars = []struct {
 	envVar string
+	value  string // empty means any non-empty value matches
 	name   string
 }{
-	{"CLAUDECODE", "claude_code"},
-	{"CURSOR_AGENT", "cursor"},
-	{"GEMINI_CLI", "gemini_cli"},
+	{"CLAUDECODE", "1", "claude_code"},
+	{"CURSOR_AGENT", "1", "cursor"},
+	{"GEMINI_CLI", "1", "gemini_cli"},
+	{"CODEX_SANDBOX", "seatbelt", "codex_cli"},
+	{"AUGMENT_AGENT", "1", "augment"},
+	{"CLINE_ACTIVE", "true", "cline"},
+	{"OPENCODE_CLIENT", "1", "opencode_client"},
+	{"TRAE_AI_SHELL_ID", "", "trae_ai"},
 }
 
 func withAgent() EventOpt {
 	return func(event Event) {
 		for _, a := range agentEnvVars {
-			if v, ok := os.LookupEnv(a.envVar); ok && v == "1" {
-				event.Properties["agent_env_var"] = a.name
-				return
+			v, ok := os.LookupEnv(a.envVar)
+			if !ok || v == "" {
+				continue
 			}
+			if a.value != "" && v != a.value {
+				continue
+			}
+			event.Properties["agent_env_var"] = a.name
+			return
+		}
+		if _, err := os.Stat("/opt/.devin"); err == nil {
+			event.Properties["agent_env_var"] = "devin"
 		}
 	}
 }

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -403,37 +403,46 @@ func TestWithHelpCommand_NotFound(t *testing.T) {
 	assert.NotContains(t, e.Properties, "help_command")
 }
 
+func clearAgentEnvVars(t *testing.T) {
+	t.Helper()
+	for _, a := range agentEnvVars {
+		t.Setenv(a.envVar, "")
+	}
+}
+
 func TestWithAgent(t *testing.T) {
-	t.Run("claude_code detected", func(t *testing.T) {
-		t.Setenv("CLAUDECODE", "1")
-		t.Setenv("CURSOR_AGENT", "")
-		e := newEvent(withAgent())
-		assert.Equal(t, "claude_code", e.Properties["agent_env_var"])
-	})
-	t.Run("cursor detected", func(t *testing.T) {
-		t.Setenv("CLAUDECODE", "")
-		t.Setenv("CURSOR_AGENT", "1")
-		e := newEvent(withAgent())
-		assert.Equal(t, "cursor", e.Properties["agent_env_var"])
-	})
-	t.Run("gemini_cli detected", func(t *testing.T) {
-		t.Setenv("CLAUDECODE", "")
-		t.Setenv("CURSOR_AGENT", "")
-		t.Setenv("GEMINI_CLI", "1")
-		e := newEvent(withAgent())
-		assert.Equal(t, "gemini_cli", e.Properties["agent_env_var"])
-	})
+	tests := []struct {
+		name   string
+		envVar string
+		value  string
+		want   string
+	}{
+		{name: "claude_code", envVar: "CLAUDECODE", value: "1", want: "claude_code"},
+		{name: "cursor", envVar: "CURSOR_AGENT", value: "1", want: "cursor"},
+		{name: "gemini_cli", envVar: "GEMINI_CLI", value: "1", want: "gemini_cli"},
+		{name: "codex_cli", envVar: "CODEX_SANDBOX", value: "seatbelt", want: "codex_cli"},
+		{name: "augment", envVar: "AUGMENT_AGENT", value: "1", want: "augment"},
+		{name: "cline", envVar: "CLINE_ACTIVE", value: "true", want: "cline"},
+		{name: "opencode_client", envVar: "OPENCODE_CLIENT", value: "1", want: "opencode_client"},
+		{name: "trae_ai", envVar: "TRAE_AI_SHELL_ID", value: "session-123", want: "trae_ai"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name+" detected", func(t *testing.T) {
+			clearAgentEnvVars(t)
+			t.Setenv(tt.envVar, tt.value)
+			e := newEvent(withAgent())
+			assert.Equal(t, tt.want, e.Properties["agent_env_var"])
+		})
+	}
 	t.Run("none set", func(t *testing.T) {
-		t.Setenv("CLAUDECODE", "")
-		t.Setenv("CURSOR_AGENT", "")
-		t.Setenv("GEMINI_CLI", "")
+		clearAgentEnvVars(t)
 		e := newEvent(withAgent())
 		assert.NotContains(t, e.Properties, "agent_env_var")
 	})
-	t.Run("non-1 values ignored", func(t *testing.T) {
+	t.Run("wrong values ignored", func(t *testing.T) {
+		clearAgentEnvVars(t)
 		t.Setenv("CLAUDECODE", "true")
-		t.Setenv("CURSOR_AGENT", "true")
-		t.Setenv("GEMINI_CLI", "true")
+		t.Setenv("CODEX_SANDBOX", "1")
 		e := newEvent(withAgent())
 		assert.NotContains(t, e.Properties, "agent_env_var")
 	})

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -421,7 +421,7 @@ func TestWithAgent(t *testing.T) {
 		{name: "cursor", envVar: "CURSOR_AGENT", value: "1", want: "cursor"},
 		{name: "gemini_cli", envVar: "GEMINI_CLI", value: "1", want: "gemini_cli"},
 		{name: "codex_cli", envVar: "CODEX_SANDBOX", value: "seatbelt", want: "codex_cli"},
-		{name: "augment", envVar: "AUGMENT_AGENT", value: "1", want: "augment"},
+		{name: "augment", envVar: "AUGMENT_AGENT", value: "1", want: "auggie_cli"},
 		{name: "cline", envVar: "CLINE_ACTIVE", value: "true", want: "cline"},
 		{name: "opencode_client", envVar: "OPENCODE_CLIENT", value: "1", want: "opencode_client"},
 		{name: "trae_ai", envVar: "TRAE_AI_SHELL_ID", value: "session-123", want: "trae_ai"},

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -425,6 +425,8 @@ func TestWithAgent(t *testing.T) {
 		{name: "cline", envVar: "CLINE_ACTIVE", value: "true", want: "cline"},
 		{name: "opencode_client", envVar: "OPENCODE_CLIENT", value: "1", want: "opencode_client"},
 		{name: "trae_ai", envVar: "TRAE_AI_SHELL_ID", value: "session-123", want: "trae_ai"},
+		{name: "amp", envVar: "AMP_AGENT", value: "1", want: "amp"},
+		{name: "goose", envVar: "GOOSE_AGENT", value: "1", want: "goose"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name+" detected", func(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-400902](https://jira.mongodb.org/browse/CLOUDP-400902)
_MCP follow-up:_ [MCP-482](https://jira.mongodb.org/browse/MCP-482)

Extends the `agent_env_var` telemetry property introduced in [#4559](https://github.com/mongodb/mongodb-atlas-cli/pull/4559) with six additional agents from the research table in the ticket.

| Agent | Detection | Value |
|-------|-----------|-------|
| Codex CLI | `CODEX_SANDBOX=seatbelt` | `codex_cli` |
| Augment | `AUGMENT_AGENT=1` | `auggie_cli` |
| Cline | `CLINE_ACTIVE=true` | `cline` |
| OpenCode | `OPENCODE_CLIENT=1` | `opencode_client` |
| TRAE AI | `TRAE_AI_SHELL_ID=<session id>` | `trae_ai` |
| Devin | `/opt/.devin` filesystem path | `devin` |
| Amp | `AMP_AGENT=1` | `amp` |
| Goose | `GOOSE_AGENT=1` | `goose` |

The data structure carries a `value` field so each entry can specify the exact match it expects (or leave it empty for any non-empty value, as TRAE AI requires). Devin is detected via a filesystem check since it doesn't use an environment variable.

The `clearAgentEnvVars` test helper iterates the slice directly, so new entries are automatically covered in future tests.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

MCP equivalent tracked in [MCP-482](https://jira.mongodb.org/browse/MCP-482).