### PR TITLE
CLOUDP-417280: Add Bun and Vercel agent env var checks to telemetry

### DIFF
--- a/internal/telemetry/event.go
+++ b/internal/telemetry/event.go
@@ -157,17 +157,56 @@ var agentEnvVars = []struct {
 	name         string
 	presenceOnly bool // match whenever the variable is set, regardless of value
 }{
+	// withAgent returns on the first match; the generic AI_AGENT and
+	// IS_CODE_AGENT flags are handled after this table so specific tools win.
 	{"CLAUDECODE", "1", "claude_code", false},
+	{"CLAUDE_CODE", "", "claude_code", true},
+	{"CLAUDE_CODE_IS_COWORK", "", "claude_code", true}, // Cowork runs on Claude Code
 	{"CURSOR_AGENT", "1", "cursor", false},
+	{"CURSOR_TRACE_ID", "", "cursor", true},
+	{"CURSOR_EXTENSION_HOST_ROLE", "", "cursor", true},
 	{"GEMINI_CLI", "1", "gemini_cli", false},
 	{"CODEX_SANDBOX", "seatbelt", "codex_cli", false},
+	{"CODEX_CI", "", "codex_cli", true},
+	{"CODEX_THREAD_ID", "", "codex_cli", true},
 	{"AUGMENT_AGENT", "1", "auggie_cli", false},
 	{"CLINE_ACTIVE", "true", "cline", false},
 	{"OPENCODE_CLIENT", "1", "opencode_client", false},
 	{"TRAE_AI_SHELL_ID", "", "trae_ai", true},
+	{"ANTIGRAVITY_AGENT", "", "antigravity", true},
+	{"REPL_ID", "", "replit", true},
 	{"AMP_AGENT", "1", "amp", false},
 	{"GOOSE_AGENT", "1", "goose", false},
+	{"COPILOT_MODEL", "", "github_copilot", true},
+	{"COPILOT_ALLOW_ALL", "", "github_copilot", true},
+	{"COPILOT_GITHUB_TOKEN", "", "github_copilot", true},
 }
+
+// aiAgentNames maps the AI_AGENT value (the agent's own name, per Vercel's
+// @vercel/detect-agent) to our agent_env_var value. Any other value still
+// signals an agent, reported as unidentifiedAgent.
+var aiAgentNames = map[string]string{
+	"cursor":             "cursor",
+	"cursor-cli":         "cursor",
+	"claude":             "claude_code",
+	"cowork":             "claude_code",
+	"devin":              "devin",
+	"replit":             "replit",
+	"gemini":             "gemini_cli",
+	"codex":              "codex_cli",
+	"antigravity":        "antigravity",
+	"augment-cli":        "auggie_cli",
+	"opencode":           "opencode_client",
+	"github-copilot":     "github_copilot",
+	"github-copilot-cli": "github_copilot",
+	"v0":                 "v0",
+}
+
+const (
+	aiAgentEnvVar     = "AI_AGENT"
+	isCodeAgentEnvVar = "IS_CODE_AGENT"
+	unidentifiedAgent = "unidentified_agent"
+)
 
 func withAgent() EventOpt {
 	return func(event Event) {
@@ -187,6 +226,23 @@ func withAgent() EventOpt {
 				continue
 			}
 			event.Properties["agent_env_var"] = a.name
+			return
+		}
+		// AI_AGENT holds the agent's own name (Vercel's @vercel/detect-agent
+		// convention). Map known names; any other value still signals an agent.
+		if v, ok := os.LookupEnv(aiAgentEnvVar); ok {
+			if v = strings.TrimSpace(v); v != "" {
+				name, known := aiAgentNames[v]
+				if !known {
+					name = unidentifiedAgent
+				}
+				event.Properties["agent_env_var"] = name
+				return
+			}
+		}
+		// IS_CODE_AGENT is Bun's generic "an agent is present" flag.
+		if v, ok := os.LookupEnv(isCodeAgentEnvVar); ok && v == "1" {
+			event.Properties["agent_env_var"] = unidentifiedAgent
 			return
 		}
 		if _, err := os.Stat("/opt/.devin"); err == nil {

--- a/internal/telemetry/event_test.go
+++ b/internal/telemetry/event_test.go
@@ -406,11 +406,16 @@ func TestWithHelpCommand_NotFound(t *testing.T) {
 
 func clearAgentEnvVars(t *testing.T) {
 	t.Helper()
+	envVars := make([]string, 0, len(agentEnvVars)+2)
 	for _, a := range agentEnvVars {
+		envVars = append(envVars, a.envVar)
+	}
+	envVars = append(envVars, aiAgentEnvVar, isCodeAgentEnvVar)
+	for _, name := range envVars {
 		// t.Setenv registers restoration of the original value; os.Unsetenv
 		// then actually clears it so presence-based checks see it as unset.
-		t.Setenv(a.envVar, "")
-		require.NoError(t, os.Unsetenv(a.envVar))
+		t.Setenv(name, "")
+		require.NoError(t, os.Unsetenv(name))
 	}
 }
 
@@ -431,6 +436,33 @@ func TestWithAgent(t *testing.T) {
 		{name: "trae_ai", envVar: "TRAE_AI_SHELL_ID", value: "session-123", want: "trae_ai"},
 		{name: "amp", envVar: "AMP_AGENT", value: "1", want: "amp"},
 		{name: "goose", envVar: "GOOSE_AGENT", value: "1", want: "goose"},
+		{name: "replit", envVar: "REPL_ID", value: "repl-abc", want: "replit"},
+		{name: "cursor via trace id", envVar: "CURSOR_TRACE_ID", value: "trace-1", want: "cursor"},
+		{name: "cursor via extension host role", envVar: "CURSOR_EXTENSION_HOST_ROLE", value: "worker", want: "cursor"},
+		{name: "codex via ci", envVar: "CODEX_CI", value: "1", want: "codex_cli"},
+		{name: "codex via thread id", envVar: "CODEX_THREAD_ID", value: "thread-1", want: "codex_cli"},
+		{name: "antigravity", envVar: "ANTIGRAVITY_AGENT", value: "1", want: "antigravity"},
+		{name: "claude_code via CLAUDE_CODE", envVar: "CLAUDE_CODE", value: "1", want: "claude_code"},
+		{name: "cowork reported as claude_code", envVar: "CLAUDE_CODE_IS_COWORK", value: "1", want: "claude_code"},
+		{name: "github_copilot via model", envVar: "COPILOT_MODEL", value: "gpt-4o", want: "github_copilot"},
+		{name: "github_copilot via allow all", envVar: "COPILOT_ALLOW_ALL", value: "1", want: "github_copilot"},
+		{name: "github_copilot via github token", envVar: "COPILOT_GITHUB_TOKEN", value: "ghs_secret", want: "github_copilot"},
+		{name: "AI_AGENT cursor", envVar: "AI_AGENT", value: "cursor", want: "cursor"},
+		{name: "AI_AGENT cursor-cli", envVar: "AI_AGENT", value: "cursor-cli", want: "cursor"},
+		{name: "AI_AGENT claude", envVar: "AI_AGENT", value: "claude", want: "claude_code"},
+		{name: "AI_AGENT cowork reported as claude_code", envVar: "AI_AGENT", value: "cowork", want: "claude_code"},
+		{name: "AI_AGENT devin", envVar: "AI_AGENT", value: "devin", want: "devin"},
+		{name: "AI_AGENT replit", envVar: "AI_AGENT", value: "replit", want: "replit"},
+		{name: "AI_AGENT gemini", envVar: "AI_AGENT", value: "gemini", want: "gemini_cli"},
+		{name: "AI_AGENT codex", envVar: "AI_AGENT", value: "codex", want: "codex_cli"},
+		{name: "AI_AGENT antigravity", envVar: "AI_AGENT", value: "antigravity", want: "antigravity"},
+		{name: "AI_AGENT augment-cli", envVar: "AI_AGENT", value: "augment-cli", want: "auggie_cli"},
+		{name: "AI_AGENT opencode", envVar: "AI_AGENT", value: "opencode", want: "opencode_client"},
+		{name: "AI_AGENT github-copilot", envVar: "AI_AGENT", value: "github-copilot", want: "github_copilot"},
+		{name: "AI_AGENT github-copilot-cli", envVar: "AI_AGENT", value: "github-copilot-cli", want: "github_copilot"},
+		{name: "AI_AGENT v0", envVar: "AI_AGENT", value: "v0", want: "v0"},
+		{name: "unidentified via AI_AGENT unknown value", envVar: "AI_AGENT", value: "some-agent", want: "unidentified_agent"},
+		{name: "unidentified via IS_CODE_AGENT", envVar: "IS_CODE_AGENT", value: "1", want: "unidentified_agent"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name+" detected", func(t *testing.T) {
@@ -461,8 +493,30 @@ func TestWithAgent(t *testing.T) {
 		clearAgentEnvVars(t)
 		t.Setenv("CLAUDECODE", "true")
 		t.Setenv("CODEX_SANDBOX", "1")
+		t.Setenv("IS_CODE_AGENT", "0")
 		e := newEvent(withAgent())
 		assert.NotContains(t, e.Properties, "agent_env_var")
+	})
+	t.Run("specific agent wins over generic flag", func(t *testing.T) {
+		clearAgentEnvVars(t)
+		t.Setenv("AI_AGENT", "some-agent")
+		t.Setenv("CURSOR_AGENT", "1")
+		e := newEvent(withAgent())
+		assert.Equal(t, "cursor", e.Properties["agent_env_var"])
+	})
+	t.Run("claude_code detected when cowork flag also set", func(t *testing.T) {
+		clearAgentEnvVars(t)
+		t.Setenv("CLAUDECODE", "1")
+		t.Setenv("CLAUDE_CODE_IS_COWORK", "1")
+		e := newEvent(withAgent())
+		assert.Equal(t, "claude_code", e.Properties["agent_env_var"])
+	})
+	t.Run("AI_AGENT known value wins over IS_CODE_AGENT", func(t *testing.T) {
+		clearAgentEnvVars(t)
+		t.Setenv("AI_AGENT", "claude")
+		t.Setenv("IS_CODE_AGENT", "1")
+		e := newEvent(withAgent())
+		assert.Equal(t, "claude_code", e.Properties["agent_env_var"])
 	})
 }
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-417280

Extends `agent_env_var` telemetry detection with the additional agent environment variables that Bun ([oven-sh/bun#21135](https://github.com/oven-sh/bun/pull/21135)) and Vercel's `@vercel/detect-agent` check. Adds agents we could not detect before (`github_copilot`, `antigravity`, `replit`, `v0`), extra fallback signals for agents already covered, and two generic flags.

New detections:

| Variable(s) | `agent_env_var` |
|---|---|
| `COPILOT_MODEL`, `COPILOT_ALLOW_ALL`, `COPILOT_GITHUB_TOKEN` | `github_copilot` |
| `ANTIGRAVITY_AGENT` | `antigravity` |
| `REPL_ID` | `replit` |
| `CLAUDE_CODE`, `CLAUDE_CODE_IS_COWORK` | `claude_code` |
| `CURSOR_TRACE_ID`, `CURSOR_EXTENSION_HOST_ROLE` | `cursor` |
| `CODEX_CI`, `CODEX_THREAD_ID` | `codex_cli` |
| `AI_AGENT=<name>` | the matching tool when recognized (`cursor`, `claude_code`, `devin`, `replit`, `gemini_cli`, `codex_cli`, `antigravity`, `auggie_cli`, `opencode_client`, `github_copilot`, `v0`), otherwise `unidentified_agent` |
| `IS_CODE_AGENT=1` | `unidentified_agent` |

Notes for reviewers:

* Cowork runs on top of Claude Code, so both its signals (`CLAUDE_CODE_IS_COWORK` and `AI_AGENT=cowork`) are reported as `claude_code` rather than as a separate value.
* `AI_AGENT` carries the agent's own name as its value (Vercel's convention), so it is handled with a value->name map rather than a table row. Known names map to the matching tool; unknown values still report `unidentified_agent`. This mirrors Vercel, including its `github-copilot` / `github-copilot-cli` normalization and `v0`.
* The table is ordered specific tools first; `withAgent` returns on the first match. The generic `AI_AGENT` and `IS_CODE_AGENT` flags are evaluated after the table, and `IS_CODE_AGENT` after `AI_AGENT`, so a named agent always wins over the bare flag. Precedence tests cover this.
* `IS_CODE_AGENT` matches the exact value `1` (Bun's semantics).
* `COPILOT_GITHUB_TOKEN` is matched on presence only. The token value is never read or stored.
* Bare `AGENT` was intentionally left out: neither Bun nor Vercel check it, it has high false-positive risk, and it collides with amp/goose.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

MCP telemetry lives in the separate `mongodb-mcp-server` repo and is out of scope here; it can follow up there.

Separately worth verifying: amp/goose are currently detected via `AMP_AGENT` / `GOOSE_AGENT`, but CLOUDP-400902 documented their signal as `AGENT=amp` / `AGENT=goose`. Those were added untested, so the current variables may be wrong. Not changed in this PR.