### PR TITLE
chore: exclude auto-generated atlas-api.txt from Docs team review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,5 @@
 
 # Auto-generated API command docs are not reviewed by the Docs team
 /docs/command/atlas-api-*  @mongodb/apix-devtools
+/docs/command/atlas-api.txt  @mongodb/apix-devtools
 /docs/command/includes/    @mongodb/apix-devtools


### PR DESCRIPTION
## Description

The Docs Cloud Team is still being requested for review on the auto-generated commands PRs. The existing CODEOWNERS exclusion covers `/docs/command/atlas-api-*` and `/docs/command/includes/`, but not `/docs/command/atlas-api.txt` — the API command index page, which is regenerated on every SDK bump and so is still matched by the broader `/docs/` rule.

This adds the missing entry so the whole auto-generated API command doc set is owned by `@mongodb/apix-devtools`.
