### PR TITLE
CLOUDP-426805: fix release slack notification endpoint

### DIFF
--- a/build/package/send-slack-notification.sh
+++ b/build/package/send-slack-notification.sh
@@ -22,9 +22,13 @@ fi
 
 VERSION="$(git tag --list "atlascli/v*" --sort=taggerdate | tail -1 | cut -d "v" -f 2)"
 
-curl --header "Api-User:${evergreen_user:?}" \
+# Use /api/rest/v2 (not /rest/v2): the Evergreen UI host now serves the Spruce SPA
+# for /rest/v2 paths, returning index.html with HTTP 200 so the notification was
+# silently dropped. --fail makes curl exit non-zero on HTTP errors so a broken
+# endpoint fails the task instead of reporting a false SUCCESS. See CLOUDP-426805.
+curl --fail --show-error --header "Api-User:${evergreen_user:?}" \
 	--header "Api-Key:${evergreen_api_key:?}" \
-	--request POST "https://evergreen.mongodb.com/rest/v2/notifications/slack" \
+	--request POST "https://evergreen.mongodb.com/api/rest/v2/notifications/slack" \
 	--data '
      {
        "target" : "'"${release_slack_channel:?}"'",


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-426805

### Problem

The release "send slack notification" task reports SUCCESS but no message is posted to `#atlascli` (broken since v1.55.0). No error is thrown.

Evergreen migrated its REST API. On the UI host `evergreen.mongodb.com`, `/rest/v2/*` paths are now served by the Spruce SPA, which returns `index.html` with HTTP 200 for unknown paths. Our `curl` had no `--fail`, so a 200 HTML response = exit 0 = task SUCCESS while the notification was silently dropped.

### Solution

- Use `/api/rest/v2/notifications/slack` instead of `/rest/v2/notifications/slack`. The `/api` prefix still routes to the API on the same host with the existing static `Api-User`/`Api-Key` service-user auth.
- Add `--fail --show-error` so `curl` exits non-zero on any HTTP error. If the endpoint breaks again, the task will FAIL loudly instead of reporting a false SUCCESS.

### Why we can't test it yet

Posting requires the Evergreen service-user credentials (`evergreen_user` / `evergreen_api_key`), which only exist in the release project. It can't be exercised locally. Real verification is the next release — and thanks to `--fail`, a wrong endpoint will now surface as a failed task rather than a silent no-op.

### References

- mongo-release-tools `evergreen.py` — migration note: REST API no longer served by the Spruce UI host, which returns SPA `index.html` (200) for unknown paths: https://github.com/10gen/mongo-release-tools/blob/master/mongorelease/evergreen.py
- mongot `run-e2e-with-bypass-check.sh` — working slack post, same host + `Api-User`/`Api-Key`, uses `/api/rest/v2/notifications/slack`: https://github.com/10gen/mongot/blob/master/scripts/evergreen/test/run-e2e-with-bypass-check.sh
- Evergreen source `rest/route/notification_test.go` — endpoint under `/api/rest/v2/notifications/slack`: https://github.com/evergreen-ci/evergreen/blob/main/rest/route/notification_test.go

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

No unit test: the change is a one-shot bash `curl` in a release-only task with no test harness. The added `--fail` is the runtime check.