### PR TITLE
CLOUDP-429974: Migrate off Artifactory

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -70,6 +70,7 @@ jobs:
       PLATFORMS: linux/amd64,linux/arm64
       QUAY: quay.io
       ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
+      ECR_ROLE_ARN: arn:aws:iam::901841024863:role/ecr-role-gha-ro
       COSIGN_IMAGE: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-cosign:2024-10-01
       DOCKER_CLI_EXPERIMENTAL: enabled # used for enabling containerd image storage. See https://github.com/docker/setup-buildx-action/issues/257#issuecomment-1722284952
     steps:
@@ -102,7 +103,7 @@ jobs:
       - name: Configure AWS credentials for DevProd Platforms ECR
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
         with:
-          role-to-assume: ${{ secrets.DEVPROD_PLATFORMS_ECR_ROLE_ARN }}
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
           aws-region: us-east-1
       - name: Download cosign image
         run: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -61,11 +61,16 @@ jobs:
     name: Sign and Publish docker image
     needs: [ build_images ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # needed to assume the DevProd Platforms ECR role via OIDC
     env:
       IMAGE_REPOSITORY: mongodb/atlas
       STAGING_IMAGE_REPOSITORY: mongodb/apix_test
       PLATFORMS: linux/amd64,linux/arm64
       QUAY: quay.io
+      ECR_REGISTRY: 901841024863.dkr.ecr.us-east-1.amazonaws.com
+      COSIGN_IMAGE: 901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-cosign:2024-10-01
       DOCKER_CLI_EXPERIMENTAL: enabled # used for enabling containerd image storage. See https://github.com/docker/setup-buildx-action/issues/257#issuecomment-1722284952
     steps:
       - name: Set date
@@ -94,13 +99,15 @@ jobs:
                 "containerd-snapshotter": true
               }
             }
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ secrets.DEVPROD_PLATFORMS_ECR_ROLE_ARN }}
+          aws-region: us-east-1
       - name: Download cosign image
-        env:
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         run: |
-          echo "${ARTIFACTORY_PASSWORD}" | docker login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
-          docker pull artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign
+          aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${COSIGN_IMAGE}"
       - name: Sign docker images with cosign
         env:
           PKCS11_URI: ${{ secrets.PKCS11_URI }}
@@ -133,7 +140,7 @@ jobs:
               -v ~/.docker/config.json:/root/.docker/config.json \
               -v "$(pwd):$(pwd)" \
               -w "$(pwd)" \
-              artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-cosign:2024-10-01 \
+              "${COSIGN_IMAGE}" \
               cosign sign --key "${PKCS11_URI}" --sign-container-identity=index.docker.io/mongodb/atlas --tlog-upload=false "${IMAGE}@${DIGEST}"
           done
       - name: Push image to dockerhub public registry

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -195,7 +195,7 @@ functions:
           DO_NOT_TRACK: "1"
           TEST_MODE: live
           TEST_CMD: gotestsum --junitfile e2e-tests.xml --format standard-verbose --
-          LOCALDEV_IMAGE: artifactory.corp.mongodb.com/dockerhub/mongodb/mongodb-atlas-local
+          LOCALDEV_IMAGE: 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/mongodb/mongodb-atlas-local
         command: make e2e-test
   "install gotestsum":
     - command: shell.exec
@@ -238,6 +238,18 @@ functions:
       params:
         files:
           - tasks.json
+  "authenticate to ecr":
+    - command: ec2.assume_role
+      params:
+        role_arn: ${ecr_role_arn|arn:aws:iam::901841024863:role/ecr-role-evergreen-ro}
+    - command: subprocess.exec
+      params:
+        <<: *go_options
+        include_expansions_in_env:
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
+        binary: build/package/ecr-login.sh
   "increase inotify limits":
     - command: shell.exec
       params:
@@ -1017,6 +1029,7 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
+      - func: "authenticate to ecr"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
@@ -1030,6 +1043,7 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
+      - func: "authenticate to ecr"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
@@ -1043,6 +1057,7 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
+      - func: "authenticate to ecr"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
@@ -1056,6 +1071,7 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
+      - func: "authenticate to ecr"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:
@@ -1069,6 +1085,7 @@ tasks:
       - func: "install gotestsum"
       - func: "install mongodb database tools"
       - func: "increase inotify limits"
+      - func: "authenticate to ecr"
       - func: "e2e test"
         timeout_secs: 11400 # 3 hours 10 minutes
         vars:

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -118,8 +118,6 @@ functions:
         <<: *go_options
         env:
           <<: *go_env
-          ARTIFACTORY_USERNAME: ${artifactory_username}
-          ARTIFACTORY_PASSWORD: ${artifactory_password}
           GRS_USERNAME: ${garasign_username}
           GRS_PASSWORD: ${garasign_password}
           AUTHENTICODE_KEY_NAME: ${authenticode_key_name}
@@ -132,6 +130,9 @@ functions:
           - notary_service_url
           - goreleaser_key
           - unstable
+          - AWS_ACCESS_KEY_ID
+          - AWS_SECRET_ACCESS_KEY
+          - AWS_SESSION_TOKEN
         binary: build/package/package.sh
   "rename pkg":
     - command: subprocess.exec
@@ -350,6 +351,7 @@ tasks:
       - func: "install goreleaser"
       - func: "install macos notarization service"
       - func: "install gh-token"
+      - func: "authenticate to ecr"
       - func: "package"
         vars:
           unstable: ${unstable}

--- a/build/package/docker/amazonlinux2023-rpm.Dockerfile
+++ b/build/package/docker/amazonlinux2023-rpm.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/amazonlinux:2023
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/amazonlinux:2023
 
 
 ARG url

--- a/build/package/docker/centos8-rpm.Dockerfile
+++ b/build/package/docker/centos8-rpm.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/centos:8
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/centos:8
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/debian11-deb.Dockerfile
+++ b/build/package/docker/debian11-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/debian:11-slim
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/debian:11-slim
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/debian12-deb.Dockerfile
+++ b/build/package/docker/debian12-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/debian:12-slim
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/debian:12-slim
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/meta/amazonlinux2023-rpm.Dockerfile
+++ b/build/package/docker/meta/amazonlinux2023-rpm.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/amazonlinux:2023
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/amazonlinux:2023
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/meta/centos8-rpm.Dockerfile
+++ b/build/package/docker/meta/centos8-rpm.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/centos:8
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/centos:8
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/meta/debian11-deb.Dockerfile
+++ b/build/package/docker/meta/debian11-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/debian:11-slim
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/debian:11-slim
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/meta/debian12-deb.Dockerfile
+++ b/build/package/docker/meta/debian12-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/debian:12-slim
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/debian:12-slim
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/meta/ubuntu20.04-deb.Dockerfile
+++ b/build/package/docker/meta/ubuntu20.04-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:20.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:20.04
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/meta/ubuntu22.04-deb.Dockerfile
+++ b/build/package/docker/meta/ubuntu22.04-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:22.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:22.04
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/meta/ubuntu24.04-deb.Dockerfile
+++ b/build/package/docker/meta/ubuntu24.04-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:24.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:24.04
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/repo/amazonlinux2023.Dockerfile
+++ b/build/package/docker/repo/amazonlinux2023.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/amazonlinux:2023
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/amazonlinux:2023
 
 ARG package
 ARG entrypoint

--- a/build/package/docker/repo/centos8.Dockerfile
+++ b/build/package/docker/repo/centos8.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/centos:8
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/centos:8
 
 ARG package
 ARG entrypoint

--- a/build/package/docker/repo/debian11.Dockerfile
+++ b/build/package/docker/repo/debian11.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/debian:11-slim
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/debian:11-slim
 
 ARG package
 ARG entrypoint

--- a/build/package/docker/repo/debian12.Dockerfile
+++ b/build/package/docker/repo/debian12.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/debian:12-slim
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/debian:12-slim
 
 ARG package
 ARG entrypoint

--- a/build/package/docker/repo/ubuntu20.04.Dockerfile
+++ b/build/package/docker/repo/ubuntu20.04.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:20.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:20.04
 
 ARG package
 ARG entrypoint

--- a/build/package/docker/repo/ubuntu22.04.Dockerfile
+++ b/build/package/docker/repo/ubuntu22.04.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:22.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:22.04
 
 ARG package
 ARG entrypoint

--- a/build/package/docker/repo/ubuntu24.04.Dockerfile
+++ b/build/package/docker/repo/ubuntu24.04.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:24.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:24.04
 
 ARG package
 ARG entrypoint

--- a/build/package/docker/ubuntu20.04-deb.Dockerfile
+++ b/build/package/docker/ubuntu20.04-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:20.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:20.04
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/ubuntu22.04-deb.Dockerfile
+++ b/build/package/docker/ubuntu22.04-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:22.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:22.04
 
 ARG url
 ARG entrypoint

--- a/build/package/docker/ubuntu24.04-deb.Dockerfile
+++ b/build/package/docker/ubuntu24.04-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM artifactory.corp.mongodb.com/dockerhub/ubuntu:24.04
+FROM 901841024863.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/ubuntu:24.04
 
 ARG url
 ARG entrypoint

--- a/build/package/ecr-login.sh
+++ b/build/package/ecr-login.sh
@@ -14,10 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ecr-login authenticates the local container runtimes against the DevProd Platforms ECR registry,
-# which hosts both the Garasign signing images and the Docker Hub pull-through cache.
-# It expects AWS credentials in the environment (in Evergreen these come from ec2.assume_role
-# with the DevProd Platforms ECR readonly role).
+# Logs the available container runtimes into the DevProd Platforms ECR registry, which hosts the
+# Garasign signing images and the Docker Hub pull-through cache. Needs AWS credentials in the
+# environment; in Evergreen these come from ec2.assume_role.
 # See https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr
 
 set -Eeou pipefail
@@ -27,16 +26,75 @@ ECR_REGION=${ECR_REGION:-us-east-1}
 
 password=$(aws ecr get-login-password --region "${ECR_REGION}")
 
+# Prepare the docker config so the token can be stored. Credential helpers need an unlocked keychain,
+# which CI does not have. Drop them, keeping any credentials already in the file.
+docker_config="${DOCKER_CONFIG:-${HOME}/.docker}/config.json"
+mkdir -p "$(dirname "${docker_config}")"
+if [[ ! -f "${docker_config}" ]]; then
+  # Linux: no config yet so we seed it with an empty JSON object so the JSON edits below have something to parse.
+  echo '{}' > "${docker_config}"
+elif command -v python3 > /dev/null 2>&1; then
+  # macOS: config ships with a helper configured. No-op elsewhere.
+  python3 - "${docker_config}" <<'PY'
+import json, sys
+
+path = sys.argv[1]
+with open(path) as f:
+    config = json.load(f)
+
+config.pop("credsStore", None)
+config.pop("credHelpers", None)
+
+with open(path, "w") as f:
+    json.dump(config, f)
+PY
+fi
+
+# Log in every container runtime installed on the host. Which one that is depends on the host:
+# docker on ubuntu/debian/al2023/macOS, podman on rhel and the packaging hosts.
 logged_in=false
 for runtime in docker podman; do
-  if command -v "${runtime}" > /dev/null 2>&1; then
-    echo "Authenticating ${runtime} to ${ECR_REGISTRY}"
-    echo "${password}" | "${runtime}" login --username AWS --password-stdin "${ECR_REGISTRY}"
-    logged_in=true
+  if ! command -v "${runtime}" > /dev/null 2>&1; then
+    continue
   fi
+
+  echo "Authenticating ${runtime} to ${ECR_REGISTRY}"
+  if echo "${password}" | "${runtime}" login --username AWS --password-stdin "${ECR_REGISTRY}"; then
+    logged_in=true
+    continue
+  fi
+
+  # A podman failure is not fatal: macOS ships the podman client but no running machine, so its
+  # login can never succeed, and docker is the runtime the tests use there. When podman is the only
+  # runtime (rhel, packaging hosts) logged_in stays false and the check after the loop still exits.
+  if [[ "${runtime}" != "docker" ]]; then
+    echo "${runtime} login to ${ECR_REGISTRY} failed, skipping it"
+    continue
+  fi
+
+  # macOS: docker resolves a default keychain helper even with none configured, so the login
+  # above authenticates and then fails to store. Writing the token ourselves both stores it and
+  # makes docker read from config.json from now on.
+  echo "docker login failed to store the token, writing it to ${docker_config} instead"
+  ECR_REGISTRY="${ECR_REGISTRY}" ECR_PASSWORD="${password}" python3 - "${docker_config}" <<'PY'
+import base64, json, os, sys
+
+path = sys.argv[1]
+with open(path) as f:
+    config = json.load(f)
+
+auth = base64.b64encode(f"AWS:{os.environ['ECR_PASSWORD']}".encode()).decode()
+config.setdefault("auths", {})[os.environ["ECR_REGISTRY"]] = {"auth": auth}
+
+with open(path, "w") as f:
+    json.dump(config, f)
+PY
+  chmod 600 "${docker_config}"
+  logged_in=true
 done
 
+# Fail only if nothing authenticated
 if [[ "${logged_in}" == "false" ]]; then
-  echo "neither docker nor podman is available, cannot authenticate to ${ECR_REGISTRY}"
+  echo "no usable container runtime could authenticate to ${ECR_REGISTRY}"
   exit 1
 fi

--- a/build/package/ecr-login.sh
+++ b/build/package/ecr-login.sh
@@ -75,6 +75,12 @@ for runtime in docker podman; do
   # macOS: docker resolves a default keychain helper even with none configured, so the login
   # above authenticates and then fails to store. Writing the token ourselves both stores it and
   # makes docker read from config.json from now on.
+  if ! command -v python3 > /dev/null 2>&1; then
+    # fail fast if python3 is not available to store the token
+    echo "docker login to ${ECR_REGISTRY} failed and python3 is not available to store the token"
+    exit 1
+  fi
+
   echo "docker login failed to store the token, writing it to ${docker_config} instead"
   ECR_REGISTRY="${ECR_REGISTRY}" ECR_PASSWORD="${password}" python3 - "${docker_config}" <<'PY'
 import base64, json, os, sys

--- a/build/package/ecr-login.sh
+++ b/build/package/ecr-login.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ecr-login authenticates the local container runtimes against the DevProd Platforms ECR registry,
+# which hosts both the Garasign signing images and the Docker Hub pull-through cache.
+# It expects AWS credentials in the environment (in Evergreen these come from ec2.assume_role
+# with the DevProd Platforms ECR readonly role).
+# See https://docs.devprod.prod.corp.mongodb.com/devprod-platforms-ecr
+
+set -Eeou pipefail
+
+ECR_REGISTRY=${ECR_REGISTRY:-901841024863.dkr.ecr.us-east-1.amazonaws.com}
+ECR_REGION=${ECR_REGION:-us-east-1}
+
+password=$(aws ecr get-login-password --region "${ECR_REGION}")
+
+logged_in=false
+for runtime in docker podman; do
+  if command -v "${runtime}" > /dev/null 2>&1; then
+    echo "Authenticating ${runtime} to ${ECR_REGISTRY}"
+    echo "${password}" | "${runtime}" login --username AWS --password-stdin "${ECR_REGISTRY}"
+    logged_in=true
+  fi
+done
+
+if [[ "${logged_in}" == "false" ]]; then
+  echo "neither docker nor podman is available, cannot authenticate to ${ECR_REGISTRY}"
+  exit 1
+fi

--- a/build/package/linux_notarize.sh
+++ b/build/package/linux_notarize.sh
@@ -28,7 +28,7 @@ fi
 echo "GRS_CONFIG_USER1_USERNAME=${GRS_USERNAME}" > "signing-envfile"
 echo "GRS_CONFIG_USER1_PASSWORD=${GRS_PASSWORD}" >> "signing-envfile"
 
-echo "${ARTIFACTORY_PASSWORD}" | podman login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
+"$(dirname "${BASH_SOURCE[0]}")/ecr-login.sh"
 
 echo "notarizing Linux binary ${artifact}"
 
@@ -37,7 +37,7 @@ podman run \
   --rm \
   -v "$(pwd)":"$(pwd)" \
   -w "$(pwd)" \
-  artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-gpg \
+  901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-gpg \
   /bin/bash -c "gpgloader && gpg --yes -v --armor -o ${artifact}.sig --detach-sign ${artifact}"
 
 rm -rf signing-envfile

--- a/build/package/windows_build_msi.sh
+++ b/build/package/windows_build_msi.sh
@@ -61,7 +61,7 @@ echo "Cleaning up ${user}@${host}:/cygdrive/c/Users/Administrator/msi"
 ssh -i "$keyfile" -o ConnectTimeout=10 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -tt "${user}@${host}" "rm -rf '/cygdrive/c/Users/Administrator/msi'"
 
 echo "Notarizing ${MSI_FILE}"
-echo "${ARTIFACTORY_PASSWORD}" | podman login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
+"$(dirname "${BASH_SOURCE[0]}")/ecr-login.sh"
 
 echo "GRS_CONFIG_USER1_USERNAME=${GRS_USERNAME}" > .env
 echo "GRS_CONFIG_USER1_PASSWORD=${GRS_PASSWORD}" >> .env
@@ -72,7 +72,7 @@ podman run \
 	--rm \
 	-v "$(pwd):$(pwd)" \
 	-w "$(pwd)" \
-	artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-jsign \
+	901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-jsign \
 	/bin/bash -c "jsign --tsaurl http://timestamp.digicert.com -a ${AUTHENTICODE_KEY_NAME} \"$MSI_FILE\""
 
 rm .env

--- a/build/package/windows_notarize.sh
+++ b/build/package/windows_notarize.sh
@@ -19,7 +19,7 @@ set -Eeou pipefail
 EXE_FILE="dist/windows_windows_amd64_v1/bin/atlas.exe"
 
 if [[ -f "$EXE_FILE" ]]; then
-	echo "${ARTIFACTORY_PASSWORD}" | podman login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
+	"$(dirname "${BASH_SOURCE[0]}")/ecr-login.sh"
 
 	echo "GRS_CONFIG_USER1_USERNAME=${GRS_USERNAME}" > .env
 	echo "GRS_CONFIG_USER1_PASSWORD=${GRS_PASSWORD}" >> .env
@@ -30,7 +30,7 @@ if [[ -f "$EXE_FILE" ]]; then
 		--rm \
 		-v "$(pwd):$(pwd)" \
 		-w "$(pwd)" \
-		artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-jsign \
+		901841024863.dkr.ecr.us-east-1.amazonaws.com/release-infrastructure/garasign-jsign \
 		/bin/bash -c "jsign --tsaurl http://timestamp.digicert.com -a ${AUTHENTICODE_KEY_NAME} \"$EXE_FILE\""
 	
 	rm .env

--- a/tools/cmd/genevergreen/generate/generate.go
+++ b/tools/cmd/genevergreen/generate/generate.go
@@ -107,6 +107,7 @@ func RepoTasks(c *shrub.Configuration) {
 					GitTagOnly(true).
 					Dependency(newDependency(os, serverVersion, repo)).
 					Function("clone").
+					Function("authenticate to ecr").
 					FunctionWithVars("docker build repo", map[string]string{
 						"server_version":     serverVersion,
 						"pgp_server_version": getGpgServerVersion(serverVersion),
@@ -139,9 +140,11 @@ func PostPkgTasks(c *shrub.Configuration) {
 		t = t.Dependency(shrub.TaskDependency{
 			Name:    "package_goreleaser",
 			Variant: "goreleaser_atlascli_snapshot",
-		}).Function("clone").FunctionWithVars("docker build", map[string]string{
-			"image": postPkgImg[os],
-		})
+		}).Function("clone").
+			Function("authenticate to ecr").
+			FunctionWithVars("docker build", map[string]string{
+				"image": postPkgImg[os],
+			})
 		c.Tasks = append(c.Tasks, t)
 		v.AddTasks(t.Name)
 	}
@@ -169,6 +172,7 @@ func PostPkgMetaTasks(c *shrub.Configuration) {
 				Name:    "package_goreleaser",
 				Variant: "goreleaser_atlascli_snapshot",
 			}).Function("clone").
+				Function("authenticate to ecr").
 				FunctionWithVars("docker build meta", map[string]string{
 					"image":              postPkgImg[os],
 					"server_version":     sv,


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-429974](https://jira.mongodb.org/browse/CLOUDP-429974)

`artifactory.corp.mongodb.com` has been decommissioned. This blocks Atlas CLI releases outright.

Two things came from Artifactory, with two different replacements:

- **Garasign signing images** (`garasign-cosign`, `garasign-gpg`, `garasign-jsign`) → DevProd Platforms ECR, `release-infrastructure/` namespace, already published there by release-tools.
- **Docker Hub base images** (adopted to dodge Docker Hub rate limiting) → ECR pull-through cache, `dockerhub/` namespace.

### What changed

- **New `build/package/ecr-login.sh`** — exchanges AWS credentials for an ECR token and logs in whichever runtimes are present (docker and/or podman), with a macOS fallback that writes the token to `config.json` when docker's keychain helper fails to store it.
- **Signing scripts** (`linux_notarize.sh`, `windows_notarize.sh`, `windows_build_msi.sh`) — Artifactory login replaced with `ecr-login.sh`, Garasign images repointed at ECR. GRS credentials, PKCS#11 config and `AUTHENTICODE_KEY_NAME` unchanged.
- **Evergreen** — new `authenticate to ecr` function (`ec2.assume_role` on the readonly role, then login), wired into the `package` task, the generated docker build/meta/repo tasks and the five local-deployment e2e tasks. `ARTIFACTORY_USERNAME`/`ARTIFACTORY_PASSWORD` dropped from `package` in favour of the assumed-role AWS credentials.
- **`tools/cmd/genevergreen`** — emits the auth step before each `docker build*` function so generated configs stay in sync.
- **21 Dockerfiles** under `build/package/docker/{,meta,repo}` — base images resolve through the ECR pull-through cache. RHEL/SUSE bases were already upstream and are untouched.
- **`LOCALDEV_IMAGE`** for local-deployment e2e tests now comes from the cache.
- **`docker-release.yml`** — authenticates to ECR with GitHub OIDC (`id-token: write` + `configure-aws-credentials`, no static credentials) and pulls the cosign image from ECR. Signing logic unchanged.

`git grep -i artifactory` returns nothing.

### Infrastructure prerequisites

- `mongodb/mongodb-atlas-cli` added to the OIDC trust policy of `arn:aws:iam::901841024863:role/ecr-role-gha-ro` — **granted**. The ARN is inlined rather than kept in a secret: it isn't a credential without a matching OIDC token, and the account ID is already committed throughout this repo.
- Evergreen project variable `ecr_role_arn` (already used by `generate sbom`); the YAML falls back to the readonly role ARN if unset. `artifactory_username` / `artifactory_password` can now be deleted.

### Testing

- Evergreen patch on `pkg_smoke_tests_docker_atlascli` (builds the migrated Dockerfiles, no push): see [here](https://spruce.corp.mongodb.com/version/6a7b1c631fac1800079cfdbc/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=%5Epkg_smoke_tests_docker_atlascli%24)
- Evergreen patch with the `localdev` alias (docker and podman variants): see [here](https://spruce.corp.mongodb.com/version/6a7b1c631fac1800079cfdbc/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
  - Tests fail but ECR login and pull works. Test failures will be addressed in a follow-up PR
- GitHub Actions ECR auth + cosign pull, verified without releasing anything: see [here](https://github.com/mongodb/mongodb-atlas-cli/actions/runs/31493792850/job/93786378296?pr=4710)
