### PR TITLE
CLOUDP-439953:  Stage unsigned release images on a host-local registry fix

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e
         with:
-          driver-opts: network=host
+          driver-opts: network=container:${{ env.LOCAL_REGISTRY_NAME }}
       - name: Build and push image to local staging registry
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-439953

Follow-up fix to #4738, which broke the daily Docker release. Run [33187739573](https://github.com/mongodb/mongodb-atlas-cli/actions/runs/33187739573) failed at the build step with:

```
ERROR: failed to resolve source metadata for docker.io/docker/dockerfile:1.3-labs:
Head "https://registry-1.docker.io/v2/...": tls: failed to verify certificate:
x509: certificate signed by unknown authority
```

