### PR TITLE
CLOUDP-440493: Retry deployments pause in e2e tests on transient cluster state

### DIFF
--- a/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_iss_test.go
+++ b/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_iss_test.go
@@ -126,6 +126,7 @@ func TestDeploymentsAtlasISS(t *testing.T) {
 	g.Run("Pause Cluster", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
 		// A freshly provisioned cluster can still report replication lag on a secondary
 		// after it reaches the IDLE state, and Atlas refuses to pause until that clears.
+		// This has been observed to take around 10 minutes.
 		var resp []byte
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			cmd := exec.Command(cliPath,
@@ -139,9 +140,16 @@ func TestDeploymentsAtlasISS(t *testing.T) {
 			)
 			cmd.Env = os.Environ()
 
-			var err error
-			resp, err = cmd.CombinedOutput()
-			assert.NoError(c, err, string(resp))
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				// EventuallyWithT discards the errors it collects once the condition
+				// eventually holds, so log every rejection to keep the wait diagnosable.
+				t.Logf("pause was rejected, retrying in %s: %s", pauseRetryInterval, string(out))
+				assert.NoError(c, err, string(out))
+
+				return
+			}
+			resp = out
 		}, pauseTimeout, pauseRetryInterval)
 		assert.Contains(t, string(resp), fmt.Sprintf("Pausing deployment '%s'", clusterName))
 	})

--- a/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_iss_test.go
+++ b/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_iss_test.go
@@ -124,18 +124,25 @@ func TestDeploymentsAtlasISS(t *testing.T) {
 	})
 
 	g.Run("Pause Cluster", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
-		cmd := exec.Command(cliPath,
-			deploymentEntity,
-			"pause",
-			clusterName,
-			"--type=ATLAS",
-			"--projectId", g.ProjectID,
-			"-P",
-			internal.ProfileName(),
-		)
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		require.NoError(t, err, string(resp))
+		// A freshly provisioned cluster can still report replication lag on a secondary
+		// after it reaches the IDLE state, and Atlas refuses to pause until that clears.
+		var resp []byte
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			cmd := exec.Command(cliPath,
+				deploymentEntity,
+				"pause",
+				clusterName,
+				"--type=ATLAS",
+				"--projectId", g.ProjectID,
+				"-P",
+				internal.ProfileName(),
+			)
+			cmd.Env = os.Environ()
+
+			var err error
+			resp, err = cmd.CombinedOutput()
+			assert.NoError(c, err, string(resp))
+		}, pauseTimeout, pauseRetryInterval)
 		assert.Contains(t, string(resp), fmt.Sprintf("Pausing deployment '%s'", clusterName))
 	})
 

--- a/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_test.go
+++ b/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_test.go
@@ -141,6 +141,7 @@ func TestDeploymentsAtlas(t *testing.T) {
 	g.Run("Pause Cluster", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
 		// A freshly provisioned cluster can still report replication lag on a secondary
 		// after it reaches the IDLE state, and Atlas refuses to pause until that clears.
+		// This has been observed to take around 10 minutes.
 		var resp []byte
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			cmd := exec.Command(cliPath,
@@ -154,9 +155,16 @@ func TestDeploymentsAtlas(t *testing.T) {
 			)
 			cmd.Env = os.Environ()
 
-			var err error
-			resp, err = cmd.CombinedOutput()
-			assert.NoError(c, err, string(resp))
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				// EventuallyWithT discards the errors it collects once the condition
+				// eventually holds, so log every rejection to keep the wait diagnosable.
+				t.Logf("pause was rejected, retrying in %s: %s", pauseRetryInterval, string(out))
+				assert.NoError(c, err, string(out))
+
+				return
+			}
+			resp = out
 		}, pauseTimeout, pauseRetryInterval)
 		assert.Contains(t, string(resp), fmt.Sprintf("Pausing deployment '%s'", clusterName))
 	})

--- a/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_test.go
+++ b/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_test.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mongodb/mongodb-atlas-cli/atlascli/test/internal"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +39,11 @@ const (
 const (
 	collectionNameAtlas = "movies"
 	databaseNameAtlas   = "sample_mflix"
+)
+
+const (
+	pauseTimeout       = 10 * time.Minute
+	pauseRetryInterval = 30 * time.Second
 )
 
 func TestDeploymentsAtlas(t *testing.T) {
@@ -133,18 +139,25 @@ func TestDeploymentsAtlas(t *testing.T) {
 	})
 
 	g.Run("Pause Cluster", func(t *testing.T) { //nolint:thelper // g.Run replaces t.Run
-		cmd := exec.Command(cliPath,
-			deploymentEntity,
-			"pause",
-			clusterName,
-			"--type=ATLAS",
-			"--projectId", g.ProjectID,
-			"-P",
-			internal.ProfileName(),
-		)
-		cmd.Env = os.Environ()
-		resp, err := cmd.CombinedOutput()
-		require.NoError(t, err, string(resp))
+		// A freshly provisioned cluster can still report replication lag on a secondary
+		// after it reaches the IDLE state, and Atlas refuses to pause until that clears.
+		var resp []byte
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			cmd := exec.Command(cliPath,
+				deploymentEntity,
+				"pause",
+				clusterName,
+				"--type=ATLAS",
+				"--projectId", g.ProjectID,
+				"-P",
+				internal.ProfileName(),
+			)
+			cmd.Env = os.Environ()
+
+			var err error
+			resp, err = cmd.CombinedOutput()
+			assert.NoError(c, err, string(resp))
+		}, pauseTimeout, pauseRetryInterval)
 		assert.Contains(t, string(resp), fmt.Sprintf("Pausing deployment '%s'", clusterName))
 	})
 

--- a/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_test.go
+++ b/test/e2e/atlas/deployments/atlasclusters/deploymentsatlas/deployments_atlas_test.go
@@ -42,7 +42,7 @@ const (
 )
 
 const (
-	pauseTimeout       = 10 * time.Minute
+	pauseTimeout       = 20 * time.Minute
 	pauseRetryInterval = 30 * time.Second
 )
 


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-440493

`TestDeploymentsAtlasISS/Pause_Cluster` has been failing on master. The pause call was rejected by Atlas with:

```
PATCH .../clusters/cluster-293-... : HTTP 400 Bad Request
Error code: "OPERATION_INVALID_MEMBER_REPLICATION_LAG"
Detail: The operation cannot begin because monitoring indicates these nodes
have too much replication lag: atlas-km9t4t-shard-00-02... (240sec).
```

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
