### PR TITLE
fix: e2e snapshot workflow on forks

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -361,9 +361,7 @@ jobs:
             output = 'plaintext'
         run: |
           echo "$CONFIG_CONTENT" > "$CONFIG_PATH"
-      - run: |
-          set +e
-          make e2e-test-snapshots
+      - run: make e2e-test-snapshots
         env:
           TEST_CMD: gotestsum --junitfile e2e-tests.xml --format standard-verbose --
           COVERAGE: coverage.out

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -330,12 +330,6 @@ jobs:
       - run: |
           go install gotest.tools/gotestsum@v1.12.3
           go install github.com/mattn/goveralls@v0.0.12
-      - name: set Apix Bot token
-        id: app-token
-        uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038
-        with:
-          app-id: ${{ secrets.APIXBOT_APP_ID }}
-          private-key: ${{ secrets.APIXBOT_APP_PEM }}
       - run: make build
       - id: config-path
         env:
@@ -370,15 +364,12 @@ jobs:
       - run: |
           set +e
           make e2e-test-snapshots
-          EXIT_CODE=$?
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "::error::Snapshot tests failed, consider adding label 'update-snapshots' to re-generate them"
-          fi
-          exit $EXIT_CODE
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TEST_CMD: gotestsum --junitfile e2e-tests.xml --format standard-verbose --
           COVERAGE: coverage.out
+      - if: failure()
+        run:
+          echo "::error::Snapshot tests failed, consider adding label 'update-snapshots' to re-generate them"
       - name: Send coverage
         continue-on-error: true
         env:


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-#

Fixes the e2e snapshot workflow so it runs cleanly on forks:

- Removes the Apix Bot token step (`apix-action/token`) which requires org secrets unavailable on forks.
- Drops the `GH_TOKEN` env var from the snapshot test step (no longer needed).

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [ ] I have run `make fmt` and formatted my code

## Further comments

This is a CI-only change — no production code or test logic is affected.