### PR TITLE
CLOUDP-427571: Skip ephemeralClusters commands in CLI auto-generation

### DIFF
--- a/tools/internal/specs/overlays/ephemeral_clusters_skip.yaml
+++ b/tools/internal/specs/overlays/ephemeral_clusters_skip.yaml
@@ -1,0 +1,13 @@
+overlay: 1.0.0
+info:
+  title: Skip ephemeralClusters commands
+  version: 1.0.0
+actions:
+  - target: $.paths['/api/atlas/v2/unauth/ephemeralClusters/{clusterId}'].get
+    update:
+      x-xgen-atlascli:
+        skip: true
+  - target: $.paths['/api/atlas/v2/unauth/ephemeralClusters:create'].post
+    update:
+      x-xgen-atlascli:
+        skip: true


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-427571](https://jira.mongodb.org/browse/CLOUDP-427571)

Adds an overlay (`tools/internal/specs/overlays/ephemeral_clusters_skip.yaml`) that sets `x-xgen-atlascli.skip: true` on the `getEphemeralCluster` and `createEphemeralCluster` operations, so an additional command expected to land soon under the `ephemeralClusters` group does not get exposed in the Atlas CLI until the team is ready.


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works (verified via manual generator run against a spec fixture with the operations present; the skip mechanism itself is already covered by `tools/cmd/api-generator`'s existing fixture tests)
- [x] I have added any necessary documentation (if appropriate) — N/A, no CLI-visible behavior change yet
- [x] I have run `make fmt` and formatted my code


