### PR TITLE
chore: auto-close Jira ticket when GitHub issue is closed

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,16 +1,17 @@
 ---
   name: Create JIRA ticket for new issues
-  
+
   on:
     issues:
-      types: [opened]
-      
-  permissions: 
+      types: [opened, closed]
+
+  permissions:
     issues: write
     contents: read
   jobs:
     jira_task:
       name: Create Jira issue
+      if: github.event.action == 'opened'
       runs-on: ubuntu-latest
       steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
@@ -51,3 +52,26 @@
           issue-number: ${{ github.event.issue.number }}
           body: |
             Thanks for opening this issue. The ticket [${{ steps.create.outputs.issue-key }}](https://jira.mongodb.org/browse/${{ steps.create.outputs.issue-key }}) was created for internal tracking.
+    close_jira:
+      name: Close Jira issue
+      if: github.event.action == 'closed'
+      runs-on: ubuntu-latest
+      steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+      - name: Set Jira key from issue comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          JIRA_KEY=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --comments | grep 'was created for internal tracking' | grep -oE 'CLOUDP-[0-9]+' | head -1)
+          echo "JIRA_KEY=$JIRA_KEY" >> "$GITHUB_ENV"
+      - name: Close JIRA ticket
+        if: env.JIRA_KEY != ''
+        uses: mongodb/apix-action/transition-jira@v14
+        with:
+          token: ${{ secrets.JIRA_API_TOKEN }}
+          issue-key: ${{ env.JIRA_KEY }}
+          transition-id: 1371 # Close Issue


### PR DESCRIPTION
## Proposed changes

When a GitHub issue is opened, the workflow creates a CLOUDP Jira tracking ticket and posts the ticket key in a bot comment. There was no corresponding automation to close that Jira ticket when the GitHub issue was closed, requiring manual intervention.

This adds a `close_jira` job to the same workflow that triggers on `issues.closed`, reads the Jira ticket key from the bot comment already on the issue, and transitions the ticket to Closed (transition-id `1371`).

The key extraction reuses the same comment-grep pattern already used in `close-jira.yml` for PR-based tickets. The close step is guarded with `if: env.JIRA_KEY != ''` so it silently skips issues that pre-date the automation and have no tracking comment.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have run `make fmt` and formatted my code

## Further comments

No Go code was changed — this is a workflow-only modification. No new tests are required.