### PR TITLE
CLOUDP-406604: Add debug log to TestPrivateEndpointsAzure

### DIFF
--- a/test/e2e/atlas/networking/privateendpoint/private_endpoint_test.go
+++ b/test/e2e/atlas/networking/privateendpoint/private_endpoint_test.go
@@ -204,6 +204,7 @@ func TestPrivateEndpointsAzure(t *testing.T) {
 	require.NoError(t, err)
 
 	region := regionsAzure[n.Int64()]
+	g.Logf("region=%s", region)
 	var id string
 
 	g.Run("Create", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run


### PR DESCRIPTION
## Proposed changes

Surfaces region used in TestPrivateEndpointsAzure through logs for future debugging.

_Jira ticket:_ [CLOUDP-406604](https://jira.mongodb.org/browse/CLOUDP-406604)

**Issue:**
We have been seeing occasional failures from the e2e test `atlas_private_endpoint_e2e` where `TestPrivateEndpointsAzure` fails on the creation step with error `HTTP 400 Bad Request (Error code: "ATLAS_GENERAL_ERROR") Detail: Reason: No Capacity.`

 
This test randomly selects a region to run against. It is possible that this error is localised to only one or a few regions.

I've been unable to replicate the failure locally after a number of reruns against all the regions.

 
**Solution:**
I am suggesting we add a simple log statement to surface what region is being used for a given test run. That way, if we continue to see this error, we will be able to determine if the issue is region specific and thus exclude that region from the pool of Azure regions the test can target to reduce flake.