### PR TITLE
docs: MCP auto-generation design documents

### DIFF
--- a/docs/autogen-framework-design.md
+++ b/docs/autogen-framework-design.md
@@ -1,0 +1,295 @@
+# Auto-generation Framework: Technical Design
+
+This document describes the auto-generation framework used in Atlas CLI to turn an OpenAPI spec into executable commands, and what it takes to apply the same approach to a different consumer — specifically an MCP server.
+
+---
+
+## The problem it solves
+
+The Atlas Admin API has hundreds of endpoints. Maintaining hand-written command definitions, flag declarations, and help text for each one does not scale. More importantly, it creates drift: the API changes, commands lag behind, documentation goes stale.
+
+The framework solves this by making the OpenAPI spec the only source of truth. Every command, every parameter, every description, and every supported version is derived from the spec. Adding or changing an API endpoint requires no human intervention on the CLI side — running `make gen-api-commands` picks it up.
+
+---
+
+## High-level pipeline
+
+```
+spec.yaml
+    │
+    ▼
+apply-overlay         (OpenAPI Overlay spec; pure YAML patching)
+    │
+    ▼
+spec-with-overlays.yaml
+    │
+    ▼
+api-generator         (Go binary; reads spec, emits Go source via text/template)
+    │
+    ▼
+internal/api/commands.go   (static Go variable; the full command tree)
+    │
+    ▼
+CLI builder           (iterates commands.go at startup, registers Cobra commands)
+```
+
+Each stage has a single, narrow responsibility. The generator does not know anything about Cobra. The CLI builder does not know anything about OpenAPI. The shared data model — the `Command` struct — is the contract between them.
+
+---
+
+## Stage 1: The upstream spec
+
+`tools/internal/specs/spec.yaml` is imported from the Atlas API team and committed as-is. Nobody edits it by hand. When the API team ships a new spec, you replace this file and re-run generation.
+
+This is the key invariant: the spec file is never modified in this repository. All Atlas CLI-specific concerns live in overlays.
+
+---
+
+## Stage 2: Overlays
+
+The overlay tool (`tools/cmd/apply-overlay`) reads the spec and applies a set of YAML overlay files in sorted alphabetical order, producing `spec-with-overlays.yaml`.
+
+Overlays follow the [OpenAPI Overlay 1.0 spec](https://spec.openapis.org/overlay/v1.0.0.html). Each overlay file has a list of `actions`, where every action targets a specific path in the spec using a JSONPath selector and either `update`s or `remove`s content at that path.
+
+```yaml
+overlay: 1.0.0
+info:
+  title: Configure groupId flag
+  version: 1.0.0
+actions:
+  - target: $.components.parameters.groupId
+    update:
+      x-xgen-atlascli:
+        aliases:
+          - projectId
+```
+
+All CLI-specific additions live under the `x-xgen-atlascli` extension key. This namespace is the contract between overlay authors and the generator. The generator reads nothing outside this namespace (except standard OpenAPI fields like `operationId`, `parameters`, `responses`, and `description`).
+
+Overlays handle:
+
+* **Flag aliases** — `groupId` is also accepted as `projectId` because that flag name predates the auto-gen framework.
+* **Description overrides** — when the upstream description is wrong or too short for CLI use, the overlay replaces it.
+* **Skip directives** — `x-xgen-atlascli: skip: true` excludes an operation from generation entirely.
+* **Operation ID overrides** — when the upstream `operationId` is too long or inconsistent with CLI conventions, the overlay renames it without touching the spec.
+* **Command aliases** — entire command names can have aliases at the operation level.
+* **Watchers** — declarative polling behavior for long-running operations (described in detail below).
+* **Usage examples** — structured examples that appear in `--help` output.
+
+Each overlay file addresses one concern. `groupID_flag.yaml` is about the `groupId` alias. `watchers.yaml` is about all watcher definitions. Keeping them separate means the diff for any change is small and reviewable in isolation.
+
+---
+
+## Stage 3: Code generation
+
+`tools/cmd/api-generator` is a Go binary that:
+
+1. Loads and validates the overlaid spec using `kin-openapi/openapi3`.
+2. Iterates every path/verb combination and calls `operationToCommand()` for each one.
+3. Groups commands by their OpenAPI tag.
+4. Sorts groups alphabetically and commands within each group by `operationId`.
+5. Validates all watcher definitions (see below).
+6. Executes a `text/template` against the sorted command tree.
+7. Runs the output through `go/format` before writing it to disk.
+
+The generator can produce two output types via `--output-type`:
+
+* `commands` — the full command tree as a Go variable (`internal/api/commands.go`)
+* `metadata` — documentation metadata for the docs generator (`tools/cmd/docs/metadata.go`)
+
+Both use the same parse/validate pipeline; only the template differs.
+
+### The Command data model
+
+The generator emits values of these types, defined in `tools/shared/api`:
+
+```go
+type Command struct {
+    OperationID       string
+    ShortOperationID  string
+    Aliases           []string
+    Description       string
+    RequestParameters RequestParameters
+    Versions          []CommandVersion
+    Watcher           *WatcherProperties
+}
+
+type RequestParameters struct {
+    URL             string       // e.g. /api/atlas/v2/groups/{groupId}/clusters
+    QueryParameters []Parameter
+    URLParameters   []Parameter
+    Verb            string       // e.g. http.MethodGet
+}
+
+type CommandVersion struct {
+    Version              Version    // StableVersion | UpcomingVersion | PreviewVersion
+    Sunset               *time.Time
+    PublicPreview        bool
+    Deprecated           bool
+    RequestContentType   string     // e.g. "json"
+    ResponseContentTypes []string   // e.g. ["json", "csv"]
+}
+
+type Parameter struct {
+    Name        string
+    Aliases     []string
+    Short       string
+    Description string
+    Required    bool
+    Type        ParameterType  // {IsArray bool, Type "string"|"int"|"bool"}
+}
+```
+
+These types live in `tools/shared/api`, which has no CLI dependencies. That is deliberate — anything that needs to understand commands imports this package, not Cobra or any CLI-specific package.
+
+### Version model
+
+Atlas API versions take one of three forms:
+
+* `2023-02-01` — a stable, date-stamped version
+* `2023-02-01.upcoming` — not yet generally available, same date format
+* `preview` — undated; subject to breaking changes at any time
+
+The `Version` interface has `StabilityLevel()`, `Less()`, `Equal()`, and `String()`. The generator sorts versions oldest-first and drops any version whose `Sunset` date is already in the past at generation time.
+
+Atlas uses versioned content types to express both version and format in a single header value:
+
+```
+application/vnd.atlas.2023-02-01+json
+```
+
+The generator parses these from the `responses` and `requestBody` content keys to build `CommandVersion.ResponseContentTypes` and `CommandVersion.RequestContentType`.
+
+### What gets skipped
+
+An operation is skipped (produces no command) if:
+
+* It has `x-xgen-atlascli: skip: true` in the overlay.
+* It has zero non-sunset versions after the sunset filter runs (the endpoint is fully retired).
+* It has more or fewer than exactly one tag (the tag becomes the command group name; ambiguity is a generator error).
+
+---
+
+## Stage 4: Runtime wiring
+
+`internal/cli/api/api.go` is the only file that knows about Cobra. `Builder()` does one thing: iterate `api.Commands` and register every command.
+
+For each `Group`, it creates a `cobra.Command` with `Use` set to the camelCase tag name.
+
+For each `Command` within a group, `convertAPIToCobraCommand()`:
+
+1. Sets `Use` to the camelCase `operationId` (or `shortOperationId` if set, with the original as an alias).
+2. Registers a `--version` flag listing all supported versions; the default is the newest stable version.
+3. Registers `--output` (content type / format) and `--output-file`.
+4. Registers `--file` for mutations that have a request body.
+5. Registers `--watch` and `--watch-timeout` if the command has a watcher.
+6. Registers every URL parameter and query parameter as a typed `--flag`.
+7. Installs a `NormalizeFunc` that rewrites flag aliases to canonical names before Cobra processes them.
+8. In `PreRunE`, fills untouched flags from the user's profile (so `--projectId` does not need to be typed every time).
+9. In `RunE`, builds a `CommandRequest`, executes it via the `Executor`, formats the output, and optionally runs the watcher.
+
+The executor (`internal/api/executor.go`) is a thin wrapper around an HTTP client. It calls `ConvertToHTTPRequest()`, which builds the full URL, query string, and `Accept`/`Content-Type` headers, then executes the request.
+
+---
+
+## Watchers
+
+Some API operations are asynchronous. You call `POST /clusters` and the cluster spends several minutes provisioning. Watchers let the user pass `--watch` and block until the cluster reaches a stable state.
+
+A watcher is defined in the overlay as a property on the triggering operation:
+
+```yaml
+x-xgen-atlascli:
+  watcher:
+    get:
+      operation-id: getGroupCluster     # which operation to poll
+      version: "2024-08-05"
+      params:
+        clusterName: body:$.name        # extract from mutation response
+        groupId: body:$.groupId
+    expect:
+      match:
+        path: $.stateName               # JSONPath into the poll response
+        values:
+          - IDLE
+```
+
+The `params` mapping uses a three-function DSL:
+
+* `input:<flag>` — copy the value from the original mutation's CLI flag
+* `body:<jsonpath>` — extract from the mutation's JSON response body
+* `const:<value>` — use a literal string
+
+The generator validates that:
+
+* The `operation-id` exists in the command tree.
+* The specified `version` exists on that operation.
+* Every parameter named in `params` exists on the watcher operation.
+* No required parameters on the watcher operation are missing from `params`.
+
+Misconfigured watchers are caught at generation time, not at runtime.
+
+At runtime, `Watcher.Wait()` polls once per second using `WatchOne()`, which executes the GET command and checks the HTTP code and/or a JSONPath condition against the response body.
+
+---
+
+## Applying this to an MCP server
+
+The data model and the HTTP execution layer are fully reusable. The only thing that changes is the consumer layer — instead of Cobra commands, you register MCP tools.
+
+### What stays the same
+
+* The upstream spec and overlay files. You can add a new extension namespace (`x-mcp`) alongside `x-xgen-atlascli` in the same overlay files if you need MCP-specific customizations, or keep them in separate overlay files and apply both sets.
+* The apply-overlay binary. It's a generic OpenAPI Overlay implementation with no Atlas CLI knowledge.
+* The `tools/shared/api` data model. `Command`, `Parameter`, `CommandVersion`, `Version`, and `WatcherProperties` are the portable intermediate representation.
+* The version parsing and sorting logic.
+* The watcher validation logic.
+
+### What changes
+
+**The generator template.** Replace `commands.go.tmpl` with a template that emits your target language's tool registration syntax. For a TypeScript MCP server, this might emit an array of `{ name, description, inputSchema, handler }` objects. For Python, it might emit a list of `@mcp.tool` decorated functions. The template receives the same sorted `GroupedAndSortedCommands` data — only the output format changes.
+
+**The executor consumer.** Instead of `internal/cli/api`, you write an MCP tool handler. That handler receives the tool call's arguments (which map to `Parameters`), constructs a `CommandRequest`, calls `executor.ExecuteCommand()`, and returns the result as an MCP tool response.
+
+**Flag-to-schema translation.** Cobra flags become JSON Schema properties in the MCP `inputSchema`. The `Parameter` struct has everything you need: `Name`, `Description`, `Required`, `Type.Type` (`string`/`int`/`bool`), and `Type.IsArray`. URL parameters and query parameters are both flat properties on the schema — there is no distinction from the tool caller's perspective.
+
+**Version selection.** In the CLI, the user passes `--version`. In MCP, you either expose this as an optional input property or pin the newest stable version at generation time. Pinning at generation time is simpler and better for most MCP use cases, since tool callers are not expected to know Atlas API versioning.
+
+**Watchers.** In the CLI, watchers block synchronously with a polling loop. In MCP, you can model this as a streaming response, as a separate `waitFor<Operation>` tool, or by polling in the tool handler before returning. The `WatcherProperties` struct is the spec for all three approaches.
+
+**Skipping operations.** Not every Atlas API endpoint makes sense as an MCP tool. Use the existing `x-xgen-atlascli: skip: true` mechanism, or add `x-mcp: skip: true` in a new overlay. The generator only needs a small change to check the new flag.
+
+### Recommended architecture
+
+```
+spec.yaml
+    │
+    ▼
+apply-overlay (existing tool, unchanged)
+    │
+    ▼
+spec-with-overlays.yaml
+    │
+    ├──► api-generator --output-type commands  →  internal/api/commands.go  (CLI)
+    │
+    └──► mcp-generator --output-type tools     →  src/generated/tools.ts    (MCP)
+         (new binary; same parsing logic, different template)
+```
+
+Both generators can share the spec parsing code. If the codebase is Go, extract the `specToCommands()` conversion into a shared package and import it in both binaries. If the MCP server is in a different language, the generator is still written in Go and emits code in the target language — the same way `api-generator` emits Go from a Go program.
+
+The clean separation between parse/convert (generator) and consume (CLI or MCP) is what makes this adaptation tractable. You are not refactoring the existing CLI; you are adding a parallel consumer that reads the same intermediate data.
+
+---
+
+## Invariants worth preserving
+
+A few properties of the existing framework are worth carrying over deliberately, because they are easy to break when adapting to a new context.
+
+**Validation at generation time.** Watcher correctness, parameter deduplication, and required-field coverage are all caught during `make gen-api-commands`. This keeps the runtime clean. If you add MCP-specific validation (e.g., tool name uniqueness, schema type compatibility), put it in the generator, not in the server startup code.
+
+**The spec is never forked.** Every customization goes through an overlay. The moment you start editing `spec.yaml` directly, you lose the ability to upgrade from the upstream API team without a painful merge.
+
+**The generated file is committed.** `commands.go` is checked into version control even though it is generated. This means CI sees exactly what the server will run, diffs are reviewable in PRs, and there is no build-time dependency on the spec at server startup. Apply the same practice to whatever file the MCP generator produces.
+
+**Sort order is deterministic.** Groups and commands are sorted alphabetically. Templates iterate with `range .` on sorted slices, not on maps. This ensures the generated file is stable across runs even when the spec's internal map ordering changes.

--- a/docs/mcp-autogen-proposal.md
+++ b/docs/mcp-autogen-proposal.md
@@ -1,0 +1,431 @@
+# Proposal: Auto-generation Framework for the MongoDB MCP Server
+
+**Status:** Draft  
+**Scope:** Atlas Admin API tool surface for the MongoDB MCP Server  
+**References:** `docs/autogen-framework-design.md`, `docs/mcp-tool-generation-alternatives.md`, `docs/mcp-tool-design-research.md`
+
+---
+
+## Problem
+
+The MongoDB MCP Server needs to expose Atlas Admin API operations as MCP tools. The Atlas Admin API has roughly 700 operations. Without a generation pipeline, that surface requires hand-maintained tool definitions that will drift the moment the API changes.
+
+The Atlas CLI already solved this problem for CLI commands. The proposal is to extend that solution to the MCP server — reusing the spec, the overlay mechanism, and the executor, while adding a new generator output and a tool surface designed for agents rather than humans.
+
+This is not a port of the CLI to MCP. An agent cannot browse a hierarchy and tab-complete through 700 operations. The tool surface must be designed around user intents, not API coverage, and the generation pipeline must enforce that.
+
+---
+
+## Proposed architecture
+
+```
+tools/internal/specs/spec.yaml          (upstream Atlas API spec, never edited)
+          │
+          ▼
+    apply-overlay                        (existing, unchanged)
+          │
+          ▼
+tools/internal/specs/spec-with-overlays.yaml
+          │
+          ├──► api-generator --output-type commands
+          │         └──► internal/api/commands.go          (CLI, unchanged)
+          │
+          └──► api-generator --output-type mcp-tools
+                    └──► internal/api/mcp_tools_gen.go     (MCP, new)
+                              │
+                              ▼
+                    MongoDB MCP Server
+                    (imports mcp_tools_gen.go or reads equivalent)
+```
+
+The generator gains a new output mode. Everything upstream of it — the spec, the overlays, the `apply-overlay` binary, the `Command` data model, the watcher validation, the executor — is unchanged. The MCP server imports the generated output and wires it into tool registration at startup.
+
+If the MCP server is in a separate repository, the generated file is published as a Go module or copied in CI, the same way generated protobuf files are handled in practice.
+
+---
+
+## Tool surface design
+
+The server exposes three layers. Each layer has a different purpose and a different generation strategy.
+
+### Layer 1 — Workflow tools (primary surface)
+
+Workflow tools are the tools an agent reaches for first. Each one maps to a user intent, not an API operation. The input schema is small (4–8 parameters), the description is written for agent consumption, and the implementation sequences multiple API calls internally.
+
+Target: **25–35 workflow tools** at launch, covering the top intents across Atlas domains.
+
+Initial workflow set, organized by domain:
+
+**Clusters**
+* `atlas_create_cluster` — Create a new cluster and wait until it is ready. Returns connection strings. Internally: `createCluster` → poll `getGroupCluster` until `stateName == IDLE`.
+* `atlas_delete_cluster` — Delete a cluster and wait until it is removed. Internally: `deleteCluster` → poll `getGroupCluster` until 404.
+* `atlas_pause_cluster` — Pause a running cluster. Internally: `updateCluster` with `paused: true` → poll until `stateName == IDLE`.
+* `atlas_resume_cluster` — Resume a paused cluster. Internally: `updateCluster` with `paused: false` → poll until `stateName == IDLE`.
+* `atlas_scale_cluster` — Change instance size. Internally: `updateCluster` with new `instanceSize` → poll until `stateName == IDLE`.
+* `atlas_get_cluster_status` — Return current state, tier, and connection strings for a cluster. Internally: `getGroupCluster`.
+
+**Projects**
+* `atlas_create_project` — Create a new project. Returns project ID. Internally: `createProject`.
+* `atlas_list_projects` — List all projects the caller can access. Internally: `listProjects`.
+* `atlas_get_project` — Get details for a specific project by ID or name. Internally: `getProject` or `getProjectByName`.
+
+**Database Users**
+* `atlas_create_database_user` — Create a database user with specified roles. Internally: `createDatabaseUser`.
+* `atlas_delete_database_user` — Remove a database user. Internally: `deleteDatabaseUser`.
+* `atlas_list_database_users` — List all database users in a project. Internally: `listDatabaseUsers`.
+
+**Network Access**
+* `atlas_allow_ip_access` — Add an IP address or CIDR block to the project IP access list. Internally: `createProjectIpAccessList`.
+* `atlas_remove_ip_access` — Remove an IP address from the access list. Internally: `deleteProjectIpAccessList`.
+* `atlas_list_ip_access` — List current IP access list entries. Internally: `listProjectIpAccessLists`.
+
+**Backups**
+* `atlas_list_snapshots` — List available snapshots for a cluster. Internally: `listReplicaSetBackups`.
+* `atlas_create_snapshot` — Trigger an on-demand snapshot. Internally: `takeSnapshot` → poll until snapshot state is `COMPLETED`.
+* `atlas_restore_snapshot` — Restore a snapshot to a cluster. Internally: `createBackupRestoreJob` → poll until job state is `COMPLETED`.
+
+**Search**
+* `atlas_create_search_index` — Create an Atlas Search index on a collection. Internally: `createAtlasSearchIndex` → poll until index status is `READY`.
+* `atlas_list_search_indexes` — List all search indexes on a cluster. Internally: `listAtlasSearchIndexes`.
+* `atlas_delete_search_index` — Delete a search index. Internally: `deleteAtlasSearchIndex`.
+
+**Streams (Atlas Stream Processing)**
+* `atlas_create_stream_instance` — Create a stream processing instance. Internally: `createStreamInstance`.
+* `atlas_list_stream_instances` — List stream instances in a project. Internally: `listStreamInstances`.
+
+**Serverless**
+* `atlas_create_serverless_instance` — Create a serverless instance. Internally: `createServerlessInstance` → poll until state is `IDLE`.
+* `atlas_delete_serverless_instance` — Delete a serverless instance. Internally: `deleteServerlessInstance`.
+
+These are the starting 25. More are added over time based on observed agent usage patterns (see the evolution strategy section).
+
+### Layer 2 — Curated raw tools (fallback surface)
+
+Raw tools expose individual API operations for cases no workflow covers. They use API-shaped descriptions but have description overrides in overlays to add agent-centric guidance.
+
+Target: **50–70 raw tools** covering the operations agents actually need.
+
+Selection criteria for inclusion:
+* Mutations (POST/PATCH/PUT/DELETE) that are not covered by a workflow and have clear standalone value.
+* Read operations that are parameterized enough that they cannot be meaningfully expressed as MCP Resources (search queries, filtered lists with many parameters).
+* Operations frequently requested in Atlas CLI telemetry.
+
+Explicit exclusions:
+* Pure audit/compliance endpoints (billing, invoice details, audit log configuration).
+* Admin-only operations requiring Organization Owner or higher that an agent is unlikely to have.
+* Deprecated operations and operations with only sunset versions.
+* Any operation that returns binary data (gzip dumps, etc.).
+* Metrics and monitoring endpoints — these are best served via Resources or a dedicated observability tool.
+
+Tool names for raw tools follow `{service}_{verb}_{noun}` using the operation's `x-xgen-atlascli: operationId` override where it exists, falling back to the camelCase `operationId`. The `x-mcp: tool-name` overlay key overrides both for agent-specific clarity.
+
+### Layer 3 — Read resources
+
+GET operations that return a single resource by ID or a simple list with minimal parameters become MCP Resources. They are accessible via URI template and do not consume tool slots.
+
+URI scheme: `atlas://{resourceType}/{...pathParams}`
+
+Examples:
+```
+atlas://clusters/{groupId}/{clusterName}
+atlas://projects/{groupId}
+atlas://database-users/{groupId}/{databaseName}/{username}
+atlas://search-indexes/{groupId}/{clusterName}/{indexId}
+```
+
+The generator emits resource templates for all GET operations marked with `x-mcp: expose-as: resource` in the overlay. The default is to not emit resources — resource designation is opt-in because GET operations with many query parameters are poor resources and are better excluded or expressed as raw tools.
+
+---
+
+## Progressive tool discovery
+
+With 25–35 workflow tools and 50–70 raw tools, the total is 75–105 tools. That exceeds the ~30-tool threshold where model performance begins to degrade noticeably.
+
+The solution is session-scoped tool discovery, following Amazon Prime Video's pattern.
+
+**Default visible tools** when a session starts:
+* All 25–35 workflow tools (always visible — these are curated and small enough).
+* One meta-tool: `atlas_find_tools`.
+
+`atlas_find_tools` accepts a `domain` parameter (an enum) and returns the raw tools for that domain. After the call, the server sends a tool list change notification. The client re-fetches the tool list, and the session now has workflow tools + the requested domain's raw tools in context.
+
+```
+domain options:
+  clusters     → raw cluster operations (resize, upgrade, modify, etc.)
+  projects     → project settings, teams, alerts
+  users        → database users, custom roles, LDAP
+  networking   → VPC peering, private endpoints, network containers
+  backups      → backup schedules, export, compliance policies
+  search       → search index management, analyzers
+  monitoring   → metrics, logs, performance advisor
+  advanced     → everything else
+```
+
+An agent focused on cluster management sees workflow tools + ~10 cluster raw tools. It never loads monitoring tools, project audit tools, or backup tools unless explicitly switching domains. Context stays under 40 tools in all practical cases.
+
+**Implementation notes:**
+* `atlas_find_tools` is always included in generation output.
+* Domain → tool mapping is static (generated), not dynamic. The server does not need to query anything to answer `atlas_find_tools`.
+* Session state for "which domains are loaded" lives in the MCP session. The 2026 MCP roadmap is evolving stateful session semantics — the implementation should be designed to work statelessly if session tracking becomes unreliable (i.e., always-available workflow tools must function without having called `atlas_find_tools` first).
+
+---
+
+## Generator changes
+
+### New `--output-type mcp-tools` flag
+
+The `api-generator` binary gains a third output type. The existing `commands` and `metadata` modes are unchanged.
+
+In `mcp-tools` mode, the generator produces a Go source file containing:
+1. A `MCPWorkflowTools` slice — workflow tool definitions with step sequences.
+2. A `MCPRawTools` slice — single-operation tool definitions, filtered by `x-mcp: skip`.
+3. A `MCPResources` slice — resource templates, populated by `x-mcp: expose-as: resource`.
+4. A `MCPToolDomains` map — the domain → raw tool name mapping for `atlas_find_tools`.
+
+The file structure mirrors `commands.go`: a static Go variable, committed to version control, formatted with `go/format`, with a `// Code generated` header.
+
+### New template: `mcp_tools.go.tmpl`
+
+Added alongside `commands.go.tmpl`. Receives the same `GroupedAndSortedCommands` data plus workflow definitions parsed from `x-mcp-workflows`. Emits MCP tool registration structs rather than Cobra commands.
+
+### Workflow resolver
+
+The generator gains a workflow resolution pass that runs before template execution:
+
+1. Reads `x-mcp-workflows` from the overlaid spec.
+2. For each workflow step that references an `operationId`, resolves it to the corresponding `Command` struct.
+3. Validates that all referenced operation IDs exist, all referenced parameters exist on those operations, and no required parameters are unaccounted for in the step's `params` mapping.
+4. Emits validation errors that fail the build — misconfigured workflow definitions are caught at `make gen-api-commands` time, not at runtime.
+
+This validation follows the same pattern as watcher validation in the existing generator.
+
+### Tool name generation
+
+MCP tool names are generated from the `operationId` (or `x-xgen-atlascli: operationId` override if set) using this priority:
+
+1. `x-mcp: tool-name` (explicit override in overlay)
+2. `x-xgen-atlascli: short-operation-id` prefixed with `atlas_`
+3. `operationId` in `snake_case` prefixed with `atlas_`
+
+All generated tool names are validated for uniqueness across the full tool set. Collisions fail the build.
+
+---
+
+## New overlay extensions
+
+### Per-operation extensions (`x-mcp`)
+
+```yaml
+x-mcp:
+  skip: true                    # exclude from MCP entirely
+  expose-as: resource           # emit as MCP Resource, not Tool
+  tool-name: "atlas_my_name"    # override generated tool name
+  tool-description: |           # agent-centric description (overrides spec description)
+    Use this to ... Requires ...
+  domain: networking            # assign to a discovery domain (raw tools only)
+```
+
+### Top-level workflow definitions (`x-mcp-workflows`)
+
+These live at the document root, not on individual operations:
+
+```yaml
+x-mcp-workflows:
+  <workflowId>:
+    tool-name: "atlas_create_cluster"
+    description: |
+      Creates a new Atlas cluster and waits until it is ready to accept connections.
+      Use this when the user wants to provision a new database cluster in a project.
+      Requires: project ID, cluster name, cloud provider, and region.
+    input:
+      groupId:
+        type: string
+        description: "The project ID. Use atlas_list_projects to find it."
+        required: true
+      clusterName:
+        type: string
+        description: "Name for the new cluster. Must be unique within the project."
+        required: true
+      provider:
+        type: string
+        enum: [AWS, GCP, AZURE]
+        description: "Cloud provider to deploy on."
+        required: true
+      region:
+        type: string
+        description: "Provider region code (e.g. US_EAST_1 for AWS, us-east1 for GCP)."
+        required: true
+      tier:
+        type: string
+        description: "Instance size tier. Defaults to M10."
+        default: "M10"
+    steps:
+      - id: create
+        operationId: createCluster
+        version: "2024-08-05"
+        body:
+          name: "{{ .Input.clusterName }}"
+          clusterType: REPLICASET
+          replicationSpecs:
+            - zoneName: Zone 1
+              regionConfigs:
+                - providerName: "{{ .Input.provider }}"
+                  regionName: "{{ .Input.region }}"
+                  electableSpecs:
+                    instanceSize: "{{ .Input.tier }}"
+                    nodeCount: 3
+      - id: wait
+        type: poll
+        operationId: getGroupCluster
+        version: "2024-08-05"
+        params:
+          groupId: "{{ .Input.groupId }}"
+          clusterName: "{{ .Steps.create.response.name }}"
+        until:
+          path: $.stateName
+          values: [IDLE]
+        timeout: 1800
+        interval: 10
+    output:
+      clusterName: "{{ .Steps.wait.response.name }}"
+      connectionString: "{{ .Steps.wait.response.connectionStrings.standardSrv }}"
+      state: "{{ .Steps.wait.response.stateName }}"
+    on-error:
+      partial-completion: |
+        The cluster was created but did not reach IDLE state within the timeout.
+        The cluster may still be provisioning. Use atlas_get_cluster_status to check.
+```
+
+The template DSL uses Go template syntax (`{{ .Input.x }}`, `{{ .Steps.id.response.x }}`). The generator validates that all referenced fields exist in the input schema or step outputs at generation time.
+
+---
+
+## Overlay file strategy
+
+New overlays live in `tools/internal/specs/overlays/` alongside the existing CLI overlays, following the same naming convention and sort order.
+
+Files to create:
+
+```
+overlays/
+  (existing CLI overlays)
+  mcp_skip_audit.yaml           — skip audit/billing/compliance endpoints
+  mcp_skip_deprecated.yaml      — skip endpoints with only deprecated versions
+  mcp_skip_binary.yaml          — skip endpoints returning non-JSON content
+  mcp_domains.yaml              — assign domain tags to raw operations
+  mcp_tool_descriptions.yaml    — agent-centric description overrides
+  mcp_resources.yaml            — mark GET operations as Resources
+  mcp_workflows.yaml            — workflow definitions (the primary authorship surface)
+```
+
+The `mcp_workflows.yaml` overlay is the most important file and the primary artifact that requires human authorship. Everything else is mechanical. This file is what the engineering team maintains as the Atlas API evolves.
+
+---
+
+## Runtime tool handler
+
+In the MCP server, tool invocation works as follows:
+
+**For raw tools:**
+1. Receive tool call with arguments.
+2. Look up the `Command` definition from the generated `MCPRawTools` slice.
+3. Map tool arguments to `CommandRequest.Parameters` (flat key → `[]string`).
+4. Select the pinned version (newest stable, determined at generation time).
+5. Call `executor.ExecuteCommand()`.
+6. Return JSON response body or structured error.
+
+**For workflow tools:**
+1. Receive tool call with arguments.
+2. Look up the workflow definition from `MCPWorkflowTools`.
+3. Execute steps sequentially, passing data between steps via the template DSL resolver.
+4. For `poll` steps, loop with configurable interval and timeout.
+5. Return the output projection from the final step.
+6. On mid-workflow error, return the structured `on-error` message from the workflow definition.
+
+**Authentication** is handled at the executor level, identical to how the CLI does it. The MCP server gets an HTTP client wired with Atlas credentials (API key or OAuth token). The tool handler never handles credentials directly.
+
+**Version pinning** — MCP tools do not expose `--version`. The generator pins each raw tool to its newest non-deprecated stable version at generation time. Workflow tools pin versions per-step in the workflow definition. Version selection is a generation-time decision, not a runtime decision.
+
+---
+
+## Implementation phases
+
+### Phase 1 — Generator foundation (2 weeks)
+
+Deliverables:
+* `--output-type mcp-tools` flag on `api-generator`.
+* New `mcp_tools.go.tmpl` template that emits raw tool definitions (no workflows yet).
+* `x-mcp: skip`, `x-mcp: domain`, and `x-mcp: tool-name` extension support.
+* Initial skip overlays (`mcp_skip_audit.yaml`, `mcp_skip_deprecated.yaml`, `mcp_skip_binary.yaml`).
+* Domain assignment overlay (`mcp_domains.yaml`).
+* Generated `internal/api/mcp_tools_gen.go` committed.
+* Unit tests for tool name generation, skip logic, and domain assignment.
+
+At the end of Phase 1, the MCP server has ~300–400 auto-generated raw tool definitions (before any description curation). These are not ready for agent use but establish the generation pipeline.
+
+### Phase 2 — Description curation and tool reduction (2 weeks)
+
+Deliverables:
+* `x-mcp: tool-description` overlay support.
+* `mcp_tool_descriptions.yaml` overlay with agent-centric descriptions for the 50–70 retained raw tools.
+* All operations not in the retained set marked `x-mcp: skip: true`.
+* `atlas_find_tools` meta-tool, statically generated from the domain map.
+* Progressive discovery in the MCP server (session → domain mapping, tool list change notifications).
+* Integration test: agent can call `atlas_find_tools`, receive domain tools, and successfully use them.
+
+At the end of Phase 2, the raw tool surface is agent-usable and the discovery mechanism is working.
+
+### Phase 3 — Workflow tools (3 weeks)
+
+Deliverables:
+* `x-mcp-workflows` overlay parsing and resolution in the generator.
+* Workflow step validation (operation ID exists, parameters exist, required params covered).
+* Workflow tool emission in `mcp_tools.go.tmpl`.
+* Workflow executor in the MCP server (step sequencing, poll loops, data flow resolution, timeout/error handling).
+* `mcp_workflows.yaml` with the initial 25-tool workflow set (see Layer 1 above).
+* Integration tests per workflow: happy path + poll timeout + mid-workflow error.
+
+At the end of Phase 3, the server has a complete three-layer tool surface.
+
+### Phase 4 — Resources and polish (1 week)
+
+Deliverables:
+* `x-mcp: expose-as: resource` support in generator.
+* `mcp_resources.yaml` overlay with initial resource designations.
+* Resource handler in the MCP server.
+* End-to-end agent evaluation: run a representative set of Atlas management tasks and measure tool selection accuracy and task completion rate.
+* Documentation for overlay authors (how to add a new workflow, how to adjust domain assignments).
+
+---
+
+## What this proposal explicitly does not cover
+
+**Telemetry and usage instrumentation.** The MCP server needs to track which tools get called, which fail, and which get retried, in order to drive the workflow evolution strategy. That is a separate design.
+
+**Authentication flows.** The proposal assumes the MCP server already handles credential acquisition. It does not propose changing how the server authenticates to Atlas.
+
+**Multi-project context.** The current design requires `groupId` on most calls. A more ergonomic design might infer the project from a session-level default. That is a session management question outside the scope of generation.
+
+**Tool evolution governance.** As agents use the server in production, the observable signals (retry rates, tool sequences) should feed back into overlay changes. Who owns `mcp_workflows.yaml`, what the review process looks like, and how often overlays are updated — that needs a process design that is separate from the technical design.
+
+**Streaming responses.** Workflow tools currently poll synchronously. For very long operations (cluster creation can take 15+ minutes), polling in the tool handler may time out before the client does. Streaming via MCP's SSE transport is the right long-term answer but requires MCP server infrastructure changes outside this proposal's scope.
+
+---
+
+## Open questions
+
+**Should the generator live in the Atlas CLI repository or in the MCP server repository?**
+
+The generator should stay in the Atlas CLI repository, next to the spec and overlays it reads. The MCP server imports the generated Go file. Keeping the generator with the spec prevents the overlay and spec from diverging across two repositories. The MCP server's only build-time dependency is the generated file, not the generator or the spec.
+
+**Should raw tools pin to newest stable or allow version selection?**
+
+The proposal recommends pinning at generation time to the newest non-deprecated stable version. Exposing version selection to agents adds complexity with little benefit — agents do not know Atlas API version semantics and will not make good version choices. If a user explicitly needs a specific version, they should use the CLI. If this assumption is wrong for a specific use case, it can be revisited.
+
+**How are breaking changes in workflows handled?**
+
+If a workflow's underlying `operationId` changes or is removed from the spec, the generator will fail the build — the same way a missing watcher `operationId` fails today. That is intentional. Breaking API changes require an explicit overlay update before the build passes. This ensures breaking changes are surfaced and handled, rather than silently producing a broken tool.
+
+**What is the right timeout for poll steps?**
+
+The proposal sets 1800 seconds (30 minutes) as the default for cluster operations. That covers normal cluster creation (typically 7–12 minutes) with headroom. The timeout is configurable per workflow step in the overlay definition. The MCP client's own timeout may be shorter than the workflow timeout, in which case the tool call will fail with a partial completion message. This is a known limitation until streaming is implemented.

--- a/docs/mcp-tool-catalog.md
+++ b/docs/mcp-tool-catalog.md
@@ -1,0 +1,301 @@
+# MongoDB MCP Server — Tool Catalog
+
+This document shows the full proposed tool list across all layers, with MCP safety annotations and implementation status against the current codebase.
+
+**Status key:**
+- ✅ **EXISTS** — tool already exists in the codebase with this name
+- 🔄 **RENAME** — equivalent tool exists under a different name; needs renaming
+- ⚙️ **EXTEND** — related tool exists but needs significant extension (e.g. polling, richer output)
+- 🆕 **NEW** — no equivalent; needs to be built
+
+---
+
+## How the codebase derives annotations today
+
+The base `ToolBase` class in `src/tools/tool.ts` maps `operationType` to `ToolAnnotations` automatically:
+
+```
+"read" | "metadata" | "connect"  →  readOnlyHint: true,  destructiveHint: false
+"delete"                          →  readOnlyHint: false, destructiveHint: true
+"create" | "update"               →  readOnlyHint: false, destructiveHint: false
+```
+
+`idempotentHint` and `openWorldHint` are not set today — they take spec defaults (`false` and `true` respectively). The proposal is to add explicit `idempotentHint` support to `ToolBase` so workflow tools and PATCH-backed raw tools can declare it.
+
+---
+
+## Layer 1 — Workflow tools (always visible, 25 tools)
+
+### Clusters
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-create-cluster` | ⚙️ EXTEND | `atlas-create-free-cluster` | create | — | — | — |
+| `atlas-delete-cluster` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-pause-cluster` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-resume-cluster` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-scale-cluster` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-get-cluster-status` | ⚙️ EXTEND | `atlas-inspect-cluster` | read | ✓ | — | ✓ |
+
+Notes:
+- `atlas-create-free-cluster` only creates M0 free tier clusters. `atlas-create-cluster` needs to support paid tiers with provider/region/tier params and poll until `stateName == IDLE`.
+- `atlas-inspect-cluster` exists but returns raw cluster metadata. `atlas-get-cluster-status` should return a simplified, agent-friendly shape (state, connection string, tier) and is the rename target.
+
+### Projects
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-create-project` | ✅ EXISTS | `atlas-create-project` | create | — | — | — |
+| `atlas-list-projects` | ✅ EXISTS | `atlas-list-projects` | read | ✓ | — | ✓ |
+| `atlas-get-project` | 🆕 NEW | — | read | ✓ | — | ✓ |
+
+### Database Users
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-create-database-user` | 🔄 RENAME | `atlas-create-db-user` | create | — | — | — |
+| `atlas-delete-database-user` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-list-database-users` | 🔄 RENAME | `atlas-list-db-users` | read | ✓ | — | ✓ |
+
+Note: `atlas-create-db-user` and `atlas-list-db-users` use abbreviated names. Proposal is to rename to the full `database-user` form for consistency.
+
+### Network Access
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-allow-ip-access` | ⚙️ EXTEND | `atlas-create-access-list` | create | — | — | ✓ |
+| `atlas-remove-ip-access` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-list-ip-access` | 🔄 RENAME | `atlas-inspect-access-list` | read | ✓ | — | ✓ |
+
+Note: `atlas-create-access-list` is the closest existing tool. `atlas-allow-ip-access` is a more agent-friendly name (the verb describes intent). `atlas-inspect-access-list` → `atlas-list-ip-access` for naming consistency.
+
+### Backups
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-list-snapshots` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-snapshot` | 🆕 NEW | — | create | — | — | — |
+| `atlas-restore-snapshot` | 🆕 NEW | — | delete* | — | ✓ | — |
+
+*`atlas-restore-snapshot` uses `operationType: "delete"` so it gets `destructiveHint: true` automatically, which is correct — restoring overwrites live data.
+
+### Search
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-create-search-index` | 🆕 NEW | — | create | — | — | — |
+| `atlas-list-search-indexes` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-delete-search-index` | 🆕 NEW | — | delete | — | ✓ | — |
+
+### Streams
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-create-stream-instance` | ⚙️ EXTEND | `atlas-streams-build` | create | — | — | — |
+| `atlas-list-stream-instances` | ⚙️ EXTEND | `atlas-streams-discover` | read | ✓ | — | ✓ |
+
+Note: `atlas-streams-build` and `atlas-streams-discover` cover streams creation and discovery. The rename/extension aligns them with the `atlas-{verb}-{resource}` naming pattern.
+
+### Serverless
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-create-serverless-instance` | 🆕 NEW | — | create | — | — | — |
+| `atlas-delete-serverless-instance` | 🆕 NEW | — | delete | — | ✓ | — |
+
+### Discovery meta-tool
+
+| Tool | Status | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|
+| `atlas-find-tools` | 🆕 NEW | read | ✓ | — | ✓ |
+
+---
+
+## Layer 2 — Raw tools by domain (loaded via `atlas-find-tools`)
+
+### Domain: `clusters` (12 tools)
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-list-clusters` | ✅ EXISTS | `atlas-list-clusters` | read | ✓ | — | ✓ |
+| `atlas-get-cluster` | ⚙️ EXTEND | `atlas-inspect-cluster` | read | ✓ | — | ✓ |
+| `atlas-update-cluster` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-get-cluster-advanced-settings` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-update-cluster-advanced-settings` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-enable-termination-protection` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-disable-termination-protection` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-get-connection-strings` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-upgrade-cluster-version` | 🆕 NEW | — | update | — | — | — |
+| `atlas-test-failover` | 🆕 NEW | — | update | — | — | — |
+| `atlas-list-cloud-provider-regions` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-list-cluster-instance-sizes` | 🆕 NEW | — | read | ✓ | — | ✓ |
+
+### Domain: `projects` (10 tools)
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-delete-project` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-get-project-settings` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-update-project-settings` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-list-project-teams` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-add-team-to-project` | 🆕 NEW | — | create | — | — | — |
+| `atlas-remove-team-from-project` | 🆕 NEW | — | delete | — | — | — |
+| `atlas-list-alert-configurations` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-alert-configuration` | 🆕 NEW | — | create | — | — | — |
+| `atlas-update-alert-configuration` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-delete-alert-configuration` | 🆕 NEW | — | delete | — | ✓ | — |
+
+### Domain: `users` (8 tools)
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-get-database-user` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-update-database-user` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-list-custom-db-roles` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-custom-db-role` | 🆕 NEW | — | create | — | — | — |
+| `atlas-update-custom-db-role` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-delete-custom-db-role` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-list-project-users` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-remove-project-user` | 🆕 NEW | — | delete | — | — | — |
+
+Note: `atlas-remove-project-user` removes access from a project, not the Atlas account itself, so `destructiveHint` should be `false` despite using `delete` operationType. This is an overlay override case.
+
+### Domain: `networking` (10 tools)
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-list-private-endpoint-services` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-get-private-endpoint-service` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-private-endpoint-service` | 🆕 NEW | — | create | — | — | — |
+| `atlas-delete-private-endpoint-service` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-list-network-peerings` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-network-peering` | 🆕 NEW | — | create | — | — | — |
+| `atlas-delete-network-peering` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-list-network-containers` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-network-container` | 🆕 NEW | — | create | — | — | — |
+| `atlas-delete-network-container` | 🆕 NEW | — | delete | — | ✓ | — |
+
+### Domain: `backups` (10 tools)
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-get-backup-schedule` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-update-backup-schedule` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-get-snapshot` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-delete-snapshot` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-list-restore-jobs` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-get-restore-job` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-list-export-buckets` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-export-bucket` | 🆕 NEW | — | create | — | — | — |
+| `atlas-delete-export-bucket` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-get-backup-compliance-policy` | 🆕 NEW | — | read | ✓ | — | ✓ |
+
+### Domain: `search` (7 tools)
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-get-search-index` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-update-search-index` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-get-search-deployment` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-search-deployment` | 🆕 NEW | — | create | — | — | — |
+| `atlas-update-search-deployment` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-delete-search-deployment` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-list-search-analyzers` | 🆕 NEW | — | read | ✓ | — | ✓ |
+
+### Domain: `monitoring` (8 tools)
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-list-alerts` | ✅ EXISTS | `atlas-list-alerts` | read | ✓ | — | ✓ |
+| `atlas-get-alert` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-acknowledge-alert` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-list-alert-configurations` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-get-measurement` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-list-namespace-metrics` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-get-slow-query-log` | ⚙️ EXTEND | `atlas-get-performance-advisor` | read | ✓ | — | ✓ |
+| `atlas-get-suggested-indexes` | ⚙️ EXTEND | `atlas-get-performance-advisor` | read | ✓ | — | ✓ |
+
+Note: The existing `atlas-get-performance-advisor` bundles both slow query log and index suggestions into one tool. The proposal splits this into two focused tools for clearer agent invocation, each targeting the relevant API endpoint.
+
+### Domain: `advanced` (8 tools)
+
+| Tool | Status | Existing name | operationType | readOnly | destructive | idempotent |
+|---|---|---|---|---|---|---|
+| `atlas-list-organizations` | 🔄 RENAME | `atlas-list-orgs` | read | ✓ | — | ✓ |
+| `atlas-get-organization` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-list-project-api-keys` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-create-project-api-key` | 🆕 NEW | — | create | — | — | — |
+| `atlas-delete-project-api-key` | 🆕 NEW | — | delete | — | ✓ | — |
+| `atlas-get-maintenance-window` | 🆕 NEW | — | read | ✓ | — | ✓ |
+| `atlas-update-maintenance-window` | 🆕 NEW | — | update | — | — | ✓ |
+| `atlas-defer-maintenance-window` | 🆕 NEW | — | update | — | — | — |
+
+---
+
+## Existing tools not in this catalog
+
+These tools exist today but sit outside the proposed auto-gen scope — either because they provide local dev infrastructure or connect the MCP session to an actual cluster.
+
+| Existing tool | Category | Notes |
+|---|---|---|
+| `atlas-connect-cluster` | atlas | Connects the MCP session to an Atlas cluster for MongoDB tools. Retained as-is; not part of the auto-gen framework. |
+| `atlas-streams-manage` | atlas | Manages running stream processor state (start/stop/drop). Retained; streams tooling may be partially auto-gen'd in future. |
+| `atlas-streams-teardown` | atlas | Tears down a stream processing pipeline. Retained. |
+| `atlas-local-create-deployment` | atlas-local | Local Atlas via CLI. Out of scope for API auto-gen. |
+| `atlas-local-connect-deployment` | atlas-local | Out of scope. |
+| `atlas-local-list-deployments` | atlas-local | Out of scope. |
+| `atlas-local-delete-deployment` | atlas-local | Out of scope. |
+| `connect` | mongodb | Direct MongoDB connection. Out of scope. |
+| `switch-connection` | mongodb | Out of scope. |
+| All `mongodb/*` tools | mongodb | CRUD on MongoDB instances, not Atlas API. Out of scope for auto-gen. |
+| `search-knowledge` | assistant | MongoDB docs search. Out of scope. |
+| `list-knowledge-sources` | assistant | MongoDB docs. Out of scope. |
+
+---
+
+## Summary
+
+| Status | Count |
+|---|---|
+| ✅ EXISTS (exact match) | 5 |
+| 🔄 RENAME (same logic, different name) | 5 |
+| ⚙️ EXTEND (exists but needs significant work) | 7 |
+| 🆕 NEW | 82 |
+| **Total proposed** | **99** |
+
+The 5 exact matches: `atlas-create-project`, `atlas-list-projects`, `atlas-list-clusters`, `atlas-list-alerts`, and `atlas-list-clusters` (raw domain duplicate of the workflow-layer read).
+
+The 5 renames touch `db-user` → `database-user`, `orgs` → `organizations`, and `inspect-*` → `list-*`/`get-*`. These are non-breaking if handled with a deprecation alias.
+
+The 7 extensions are all workflow tools that need polling added on top of existing single-operation tools (`atlas-create-free-cluster` → paid tiers + wait, `atlas-inspect-cluster` → simplified output shape, access list + performance advisor splits).
+
+---
+
+## Annotation override cases
+
+The `operationType` → `ToolAnnotations` mapping in `ToolBase` handles the common cases. Two tools need explicit overrides because the automatic mapping is wrong:
+
+**`atlas-remove-project-user` (operationType: `delete`)** — automatically gets `destructiveHint: true`, but removing a user from a project does not delete their Atlas account or any data. Should be `destructiveHint: false`. Requires either a new `operationType` value (`"revoke"`) or an explicit annotation override in the tool class.
+
+**`atlas-restore-snapshot` (operationType: `delete`\*)** — correctly gets `destructiveHint: true`. The asterisk is because this operation is modeled as `delete`-class purely for annotation purposes; internally it calls a POST endpoint. The operationType should be chosen for what it means to the user, not what HTTP verb is used.
+
+A small addition to `ToolBase` that lets individual tool classes override specific annotation fields would handle both cases without changing the automatic mapping for everything else:
+
+```typescript
+// In ToolBase — optional override per tool
+protected annotationOverrides(): Partial<ToolAnnotations> {
+    return {};
+}
+
+public get annotations(): ToolAnnotations {
+    const base = this.baseAnnotations();  // existing switch block
+    return { ...base, ...this.annotationOverrides() };
+}
+```
+
+```typescript
+// In RemoveProjectUserTool
+protected annotationOverrides(): Partial<ToolAnnotations> {
+    return { destructiveHint: false };
+}
+```

--- a/docs/mcp-tool-design-research.md
+++ b/docs/mcp-tool-design-research.md
@@ -1,0 +1,146 @@
+# MCP Tool Design: Research Synthesis
+
+This document synthesizes recent writing (February–May 2026) on building MCP tools, with a focus on what the research says about auto-generation from API specs, tool design at scale, and workflow composition. The goal is to extract what matters for the Atlas CLI → MCP adaptation.
+
+---
+
+## The central finding: 1:1 API-to-tool mapping does not work
+
+This appears in every serious article on the subject. It is not a minor caveat — it is the primary failure mode for MCP servers built by teams coming from API design backgrounds.
+
+The concrete evidence:
+
+* **GitHub Copilot** reduced its tool count from 40 to 13 and saw measurable benchmark improvements.
+* **Block rebuilt its Linear MCP server three times**, going from 30+ tools to 2. Each rebuild was a response to observed agent failures, not a premature optimization.
+* **Chroma research** tested 18 LLMs and found performance degradation as input length grows, even on simple tasks. The assumption that a model handles the 10,000th token as reliably as the 100th does not hold.
+* At 50+ tools, tool schemas alone consume 5–7% of the model's context window before a single user message arrives. That number only gets worse as tool descriptions are made more informative.
+* Anthropic's own guidance puts the accuracy degradation threshold at 30–50 tools. Arcade's research (54 Patterns) puts it even lower in practice.
+
+The failure modes past ~20 tools are two distinct problems. The first is context bloat: schemas, names, and descriptions consume tokens that were needed for reasoning. The second is tool hallucination: models start inventing nonexistent tool names, conflating parameters between tools, or calling the right tool with arguments from a different tool's schema. These are different bugs and require different fixes, but both have the same root cause — too many tools in context.
+
+---
+
+## What Cloudflare learned
+
+The [Cloudflare CF CLI Local Explorer post](https://blog.cloudflare.com/cf-cli-local-explorer/) is the closest analog to the Atlas CLI auto-generation problem that exists in public writing. Cloudflare builds a CLI, an SDK, a Terraform provider, and an MCP server from a single source of truth. Their experience is directly applicable.
+
+**The schema-first architecture.** Cloudflare moved beyond OpenAPI as a source of truth and replaced it with a custom TypeScript schema system. Their description: "The schema format is 'just' a set of TypeScript types with conventions, linting, and guardrails to ensure consistency." From this schema, they generate all their surface areas — CLI, SDK, Terraform, MCP — using different templates against the same model. This is structurally identical to the Atlas CLI approach (spec + overlays → generator → template), but Cloudflare went further by owning the schema format itself rather than adapting OpenAPI.
+
+**Consistency enforced at the schema layer.** Cloudflare establishes guardrails like: always use `get` (never `info`), standardize on `--force` (never `--skip-confirmations`), always support `--json`. These are linting rules on the schema, not conventions in documentation. The result is that agents encounter consistent command shapes across all Cloudflare products, which matters because agents build mental models from patterns — inconsistent naming forces them to treat every tool as novel.
+
+**Local-remote API parity.** Local Explorer mirrors the Cloudflare API for local resources (KV, R2, D1, Durable Objects). Developers and agents interact with identical command structures whether targeting local or remote. This eliminates a class of agent errors where the model understands the operation but gets confused about which environment it is targeting.
+
+**Agent-centric context engineering.** The design uses clear signals about whether commands operate on local or remote resources, predictable defaults, and consistent output formatting. These sound like small decisions but they directly affect whether an agent can reliably interpret results across different tools.
+
+The lesson from Cloudflare is that schema quality and consistency matter more than coverage. A smaller, internally consistent schema with good descriptions produces better agent behavior than a complete schema with variable quality.
+
+---
+
+## The OpenAPI auto-generation landscape
+
+Several tools now generate MCP servers from OpenAPI specs: Stainless, FastMCP, AWS's openapi-mcp-server, Speakeasy's Gram, and various open-source generators. Their existence is useful as a signal — the problem is considered solved at the syntax level. The question is whether that matters.
+
+**Neon's conclusion:** treat auto-generation as a starting point, not a final product. Their process:
+
+1. Use the TypeScript SDK as a foundation (not raw OpenAPI).
+2. Implement only tools that are genuinely appropriate for LLM use.
+3. Build higher-level workflows that combine multiple endpoints — their example is a "streamlined database migration testing" tool that never appears in the raw API.
+4. Aggressively prune everything that doesn't pass the "would an agent actually need this" test.
+
+Neon's word is "aggressively." The implication is that the natural output of a generator requires removing the vast majority of what it produces.
+
+**Speakeasy's conclusion:** documentation quality determines tool quality. The generator handles syntax transformation reliably. Semantic quality — helping agents understand *when* and *how* to use a tool — requires human judgment. Specific gaps that cause hallucinations:
+
+* Unclear endpoint purpose (what is this for, not just what it does)
+* Vague parameter descriptions
+* Missing response examples
+* No guidance on parameter lookup patterns (e.g., "get task IDs via `listTasks` first")
+
+Speakeasy ships an `x-speakeasy-mcp` extension for overriding tool names in agent contexts — a direct parallel to Atlas CLI's `x-xgen-atlascli` extension for CLI-specific customizations. This is not a coincidence; it is the right architectural answer. You cannot fix semantic quality by forking the spec.
+
+**The shared takeaway** across Neon, Speakeasy, and Cloudflare: generation handles the mechanical work. Every generator in this space is essentially doing what Atlas CLI's `api-generator` does — parsing a schema and emitting code via a template. The differentiation is in the curation layer on top: overlays, extensions, and higher-level workflow definitions that inject human judgment into the process without breaking the generation pipeline.
+
+---
+
+## Tool design patterns from the research
+
+Arcade's 54-pattern taxonomy organizes the space across three axes — maturity (atomic to orchestrated), integration type, and access pattern — and ten concern categories. The most practically useful patterns for the Atlas use case:
+
+**Outcomes over operations.** Phil Schmid's formulation is the clearest: instead of `getUser`, `listOrders`, and `getStatus`, expose `trackLatestOrder(email)`. The single tool handles all three API calls internally. This reduces context window bloat and API round-trips simultaneously, and the description can speak to user intent rather than API mechanics.
+
+**Flatten arguments.** Nested objects in tool input schemas cause hallucinations because the model has to reason about structure at the same time as it reasons about values. Top-level primitives with constrained types (enums as `Literal`, explicit string formats) reduce the cognitive load on the model. This is a direct implication for any tool generated from an OpenAPI spec, since REST request bodies are often deeply nested.
+
+**Service-prefixed names.** The `{service}_{action}_{resource}` convention (e.g., `atlas_create_cluster`, `atlas_list_projects`) prevents naming collisions when multiple MCP servers are active simultaneously. It also helps the model identify which server owns a tool without needing to read the description.
+
+**Descriptions written for agents, not developers.** Speakeasy's observation that "humans can infer context from brief descriptions; AI agents cannot" is backed up by real failure data. A description that says "Returns cluster details" fails agents. A description that says "Use this to check if a cluster is ready after creation, or to get connection strings for an existing cluster. Requires a project ID and cluster name." succeeds. The difference is intent guidance, not information density.
+
+**Observable signals drive design evolution.** Arcade's framework provides a practical rule: if you see high retry rates, the tool's description needs work. If you see agents calling the same sequence of tools repeatedly across sessions, that sequence should become a single workflow tool. Let observed failure modes drive the curation decisions, rather than trying to anticipate them entirely upfront.
+
+**Structured error responses that enable self-correction.** Errors should include actionable recovery guidance: "rate limited, retry after 30 seconds" rather than just the HTTP status code. Agents that receive structured errors can self-correct; agents that receive opaque errors stall or hallucinate a recovery path.
+
+**The Tools/Resources/Prompts split.** The DDD article makes a useful point about using all three MCP capability types. Tools for active operations with side effects. Resources for read-only contextual data (accessible via URIs, not tool calls). Prompts for templated workflows that guide the agent through a multi-step process. Keeping GET operations in Resources rather than Tools removes them from the tool list without removing their accessibility.
+
+---
+
+## Progressive tool discovery
+
+Amazon Prime Video faced the problem at scale: a centralized MCP server with hundreds of tools, but individual tasks only needing 3–4 of them. Their solution exploits two MCP protocol features: tool list change notifications and session tracking.
+
+The flow:
+
+1. The agent starts with a single "find tools" meta-tool visible in context.
+2. When the agent calls it with a problem category (operations, results, training, etc.), the server maps that session to the relevant tools.
+3. A notification fires, the agent re-fetches the tool list, and now sees only the 3–4 tools appropriate for its current task.
+4. The agent can switch categories mid-session, dropping old tools and loading new ones.
+
+The result: hundreds of tools become manageable without removing coverage, at the cost of one additional round-trip at the start of each task.
+
+The design trade-offs are real. Category design is hard — too many categories reproduces the original problem one level up, and the categories have to be stable enough that the agent can reliably navigate them. The approach also introduces protocol dependency on MCP session tracking, which the 2026 MCP roadmap is still evolving (stateful sessions are a known scaling problem).
+
+Progressive discovery is best understood as a scaling mechanism, not a replacement for curation. Amazon's approach works because they also maintain "clean tool definitions" — the discovery mechanism routes the agent to good tools, not just fewer tools.
+
+---
+
+## The 2026 MCP roadmap and what it means for generation
+
+The official roadmap identifies four priorities: transport scalability (Streamable HTTP at scale), agent communication (Tasks primitive refinement), governance maturation, and enterprise readiness (audit trails, SSO, gateway behavior, configuration portability).
+
+Two items are relevant to tool generation:
+
+**Stateful sessions are a first-class problem.** The protocol's current session model makes horizontal scaling hard. Any tool generator that produces tools relying on server-side session state is building on unstable ground. The architectural preference should be stateless tool execution — parameters carry everything needed, server-side state is minimal. This aligns with the REST-like design of the Atlas CLI's executor (the `CommandRequest` struct is self-contained).
+
+**Enterprise features as extensions.** The roadmap explicitly endorses handling enterprise concerns through extensions rather than core spec changes. This is the same philosophy as the overlay system: extend the spec without forking it. For tool generation, it reinforces the pattern of using extension namespaces (`x-mcp`, `x-xgen-atlascli`) for tooling-specific concerns.
+
+---
+
+## Synthesis for the Atlas CLI → MCP adaptation
+
+Drawing the thread across all of this:
+
+**The auto-generation pipeline is the right foundation.** Every source confirms that generators handle the mechanical transformation correctly. Stainless, FastMCP, Speakeasy's Gram — they all do what `api-generator` does. The Atlas CLI is not behind the curve; the pipeline is sound.
+
+**The gap is the curation layer.** Neon, Cloudflare, and Speakeasy all arrived at the same place: the generator is the starting point. What makes tools agent-usable is the work that happens in overlays — description overrides, tool groupings, workflow definitions, skip directives. This is already the mechanism; it just needs to be expanded with agent-centric concerns.
+
+**Workflow tools are the primary product.** Every source that discusses production agent failures points to multi-step operations as the place where 1:1 tools fail most visibly. The `x-mcp-workflows` overlay extension described in the alternatives document is not a nice-to-have — it is the mechanism that separates tools that work from tools that work for agents.
+
+**Keep the raw operation layer, but filter it aggressively.** The Atlas API has ~700 operations. The right exposure is probably 20–40 workflow tools plus 40–60 curated raw tools, not 700. GitHub Copilot's trajectory (40→13) and Block's (30+→2) are reference points, but those numbers are appropriate for narrow-scope servers. A general-purpose Atlas MCP server has broader scope and can sustain more tools than a single-purpose Linear integration.
+
+**Progressive discovery is the scaling answer.** Once the server has curated workflow tools and filtered raw tools, progressive discovery (Amazon's pattern) addresses the remaining context problem. The implementation is small — one meta-tool plus category mapping — but it unlocks the ability to register significantly more tools without context bloat. Design the categories around Atlas domains: clusters, projects, networking, users, backups, search.
+
+**The 5–15 tool guidance is for narrow servers.** Phil Schmid's recommendation is widely cited but applies to servers with a single well-defined purpose. A general-purpose Atlas MCP server is more like Amazon Prime Video's case — many tools organized into domains — and the progressive discovery pattern is the appropriate solution for that scale.
+
+---
+
+## Sources
+
+* [Cloudflare CF CLI Local Explorer](https://blog.cloudflare.com/cf-cli-local-explorer/)
+* [54 Patterns for Building Better MCP Tools — Arcade](https://www.arcade.dev/blog/mcp-tool-patterns)
+* [MCP is Not the Problem, It's Your Server — Phil Schmid](https://www.philschmid.de/mcp-best-practices)
+* [Auto-generating MCP Servers from OpenAPI Schemas: Yay or Nay? — Neon](https://neon.com/blog/autogenerating-mcp-servers-openai-schemas)
+* [Generating MCP Tools from OpenAPI: Benefits, Limits, Best Practices — Speakeasy](https://www.speakeasy.com/mcp/tool-design/generate-mcp-tools-from-openapi)
+* [Progressive Tool Discovery for MCP Servers to Manage Context at Scale — Amazon / ZenML](https://www.zenml.io/llmops-database/progressive-tool-discovery-for-mcp-servers-to-manage-context-at-scale)
+* [Building Scalable MCP Servers with Domain-Driven Design — Chris Hughes](https://medium.com/@chris.p.hughes10/building-scalable-mcp-servers-with-domain-driven-design-fb9454d4c726)
+* [A Practical Guide to Architectures of Agentic Applications — Speakeasy](https://www.speakeasy.com/mcp/using-mcp/ai-agents/architecture-patterns)
+* [The 2026 MCP Roadmap — Model Context Protocol Blog](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/)
+* [MCP Tool Design: Why Your AI Agent Is Failing — AWS Heroes / DEV Community](https://dev.to/aws-heroes/mcp-tool-design-why-your-ai-agent-is-failing-and-how-to-fix-it-40fc)
+* [When Too Many Tools Become Too Much Context: RAG-MCP — Pankaj Pandey](https://medium.com/@pankaj_pandey/when-too-many-tools-become-too-much-context-a-deep-dive-into-rag-mcp-9b628c8476d3)

--- a/docs/mcp-tool-generation-alternatives.md
+++ b/docs/mcp-tool-generation-alternatives.md
@@ -1,0 +1,288 @@
+# MCP Tool Generation: Design Alternatives
+
+This document explores the design space for auto-generating MCP tools from an OpenAPI spec, using the Atlas CLI framework as a starting point. The core tension is that the Atlas CLI framework does a 1:1 mapping (one operation → one command), which works for a CLI but breaks down in MCP. This document works through the alternatives and their trade-offs.
+
+---
+
+## Why 1:1 mapping does not work for MCP
+
+The Atlas Admin API has roughly 700 operations. A CLI can expose all of them as leaf commands because humans navigate hierarchically (`atlas api clusters createOne`) and tab-complete their way through. A CLI user can also read a man page.
+
+An LLM cannot. Tool selection in MCP happens by the model reading all tool names and descriptions simultaneously and picking the best match. Two things degrade that process fast:
+
+**Too many tools.** Most model providers start seeing quality degradation somewhere between 20 and 60 tools in context. At 700, tool selection is effectively random. Even at 100, a model looking for "create a cluster" will be distracted by `listClusterAuditingExpressions` and `getClusterAdvancedSettings`.
+
+**API-shaped descriptions.** Descriptions written for API reference docs describe what the endpoint does mechanically. They do not describe when to use it, what preconditions it requires, or what the user's goal is. An LLM agent needs the latter. `Creates, edits, verifies, and removes IP access list entries for the specified project` is the kind of text that confuses tool selection. A useful MCP tool description answers the question: "what is the user trying to accomplish when they invoke this?"
+
+**Multi-step operations.** Many useful tasks in Atlas require a sequence of API calls. Creating a cluster means calling `createCluster`, then polling `getCluster` until `stateName == IDLE`, then possibly calling `createDatabaseUser` and `createProjectIpAccessList`. A 1:1 mapping forces the agent to discover and sequence these calls itself, which is error-prone and produces bad user experiences. The CLI partially solves this with watchers, but even watcher-aware CLI commands are still single-operation.
+
+The conclusion is: the right design for MCP tool generation is different from the right design for CLI command generation, even when both draw from the same OpenAPI spec.
+
+---
+
+## The design space
+
+Five meaningfully different approaches exist. They are not mutually exclusive — the right answer for a real MCP server is likely a combination of two or three.
+
+---
+
+### Alternative 1: Filtered 1:1 mapping
+
+The simplest adaptation: generate one MCP tool per operation, but use `skip` overlays aggressively to reduce coverage to the 50–80 operations that actually matter. Everything that's read-only and rarely needed by an agent, all admin/internal endpoints, all endpoints that require context an agent can't have — those get skipped.
+
+**How it works.** This reuses the Atlas CLI pipeline almost unchanged. The generator emits MCP tool registrations instead of Cobra commands. The `--output-type tools` flag produces TypeScript/Python/Go tool definitions rather than `commands.go`. The filter logic lives in overlays: `x-mcp: skip: true` on everything you do not want exposed.
+
+**What the overlay looks like:**
+```yaml
+overlay: 1.0.0
+info:
+  title: MCP tool filter - skip audit and metrics endpoints
+  version: 1.0.0
+actions:
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/auditLog'].get
+    update:
+      x-mcp:
+        skip: true
+  - target: $.paths['/api/atlas/v2/groups/{groupId}/metrics/**']
+    update:
+      x-mcp:
+        skip: true
+```
+
+**Trade-offs.**
+- Generating this is easy — the pipeline already exists.
+- Tool descriptions are still API-shaped, not agent-shaped. You can mitigate this with description overrides in overlays, but you are fighting the grain of API documentation.
+- No workflow composition. The agent still has to sequence multi-step operations.
+- Good as a foundation layer but insufficient as a complete MCP tool design.
+
+**When to use it.** As the baseline. You want this layer to exist because it gives the agent escape hatches for operations that no one thought to make into a workflow tool. The agent should be able to fall back to `raw_api_call` when no higher-level tool fits.
+
+---
+
+### Alternative 2: Resource/tool split following MCP semantics
+
+MCP distinguishes between Resources (data that can be read) and Tools (actions that have side effects). GET operations are natural Resources. POST/PUT/PATCH/DELETE are natural Tools. This alternative exploits that distinction to remove all read operations from the tool list.
+
+**How it works.** The generator applies a rule: operations with `GET` verb become MCP Resources; all other verbs become MCP Tools. Resources are accessed by the model via `read_resource` with a URI, not via tool call. This immediately halves the tool count.
+
+Resources would use URI templates based on the operation's URL path:
+```
+atlas://groups/{groupId}/clusters
+atlas://groups/{groupId}/clusters/{clusterName}
+```
+
+**What this changes in the pipeline.** The generator needs to emit two output types: a resource registry and a tool registry. The resource registry maps URI templates to operations. The tool registry maps tool names to operations. The overlay can add `x-mcp: expose-as: resource` or `x-mcp: expose-as: tool` to override the default verb-based rule.
+
+**Trade-offs.**
+- Reduces tool count significantly.
+- Aligns with MCP's semantic model. Resources represent state; tools represent actions.
+- Resources are less ergonomic for agents than tools in current MCP implementations. Most LLMs are better at tool-calling than resource-reading, and resources do not appear in the tool list that models use for planning.
+- GET operations that are "search" operations (with many query parameters) are awkward as resources. A resource URI for `listClusters?pageNum=2&includeCount=true` is not a natural URI.
+- Pagination is unsolved — MCP Resources do not have a standard pagination model.
+
+**When to use it.** When the MCP server is consumed by a model that handles resources well, or when the primary goal is reducing tool count. Not recommended as the sole approach because of the ergonomics gap.
+
+---
+
+### Alternative 3: Tag-grouped dispatch tools
+
+Instead of one tool per operation, expose one tool per OpenAPI tag — one tool for all of Clusters, one for Projects, one for Database Users. The tool accepts an `operation` parameter that specifies which API operation to call, and a `parameters` object for that operation's inputs.
+
+**What a tool call looks like:**
+```json
+{
+  "tool": "atlas_clusters",
+  "input": {
+    "operation": "createCluster",
+    "version": "2024-08-05",
+    "parameters": {
+      "groupId": "abc123",
+      "body": { "name": "my-cluster", "clusterType": "REPLICASET" }
+    }
+  }
+}
+```
+
+**How it works.** The generator emits one tool per tag. Each tool's description covers the whole tag and lists available operations. The input schema has a discriminated union: `operation` is an enum of all operation IDs in the tag, and `parameters` is typed per-operation (or typed as a free-form object if the implementation accepts the loss of static typing).
+
+**Trade-offs.**
+- Reduces tool count to the number of tags (~30 for Atlas), which is manageable.
+- The model must know the `operationId` to use the tool. This reintroduces the problem of API-shaped mental models. An agent that doesn't know `getGroupCluster` is a thing cannot easily discover it by looking at the `atlas_clusters` tool's description.
+- Schemas become very large (a union of all operation schemas per tag). Models do not handle large schemas well.
+- Static type checking is largely lost — you're back to a generic dispatch pattern.
+- Discovery inside a tag requires either a long description or a separate `list_operations` call.
+
+**When to use it.** Not recommended as the primary design. This solves the count problem but makes the model's job harder, trading one failure mode for another. Could work as a "power user" escape hatch alongside higher-level tools.
+
+---
+
+### Alternative 4: Workflow tools with declarative composition
+
+This is the most significant departure from the CLI model. Instead of exposing API operations directly, you define workflows — multi-step sequences with a single user intent — and generate tools from those workflow definitions.
+
+A workflow is not a single API operation. It is a named sequence of operations with data flow between steps, a coherent description written for agent consumption, and a simplified input schema that hides intermediate parameters.
+
+**What a workflow definition looks like in an overlay:**
+
+```yaml
+overlay: 1.0.0
+info:
+  title: MCP workflow definitions
+  version: 1.0.0
+actions:
+  - target: $.x-mcp-workflows
+    update:
+      createCluster:
+        description: |
+          Creates a new Atlas cluster and waits until it is ready to accept connections.
+          Use this when the user wants to provision a new database cluster in a project.
+          Requires: project ID, cluster name, and cloud provider/region.
+        input:
+          groupId:
+            from: parameter
+            operation: createCluster
+            name: groupId
+          clusterName:
+            type: string
+            description: Name for the new cluster
+          provider:
+            type: string
+            enum: [AWS, GCP, AZURE]
+            description: Cloud provider to deploy on
+          region:
+            type: string
+            description: Provider-specific region code (e.g. US_EAST_1)
+        steps:
+          - id: create
+            operationId: createCluster
+            version: "2024-08-05"
+            body:
+              name: "{{ input.clusterName }}"
+              clusterType: REPLICASET
+              replicationSpecs:
+                - zoneName: Zone 1
+                  regionConfigs:
+                    - providerName: "{{ input.provider }}"
+                      regionName: "{{ input.region }}"
+                      electableSpecs:
+                        instanceSize: M10
+                        nodeCount: 3
+          - id: wait
+            type: poll
+            operationId: getGroupCluster
+            version: "2024-08-05"
+            params:
+              groupId: "{{ input.groupId }}"
+              clusterName: "{{ steps.create.response.name }}"
+            until:
+              path: $.stateName
+              values: [IDLE]
+        output:
+          clusterName: "{{ steps.create.response.name }}"
+          connectionString: "{{ steps.wait.response.connectionStrings.standardSrv }}"
+```
+
+**How the generator handles this.** The generator reads the `x-mcp-workflows` extension block, resolves all referenced `operationId`s to their `Command` definitions (for type validation and header construction), and emits workflow tool handlers in the target language. Each step in the sequence uses the same `executor.ExecuteCommand()` machinery as raw operation tools — the workflow is just orchestration on top.
+
+**What this produces.** The tool `createCluster` takes four parameters (`groupId`, `clusterName`, `provider`, `region`), handles the full create+poll sequence internally, and returns connection strings. The agent never sees the intermediate `getGroupCluster` polling calls.
+
+**Trade-offs.**
+- This is the most useful design for agents. The tool descriptions map to user intents. The schemas are small. The agent does not need to know Atlas API internals.
+- Workflow definitions require human authorship. You cannot auto-generate workflows from an OpenAPI spec alone — you need someone who understands what users are trying to accomplish. This is a one-time cost per workflow, but it is real cost.
+- The template DSL for data flow (`{{ steps.create.response.name }}`) adds complexity to the generator.
+- Error handling mid-workflow is more complex than single-operation errors. If `createCluster` succeeds but the poll times out, the cluster exists but is not returned — the agent is in a confused state. Rollback behavior needs a design decision.
+- Keeping workflow definitions in sync with spec changes requires attention. If `createCluster`'s request body schema changes, the workflow body template may need updating.
+
+**When to use it.** As the primary tool surface. Every tool the agent reaches for first should be a workflow tool. Raw operation tools are the fallback.
+
+---
+
+### Alternative 5: Layered tool sets with dynamic exposure
+
+The model context limit problem is not just about count — it is about relevance. If an agent is helping a user manage clusters, it does not need database user tools in context. This alternative registers a large tool set but only injects relevant tools based on conversation context.
+
+**How it works.** The MCP server implements tool filtering at the session or message level. Tools are grouped into feature sets (clusters, networking, users, backups, etc.). The server starts with a minimal bootstrap set — maybe 5–10 tools — and exposes a `get_available_tools` meta-tool that returns tools relevant to a given intent or resource type.
+
+```json
+{
+  "tool": "get_available_tools",
+  "input": {
+    "intent": "I want to set up a new Atlas project with a cluster"
+  }
+}
+```
+
+The meta-tool returns a filtered list of tool names and descriptions. The client then injects those tools into context for subsequent turns.
+
+This approach is implemented in some MCP servers today as "tool pagination" and is likely to become a more standard pattern as the MCP specification matures.
+
+**Trade-offs.**
+- Solves the context limit problem most cleanly.
+- The meta-tool layer adds a round-trip. Agents that do not know to call `get_available_tools` first will work with a degraded tool set.
+- Requires session state or conversation context to determine which tools are relevant.
+- Does not solve the API-shaped description problem — tools still need agent-friendly descriptions.
+- The MCP spec does not yet standardize this pattern, so implementation is bespoke.
+
+**When to use it.** As a scaling mechanism on top of Alternative 1 or Alternative 4. Start with a curated tool set; add dynamic exposure when the tool count becomes a problem.
+
+---
+
+## Recommendation
+
+A production MCP server for Atlas should combine three of these alternatives:
+
+**Layer 1 — Workflow tools (Alternative 4) as the primary surface.** Define 20–40 workflow tools that map to the most common user intents: create cluster, delete cluster, add database user, configure IP access, create backup policy, and so on. These are the tools the agent reaches for 90% of the time. Write their descriptions for agents, not API readers.
+
+**Layer 2 — Filtered raw operation tools (Alternative 1) as the fallback.** Expose the 50–80 most useful individual operations directly. An agent that needs to do something no workflow covers should be able to call the raw operation. These tools have API-shaped descriptions and full parameter sets, but they exist. Skip everything that is read-heavy, audit-related, internal, or requires complex setup.
+
+**Layer 3 — Resource/tool split (Alternative 2) for reads.** GET operations that return single resources by ID or list resources become MCP Resources rather than tools. This keeps them accessible without polluting the tool list.
+
+Together this gives the agent roughly 25–45 tools in the default configuration — inside the performance window — plus a resource layer for reads and an escape hatch for edge cases.
+
+---
+
+## How the generator pipeline adapts
+
+The overlay pipeline already supports everything this architecture needs. The changes are in what the generator reads and what it emits.
+
+**New extension keys in overlays:**
+
+```
+x-mcp:
+  skip: true                     # exclude from MCP entirely
+  expose-as: resource            # emit as MCP Resource, not Tool
+  tool-description: "..."        # override tool description for agent use
+  workflow: <workflow-id>        # this operation belongs to workflow X
+```
+
+**New top-level overlay section:**
+```
+x-mcp-workflows:
+  <workflowId>:
+    description: "..."
+    input: { ... }
+    steps: [ ... ]
+    output: { ... }
+```
+
+**Generator changes:**
+
+The generator gains a new `--output-type mcp-tools` mode. In this mode:
+
+1. It reads `x-mcp-workflows` and resolves each step's `operationId` to a `Command` struct — same lookup it already does for watcher validation.
+2. It emits workflow tool handlers that internally sequence `executor.ExecuteCommand()` calls.
+3. It reads `x-mcp: expose-as: resource` and emits resource definitions for those operations.
+4. It reads the filtered raw operations and emits single-operation tools for them.
+5. It validates at generation time that all workflow `operationId` references exist and that all referenced parameters exist on those operations.
+
+The core parsing (`specToCommands()`), the `Command` data model, the `executor`, and the HTTP request builder are unchanged. The generator gains a new output branch; everything upstream of it stays the same.
+
+---
+
+## The key shift from CLI to MCP
+
+The CLI framework optimized for completeness: expose every operation, let the user find what they need via tab-completion and help text. An agent cannot browse. It must be steered.
+
+MCP tool generation optimizes for intent coverage: expose tools that match what a user is trying to accomplish, not tools that match what the API offers. This is a higher-level abstraction, and it requires human judgment about what users want — judgment that cannot come from parsing an OpenAPI spec alone.
+
+The overlay mechanism is the right place for that judgment to live. A workflow definition in an overlay is explicit, reviewable, versioned, and kept close to the spec that backs it. When the underlying API changes, the overlay is the first thing to update, and the generator catches any mismatch between the overlay's referenced operations and the spec. The same invariant the CLI framework enforces — spec is the source of truth, customizations live in overlays, mismatches are caught at generation time — holds for MCP workflow tools.


### PR DESCRIPTION
## Summary

* Adds five design and research documents produced while scoping and implementing the MCP auto-generation pipeline for the MongoDB MCP Server.
* These docs live in `docs/` so they are versioned alongside the Atlas CLI spec they reference.

## Documents

**`autogen-framework-design.md`** — Technical walkthrough of the Atlas CLI auto-generation pipeline (spec → overlays → generator → committed static file) and a guide for adapting the same pattern to an MCP server. Covers the `Command` data model, version parsing, watcher DSL, and what changes vs. what stays the same when targeting MCP.

**`mcp-tool-generation-alternatives.md`** — Five design alternatives for generating MCP tools from an OpenAPI spec: filtered 1:1 mapping, resource/tool split, tag-grouped dispatch, workflow composition, and layered dynamic exposure. Each includes a concrete example, trade-offs, and when to use it. Ends with a recommended three-layer architecture.

**`mcp-tool-design-research.md`** — Synthesis of recent writing (Feb–May 2026) on building MCP tools. Covers the evidence for why 1:1 API mapping fails, Cloudflare's schema-first approach, Neon and Speakeasy's conclusions on OpenAPI auto-generation, Amazon Prime Video's progressive discovery pattern, and the 2026 MCP roadmap priorities.

**`mcp-autogen-proposal.md`** — Concrete implementation proposal for the MongoDB MCP Server: the generator pipeline design, overlay extension keys, and the full proposed tool list with safety annotations.

**`mcp-tool-catalog.md`** — Full proposed tool catalog (99 tools across two layers) with MCP safety annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) and implementation status against the existing codebase (EXISTS / RENAME / EXTEND / NEW).

## Context

The implementation described in these docs has been built in the `mongodb-mcp-server` repository. This PR commits the design artifacts to the atlas-cli repo since:
- The generator reads `tools/internal/specs/spec.yaml` (the Atlas API spec that lives here)
- The overlay files reference `x-xgen-atlascli` extension keys defined here
- Future spec changes in this repo should be coordinated with the MCP overlay files

## Reviewer notes

These are documentation files only — no Go code changed. Review focus should be on accuracy of the framework description and whether the design decisions are sound.