### PR TITLE
CLOUDP-410005: support paths with different variable names in gen-api-commands

### DIFF
--- a/tools/cmd/api-generator/main.go
+++ b/tools/cmd/api-generator/main.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 	"text/template"
@@ -116,13 +117,26 @@ func convertSpecToMetadata(ctx context.Context, now time.Time, r io.Reader, w io
 }
 
 func convertSpec[T any](ctx context.Context, now time.Time, r io.Reader, w io.Writer, mapper func(now time.Time, spec *openapi3.T) (T, error), templateContent string) error {
-	spec, err := loadSpec(r)
+	specBytes, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("failed to read spec, error: %w", err)
+	}
+
+	spec, err := loadSpec(bytes.NewReader(specBytes))
 	if err != nil {
 		return fmt.Errorf("failed to load spec, error: %w", err)
 	}
 
 	if templateContent != metadataTemplateContent {
-		if err := spec.Validate(ctx, openapi3.DisableSchemaPatternValidation(), openapi3.DisableExamplesValidation()); err != nil {
+		// Validate a deduplicated copy: some paths are structurally identical but use different
+		// parameter names, which kin-openapi treats as conflicting. Dedup the copy only so the
+		// original spec retains correct parameter names for command generation.
+		specCopy, err := loadSpec(bytes.NewReader(specBytes))
+		if err != nil {
+			return fmt.Errorf("failed to load spec copy for validation, error: %w", err)
+		}
+		deduplicateConflictingPaths(specCopy)
+		if err := specCopy.Validate(ctx, openapi3.DisableSchemaPatternValidation(), openapi3.DisableExamplesValidation()); err != nil {
 			return fmt.Errorf("spec validation failed, error: %w", err)
 		}
 	}
@@ -133,6 +147,29 @@ func convertSpec[T any](ctx context.Context, now time.Time, r io.Reader, w io.Wr
 	}
 
 	return writeCommands(now, w, templateContent, commands)
+}
+
+var pathParamPattern = regexp.MustCompile(`\{[^}]+\}`)
+
+// deduplicateConflictingPaths merges paths that are structurally identical but use different
+// parameter names (e.g. /groups/{groupId}/load/{sampleDatasetId} vs /groups/{groupId}/load/{name}).
+// OpenAPI treats these as conflicting; we merge all operations into the first occurrence and discard the rest.
+func deduplicateConflictingPaths(spec *openapi3.T) {
+	seen := make(map[string]string) // normalized path -> first real path
+	for _, path := range spec.Paths.Keys() {
+		normalized := pathParamPattern.ReplaceAllString(path, "{}")
+		if firstPath, exists := seen[normalized]; exists {
+			// Merge operations from this duplicate into the first path
+			first := spec.Paths.Value(firstPath)
+			duplicate := spec.Paths.Value(path)
+			for verb, op := range duplicate.Operations() {
+				first.SetOperation(verb, op)
+			}
+			spec.Paths.Delete(path)
+		} else {
+			seen[normalized] = path
+		}
+	}
 }
 
 func loadSpec(r io.Reader) (*openapi3.T, error) {

--- a/tools/cmd/api-generator/main_test.go
+++ b/tools/cmd/api-generator/main_test.go
@@ -25,6 +25,9 @@ import (
 	"time"
 
 	"github.com/bradleyjkemp/cupaloy/v2"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testSpec(t *testing.T, name, specPath string) {
@@ -56,6 +59,30 @@ func testSpec(t *testing.T, name, specPath string) {
 			t.Fatalf("unexpected result %s", err)
 		}
 	}
+}
+
+func TestDeduplicateConflictingPaths(t *testing.T) {
+	getOp := &openapi3.Operation{OperationID: "getGroupSampleDatasetLoad"}
+	postOp := &openapi3.Operation{OperationID: "requestGroupSampleDatasetLoad"}
+
+	spec := &openapi3.T{
+		Paths: openapi3.NewPaths(
+			openapi3.WithPath("/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}", &openapi3.PathItem{
+				Post: postOp,
+			}),
+			openapi3.WithPath("/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{sampleDatasetId}", &openapi3.PathItem{
+				Get: getOp,
+			}),
+		),
+	}
+
+	deduplicateConflictingPaths(spec)
+
+	require.Equal(t, 1, spec.Paths.Len(), "expected duplicate path to be removed")
+	remaining := spec.Paths.Value("/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}")
+	require.NotNil(t, remaining, "expected first path to be kept")
+	assert.Equal(t, postOp, remaining.Post, "POST operation should be preserved")
+	assert.Equal(t, getOp, remaining.Get, "GET operation should be merged from duplicate")
 }
 
 // To update snapshots run: UPDATE_SNAPSHOTS=true go test ./...


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-410005](https://jira.mongodb.org/browse/CLOUDP-410005)

The MongoDB Atlas OpenAPI spec defines two paths that are structurally identical — same URL pattern, only the path parameter names differ:

- `/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}` (POST)
- `/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{sampleDatasetId}` (GET)

These are genuinely conflicting from an OpenAPI perspective: any request to e.g. `/groups/abc/sampleDatasetLoad/xyz` matches both templates, so a router cannot distinguish them. `kin-openapi` correctly rejects the spec with:

```
Error: spec validation failed, error: invalid paths: conflicting paths
"/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{sampleDatasetId}" and
"/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}"
```

`kin-openapi` does not expose a validation option to disable this check.

**Fix:** before calling `spec.Validate()`, load a second copy of the spec and deduplicate structurally identical paths in that copy by merging their operations. Validation runs on the deduplicated copy; command generation runs on the original spec so parameter names are preserved.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works (`TestDeduplicateConflictingPaths` verifies that two paths differing only in parameter name are merged into one path with all operations intact, preventing regression)
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

The `deduplicateConflictingPaths` function keeps the first path key and merges HTTP operations from any duplicate into it. If the spec ever gains more such pairs, the function handles them generically without further changes.