### PR TITLE
chore: fix path typo in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ scripts/                — Utility scripts
 
 - Commands use the [Cobra framework](https://github.com/spf13/cobra). Each command has `*Opts` struct + `Run()` method + `*Builder()` function.
 - API integration uses [atlas-sdk-go](https://github.com/mongodb/atlas-sdk-go) via `internal/store/` interfaces.
-- New commands are registered in `internal/cli/root/atlas/builder.go`.
+- New commands are registered in `internal/cli/root/builder.go`.
 
 ## Before Submitting Changes
 


### PR DESCRIPTION
<!--
Thanks for contributing to MongoDB Atlas CLI!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and getting you pull request merged!
-->

## Proposed changes


Corrected typo in AGENTS.md that incorrectly pointed to "internal/cli/root/atlas/builder.go" instead of "internal/cli/root/builder.go".

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have updated [test/README.md](https://github.com/mongodb/mongodb-atlas-cli/blob/master/test/README.md) (if an e2e test has been added)
- [x] I have run `make fmt` and formatted my code

