### PR TITLE
CLOUDP-392159: handle rate-limited MCP telemetry

### DIFF
--- a/internal/cli/output_opts.go
+++ b/internal/cli/output_opts.go
@@ -117,7 +117,7 @@ func isNil(o any) bool {
 	}
 	ot := reflect.TypeOf(o)
 	otk := ot.Kind()
-	switch otk { //nolint:exhaustive // clearer cod
+	switch otk { //nolint:exhaustive // only nilable kinds matter here
 	case reflect.Array, reflect.Slice, reflect.Map, reflect.Chan, reflect.Pointer, reflect.UnsafePointer, reflect.Interface:
 		return reflect.ValueOf(o).IsNil()
 	default:
@@ -131,13 +131,13 @@ func isOrPtrToSliceOrArray(o any) bool {
 		return false
 	}
 	otk := ot.Kind()
-	switch otk { //nolint:exhaustive // clearer code
+	switch otk { //nolint:exhaustive // only slice/array/pointer kinds matter here
 	case reflect.Array, reflect.Slice:
 		return true
 	case reflect.Pointer:
 		opt := reflect.PointerTo(ot)
 		optk := opt.Kind()
-		switch optk { //nolint:exhaustive // clearer code
+		switch optk { //nolint:exhaustive // only slice/array kinds matter here
 		case reflect.Array, reflect.Slice:
 			return true
 		}

--- a/internal/telemetry/tracker.go
+++ b/internal/telemetry/tracker.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mongodb/atlas-cli-core/config"
@@ -31,9 +32,12 @@ import (
 
 const (
 	cacheFilename           = "telemetry"
+	backoffFilename         = "telemetry_backoff"
 	dirPermissions          = 0700
 	filePermissions         = 0600
-	defaultMaxCacheFileSize = 500_000 // 500KB
+	defaultMaxCacheFileSize = 500_000     // 500KB
+	maxBatchSize            = 32          // backend rate limit per request
+	backoffDuration         = time.Minute // minimum gap between send attempts
 )
 
 const (
@@ -134,35 +138,63 @@ func (t *tracker) trackCommand(data TrackOptions, opt ...EventOpt) error {
 	}
 	o = append(o, opt...)
 	event := newEvent(o...)
-	events, err := t.read()
+
+	// Skip sending if we're in a backoff window; just cache the event.
+	if t.isBackedOff() {
+		_, _ = log.Debugf("telemetry: in backoff window, caching event for later\n")
+		return t.save(event)
+	}
+
+	cachedEvents, err := t.read()
 	if err != nil {
 		_, _ = log.Debugf("telemetry: failed to read cache: %v\n", err)
 	}
-	events = append(events, event)
-	_, _ = log.Debugf("telemetry: events: %v\n", events)
-	if !t.storeSet {
-		err = t.unauthStore.SendUnauthEvents(events)
-	} else {
-		err = t.store.SendEvents(events)
+
+	cachedEvents = append(cachedEvents, event)
+
+	// Cap batch at maxBatchSize; backend enforces a per-request rate limit.
+	// Three-index slice prevents batch and remaining from sharing a backing array,
+	// so serialization of batch cannot silently corrupt remaining.
+	batch := cachedEvents
+	var remaining []Event
+	if len(cachedEvents) > maxBatchSize {
+		batch = cachedEvents[:maxBatchSize:maxBatchSize]
+		remaining = cachedEvents[maxBatchSize:]
 	}
-	if err != nil {
+
+	_, _ = log.Debugf("telemetry: sending %d events (remaining cached: %d)\n", len(batch), len(remaining))
+
+	var sendErr error
+	if !t.storeSet {
+		sendErr = t.unauthStore.SendUnauthEvents(batch)
+	} else {
+		sendErr = t.store.SendEvents(batch)
+	}
+
+	if sendErr != nil {
+		// On any error: do not retry. Create backoff file so rapid subsequent
+		// invocations skip the send entirely instead of hammering the backend.
+		_, _ = log.Debugf("telemetry: send error (%v), backing off for %v\n", sendErr, backoffDuration)
+		_ = t.saveBackoff() // best-effort: failure just means no backoff protection
+		// Old cached events remain on disk (remove() not called).
+		// Append only the new event so it's preserved for the next run.
 		return t.save(event)
 	}
-	return t.remove()
+
+	// Batch sent successfully: clear backoff, clear cache, persist remaining events.
+	_ = t.removeBackoff() // best-effort: stale file only wastes one invocation
+	if err := t.remove(); err != nil {
+		return err
+	}
+	return t.saveAll(remaining)
 }
 
 func (t *tracker) openCacheFile() (afero.File, error) {
-	exists, err := afero.DirExists(t.fs, t.cacheDir)
-	if err != nil {
-		return nil, err
-	}
-	if !exists {
-		if mkdirError := t.fs.MkdirAll(t.cacheDir, dirPermissions); mkdirError != nil {
-			return nil, mkdirError
-		}
+	if mkdirError := t.fs.MkdirAll(t.cacheDir, dirPermissions); mkdirError != nil {
+		return nil, mkdirError
 	}
 	filename := filepath.Join(t.cacheDir, cacheFilename)
-	exists, err = afero.Exists(t.fs, filename)
+	exists, err := afero.Exists(t.fs, filename)
 	if err != nil {
 		return nil, err
 	}
@@ -178,6 +210,55 @@ func (t *tracker) openCacheFile() (afero.File, error) {
 	}
 	file, err := t.fs.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, filePermissions)
 	return file, err
+}
+
+// Append multiple events to the cache file.
+func (t *tracker) saveAll(events []Event) error {
+	for _, e := range events {
+		if err := t.save(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// saveBackoff creates the backoff sentinel file. Its mtime marks when the
+// backoff window started; no content is written.
+func (t *tracker) saveBackoff() error {
+	if err := t.fs.MkdirAll(t.cacheDir, dirPermissions); err != nil {
+		return err
+	}
+	filename := filepath.Join(t.cacheDir, backoffFilename)
+	file, err := t.fs.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, filePermissions)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+// isBackedOff returns true when the backoff file exists and backoffDuration has
+// not yet elapsed since its creation. Deletes the file once the window expires.
+func (t *tracker) isBackedOff() bool {
+	filename := filepath.Join(t.cacheDir, backoffFilename)
+	info, err := t.fs.Stat(filename)
+	if err != nil {
+		return false
+	}
+	if time.Since(info.ModTime()) > backoffDuration {
+		_ = t.fs.Remove(filename)
+		return false
+	}
+	return true
+}
+
+// removeBackoff deletes the backoff file.
+func (t *tracker) removeBackoff() error {
+	filename := filepath.Join(t.cacheDir, backoffFilename)
+	err := t.fs.Remove(filename)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 // Append a single event to the cache file.

--- a/internal/telemetry/tracker_test.go
+++ b/internal/telemetry/tracker_test.go
@@ -210,6 +210,257 @@ func TestOpenCacheFile(t *testing.T) {
 	a.Equal(expectedSize, info.Size())
 }
 
+func TestTrackCommandBatchLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockEventsSender(ctrl)
+
+	cmd := &cobra.Command{
+		Use: "test-command",
+		Run: func(_ *cobra.Command, _ []string) {},
+	}
+	_ = cmd.ExecuteContext(NewContext())
+
+	cacheDir := t.TempDir()
+	tr := &tracker{
+		fs:               afero.NewMemMapFs(),
+		maxCacheFileSize: defaultMaxCacheFileSize,
+		cacheDir:         cacheDir,
+		store:            mockStore,
+		storeSet:         true,
+		cmd:              cmd,
+	}
+
+	// Pre-fill cache with maxBatchSize events so total = maxBatchSize+1 after new event.
+	for i := range maxBatchSize {
+		require.NoError(t, tr.save(Event{Properties: map[string]any{"i": i}}))
+	}
+
+	// Expect exactly maxBatchSize events in the batch (not maxBatchSize+1).
+	mockStore.EXPECT().
+		SendEvents(gomock.Len(maxBatchSize)).
+		Return(nil).
+		Times(1)
+
+	require.NoError(t, tr.trackCommand(TrackOptions{}))
+
+	// The new event (allEvents[maxBatchSize]) was not in the batch and should be written back to cache.
+	remaining, err := tr.read()
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1)
+}
+
+func TestTrackCommandRemainingEventsPersistedAfterSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockEventsSender(ctrl)
+
+	cmd := &cobra.Command{
+		Use: "test-command",
+		Run: func(_ *cobra.Command, _ []string) {},
+	}
+	_ = cmd.ExecuteContext(NewContext())
+
+	cacheDir := t.TempDir()
+	tr := &tracker{
+		fs:               afero.NewMemMapFs(),
+		maxCacheFileSize: defaultMaxCacheFileSize,
+		cacheDir:         cacheDir,
+		store:            mockStore,
+		storeSet:         true,
+		cmd:              cmd,
+	}
+
+	totalCached := maxBatchSize + 10
+	for i := range totalCached {
+		require.NoError(t, tr.save(Event{Properties: map[string]any{"i": i}}))
+	}
+
+	mockStore.EXPECT().
+		SendEvents(gomock.Len(maxBatchSize)).
+		Return(nil).
+		Times(1)
+
+	require.NoError(t, tr.trackCommand(TrackOptions{}))
+
+	// totalCached+1 (new event) - maxBatchSize should remain.
+	remaining, err := tr.read()
+	require.NoError(t, err)
+	assert.Len(t, remaining, totalCached+1-maxBatchSize)
+}
+
+func TestTrackCommandRateLimitedPreservesEvents(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockEventsSender(ctrl)
+
+	cmd := &cobra.Command{
+		Use: "test-command",
+		Run: func(_ *cobra.Command, _ []string) {},
+	}
+	_ = cmd.ExecuteContext(NewContext())
+
+	cacheDir := t.TempDir()
+	tr := &tracker{
+		fs:               afero.NewMemMapFs(),
+		maxCacheFileSize: defaultMaxCacheFileSize,
+		cacheDir:         cacheDir,
+		store:            mockStore,
+		storeSet:         true,
+		cmd:              cmd,
+	}
+
+	// Pre-fill cache with some events.
+	preCached := 5
+	for i := range preCached {
+		require.NoError(t, tr.save(Event{Properties: map[string]any{"i": i}}))
+	}
+
+	mockStore.EXPECT().
+		SendEvents(gomock.Any()).
+		Return(errors.New("http 429: too many requests")).
+		Times(1)
+
+	require.NoError(t, tr.trackCommand(TrackOptions{}))
+
+	// Old events still in cache + new event appended = preCached+1.
+	remaining, err := tr.read()
+	require.NoError(t, err)
+	assert.Len(t, remaining, preCached+1)
+}
+
+func TestSaveAndIsBackedOff(t *testing.T) {
+	cacheDir := t.TempDir()
+	tr := &tracker{fs: afero.NewMemMapFs(), cacheDir: cacheDir}
+
+	// No backoff file yet.
+	assert.False(t, tr.isBackedOff())
+
+	// Create backoff sentinel file — mtime = now, within backoffDuration.
+	require.NoError(t, tr.saveBackoff())
+	assert.True(t, tr.isBackedOff())
+}
+
+func TestRemoveBackoff(t *testing.T) {
+	cacheDir := t.TempDir()
+	tr := &tracker{fs: afero.NewMemMapFs(), cacheDir: cacheDir}
+
+	require.NoError(t, tr.saveBackoff())
+	assert.True(t, tr.isBackedOff())
+
+	require.NoError(t, tr.removeBackoff())
+	assert.False(t, tr.isBackedOff())
+}
+
+func TestBackoffExpired(t *testing.T) {
+	cacheDir := t.TempDir()
+	fs := afero.NewMemMapFs()
+	tr := &tracker{fs: fs, cacheDir: cacheDir}
+
+	require.NoError(t, tr.saveBackoff())
+
+	// Wind the file's mtime back past backoffDuration.
+	filename := filepath.Join(cacheDir, backoffFilename)
+	past := time.Now().Add(-(backoffDuration + time.Second))
+	require.NoError(t, fs.Chtimes(filename, past, past))
+
+	assert.False(t, tr.isBackedOff())
+}
+
+func TestTrackCommandSkipsSendWhenBackedOff(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockEventsSender(ctrl)
+
+	cmd := &cobra.Command{
+		Use: "test-command",
+		Run: func(_ *cobra.Command, _ []string) {},
+	}
+	_ = cmd.ExecuteContext(NewContext())
+
+	cacheDir := t.TempDir()
+	tr := &tracker{
+		fs:               afero.NewMemMapFs(),
+		maxCacheFileSize: defaultMaxCacheFileSize,
+		cacheDir:         cacheDir,
+		store:            mockStore,
+		storeSet:         true,
+		cmd:              cmd,
+	}
+
+	require.NoError(t, tr.saveBackoff())
+
+	// SendEvents must NOT be called.
+	mockStore.EXPECT().SendEvents(gomock.Any()).Times(0)
+
+	require.NoError(t, tr.trackCommand(TrackOptions{}))
+
+	// Event should be cached for later.
+	events, err := tr.read()
+	require.NoError(t, err)
+	assert.Len(t, events, 1)
+}
+
+func TestTrackCommandSetsBackoffOnSendError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"rate limit 429", errors.New("http 429")},
+		{"connection refused", errors.New("connection refused")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockStore := NewMockEventsSender(ctrl)
+
+			cmd := &cobra.Command{
+				Use: "test-command",
+				Run: func(_ *cobra.Command, _ []string) {},
+			}
+			_ = cmd.ExecuteContext(NewContext())
+
+			cacheDir := t.TempDir()
+			tr := &tracker{
+				fs:               afero.NewMemMapFs(),
+				maxCacheFileSize: defaultMaxCacheFileSize,
+				cacheDir:         cacheDir,
+				store:            mockStore,
+				storeSet:         true,
+				cmd:              cmd,
+			}
+
+			mockStore.EXPECT().SendEvents(gomock.Any()).Return(tc.err).Times(1)
+
+			require.NoError(t, tr.trackCommand(TrackOptions{}))
+
+			assert.True(t, tr.isBackedOff())
+		})
+	}
+}
+
+func TestTrackCommandClearsBackoffOnSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockStore := NewMockEventsSender(ctrl)
+
+	cmd := &cobra.Command{
+		Use: "test-command",
+		Run: func(_ *cobra.Command, _ []string) {},
+	}
+	_ = cmd.ExecuteContext(NewContext())
+
+	cacheDir := t.TempDir()
+	tr := &tracker{
+		fs:               afero.NewMemMapFs(),
+		maxCacheFileSize: defaultMaxCacheFileSize,
+		cacheDir:         cacheDir,
+		store:            mockStore,
+		storeSet:         true,
+		cmd:              cmd,
+	}
+
+	mockStore.EXPECT().SendEvents(gomock.Any()).Return(nil).Times(1)
+
+	require.NoError(t, tr.trackCommand(TrackOptions{}))
+
+	assert.False(t, tr.isBackedOff())
+}
+
 func TestTrackSurvey(t *testing.T) {
 	cacheDir := t.TempDir()
 	cmd := &cobra.Command{


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-392159](https://jira.mongodb.org/browse/CLOUDP-392159)

The MMS backend enforces a rate limit on telemetry events (CLOUDP-387377), returning HTTP 429 when clients exceed the per-request threshold of 32 events. The CLI was sending all cached events in a single unbatched request, so a command run in a tight loop would accumulate events, trigger 429, and then retry the full set on every subsequent invocation — continuously spamming the backend.

**Batch cap:** `trackCommand` now sends at most 32 events per invocation. Any remainder is written back to the cache for the next run.

**Backoff:** On any send error, a sentinel file (`telemetry_backoff`) is created in the cache directory. Its mtime marks when the backoff window started. Subsequent invocations skip the HTTP send entirely for one minute and just append their event to the cache. On a successful send the file is removed. No content is stored in the file — existence + mtime is sufficient.

## Tests added

- `TestTrackCommandBatchLimit` — exactly 32 events sent when cache has 31 + 1 new; remaining 1 written back
- `TestTrackCommandRemainingEventsPersistedAfterSuccess` — overflow events correctly written back after a successful partial send
- `TestTrackCommandRateLimitedPreservesEvents` — all events (cached + new) survive a send failure
- `TestSaveAndIsBackedOff` — backoff file created and detected
- `TestRemoveBackoff` — backoff file removed on explicit clear
- `TestBackoffExpired` — expired backoff (past mtime) is not active
- `TestTrackCommandSkipsSendWhenBackedOff` — no HTTP call made during active backoff; event cached
- `TestTrackCommandSetsBackoffOnSendError` — backoff file created for both 429 and generic errors
- `TestTrackCommandClearsBackoffOnSuccess` — backoff file removed after successful send

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code