### PR TITLE
CLOUDP-417280: Match TRAE_AI_SHELL_ID agent telemetry on presence

### DIFF
--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -152,26 +152,34 @@ func withCI() EventOpt {
 }
 
 var agentEnvVars = []struct {
-	envVar string
-	value  string // empty means any non-empty value matches
-	name   string
+	envVar       string
+	value        string // expected value; empty matches any non-empty value
+	name         string
+	presenceOnly bool // match whenever the variable is set, regardless of value
 }{
-	{"CLAUDECODE", "1", "claude_code"},
-	{"CURSOR_AGENT", "1", "cursor"},
-	{"GEMINI_CLI", "1", "gemini_cli"},
-	{"CODEX_SANDBOX", "seatbelt", "codex_cli"},
-	{"AUGMENT_AGENT", "1", "auggie_cli"},
-	{"CLINE_ACTIVE", "true", "cline"},
-	{"OPENCODE_CLIENT", "1", "opencode_client"},
-	{"TRAE_AI_SHELL_ID", "", "trae_ai"},
-	{"AMP_AGENT", "1", "amp"},
-	{"GOOSE_AGENT", "1", "goose"},
+	{"CLAUDECODE", "1", "claude_code", false},
+	{"CURSOR_AGENT", "1", "cursor", false},
+	{"GEMINI_CLI", "1", "gemini_cli", false},
+	{"CODEX_SANDBOX", "seatbelt", "codex_cli", false},
+	{"AUGMENT_AGENT", "1", "auggie_cli", false},
+	{"CLINE_ACTIVE", "true", "cline", false},
+	{"OPENCODE_CLIENT", "1", "opencode_client", false},
+	{"TRAE_AI_SHELL_ID", "", "trae_ai", true},
+	{"AMP_AGENT", "1", "amp", false},
+	{"GOOSE_AGENT", "1", "goose", false},
 }
 
 func withAgent() EventOpt {
 	return func(event Event) {
 		for _, a := range agentEnvVars {
 			v, ok := os.LookupEnv(a.envVar)
+			if a.presenceOnly {
+				if ok {
+					event.Properties["agent_env_var"] = a.name
+					return
+				}
+				continue
+			}
 			if !ok || v == "" {
 				continue
 			}

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -17,6 +17,7 @@ package telemetry
 import (
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -406,7 +407,10 @@ func TestWithHelpCommand_NotFound(t *testing.T) {
 func clearAgentEnvVars(t *testing.T) {
 	t.Helper()
 	for _, a := range agentEnvVars {
+		// t.Setenv registers restoration of the original value; os.Unsetenv
+		// then actually clears it so presence-based checks see it as unset.
 		t.Setenv(a.envVar, "")
+		require.NoError(t, os.Unsetenv(a.envVar))
 	}
 }
 
@@ -436,6 +440,18 @@ func TestWithAgent(t *testing.T) {
 			assert.Equal(t, tt.want, e.Properties["agent_env_var"])
 		})
 	}
+	t.Run("trae_ai detected when set to empty value", func(t *testing.T) {
+		clearAgentEnvVars(t)
+		t.Setenv("TRAE_AI_SHELL_ID", "")
+		e := newEvent(withAgent())
+		assert.Equal(t, "trae_ai", e.Properties["agent_env_var"])
+	})
+	t.Run("value-matched var ignored when set to empty", func(t *testing.T) {
+		clearAgentEnvVars(t)
+		t.Setenv("CLAUDECODE", "")
+		e := newEvent(withAgent())
+		assert.NotContains(t, e.Properties, "agent_env_var")
+	})
 	t.Run("none set", func(t *testing.T) {
 		clearAgentEnvVars(t)
 		e := newEvent(withAgent())


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-417280

This PR is the first in the ticket to expend tracing support for AI agents.

`TRAE_AI_SHELL_ID` is now detected whenever the variable is set, rather than only when it holds a non-empty value. Its value is a session id, so presence alone is the agent signal.

This is implemented with a `presenceOnly` flag on the agent env var table, set only for `TRAE_AI_SHELL_ID`. The existing value-matching logic for every other agent is left unchanged.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Follow-up to CLOUDP-400902. The broader Bun/Vercel env var additions tracked in this ticket are not included here.