### PR TITLE
CLOUDP-427199: fix create-jira workflow permission mismatch

### DIFF
--- a/.github/workflows/create-jira.yaml
+++ b/.github/workflows/create-jira.yaml
@@ -16,5 +16,8 @@ permissions: {}
 jobs:
   create-jira:
     if: github.event.label.name == 'create_jira'
+    permissions:
+      contents: read
+      pull-requests: write
     uses: mongodb/apix-action/.github/workflows/_create-jira.yaml@main
     secrets: inherit


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-427199

The `create-jira` caller workflow set `permissions: {}`, but the reusable `mongodb/apix-action/.github/workflows/_create-jira.yaml` requires `contents: read` and `pull-requests: write`. GitHub validates permissions across caller and reusable workflow before running, so every run failed at startup:

```
The workflow is requesting contents: read, pull-requests: write, but is only allowed contents: none, pull-requests: none.
```

Broken run: https://github.com/mongodb/mongodb-atlas-cli/actions/runs/29932984509/workflow

Fix: grant the required permissions on the `create-jira` job.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Workflow-only change; validated by matching the reusable workflow's declared permissions. Other apix-action usages in this repo are step-level actions (not reusable-workflow callers) and are unaffected by this validation bug.