### PR TITLE
fix(release): Allows slack notification to not block release

### DIFF
--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -186,7 +186,7 @@ functions:
       type: test
       params:
         working_dir: src/github.com/mongodb/mongodb-atlas-cli
-        silent: true
+        continue_on_err: true
         include_expansions_in_env:
           - evergreen_user
           - evergreen_api_key


### PR DESCRIPTION
At the end of  `package_goreleaser`, we send a slack notification. This action has been failing for a number of releases. A fix was put in place to not hide the error but this now blocks releases on failure.
This PR allows the release to continue on error and removes the silent=true so that the error is visible from evergreen