### PR TITLE
CLOUDP-435365: Remove remaining build unused packages for Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ RUN microdnf -y install jq &&\
     microdnf clean all &&\
     rm -rf /var/cache &&\
     rpm -e --nodeps \
-      curl-minimal libcurl-minimal libxml2 sqlite-libs \
+      curl-minimal libcurl-minimal libxml2 \
       glib2 libarchive libgcrypt systemd-libs libsolv libnghttp2 \
       libblkid libmount libsmartcols libuuid \
-      gnupg2 krb5-libs bzip2-libs openldap sed libyaml &&\
+      gnupg2 krb5-libs openldap sed libyaml &&\
     ! command -v curl &&\
     ! command -v yum
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN microdnf -y install jq &&\
     rpm -e --nodeps \
       curl-minimal libcurl-minimal libxml2 sqlite-libs \
       glib2 libarchive libgcrypt systemd-libs libsolv libnghttp2 \
-      libblkid libmount libsmartcols libuuid &&\
+      libblkid libmount libsmartcols libuuid \
+      gnupg2 krb5-libs bzip2-libs openldap sed libyaml &&\
     ! command -v curl &&\
     ! command -v yum
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-437429

Reduce the Atlas CLI Docker image attack surface by removing packages that are not needed at runtime after installation. Retain jq for JSON workflows, RPM/RPM libraries for SBOM generation, bzip2/sqlite for RPM operation, OpenSSL/FIPS and p11-kit for TLS/certificate handling, and libattr/coreutils for the container shell and default command.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make fmt` and formatted my code

## Further comments

- Docker image builds successfully for `linux/amd64`.
- Snyk reduced the local latest-master candidate from 81 to 39 unique CVEs.
- `atlas`, `jq`, `mongosh`, `rpm`, and `rpm -qa` pass in the final image.
- Full Atlas Local lifecycle passed: setup, list, connect, logs, stop, start, delete, and mongosh ping before and after restart.
- Repository pre-PR checks passed: formatting, lint, build, and unit tests.
- No release workflow was triggered.