### PR TITLE
CLOUDP-416068: Fetch plugin using unauth gh client if auth fails with…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore AI agent artifacts
+docs/superpowers/**

--- a/internal/cli/plugin/github.go
+++ b/internal/cli/plugin/github.go
@@ -30,3 +30,13 @@ func NewAuthenticatedGithubClient() *github.Client {
 
 	return ghClient
 }
+
+// newUnauthenticatedGithubClient returns a GitHub client with no auth token. It
+// preserves the base and upload URLs of the provided client so it keeps
+// targeting the same host (important for tests using a mock server).
+func newUnauthenticatedGithubClient(ghClient *github.Client) *github.Client {
+	client := github.NewClient(nil)
+	client.BaseURL = ghClient.BaseURL
+	client.UploadURL = ghClient.UploadURL
+	return client
+}

--- a/internal/cli/plugin/install.go
+++ b/internal/cli/plugin/install.go
@@ -79,10 +79,13 @@ func (opts *InstallOpts) validatePlugin(pluginDirectoryPath string) error {
 
 func (opts *InstallOpts) Run(ctx context.Context) error {
 	// get all plugin assets info from github repository
-	assets, err := opts.githubAsset.getReleaseAssets(opts.ghClient)
+	// getReleaseAssets may fall back to an unauthenticated client; reuse the
+	// returned client for the subsequent asset downloads.
+	assets, ghClient, err := opts.githubAsset.getReleaseAssets(opts.ghClient)
 	if err != nil {
 		return err
 	}
+	opts.ghClient = ghClient
 
 	// find correct assetID, signatureID and pubKeyID using system requirements
 	assetID, signatureID, pubKeyID, err := opts.githubAsset.getIDs(assets)

--- a/internal/cli/plugin/plugin_github_asset.go
+++ b/internal/cli/plugin/plugin_github_asset.go
@@ -76,10 +76,33 @@ func (g *GithubAsset) getPluginDirectoryName() string {
 	return fmt.Sprintf("%s@%s", g.owner, g.name)
 }
 
-func (g *GithubAsset) getReleaseAssets(ghClient *github.Client) ([]*github.ReleaseAsset, error) {
-	var err error
-	var release *github.RepositoryRelease
+// getReleaseAssets fetches the release assets for the plugin. It returns the
+// assets together with the client that succeeded, so callers can reuse it for
+// the subsequent asset downloads.
+func (g *GithubAsset) getReleaseAssets(ghClient *github.Client) ([]*github.ReleaseAsset, *github.Client, error) {
+	release, err := g.getRelease(ghClient)
+	if err != nil {
+		// Only retry without the token when the failure is a 403 caused by the
+		// configured token/login lacking access (e.g. org SAML/SSO enforcement).
+		// If the target plugin repository is public, an unauthenticated request
+		// can succeed. Any other error is surfaced as-is.
+		if !isForbiddenErr(err) {
+			return nil, nil, err
+		}
+		_, _ = log.Debugf("-- plugin debug: authenticated github request for %s was forbidden: %v\n", g.repository(), err)
+		_, _ = log.Debugf("-- plugin debug: retrying with unauthenticated github client\n")
+		ghClient = newUnauthenticatedGithubClient(ghClient)
+		release, err = g.getRelease(ghClient)
+	}
+	if err != nil {
+		_, _ = log.Debugf("-- plugin debug: unauthenticated GitHub request for %s also failed: %v\n", g.repository(), err)
+		return nil, nil, err
+	}
 
+	return release.Assets, ghClient, nil
+}
+
+func (g *GithubAsset) getRelease(ghClient *github.Client) (*github.RepositoryRelease, error) {
 	// download latest release if version is not specified
 	if g.version == nil {
 		// download the 100 latest releases
@@ -90,31 +113,43 @@ func (g *GithubAsset) getReleaseAssets(ghClient *github.Client) ([]*github.Relea
 		})
 
 		if err != nil {
-			return nil, fmt.Errorf("could not fetch releases for %s, access to GitHub is required, see https://dochub.mongodb.org/core/atlas-cli-deploy-docker\n"+
-				"if you are using a private repository, you need to set the GH_TOKEN environment variable (needs content read access to the repository) or authenticate with the github cli\n"+
-				"more info about access tokens: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token\n\n"+
+			return nil, fmt.Errorf("could not fetch the release for %s. Make sure you have access to GitHub.\n"+
+				"If you are running the Atlas CLI via Docker, see https://dochub.mongodb.org/core/atlas-cli-deploy-docker\n"+
+				"If the plugin is stored in a private repository, set the GH_TOKEN environment variable to a token with content read access to that repository, or authenticate with the GitHub CLI.\n"+
+				"For more information about access tokens, see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token\n\n"+
 				"error: %w", g.repository(), err)
 		}
 
 		// get the latest release that doesn't have prerelease info or metadata in the version tag
-		release = getLatestStableRelease(releases)
+		release := getLatestStableRelease(releases)
 		if release == nil {
 			return nil, fmt.Errorf("could not find latest stable release for %s", g.repository())
 		}
-	} else {
-		// try to find the release with the version tag with v prefix, if it does not exist try again without the prefix
-		release, _, err = ghClient.Repositories.GetReleaseByTag(context.Background(), g.owner, g.name, "v"+g.version.String())
 
-		if release == nil || err != nil {
-			release, _, err = ghClient.Repositories.GetReleaseByTag(context.Background(), g.owner, g.name, g.version.String())
-		}
-
-		if err != nil {
-			return nil, fmt.Errorf("could not find the release %s for %s", g.version, g.repository())
-		}
+		return release, nil
 	}
 
-	return release.Assets, nil
+	// try to find the release with the version tag with v prefix, if it does not exist try again without the prefix
+	release, _, err := ghClient.Repositories.GetReleaseByTag(context.Background(), g.owner, g.name, "v"+g.version.String())
+
+	if release == nil || err != nil {
+		release, _, err = ghClient.Repositories.GetReleaseByTag(context.Background(), g.owner, g.name, g.version.String())
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("could not find the release %s for %s: %w", g.version, g.repository(), err)
+	}
+
+	return release, nil
+}
+
+// isForbiddenErr reports whether err is a GitHub 403 response. This is returned
+// when the configured token or login lacks access to the repository, most
+// notably when a Personal Access Token is blocked by an organization's SAML/SSO
+// enforcement ("Resource protected by organization SAML enforcement").
+func isForbiddenErr(err error) bool {
+	var ghErr *github.ErrorResponse
+	return errors.As(err, &ghErr) && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusForbidden
 }
 
 func getLatestStableRelease(releases []*github.RepositoryRelease) *github.RepositoryRelease {

--- a/internal/cli/plugin/plugin_github_asset_test.go
+++ b/internal/cli/plugin/plugin_github_asset_test.go
@@ -16,6 +16,10 @@ package plugin
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -512,6 +516,165 @@ func Test_createGithubAssetFromPlugin(t *testing.T) {
 					t.Errorf("expected: %v, got: %v", tt.expected, got)
 				}
 			}
+		})
+	}
+}
+
+// newGithubTestClient returns an authenticated client pointing at the given
+// test server, mimicking NewAuthenticatedGithubClient when a token is present.
+func newGithubTestClient(t *testing.T, serverURL string) *github.Client {
+	t.Helper()
+	base, err := url.Parse(serverURL + "/")
+	require.NoError(t, err)
+	client := github.NewClient(nil).WithAuthToken("saml-blocked-token")
+	client.BaseURL = base
+	return client
+}
+
+func Test_getReleaseAssets_fallsBackToUnauthenticated(t *testing.T) {
+	const releasesBody = `[{"tag_name":"v1.0.0","assets":[{"id":1,"name":"plugin_linux_amd64.tar.gz","content_type":"application/gzip"}]}]`
+
+	var authedCalls, unauthedCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// the configured token is rejected (e.g. org SAML/SSO enforcement);
+		// an unauthenticated request to the public repo succeeds
+		if r.Header.Get("Authorization") != "" {
+			authedCalls++
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Resource protected by organization SAML enforcement"}`))
+			return
+		}
+		unauthedCalls++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(releasesBody))
+	}))
+	t.Cleanup(server.Close)
+
+	asset := &GithubAsset{owner: "mongodb", name: "atlas-local-cli"}
+	authedClient := newGithubTestClient(t, server.URL)
+
+	assets, effectiveClient, err := asset.getReleaseAssets(authedClient)
+	require.NoError(t, err)
+	require.Len(t, assets, 1)
+	assert.Equal(t, "plugin_linux_amd64.tar.gz", assets[0].GetName())
+
+	// authenticated request tried first, then retried unauthenticated
+	assert.Equal(t, 1, authedCalls)
+	assert.Equal(t, 1, unauthedCalls)
+
+	// the returned client is unauthenticated so downloads reuse it
+	assert.NotEqual(t, authedClient, effectiveClient)
+}
+
+func Test_getReleaseAssets_succeedsWithoutFallback(t *testing.T) {
+	const releasesBody = `[{"tag_name":"v1.0.0","assets":[{"id":1,"name":"plugin_linux_amd64.tar.gz","content_type":"application/gzip"}]}]`
+
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(releasesBody))
+	}))
+	t.Cleanup(server.Close)
+
+	asset := &GithubAsset{owner: "mongodb", name: "atlas-local-cli"}
+	client := newGithubTestClient(t, server.URL)
+
+	assets, effectiveClient, err := asset.getReleaseAssets(client)
+	require.NoError(t, err)
+	require.Len(t, assets, 1)
+
+	// no retry needed; same client returned
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, client, effectiveClient)
+}
+
+func Test_getReleaseAssets_failsWhenBothAttemptsFail(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	asset := &GithubAsset{owner: "mongodb", name: "atlas-local-cli"}
+	client := newGithubTestClient(t, server.URL)
+
+	_, _, err := asset.getReleaseAssets(client)
+	require.Error(t, err)
+	// authenticated attempt plus one unauthenticated retry
+	assert.Equal(t, 2, calls)
+}
+
+func Test_getReleaseAssets_doesNotRetryOnNonForbiddenError(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	asset := &GithubAsset{owner: "mongodb", name: "atlas-local-cli"}
+	client := newGithubTestClient(t, server.URL)
+
+	_, _, err := asset.getReleaseAssets(client)
+	require.Error(t, err)
+	// non-403 error is surfaced without an unauthenticated retry
+	assert.Equal(t, 1, calls)
+}
+
+func Test_isForbiddenErr(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "plain error",
+			err:      errors.New("boom"),
+			expected: false,
+		},
+		{
+			name: "403 error response (SAML/SSO)",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+				Message:  "Resource protected by organization SAML enforcement",
+			},
+			expected: true,
+		},
+		{
+			name: "wrapped 403 error response",
+			err: fmt.Errorf("could not fetch releases: %w", &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+			}),
+			expected: true,
+		},
+		{
+			name: "404 error response",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotFound},
+			},
+			expected: false,
+		},
+		{
+			name: "rate limit error is not treated as forbidden",
+			err: &github.RateLimitError{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isForbiddenErr(tt.err))
 		})
 	}
 }

--- a/internal/cli/plugin/update.go
+++ b/internal/cli/plugin/update.go
@@ -138,10 +138,13 @@ func (opts *UpdateOpts) validatePlugin(pluginDirectoryPath string) error {
 
 func (opts *UpdateOpts) updatePlugin(ctx context.Context, githubAssetRelease *GithubAsset, existingPlugin *plugin.Plugin) error {
 	// get all plugin assets info from github repository
-	assets, err := githubAssetRelease.getReleaseAssets(opts.ghClient)
+	// getReleaseAssets may fall back to an unauthenticated client; reuse the
+	// returned client for the subsequent asset downloads.
+	assets, ghClient, err := githubAssetRelease.getReleaseAssets(opts.ghClient)
 	if err != nil {
 		return err
 	}
+	opts.ghClient = ghClient
 
 	// find correct assetID, signatureID and pubKeyID using system requirements
 	assetID, signatureID, pubKeyID, err := githubAssetRelease.getIDs(assets)


### PR DESCRIPTION
… 403 Forbidden

## Proposed changes

_Jira ticket:_ [CLOUDP-416068](https://jira.mongodb.org/browse/CLOUDP-416068)

atlas local (and any other plugins living in the gh org mongodb) failed for internal users who had a `GitHub token configured but not authorized for the mongodb org:
```
Installing first class plugin atlas-local-plugin
Error: failed to install first class plugin atlas-local-plugin: could not fetch releases for mongodb/atlas-local-cli, access to GitHub is required, see https://dochub.mongodb.org/core/atlas-cli-deploy-docker
if you are using a private repository, you need to set the GH_TOKEN environment variable (needs content read access to the repository) or authenticate with the github cli
more info about access tokens: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token

error: GET https://api.github.com/repos/mongodb/atlas-local-cli/releases?per_page=100: 403 Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization. []
```

Root cause: `NewAuthenticatedGithubClient` attaches any token found via GH_TOKEN/GITHUB_TOKEN or the gh CLI (auth.TokenForHost) to every GitHub request. Internal users'  tokens are subject to the mongodb org's SAML/SSO enforcement even if the target repo is public (like mong/atlas-local-cli) and so the request is rejected with a 403. The token that was meant to help instead broke the install.

  Changes
  - plugin_github_asset.go
    - If a 403 Forbidden error is encountered when getting the asset releases using the authenticated gh client, a debug message is logged and the fetch is reattempted with a new unauth client
    - If the unauth client succeeds, that client will be used for the subsequent call to download the assets
    - Error messaging for the "could not fetch release" error minorly reworded for clarity.

  Testing
  - New unit tests (plugin_github_asset_test.go) using an httptest server to ensure correct clients are used given different failures.

Closes #4623


## Before vs After cmd output

### Before - fails using intenral toke not authorized w mdb
```
> export GH_TOKEN=<>
> atlas local
Installing first class plugin atlas-local-plugin
Error: failed to install first class plugin atlas-local-plugin: could not fetch releases for mongodb/atlas-local-cli, access to GitHub is required, see https://dochub.mongodb.org/core/atlas-cli-deploy-docker
if you are using a private repository, you need to set the GH_TOKEN environment variable (needs contentread access to the repository) or authenticate with the github cli
more info about access tokens: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token

error: GET https://api.github.com/repos/mongodb/atlas-local-cli/releases?per_page=100: 403 Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization. []
```

### After - succeeds using internal toke not authorized w mdb
```
> export GH_TOKEN=<>
> ./bin/atlas local
Installing first class plugin atlas-local-plugin
Plugin mongodb/atlas-local-cli successfully installed
Manage local deployments

Usage: atlas local [OPTIONS] <COMMAND>

Commands:
  setup    Create a local deployment
  connect  Connect to a deployment
  list     List all local deployments
  start    Start a deployment
  stop     Stop (pause) a deployment
  logs     Get deployment logs
  delete   Delete a deployment
  search   Manage search for local deployments.
  help     Print this message or the help of the given subcommand(s)

Options:
  -o, --output <FORMAT>    Output format [possible values: text, json]
  -P, --profile <PROFILE>  Name of the profile to use from your configuration file. To learn about profiles forthe Atlas CLI, see https://dochub.mongodb.org/core/atlas-cli-save-connection-settings
  -h, --help               Print help
```

### After - new debug logs
```
> export GH_TOKEN=<>
> ./bin/atlas plugin install mongodb/atlas-cli-plugin-example --debug 
-- plugin debug: authenticated GitHub request for mongodb/atlas-cli-plugin-example was forbidden: could not fetch the release for mongodb/atlas-cli-plugin-example. Make sure you have access to GitHub.
If you are running the Atlas CLI via Docker, see https://dochub.mongodb.org/core/atlas-cli-deploy-docker
If the plugin is stored in a private repository, set the GH_TOKEN environment variable to a token with content read access to that repository, or authenticate with the GitHub CLI.
For more information about access tokens, see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token

error: GET https://api.github.com/repos/mongodb/atlas-cli-plugin-example/releases?per_page=100: 403 Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.[]
-- plugin debug: retrying with unauthenticated githubclient
-- plugin warning: no corresponding signature asset found for package atlas-cli-plugin-example_3.1.3_darwin_arm64.tar.gz
Plugin mongodb/atlas-cli-plugin-example successfully installed
```