### PR TITLE
CLOUDP-391808: Reduce org/project fetch limit from 500 to 50 on login

### DIFF
--- a/internal/cli/default_setter_opts.go
+++ b/internal/cli/default_setter_opts.go
@@ -65,7 +65,7 @@ func (opts *DefaultSetterOpts) InitStore(ctx context.Context) error {
 	return err
 }
 
-const resultsLimit = 500
+const resultsLimit = 50
 
 var (
 	errTooManyResults = errors.New("too many results")

--- a/internal/cli/default_setter_opts_test.go
+++ b/internal/cli/default_setter_opts_test.go
@@ -89,6 +89,15 @@ func TestDefaultOpts_Projects(t *testing.T) {
 		assert.Equal(t, []string{"1"}, gotIDs)
 		assert.Equal(t, []string{"Project 1"}, gotNames)
 	})
+	t.Run("too many projects", func(t *testing.T) {
+		expectedProjects := &atlasv2.PaginatedAtlasGroup{
+			Results:    []atlasv2.Group{},
+			TotalCount: pointer.Get(resultsLimit + 1),
+		}
+		mockStore.EXPECT().Projects(gomock.Any()).Return(expectedProjects, nil).Times(1)
+		_, _, err := opts.projects()
+		require.ErrorIs(t, err, errTooManyResults)
+	})
 }
 
 func TestDefaultOpts_Orgs(t *testing.T) {
@@ -136,5 +145,14 @@ func TestDefaultOpts_Orgs(t *testing.T) {
 		_, err := opts.orgs("")
 		require.Error(t, err)
 		require.EqualError(t, err, errNoResults.Error())
+	})
+	t.Run("too many orgs", func(t *testing.T) {
+		expectedOrgs := &atlasv2.PaginatedOrganization{
+			Results:    []atlasv2.AtlasOrganization{},
+			TotalCount: pointer.Get(resultsLimit + 1),
+		}
+		mockStore.EXPECT().Organizations(gomock.Any()).Return(expectedOrgs, nil).Times(1)
+		_, err := opts.orgs("")
+		require.ErrorIs(t, err, errTooManyResults)
 	})
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-391808](https://jira.mongodb.org/browse/CLOUDP-391808)

Reduces the maximum number of orgs and projects fetched during `atlas login` from 500 to 50. Users with access to more than 50 orgs or projects will now see the filter prompt much sooner, cutting the wait from 30+ seconds down significantly for internal users on environments like cloud-dev.

The user-facing messages already reference the limit via `%d`, so they automatically reflect the new threshold.

### Testing

```shell

git:(CLOUDP-391808) MCLI_CLIENT_ID=0oadn4hoajpzxeSEy357 MCLI_OPS_MANAGER_URL=https://cloud.mongodb.com/ ./bin/atlas login
? Select authentication type: UserAccount

To verify your account, copy your one-time verification code:
XW37-GRHF

Paste the code in the browser when prompted to activate your Atlas CLI. Your code will expire after 3 minutes.

To continue, go to https://account.mongodb.com/account/connect

Press Enter to open the browser and complete authentication...
Successfully logged in as <redacted>@mongodb.com.
Now set your default organization and project.
Since you have access to more than 50 organizations, please type the organization ID or the organization name to filter.
? Organization filter: [? for help]
```

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code