### PR TITLE
CLOUDP-426871: fix docs notification workflow for fork PRs

### DIFF
--- a/.github/workflows/docs-notification.yaml
+++ b/.github/workflows/docs-notification.yaml
@@ -1,6 +1,6 @@
 name: Docs Team Notification
 on:
-  pull_request:
+  pull_request_target:
     types:
       - review_requested
 jobs:


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-426871

The Docs Team Notification workflow failed on PR #4666 with `Resource not accessible by integration` when posting the sticky PR comment.

Root cause: the PR came from a fork. The `pull_request` event grants a read-only `GITHUB_TOKEN` for fork PRs, so `permissions: pull-requests: write` is capped to read and the comment cannot be created. Prior PRs came from internal branches (same repo), so it only surfaced now on the first fork PR.

Fix: switch the trigger to `pull_request_target`, which runs in the base-repo context with a write-capable token. Safe here — the workflow only posts a comment and a Slack message; it never checks out or runs fork code.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

CI workflow change only; no unit tests apply.