### PR TITLE
CLOUDP-405482: redact PEM private keys from e2e test snapshots

### DIFF
--- a/test/internal/atlas_e2e_test_generator.go
+++ b/test/internal/atlas_e2e_test_generator.go
@@ -45,6 +45,12 @@ import (
 const redactedToken = "redactedToken"
 const ipMax = 255
 
+var pemPrivateKeyRe = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+
+func redactPEMPrivateKeys(body []byte) []byte {
+	return pemPrivateKeyRe.ReplaceAll(body, []byte("REDACTED"))
+}
+
 func decompress(r *http.Response) error {
 	var err error
 	shouldRemoveHeaders := false
@@ -671,22 +677,24 @@ func (g *AtlasE2ETestGenerator) prepareSnapshot(r *http.Response) *http.Response
 		g.t.Fatal(err)
 	}
 
-	if resp.ContentLength > 0 && strings.Contains(resp.Header.Get("Content-Type"), "json") {
+	if resp.ContentLength > 0 {
 		buf, err := io.ReadAll(resp.Body)
 		if err != nil {
 			g.t.Fatal(err)
 		}
 
+		buf = redactPEMPrivateKeys(buf)
 		buf = []byte(g.maskString(string(buf)))
-		resp.Body = io.NopCloser(bytes.NewReader(buf))
-		resp.ContentLength = int64(len(buf))
-		resp.Header["Content-Length"] = []string{strconv.FormatInt(resp.ContentLength, 10)}
 
 		for k, mv := range resp.Header {
 			for i, v := range mv {
 				resp.Header[k][i] = g.maskString(v)
 			}
 		}
+
+		resp.Body = io.NopCloser(bytes.NewReader(buf))
+		resp.ContentLength = int64(len(buf))
+		resp.Header.Set("Content-Length", strconv.FormatInt(resp.ContentLength, 10))
 	}
 
 	return resp

--- a/test/internal/atlas_e2e_test_generator_test.go
+++ b/test/internal/atlas_e2e_test_generator_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactPEMPrivateKeys(t *testing.T) {
+	const certBlock = "-----BEGIN CERTIFICATE-----\nMIIFBzCC\n-----END CERTIFICATE-----\n"
+	const pkcs8Key = "-----BEGIN PRIVATE KEY-----\nMIIJQwIBADA\n-----END PRIVATE KEY-----"
+	const rsaKey = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAK\n-----END RSA PRIVATE KEY-----"
+	const ecKey = "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIP\n-----END EC PRIVATE KEY-----"
+	const pubKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkq\n-----END PUBLIC KEY-----"
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no key material unchanged",
+			input: "plain text response",
+			want:  "plain text response",
+		},
+		{
+			name:  "PKCS8 private key redacted",
+			input: pkcs8Key,
+			want:  "REDACTED",
+		},
+		{
+			name:  "RSA private key redacted",
+			input: rsaKey,
+			want:  "REDACTED",
+		},
+		{
+			name:  "EC private key redacted",
+			input: ecKey,
+			want:  "REDACTED",
+		},
+		{
+			name:  "cert preserved key redacted in mixed payload",
+			input: certBlock + pkcs8Key,
+			want:  certBlock + "REDACTED",
+		},
+		{
+			name:  "public key unchanged",
+			input: pubKey,
+			want:  pubKey,
+		},
+		{
+			name:  "certificate alone unchanged",
+			input: certBlock,
+			want:  certBlock,
+		},
+		{
+			name:  "multiple private keys all redacted",
+			input: pkcs8Key + "\n" + rsaKey,
+			want:  "REDACTED\nREDACTED",
+		},
+		{
+			name:  "json-encoded PEM (escaped newlines) redacted",
+			input: `{"key":"-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAK\n-----END RSA PRIVATE KEY-----"}`,
+			want:  `{"key":"REDACTED"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := redactPEMPrivateKeys([]byte(tt.input))
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-405482](https://jira.mongodb.org/browse/CLOUDP-405482)

### Issue

GitHub secret scanning flagged a real RSA private key committed to the repo inside a test snapshot file. The `dbusers certs create` endpoint returns `text/plain` PEM data (certificate + private key). The snapshot recorder in `prepareSnapshot` only masked JSON responses, so the raw PEM — private key included — was written verbatim to disk and committed.

### Fix

`prepareSnapshot` now reads every response body (not just JSON), applies PEM private key redaction via regex before writing the snapshot, then applies the existing `maskString` and header masking. The regex covers PKCS8, RSA, and EC key types:

```
(?s)-----BEGIN [A-Z ]* PRIVATE KEY-----.*?-----END [A-Z ]* PRIVATE KEY-----
```

The existing snapshot file with the leaked key will be overwritten when snapshot recording is re-run for `TestDBUserCerts`.

### Fly-by

The pre-existing `resp.Header["Content-Length"]` direct map write was replaced with the idiomatic `resp.Header.Set(...)`. Body masking (`maskString`) and header masking are now applied to all response content types, not just JSON — this is an improvement since non-JSON responses (e.g. certs) can also contain project IDs or other identifiable values.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code