### PR TITLE
CLOUDP-408806: fix snapshot PR failing due to stale checkout ref

### DIFF
--- a/.github/workflows/update-e2e-tests.yml
+++ b/.github/workflows/update-e2e-tests.yml
@@ -305,6 +305,7 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          ref: master
       - run: find test/e2e -type d -name .snapshots -exec rm -rf {} +
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-408806](https://jira.mongodb.org/browse/CLOUDP-408806)

The `Update E2E Tests Snapshots` workflow runs on a Monday cron. The `pr` job depends on all `update-tests` matrix jobs completing, which can take hours. By then, `master` may have received new commits that touch `.github/workflows/` files.

The `pr` job was checking out at `GITHUB_SHA` (the `master` tip at cron trigger time). When commits modifying `code-health.yml` landed between the trigger and the `pr` job running, the snapshot branch was built on the stale base. GitHub compared the pushed branch against current `master`, saw `.github/workflows/code-health.yml` as modified, and rejected the push:

```
refusing to allow a GitHub App to create or update workflow
`.github/workflows/code-health.yml` without `workflows` permission
```

Root cause was identified while investigating the failing run at https://github.com/mongodb/mongodb-atlas-cli/actions/runs/26381516991/job/78303879490, triggered by [CLOUDP-407916](https://jira.mongodb.org/browse/CLOUDP-407916).

**Fix:** Add `ref: master` to the `pr` job's checkout so it always works off the current master tip, ensuring the snapshot branch never diverges from master on workflow files.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

No tests applicable — this is a CI workflow fix. The change is a one-liner: `ref: master` on the `actions/checkout` step in the `pr` job of `update-e2e-tests.yml`.