### PR TITLE
fix(test): Bump local deployment e2e MDB version assertion

### DIFF
--- a/test/e2e/atlas/deployments/local/auth/deprecated/deploymentslocalauthindexdeprecated/deployments_local_auth_index_deprecated_test.go
+++ b/test/e2e/atlas/deployments/local/auth/deprecated/deploymentslocalauthindexdeprecated/deployments_local_auth_index_deprecated_test.go
@@ -145,7 +145,7 @@ func TestDeploymentsLocalWithAuthIndexDeprecated(t *testing.T) {
 		cols := strings.Fields(outputLines[1])
 		assert.Equal(t, deploymentName, cols[0])
 		assert.Equal(t, "LOCAL", cols[1])
-		assert.Contains(t, cols[2], "8.2.")
+		assert.Contains(t, cols[2], internal.LocalDevMDBVersionPrefix)
 		assert.Equal(t, "IDLE", cols[3])
 	})
 

--- a/test/e2e/atlas/deployments/local/auth/new/deploymentslocalauth/deployments_local_auth_test.go
+++ b/test/e2e/atlas/deployments/local/auth/new/deploymentslocalauth/deployments_local_auth_test.go
@@ -145,7 +145,7 @@ func TestDeploymentsLocalWithAuth(t *testing.T) {
 		cols := strings.Fields(outputLines[1])
 		assert.Equal(t, deploymentName, cols[0])
 		assert.Equal(t, "LOCAL", cols[1])
-		assert.Contains(t, cols[2], "8.2.")
+		assert.Contains(t, cols[2], internal.LocalDevMDBVersionPrefix)
 		assert.Equal(t, "IDLE", cols[3])
 	})
 

--- a/test/e2e/atlas/deployments/local/noauth/deploymentslocalnoauth/deployments_local_noauth_test.go
+++ b/test/e2e/atlas/deployments/local/noauth/deploymentslocalnoauth/deployments_local_noauth_test.go
@@ -138,7 +138,7 @@ func TestDeploymentsLocal(t *testing.T) {
 		cols := strings.Fields(outputLines[1])
 		assert.Equal(t, deploymentName, cols[0])
 		assert.Equal(t, "LOCAL", cols[1])
-		assert.Contains(t, cols[2], "8.2.")
+		assert.Contains(t, cols[2], internal.LocalDevMDBVersionPrefix)
 		assert.Equal(t, "IDLE", cols[3])
 	})
 

--- a/test/e2e/atlas/deployments/local/nocli/deploymentslocalnocli/deployments_local_nocli_test.go
+++ b/test/e2e/atlas/deployments/local/nocli/deploymentslocalnocli/deployments_local_nocli_test.go
@@ -145,7 +145,7 @@ func TestDeploymentsLocalWithNoCLI(t *testing.T) {
 		cols := strings.Fields(outputLines[1])
 		assert.Equal(t, deploymentName, cols[0])
 		assert.Equal(t, "LOCAL", cols[1])
-		assert.Contains(t, cols[2], "8.2.")
+		assert.Contains(t, cols[2], internal.LocalDevMDBVersionPrefix)
 		assert.Equal(t, "IDLE", cols[3])
 	})
 

--- a/test/internal/env.go
+++ b/test/internal/env.go
@@ -230,6 +230,10 @@ func IsGov() bool {
 	return profile["service"] == cloudgov
 }
 
+// LocalDevMDBVersionPrefix is the MongoDB version the local deployment e2e tests expect
+// LocalDevImage to report. Bump it when mongodb-atlas-local ships a new minor version of MDB.
+const LocalDevMDBVersionPrefix = "8.3."
+
 func LocalDevImage() string {
 	image, ok := os.LookupEnv("LOCALDEV_IMAGE")
 	if !ok || image == "" {


### PR DESCRIPTION
## Issue

All 36 `e2e_local_deployments_*` tasks fail with `"8.3.4" does not contain "8.2."`. `LOCALDEV_IMAGE` is untagged, so the tests run against `mongodb-atlas-local:latest`, which now ships MongoDB 8.3. (see [failed EVG patch](https://spruce.corp.mongodb.com/version/6a7c328d95bf0500076317e9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC))

## Proposed changes
- New `internal.LocalDevMDBVersionPrefix` const in `test/internal/env.go`, set to `8.3.`.
- The four local deployment e2e tests (auth, auth-deprecated, noauth, nocli) assert against the const instead of a hardcoded `"8.2."`.

Future MDB bumps are a one-line change.

### Testing

- Evergreen patch with the `localdev` alias: [link](https://spruce.corp.mongodb.com/version/6a7c4270235322000737c369/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)