### PR TITLE
CLOUDP-394561: Add Ubuntu 25.10 (questing) support

### DIFF
--- a/build/ci/repo_config.yaml
+++ b/build/ci/repo_config.yaml
@@ -173,6 +173,19 @@ repos:
     repos:
       - apt/ubuntu/dists/noble/mongodb-org
 
+  - name: ubuntu2510
+    type: deb
+    code_name: "questing"
+    edition: org
+    bucket: repo.mongodb.org
+    component: multiverse
+    architectures:
+      - amd64
+      - s390x
+      - arm64
+    repos:
+      - apt/ubuntu/dists/questing/mongodb-org
+
 
   ####################
   #
@@ -289,3 +302,17 @@ repos:
       - arm64
     repos:
       - apt/ubuntu/dists/noble/mongodb-enterprise
+
+  - name: ubuntu2510
+    type: deb
+    code_name: "questing"
+    edition: enterprise
+    bucket: repo.mongodb.com
+    component: multiverse
+    architectures:
+      - amd64
+      - ppc64el
+      - s390x
+      - arm64
+    repos:
+      - apt/ubuntu/dists/questing/mongodb-enterprise

--- a/build/package/docker/meta/ubuntu25.10-deb.Dockerfile
+++ b/build/package/docker/meta/ubuntu25.10-deb.Dockerfile
@@ -1,0 +1,35 @@
+FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:25.10
+
+ARG url
+ARG entrypoint
+ARG server_version
+ARG pgp_server_version
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		curl \
+		gnupg \
+	; \
+	if ! command -v ps > /dev/null; then \
+		apt-get install -y --no-install-recommends procps; \
+	fi; \
+	curl -L https://www.mongodb.org/static/pgp/server-${pgp_server_version}.asc | apt-key add -; \
+	echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu questing/mongodb-org/${server_version} multiverse" | tee /etc/apt/sources.list.d/mongodb-org-${server_version}.list; \
+	rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    curl --silent --show-error --fail --location --retry 3 \
+    --output ${entrypoint}.deb \
+    ${url}; \
+	apt-get update; \
+	apt-get install -y ./${entrypoint}.deb; \
+	rm -rf /var/lib/apt/lists/* ./${entrypoint}.deb
+
+RUN mongosh --version
+RUN ${entrypoint} --version
+
+ENV ENTRY=${entrypoint}
+
+ENTRYPOINT $ENTRY

--- a/build/package/docker/repo/ubuntu25.10.Dockerfile
+++ b/build/package/docker/repo/ubuntu25.10.Dockerfile
@@ -1,0 +1,30 @@
+FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:25.10
+
+ARG package
+ARG entrypoint
+ARG server_version
+ARG pgp_server_version
+ARG mongo_package
+ARG mongo_repo
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		curl \
+		gnupg \
+	; \
+	if ! command -v ps > /dev/null; then \
+		apt-get install -y --no-install-recommends procps; \
+	fi; \
+	curl -L https://www.mongodb.org/static/pgp/server-${pgp_server_version}.asc | apt-key add -; \
+	echo "deb [ arch=amd64,arm64 ] ${mongo_repo}/apt/ubuntu questing/${mongo_package}/${server_version} multiverse" | tee /etc/apt/sources.list.d/${mongo_package}-${server_version}.list; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ${package}; \
+	rm -rf /var/lib/apt/lists/*
+
+RUN ${entrypoint} --version
+
+ENV ENTRY=${entrypoint}
+
+ENTRYPOINT $ENTRY

--- a/build/package/docker/ubuntu25.10-deb.Dockerfile
+++ b/build/package/docker/ubuntu25.10-deb.Dockerfile
@@ -1,0 +1,27 @@
+FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:25.10
+
+ARG url
+ARG entrypoint
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+	  ca-certificates \
+		curl \
+	; \
+	if ! command -v ps > /dev/null; then \
+		apt-get install -y --no-install-recommends procps; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    curl --silent --show-error --fail --location --retry 3 \
+    --output ${entrypoint}.deb \
+    ${url}; \
+    dpkg -i ${entrypoint}.deb;
+
+RUN ${entrypoint} --version
+
+ENV ENTRY=${entrypoint}
+
+ENTRYPOINT $ENTRY

--- a/tools/cmd/genevergreen/generate/generate.go
+++ b/tools/cmd/genevergreen/generate/generate.go
@@ -37,8 +37,8 @@ var (
 	unsupportedNewOsByVersion = map[string][]string{
 		"8.2": {"debian11"},
 		"8.0": {"debian11"},
-		"7.0": {"ubuntu2404"},
-		"6.0": {"ubuntu2404"},
+		"7.0": {"ubuntu2404", "ubuntu2510"},
+		"6.0": {"ubuntu2404", "ubuntu2510"},
 	}
 
 	oses = []string{
@@ -49,6 +49,7 @@ var (
 		"debian12",
 		"ubuntu22.04",
 		"ubuntu24.04",
+		"ubuntu25.10",
 	}
 	repos      = []string{"org", "enterprise"}
 	postPkgImg = map[string]string{
@@ -57,6 +58,7 @@ var (
 		"rhel9":       "rhel9-rpm",
 		"ubuntu22.04": "ubuntu22.04-deb",
 		"ubuntu24.04": "ubuntu24.04-deb",
+		"ubuntu25.10": "ubuntu25.10-deb",
 		"debian11":    "debian11-deb",
 		"debian12":    "debian12-deb",
 	}
@@ -66,6 +68,7 @@ var (
 		"rhel9":           "rhel90",
 		"ubuntu22.04":     "ubuntu2204",
 		"ubuntu24.04":     "ubuntu2404",
+		"ubuntu25.10":     "ubuntu2510",
 		"debian11":        "debian11",
 		"debian12":        "debian12",
 		"amazonlinux2023": "amazon2023",

--- a/tools/cmd/genevergreen/generate/generate_test.go
+++ b/tools/cmd/genevergreen/generate/generate_test.go
@@ -29,7 +29,7 @@ const (
 func TestPublishSnapshotTasks(t *testing.T) {
 	c := &shrub.Configuration{}
 	PublishSnapshotTasks(c)
-	assert.Len(t, c.Tasks, 30)
+	assert.Len(t, c.Tasks, 34)
 	commandFound := false
 	for _, task := range c.Tasks {
 		for _, c := range task.Commands {
@@ -71,7 +71,7 @@ func TestPublishStableTasks(t *testing.T) {
 
 	assert.True(t, commandFound, "expected to find a push command")
 	assert.Len(t, c.Variants, 4)
-	assert.Len(t, c.Tasks, 120)
+	assert.Len(t, c.Tasks, 128)
 }
 
 func TestPostPkgMetaTasks(t *testing.T) {
@@ -96,7 +96,7 @@ func TestPostPkgMetaTasks(t *testing.T) {
 		}
 	}
 	assert.Len(t, c.Variants, 1)
-	assert.Len(t, c.Tasks, 24)
+	assert.Len(t, c.Tasks, 26)
 }
 
 func TestRepoTasks(t *testing.T) {
@@ -119,7 +119,7 @@ func TestRepoTasks(t *testing.T) {
 	}
 
 	assert.Len(t, c.Variants, 4)
-	assert.Len(t, c.Tasks, 48)
+	assert.Len(t, c.Tasks, 52)
 }
 
 func TestGetGpgServerVersion(t *testing.T) {

--- a/tools/cmd/genevergreen/generate/publish.go
+++ b/tools/cmd/genevergreen/generate/publish.go
@@ -69,6 +69,10 @@ var distros = map[string]Platform{
 		extension:     deb,
 		architectures: []string{x86_64, arm64},
 	},
+	"ubuntu2510": {
+		extension:     deb,
+		architectures: []string{x86_64, arm64},
+	},
 	"suse15": {
 		extension:     rpm,
 		architectures: []string{x86_64},

--- a/tools/cmd/release/main.go
+++ b/tools/cmd/release/main.go
@@ -99,8 +99,8 @@ func generateFile(name, version string) error {
 		Platform: []*Platform{
 			newPlatform(version, "x86_64", "linux", "Linux (x86_64)", []string{"tar.gz"}),
 			newPlatform(version, "arm64", "linux", "Linux (arm64)", []string{"tar.gz"}),
-			newPlatform(version, "x86_64", "linux", "Debian 11, 12 / Ubuntu 22.04, 24.04 (x86_64)", []string{"deb"}),
-			newPlatform(version, "arm64", "linux", "Debian 11, 12 / Ubuntu 22.04, 24.04 (arm64)", []string{"deb"}),
+			newPlatform(version, "x86_64", "linux", "Debian 11, 12 / Ubuntu 22.04, 24.04, 25.10 (x86_64)", []string{"deb"}),
+			newPlatform(version, "arm64", "linux", "Debian 11, 12 / Ubuntu 22.04, 24.04, 25.10 (arm64)", []string{"deb"}),
 			newPlatform(version, "x86_64", "linux", "Red Hat + CentOS 8, 9 / SUSE 12 + 15 / Amazon Linux 2023 (x86_64)", []string{"rpm"}),
 			newPlatform(version, "arm64", "linux", "Red Hat + CentOS 8, 9 / SUSE 12 + 15 / Amazon Linux 2023 (arm64)", []string{"rpm"}),
 			newPlatform(version, "x86_64", "windows", "Microsoft Windows", []string{"msi", "zip"}),


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-394561

Registers Ubuntu 25.10 (codename `questing`, distro id `ubuntu2510`) across the packaging and release pipeline so `.deb` packages publish to the MongoDB apt repos and are covered by repo/smoke tests. Templated off the existing 24.04 (`noble`) entries.

Changes:
- `build/ci/repo_config.yaml` — org (`repo.mongodb.org`) and enterprise (`repo.mongodb.com`) apt repo entries for `questing`.
- `tools/cmd/genevergreen/generate/generate.go` — add `ubuntu25.10` to `oses`, `postPkgImg`, `newOs`; exclude `ubuntu2510` from MongoDB 6.0/7.0 in `unsupportedNewOsByVersion` (mirrors `noble`).
- `tools/cmd/genevergreen/generate/publish.go` — add `ubuntu2510` to the `distros` map (kept in sync with `repo_config.yaml`).
- `tools/cmd/genevergreen/generate/generate_test.go` — updated task-count assertions (snapshot 30→34, stable 120→128, meta 24→26, repo 48→52).
- `tools/cmd/release/main.go` — add 25.10 to the deb download platform descriptions.
- `build/package/docker/{,meta/,repo/}` — three new Dockerfiles for the package/meta/repo smoke tests.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

**Draft — blocked on upstream apt repo.** The MongoDB apt repos do not serve `questing` yet (`https://repo.mongodb.org/apt/ubuntu/dists/questing/` and the `repo.mongodb.com` equivalent both return 404; `noble` returns 200). Until release-infra publishes the dist, the `test_repo_atlascli_*` and `pkg_test_atlascli_meta_*` CI tasks will fail because they install from that path. This is the same dependency that caused Ubuntu 24.04 to be added (#2941), reverted (#3037), then re-added (#3064). Keep this in draft and only mark ready once both dist URLs return a populated tree.

**Assumption to confirm:** `ubuntu2510` is excluded from MongoDB server 6.0/7.0 (matching `noble`). Verify the actual server-version support once `questing` is published and adjust `unsupportedNewOsByVersion` if needed.

Local validation: `make fmt`, `make lint`, `make build`, `make unit-test`, and `go test ./tools/cmd/genevergreen/generate/` all pass.